### PR TITLE
feat: allow dynamic linking against system libduckdb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,9 +85,9 @@ jobs:
       - name: Run tests
         run: |
           if [[ "$RUNNER_OS" == "macOS" ]]; then
-            cargo test --features skip-tests-with-docker,duckdb-bundled
+            cargo test --features skip-tests-with-docker
           else
-            cargo test --features duckdb-bundled
+            cargo test
           fi
 
       - name: Check documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,9 +85,9 @@ jobs:
       - name: Run tests
         run: |
           if [[ "$RUNNER_OS" == "macOS" ]]; then
-            cargo test --features skip-tests-with-docker
+            cargo test --features skip-tests-with-docker,duckdb-bundled
           else
-            cargo test
+            cargo test --features duckdb-bundled
           fi
 
       - name: Check documentation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ hex = { version = "0.4", optional = true }
 uuid = { version = "1.0", features = ["v4"], optional = true }
 
 # Metadata providers (optional)
-duckdb = { version = "1.4.1", features = ["bundled"], optional = true }
+duckdb = { version = "1.4.1", optional = true }
 sqlx = { version = "0.8", features = ["runtime-tokio"], optional = true }
 
 [dev-dependencies]
@@ -60,6 +60,11 @@ metadata-duckdb = ["dep:duckdb"]
 metadata-postgres = ["dep:sqlx", "sqlx/postgres", "sqlx/chrono"]
 metadata-mysql = ["dep:sqlx", "sqlx/mysql", "sqlx/chrono"]
 metadata-sqlite = ["dep:sqlx", "sqlx/sqlite", "sqlx/chrono"]
+
+# Opt-in to bundled DuckDB compilation (compiles DuckDB C++ from source).
+# By default, `metadata-duckdb` dynamically links against a system libduckdb,
+# which is much faster to build. Enable this feature to statically bundle DuckDB.
+duckdb-bundled = ["duckdb/bundled"]
 
 # Encryption support for Parquet files
 encryption = ["parquet/encryption", "datafusion/parquet_encryption", "dep:base64", "dep:hex"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ aws-credential-types = "1.2"
 sqllogictest = "0.23"
 
 [features]
-default = ["metadata-duckdb"]
+default = ["metadata-duckdb", "duckdb-bundled"]
 
 # Allow skipping tests that use docker (in CI, macos doesn't support docker).
 skip-tests-with-docker = []
@@ -61,10 +61,10 @@ metadata-postgres = ["dep:sqlx", "sqlx/postgres", "sqlx/chrono"]
 metadata-mysql = ["dep:sqlx", "sqlx/mysql", "sqlx/chrono"]
 metadata-sqlite = ["dep:sqlx", "sqlx/sqlite", "sqlx/chrono"]
 
-# Opt-in to bundled DuckDB compilation (compiles DuckDB C++ from source).
-# By default, `metadata-duckdb` dynamically links against a system libduckdb,
-# which is much faster to build. Enable this feature to statically bundle DuckDB.
-duckdb-bundled = ["duckdb/bundled"]
+# Compile DuckDB C++ from source and statically bundle it. Enabled by default.
+# Consumers who want to dynamically link against a system libduckdb can disable
+# this by using `default-features = false, features = ["metadata-duckdb"]`.
+duckdb-bundled = ["metadata-duckdb", "duckdb/bundled"]
 
 # Encryption support for Parquet files
 encryption = ["parquet/encryption", "datafusion/parquet_encryption", "dep:base64", "dep:hex"]

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ This project is under active development. The roadmap below reflects major areas
 | Feature | Description | Default |
 |---------|-------------|---------|
 | `metadata-duckdb` | DuckDB catalog backend | ✅ |
+| `duckdb-bundled` | Statically compile and bundle DuckDB (disable for dynamic linking) | ✅ |
 | `metadata-postgres` | PostgreSQL catalog backend | |
 | `metadata-mysql` | MySQL catalog backend | |
 | `metadata-sqlite` | SQLite catalog backend | |
@@ -89,8 +90,12 @@ This project is under active development. The roadmap below reflects major areas
 | `write` | Write support (INSERT INTO) | |
 
 ```bash
-# DuckDB only (default)
+# DuckDB only (default, bundled build)
 cargo build
+
+# DuckDB dynamically linked against a system libduckdb
+# (requires libduckdb installed; set DUCKDB_LIB_DIR and DUCKDB_INCLUDE_DIR)
+cargo build --no-default-features --features metadata-duckdb
 
 # PostgreSQL only
 cargo build --no-default-features --features metadata-postgres


### PR DESCRIPTION
Splits the bundled DuckDB build into its own `duckdb-bundled` feature (still in `default`, so no behavior change for existing consumers) and lets consumers opt into dynamic linking against a system libduckdb via `default-features = false, features = ["metadata-duckdb"]`.