### PR TITLE
chore: prepare v0.0.6 release (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.6] - 2026-02-13
+
+### Added
+- S3/ObjectStore write support for DuckLake catalogs
+
+### Changed
+- Upgraded DataFusion 50→51, Arrow/Parquet 56→57
+
 ## [0.0.5] - 2026-02-04
 
 ### Added
@@ -58,6 +66,7 @@ Initial release.
 - Filter pushdown to Parquet
 - Query-scoped snapshot isolation
 
+[0.0.6]: https://github.com/hotdata-dev/datafusion-ducklake/compare/v0.0.5...v0.0.6
 [0.0.5]: https://github.com/hotdata-dev/datafusion-ducklake/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/hotdata-dev/datafusion-ducklake/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/hotdata-dev/datafusion-ducklake/compare/v0.0.2...v0.0.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1849,7 +1849,7 @@ checksum = "2b99e13947667b36ad713549237362afb054b2d8f8cc447751e23ec61202db07"
 
 [[package]]
 name = "datafusion-ducklake"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "arrow 57.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "benchmark"]
 
 [package]
 name = "datafusion-ducklake"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2024"
 authors = ["zac@hotdata.dev", "shefeek@hotdata.dev", "anoop@hotdata.dev"]
 description = "DuckLake query engine for rust, built with datafusion."

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This project is under active development. The roadmap below reflects major areas
 ### Write Support
 
 - ~~Initial write support for DuckLake tables~~ (Done in v0.0.5)
+- ~~S3/ObjectStore write support~~ (Done in v0.0.6)
 - UPDATE and DELETE operations
 
 ### Time Travel & Versioning


### PR DESCRIPTION
Bump version to 0.0.6, update changelog with S3/ObjectStore write support and DataFusion 50→51, Arrow/Parquet 56→57 upgrade.