### PR TITLE
 Reuse DuckDB connection for metadata queries instead of creating new connection per call

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ The codebase follows a layered architecture with clear separation of concerns:
    - Also provides individual lookup methods: `get_schema_by_name()`, `get_table_by_name()`, and `table_exists()`
    - `DuckdbMetadataProvider` implements the trait using DuckDB as the catalog backend
    - Executes SQL queries against standard DuckLake catalog tables (`ducklake_snapshot`, `ducklake_schema`, `ducklake_table`, `ducklake_column`, `ducklake_data_file`, `ducklake_delete_file`, `ducklake_metadata`)
-   - Thread-safe: Opens a new read-only connection for each query
+   - Thread-safe: Uses a single shared connection protected by Mutex for efficiency
    - Supports delete files: `get_table_files_for_select()` returns data files with associated delete files
 
 2. **DataFusion Integration Layer** (`src/catalog.rs`, `src/schema.rs`, `src/table.rs`)

--- a/src/metadata_provider_duckdb.rs
+++ b/src/metadata_provider_duckdb.rs
@@ -20,6 +20,9 @@ use std::sync::{Arc, Mutex, MutexGuard};
 #[derive(Debug, Clone)]
 pub struct DuckdbMetadataProvider {
     conn: Arc<Mutex<Connection>>,
+    /// Path to the catalog database, retained for logging/debugging
+    #[allow(dead_code)]
+    catalog_path: String,
 }
 
 impl DuckdbMetadataProvider {
@@ -30,6 +33,7 @@ impl DuckdbMetadataProvider {
 
         Ok(Self {
             conn: Arc::new(Mutex::new(conn)),
+            catalog_path,
         })
     }
 

--- a/tests/concurrent_tests.rs
+++ b/tests/concurrent_tests.rs
@@ -15,7 +15,7 @@
 //! ## Thread Safety Guarantees
 //!
 //! The DuckLake implementation is designed to be thread-safe:
-//! - **MetadataProvider**: Opens a new read-only DuckDB connection per query
+//! - **MetadataProvider**: Uses a single shared connection protected by Mutex
 //! - **Catalog/Schema**: Dynamic metadata lookup with no shared mutable state
 //! - **Table**: Immutable metadata cached at creation time
 //! - **ObjectStore**: DataFusion's object stores are Arc<dyn ObjectStore> (thread-safe)


### PR DESCRIPTION
 ## Summary
  - Refactored `DuckdbMetadataProvider` to use a single shared DuckDB connection protected by `Arc<Mutex<Connection>>` instead of creating a new connection for each metadata query
  - Reduces connection creation overhead for read-only metadata operations

https://github.com/hotdata-dev/datafusion-ducklake/issues/44

  ## Changes
  - Changed struct field from `catalog_path: String` to `conn: Arc<Mutex<Connection>>`
  - Connection is now created once in `new()` and reused across all metadata calls
  - Added `connection()` method that returns `MutexGuard<Connection>` for thread-safe access
  - Renamed `open_connection_with_path()` to `create_connection()` for clarity

  ## Rationale
  Previously, each of the 14+ metadata methods (`get_current_snapshot`, `list_schemas`, `get_table_by_name`, etc.) opened a new DuckDB connection. Since all operations are read-only and metadata queries are fast, a mutex-protected shared connection is sufficient and eliminates unnecessary connection overhead.
