### PR TITLE
chore(release): prepare v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2026-04-13
+
+### Added
+- Allow dynamic linking against system libduckdb (#103)
+
+### Fixed
+- Update workflow actions for Node.js 24 compatibility (#100)
+- Pin 3rd party GitHub Actions to specific SHAs for supply-chain security (#97, #98, #99)
+
 ## [0.1.1] - 2026-04-01
 
 ### Added
@@ -99,6 +108,7 @@ Initial release.
 - Filter pushdown to Parquet
 - Query-scoped snapshot isolation
 
+[0.1.2]: https://github.com/hotdata-dev/datafusion-ducklake/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/hotdata-dev/datafusion-ducklake/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/hotdata-dev/datafusion-ducklake/compare/v0.0.7...v0.1.0
 [0.0.7]: https://github.com/hotdata-dev/datafusion-ducklake/compare/v0.0.6...v0.0.7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1799,7 +1799,7 @@ checksum = "e44b41f3e8267c6cf3eec982d63f34db9f1dd5f30abfd2e1f124f0871708952e"
 
 [[package]]
 name = "datafusion-ducklake"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "arrow 57.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "benchmark"]
 
 [package]
 name = "datafusion-ducklake"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 authors = ["zac@hotdata.dev", "shefeek@hotdata.dev", "anoop@hotdata.dev"]
 description = "DuckLake query engine for rust, built with datafusion."


### PR DESCRIPTION
Bumps version to 0.1.2. See [CHANGELOG](./CHANGELOG.md#012---2026-04-13) for details.