### PR TITLE
chore: prepare v0.0.3 release (fixed)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1695,7 +1695,7 @@ checksum = "b71f8c2c0d5c57620003c3bf1ee577b738404a7fd9642f6cf73d10e44ffaa70f"
 
 [[package]]
 name = "datafusion-ducklake"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "arrow",


### PR DESCRIPTION
Stupidly missed the lock file as part of #36, which caused the [deploy](https://github.com/hotdata-dev/datafusion-ducklake/actions/runs/20863911203/job/59950329313) to fail. 