### PR TITLE
feat: DuckLake row lineage (rowid virtual column)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5024,6 +5024,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
+ "rustls 0.23.37",
  "serde",
  "serde_json",
  "sha2",
@@ -5033,6 +5034,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -6018,6 +6020,24 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ skip-tests-with-docker = []
 
 # Metadata provider backends
 metadata-duckdb = ["dep:duckdb"]
-metadata-postgres = ["dep:sqlx", "sqlx/postgres", "sqlx/chrono"]
+metadata-postgres = ["dep:sqlx", "sqlx/postgres", "sqlx/chrono", "sqlx/tls-rustls-ring"]
 metadata-mysql = ["dep:sqlx", "sqlx/mysql", "sqlx/chrono"]
 metadata-sqlite = ["dep:sqlx", "sqlx/sqlite", "sqlx/chrono"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,3 +72,13 @@ encryption = ["parquet/encryption", "datafusion/parquet_encryption", "dep:base64
 # Write support
 write = ["dep:uuid"]
 write-sqlite = ["write", "metadata-sqlite"]
+
+# Rowid verification examples need both the DuckDB extension (writes the
+# catalog + writes data) and the postgres provider (DataFusion-side reads).
+[[example]]
+name = "compare_rowid_against_duckdb"
+required-features = ["metadata-duckdb", "metadata-postgres"]
+
+[[example]]
+name = "rowid_lifecycle"
+required-features = ["metadata-duckdb", "metadata-postgres"]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ To meet the [Hotdata](https://www.hotdata.dev) team, [Join the Hotdata Discord](
 - Dynamic metadata lookup (no upfront catalog caching)
 - SQL-queryable `information_schema` for catalog metadata (snapshots, schemas, tables, columns, files)
 - DuckDB-style table functions: `ducklake_snapshots()`, `ducklake_table_info()`, `ducklake_list_files()`, `ducklake_table_changes()`
+- DuckLake row lineage (`rowid` virtual column), opt-in via `DuckLakeCatalog::with_row_lineage(true)`. Writers always populate the lineage counter, matching DuckDB's default; the flag is read-only. Compatible with files produced by DuckDB's `UPDATE` / compaction (embedded `_ducklake_internal_row_id`).
 
 ---
 
@@ -34,6 +35,7 @@ To meet the [Hotdata](https://www.hotdata.dev) team, [Join the Hotdata Discord](
 - No partition-based file pruning
 - No time travel support
 - DuckDB-encrypted Parquet files (non-PME) are not supported
+- **Data inlining is not read.** DuckDB's ducklake extension inlines small INSERTs (≤ `ducklake_default_data_inlining_row_limit`, default 10 rows) into the catalog itself rather than parquet files. This crate only reads `ducklake_data_file` rows, so inlined data is invisible — `SELECT COUNT(*)` will silently undercount. If you write through DuckDB and read through this crate, either disable inlining at write time (`SET ducklake_default_data_inlining_row_limit = 0` on every writer connection) or run `COMPACT` before reading. Catalogs written entirely through this crate's `SqliteMetadataWriter` are unaffected — we never inline.
 
 ---
 

--- a/examples/compare_rowid_against_duckdb.rs
+++ b/examples/compare_rowid_against_duckdb.rs
@@ -161,10 +161,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .with_region("auto")
             .build()?,
     );
-    runtime.register_object_store(
-        &Url::parse(&format!("s3://{}/", cfg.s3_bucket))?,
-        s3,
-    );
+    runtime.register_object_store(&Url::parse(&format!("s3://{}/", cfg.s3_bucket))?, s3);
 
     let catalog = DuckLakeCatalog::new(provider)?.with_row_lineage(true);
     let cfg = SessionConfig::new().with_default_catalog_and_schema("dl", "main");
@@ -175,7 +172,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // ----- 3. Compare table by table -----
     let mut overall_ok = true;
     for &(schema, table, key, key_type, limit) in TEST_TABLES {
-        print_header(&format!("Comparing {schema}.{table} (key={key}, limit={limit})"));
+        print_header(&format!(
+            "Comparing {schema}.{table} (key={key}, limit={limit})"
+        ));
         match compare_table(&duckdb_conn, &ctx, schema, table, key, key_type, limit).await {
             Ok(true) => println!("✅ rowid + {key} match between DuckDB and DataFusion"),
             Ok(false) => {
@@ -275,7 +274,10 @@ fn duckdb_query(
         } else {
             return Err("unsupported key type from DuckDB".into());
         };
-        out.push(Row { rowid, key });
+        out.push(Row {
+            rowid,
+            key,
+        });
     }
     Ok(out)
 }
@@ -331,7 +333,10 @@ fn extract_rows(
                 )
                 .into());
             };
-            out.push(Row { rowid, key });
+            out.push(Row {
+                rowid,
+                key,
+            });
         }
     }
     Ok(out)

--- a/examples/compare_rowid_against_duckdb.rs
+++ b/examples/compare_rowid_against_duckdb.rs
@@ -1,0 +1,348 @@
+//! Side-by-side verification of our rowid implementation against the
+//! upstream DuckDB ducklake extension.
+//!
+//! For each candidate table, this example:
+//!   1. Queries `SELECT rowid, <key> FROM t ORDER BY rowid LIMIT N` via
+//!      DuckDB's native ducklake extension (the ground truth).
+//!   2. Runs the same query via DataFusion + our `with_row_lineage(true)`.
+//!   3. Compares row-by-row and prints a pass/fail summary.
+//!
+//! Credentials are read from the env vars set by the loader at the top of
+//! `main`. The example connects to a Postgres catalog and a Tigris S3
+//! bucket — both pulled from `secrets/ducklake_storage_creds`.
+
+use std::error::Error;
+use std::sync::Arc;
+
+use arrow::array::{Array, Int32Array, Int64Array, StringArray};
+use datafusion::execution::runtime_env::RuntimeEnv;
+use datafusion::prelude::*;
+use datafusion_ducklake::{DuckLakeCatalog, PostgresMetadataProvider};
+use object_store::ObjectStore;
+use object_store::aws::AmazonS3Builder;
+use url::Url;
+
+// Configuration is read from env vars at startup so no credentials are
+// checked in. Required:
+//
+//   DUCKLAKE_PG_CONN  — libpq-style key=value (used by DuckDB's `ATTACH 'ducklake:postgres:...'`)
+//   DUCKLAKE_PG_URI   — URL form (used by datafusion-ducklake's PostgresMetadataProvider)
+//   DUCKLAKE_S3_KEY, DUCKLAKE_S3_SECRET
+//
+// Optional, with sensible defaults for Tigris/S3-compatible setups:
+//
+//   DUCKLAKE_S3_ENDPOINT   (default https://t3.storage.dev)
+//   DUCKLAKE_S3_BUCKET     (default ducklake-storage)
+//   DUCKLAKE_S3_ENDPOINT_HOST  (default t3.storage.dev — used in the DuckDB SECRET ENDPOINT)
+//   DUCKLAKE_DATA_PATH     (default ducklake_demo/)
+
+/// (schema, table, key_column, key_type, limit).
+/// key_type is a hint for how to read the column from arrow batches.
+const TEST_TABLES: &[(&str, &str, &str, KeyType, usize)] = &[
+    ("tpch_sf0001", "region", "r_regionkey", KeyType::Int32, 50),
+    ("tpch_sf0001", "nation", "n_nationkey", KeyType::Int32, 50),
+    ("tpch_sf0001", "supplier", "s_suppkey", KeyType::Int32, 50),
+    ("tpch_sf0001", "customer", "c_custkey", KeyType::Int32, 200),
+    ("main", "demo_users", "id", KeyType::Int32, 100),
+    // Stress: 17 files, ~1.2M rows. Comparing the head + a few mid-range
+    // rowids should be enough to catch any cross-file offset bug.
+    ("sphere_vector_1m", "vectors", "id", KeyType::Utf8, 200),
+];
+
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
+enum KeyType {
+    Int32,
+    Int64,
+    Utf8,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+struct Row {
+    rowid: i64,
+    key: KeyValue,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+enum KeyValue {
+    I64(i64),
+    Str(String),
+    Null,
+}
+
+fn print_header(title: &str) {
+    println!("\n========================================");
+    println!("{}", title);
+    println!("========================================");
+}
+
+struct Config {
+    pg_conn: String,
+    pg_uri: String,
+    s3_key: String,
+    s3_secret: String,
+    s3_endpoint: String,
+    s3_bucket: String,
+    s3_endpoint_host: String,
+    data_path: String,
+}
+
+fn load_config() -> Result<Config, Box<dyn Error>> {
+    fn required(var: &str) -> Result<String, Box<dyn Error>> {
+        std::env::var(var).map_err(|_| {
+            format!(
+                "{} is required — see the header comment for the full list of env vars",
+                var
+            )
+            .into()
+        })
+    }
+    Ok(Config {
+        pg_conn: required("DUCKLAKE_PG_CONN")?,
+        pg_uri: required("DUCKLAKE_PG_URI")?,
+        s3_key: required("DUCKLAKE_S3_KEY")?,
+        s3_secret: required("DUCKLAKE_S3_SECRET")?,
+        s3_endpoint: std::env::var("DUCKLAKE_S3_ENDPOINT")
+            .unwrap_or_else(|_| "https://t3.storage.dev".to_string()),
+        s3_bucket: std::env::var("DUCKLAKE_S3_BUCKET")
+            .unwrap_or_else(|_| "ducklake-storage".to_string()),
+        s3_endpoint_host: std::env::var("DUCKLAKE_S3_ENDPOINT_HOST")
+            .unwrap_or_else(|_| "t3.storage.dev".to_string()),
+        data_path: std::env::var("DUCKLAKE_DATA_PATH")
+            .unwrap_or_else(|_| "ducklake_demo/".to_string()),
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let cfg = load_config()?;
+
+    // ----- 1. Spin up DuckDB-with-ducklake (the reference) -----
+    print_header("Configuring DuckDB ducklake reference path");
+    let duckdb_conn = duckdb::Connection::open_in_memory()?;
+    duckdb_conn.execute_batch(
+        "INSTALL ducklake; LOAD ducklake;
+         INSTALL httpfs;   LOAD httpfs;
+         INSTALL postgres; LOAD postgres;",
+    )?;
+    duckdb_conn.execute_batch(&format!(
+        "CREATE OR REPLACE SECRET tigris (
+             TYPE S3,
+             KEY_ID '{key}',
+             SECRET '{secret}',
+             REGION 'auto',
+             ENDPOINT '{endpoint_host}',
+             URL_STYLE 'path',
+             SCOPE 's3://{bucket}'
+         );",
+        key = cfg.s3_key,
+        secret = cfg.s3_secret,
+        endpoint_host = cfg.s3_endpoint_host,
+        bucket = cfg.s3_bucket,
+    ))?;
+    duckdb_conn.execute_batch(&format!(
+        "ATTACH 'ducklake:postgres:{pg}' AS dl (DATA_PATH 's3://{bucket}/{data_path}');",
+        pg = cfg.pg_conn,
+        bucket = cfg.s3_bucket,
+        data_path = cfg.data_path,
+    ))?;
+
+    // ----- 2. Spin up DataFusion + our extension -----
+    print_header("Configuring DataFusion with datafusion-ducklake");
+    let provider = PostgresMetadataProvider::new(&cfg.pg_uri).await?;
+
+    let runtime = Arc::new(RuntimeEnv::default());
+    let s3: Arc<dyn ObjectStore> = Arc::new(
+        AmazonS3Builder::new()
+            .with_endpoint(&cfg.s3_endpoint)
+            .with_bucket_name(&cfg.s3_bucket)
+            .with_access_key_id(&cfg.s3_key)
+            .with_secret_access_key(&cfg.s3_secret)
+            .with_region("auto")
+            .build()?,
+    );
+    runtime.register_object_store(
+        &Url::parse(&format!("s3://{}/", cfg.s3_bucket))?,
+        s3,
+    );
+
+    let catalog = DuckLakeCatalog::new(provider)?.with_row_lineage(true);
+    let cfg = SessionConfig::new().with_default_catalog_and_schema("dl", "main");
+    let ctx = SessionContext::new_with_config_rt(cfg, runtime);
+    ctx.register_catalog("dl", Arc::new(catalog));
+    println!("✓ DataFusion catalog registered with row lineage enabled");
+
+    // ----- 3. Compare table by table -----
+    let mut overall_ok = true;
+    for &(schema, table, key, key_type, limit) in TEST_TABLES {
+        print_header(&format!("Comparing {schema}.{table} (key={key}, limit={limit})"));
+        match compare_table(&duckdb_conn, &ctx, schema, table, key, key_type, limit).await {
+            Ok(true) => println!("✅ rowid + {key} match between DuckDB and DataFusion"),
+            Ok(false) => {
+                println!("❌ MISMATCH for {schema}.{table}");
+                overall_ok = false;
+            },
+            Err(e) => {
+                println!("⚠️  error comparing {schema}.{table}: {e}");
+                overall_ok = false;
+            },
+        }
+    }
+
+    print_header(if overall_ok {
+        "ALL TABLES MATCH ✅"
+    } else {
+        "FAILURES DETECTED ❌"
+    });
+    if overall_ok {
+        Ok(())
+    } else {
+        Err("at least one table mismatched".into())
+    }
+}
+
+async fn compare_table(
+    duckdb_conn: &duckdb::Connection,
+    ctx: &SessionContext,
+    schema: &str,
+    table: &str,
+    key: &str,
+    key_type: KeyType,
+    limit: usize,
+) -> Result<bool, Box<dyn Error>> {
+    let sql = format!(
+        "SELECT rowid, {key} FROM dl.{schema}.{table} ORDER BY rowid LIMIT {limit}",
+        key = key,
+        schema = schema,
+        table = table,
+        limit = limit,
+    );
+
+    // ----- DuckDB ground truth -----
+    let duckdb_rows = duckdb_query(duckdb_conn, &sql, key_type)?;
+    println!("DuckDB returned {} rows", duckdb_rows.len());
+    print_sample("DuckDB", &duckdb_rows);
+
+    // ----- DataFusion -----
+    let df = ctx.sql(&sql).await?;
+    let batches = df.collect().await?;
+    let datafusion_rows = extract_rows(&batches, key_type)?;
+    println!("DataFusion returned {} rows", datafusion_rows.len());
+    print_sample("DataFusion", &datafusion_rows);
+
+    if duckdb_rows.len() != datafusion_rows.len() {
+        println!(
+            "Row count differs: DuckDB={} DataFusion={}",
+            duckdb_rows.len(),
+            datafusion_rows.len()
+        );
+        return Ok(false);
+    }
+
+    let mut diffs = 0;
+    for (i, (a, b)) in duckdb_rows.iter().zip(datafusion_rows.iter()).enumerate() {
+        if a != b {
+            if diffs < 10 {
+                println!("  diff at row {i}: DuckDB={a:?}, DataFusion={b:?}");
+            }
+            diffs += 1;
+        }
+    }
+    if diffs > 0 {
+        println!("Total differing rows: {diffs}");
+    }
+    Ok(diffs == 0)
+}
+
+fn duckdb_query(
+    conn: &duckdb::Connection,
+    sql: &str,
+    _key_type: KeyType,
+) -> Result<Vec<Row>, Box<dyn Error>> {
+    let mut stmt = conn.prepare(sql)?;
+    let mut rows = stmt.query([])?;
+    let mut out = Vec::new();
+    while let Some(r) = rows.next()? {
+        let rowid: i64 = r.get(0)?;
+        // Try i32 → i64 → String in turn so we don't need to know the column
+        // type up front. Canonicalize ints to i64.
+        let key = if let Ok(v) = r.get::<_, Option<i32>>(1) {
+            v.map(|x| KeyValue::I64(x as i64)).unwrap_or(KeyValue::Null)
+        } else if let Ok(v) = r.get::<_, Option<i64>>(1) {
+            v.map(KeyValue::I64).unwrap_or(KeyValue::Null)
+        } else if let Ok(v) = r.get::<_, Option<String>>(1) {
+            v.map(KeyValue::Str).unwrap_or(KeyValue::Null)
+        } else {
+            return Err("unsupported key type from DuckDB".into());
+        };
+        out.push(Row { rowid, key });
+    }
+    Ok(out)
+}
+
+fn extract_rows(
+    batches: &[arrow::record_batch::RecordBatch],
+    _key_type: KeyType,
+) -> Result<Vec<Row>, Box<dyn Error>> {
+    let mut out = Vec::new();
+    for batch in batches {
+        let rowids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .ok_or_else(|| {
+                format!(
+                    "expected rowid column to be Int64; got {:?}",
+                    batch.column(0).data_type()
+                )
+            })?;
+        let key_col = batch.column(1);
+        for i in 0..batch.num_rows() {
+            let rowid = if rowids.is_null(i) {
+                return Err("rowid null in DataFusion output".into());
+            } else {
+                rowids.value(i)
+            };
+            // Auto-detect key column type. We canonicalize integers to i64 so
+            // a DuckDB Int32 and a DataFusion Int64 of the same value compare
+            // equal — this is purely a row-equality probe, not a type check.
+            let key = if let Some(arr) = key_col.as_any().downcast_ref::<Int32Array>() {
+                if arr.is_null(i) {
+                    KeyValue::Null
+                } else {
+                    KeyValue::I64(arr.value(i) as i64)
+                }
+            } else if let Some(arr) = key_col.as_any().downcast_ref::<Int64Array>() {
+                if arr.is_null(i) {
+                    KeyValue::Null
+                } else {
+                    KeyValue::I64(arr.value(i))
+                }
+            } else if let Some(arr) = key_col.as_any().downcast_ref::<StringArray>() {
+                if arr.is_null(i) {
+                    KeyValue::Null
+                } else {
+                    KeyValue::Str(arr.value(i).to_string())
+                }
+            } else {
+                return Err(format!(
+                    "unsupported key column type {:?} in DataFusion output",
+                    key_col.data_type()
+                )
+                .into());
+            };
+            out.push(Row { rowid, key });
+        }
+    }
+    Ok(out)
+}
+
+fn print_sample(label: &str, rows: &[Row]) {
+    let n = rows.len().min(5);
+    for r in &rows[..n] {
+        println!("  [{label}] rowid={:>6}  key={:?}", r.rowid, r.key);
+    }
+    if rows.len() > n {
+        println!("  [{label}] ... ({} more rows)", rows.len() - n);
+    }
+}

--- a/examples/rowid_lifecycle.rs
+++ b/examples/rowid_lifecycle.rs
@@ -138,9 +138,7 @@ async fn run_lifecycle(
     // Step 3: DELETE a single row → exercises DeleteFilterExec
     // -------------------------------------------------------------------
     header("Step 3: DELETE id=4");
-    duckdb_conn.execute_batch(&format!(
-        "DELETE FROM dl.main.{TABLE} WHERE id = 4;"
-    ))?;
+    duckdb_conn.execute_batch(&format!("DELETE FROM dl.main.{TABLE} WHERE id = 4;"))?;
     all_passed &= compare_step("After DELETE id=4", duckdb_conn, runtime, cfg).await?;
 
     // -------------------------------------------------------------------
@@ -263,7 +261,11 @@ fn duckdb_read(conn: &duckdb::Connection, sql: &str) -> Result<Vec<Row>, Box<dyn
             r.get::<_, Option<i64>>(1)?.unwrap_or(0)
         };
         let name: Option<String> = r.get(2)?;
-        out.push(Row { rowid, id, name });
+        out.push(Row {
+            rowid,
+            id,
+            name,
+        });
     }
     Ok(out)
 }
@@ -304,9 +306,17 @@ fn rows_from_batches(batches: &[RecordBatch]) -> Result<Vec<Row>, Box<dyn Error>
 
             // id may come back as Int32 or Int64; coerce to i64.
             let id: i64 = if let Some(arr) = id_col.as_any().downcast_ref::<Int32Array>() {
-                if arr.is_null(i) { 0 } else { arr.value(i) as i64 }
+                if arr.is_null(i) {
+                    0
+                } else {
+                    arr.value(i) as i64
+                }
             } else if let Some(arr) = id_col.as_any().downcast_ref::<Int64Array>() {
-                if arr.is_null(i) { 0 } else { arr.value(i) }
+                if arr.is_null(i) {
+                    0
+                } else {
+                    arr.value(i)
+                }
             } else {
                 return Err(format!("unexpected id type {:?}", id_col.data_type()).into());
             };
@@ -321,7 +331,11 @@ fn rows_from_batches(batches: &[RecordBatch]) -> Result<Vec<Row>, Box<dyn Error>
                 return Err(format!("unexpected name type {:?}", name_col.data_type()).into());
             };
 
-            out.push(Row { rowid, id, name });
+            out.push(Row {
+                rowid,
+                id,
+                name,
+            });
         }
     }
     Ok(out)

--- a/examples/rowid_lifecycle.rs
+++ b/examples/rowid_lifecycle.rs
@@ -1,0 +1,340 @@
+//! Full lifecycle comparison of rowid behavior between the upstream DuckDB
+//! ducklake extension and datafusion-ducklake.
+//!
+//! Writes are issued exclusively through DuckDB (the source of truth);
+//! after each mutation step we read the same query through BOTH engines and
+//! verify the row sets match exactly.
+//!
+//! Steps:
+//!   1. CREATE TABLE + two INSERT batches (→ 2 data files, distinct row_id_start)
+//!   2. UPDATE half the rows  (→ a new file with embedded `_ducklake_internal_row_id`)
+//!   3. DELETE one row        (→ a delete file)
+//!   4. DELETE all rows       (→ table-wide delete)
+//!   5. DROP the table        (cleanup)
+//!
+//! The table lives at `main._rowid_verify_demo` and is always dropped at the
+//! end of the run, including on failure.
+
+use std::error::Error;
+use std::sync::Arc;
+
+use arrow::array::{Array, Int32Array, Int64Array, StringArray};
+use arrow::record_batch::RecordBatch;
+use datafusion::execution::runtime_env::RuntimeEnv;
+use datafusion::prelude::*;
+use datafusion_ducklake::{DuckLakeCatalog, PostgresMetadataProvider};
+use object_store::ObjectStore;
+use object_store::aws::AmazonS3Builder;
+use url::Url;
+
+// Configuration is read from env vars at startup so no credentials are
+// checked in. See compare_rowid_against_duckdb.rs for the full list.
+
+const TABLE: &str = "_rowid_verify_demo";
+const QUERY: &str = "SELECT rowid, id, name FROM dl.main._rowid_verify_demo ORDER BY rowid";
+
+struct Config {
+    pg_conn: String,
+    pg_uri: String,
+    s3_key: String,
+    s3_secret: String,
+    s3_endpoint: String,
+    s3_bucket: String,
+    s3_endpoint_host: String,
+    data_path: String,
+}
+
+fn load_config() -> Result<Config, Box<dyn Error>> {
+    fn required(var: &str) -> Result<String, Box<dyn Error>> {
+        std::env::var(var).map_err(|_| {
+            format!(
+                "{} is required — see the header comment for the full list of env vars",
+                var
+            )
+            .into()
+        })
+    }
+    Ok(Config {
+        pg_conn: required("DUCKLAKE_PG_CONN")?,
+        pg_uri: required("DUCKLAKE_PG_URI")?,
+        s3_key: required("DUCKLAKE_S3_KEY")?,
+        s3_secret: required("DUCKLAKE_S3_SECRET")?,
+        s3_endpoint: std::env::var("DUCKLAKE_S3_ENDPOINT")
+            .unwrap_or_else(|_| "https://t3.storage.dev".to_string()),
+        s3_bucket: std::env::var("DUCKLAKE_S3_BUCKET")
+            .unwrap_or_else(|_| "ducklake-storage".to_string()),
+        s3_endpoint_host: std::env::var("DUCKLAKE_S3_ENDPOINT_HOST")
+            .unwrap_or_else(|_| "t3.storage.dev".to_string()),
+        data_path: std::env::var("DUCKLAKE_DATA_PATH")
+            .unwrap_or_else(|_| "ducklake_demo/".to_string()),
+    })
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+struct Row {
+    rowid: i64,
+    id: i64,
+    name: Option<String>,
+}
+
+fn header(title: &str) {
+    println!("\n========================================");
+    println!("{title}");
+    println!("========================================");
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let cfg = load_config()?;
+
+    header("Setting up DuckDB ducklake reference path");
+    let duckdb_conn = setup_duckdb(&cfg)?;
+
+    header("Setting up S3 runtime for DataFusion");
+    let runtime = setup_runtime(&cfg)?;
+
+    // Always run cleanup at the end, success or failure.
+    let result = run_lifecycle(&duckdb_conn, &runtime, &cfg).await;
+    let _ = drop_table(&duckdb_conn);
+    println!("\n(cleanup) ✓ dropped {TABLE}");
+    result
+}
+
+async fn run_lifecycle(
+    duckdb_conn: &duckdb::Connection,
+    runtime: &Arc<RuntimeEnv>,
+    cfg: &Config,
+) -> Result<(), Box<dyn Error>> {
+    // Defensive cleanup of any leftover from a prior failed run.
+    let _ = drop_table(duckdb_conn);
+
+    let mut all_passed = true;
+
+    // -------------------------------------------------------------------
+    // Step 1: CREATE TABLE + two INSERT batches → multi-file synthesized rowid
+    // -------------------------------------------------------------------
+    header("Step 1: CREATE TABLE + two INSERT batches");
+    duckdb_conn.execute_batch(&format!(
+        "CREATE TABLE dl.main.{TABLE}(id INTEGER, name VARCHAR);"
+    ))?;
+    duckdb_conn.execute_batch(&format!(
+        "INSERT INTO dl.main.{TABLE} VALUES (1, 'alice'), (2, 'bob'), (3, 'charlie');"
+    ))?;
+    duckdb_conn.execute_batch(&format!(
+        "INSERT INTO dl.main.{TABLE} VALUES (4, 'dave'), (5, 'eve');"
+    ))?;
+    all_passed &= compare_step("After two INSERTs", duckdb_conn, runtime, cfg).await?;
+
+    // -------------------------------------------------------------------
+    // Step 2: UPDATE → exercises embedded `_ducklake_internal_row_id` path
+    // -------------------------------------------------------------------
+    header("Step 2: UPDATE id IN (1, 3) → file rewrite with embedded rowids");
+    duckdb_conn.execute_batch(&format!(
+        "UPDATE dl.main.{TABLE} SET name = name || '_v2' WHERE id IN (1, 3);"
+    ))?;
+    all_passed &= compare_step("After UPDATE", duckdb_conn, runtime, cfg).await?;
+
+    // -------------------------------------------------------------------
+    // Step 3: DELETE a single row → exercises DeleteFilterExec
+    // -------------------------------------------------------------------
+    header("Step 3: DELETE id=4");
+    duckdb_conn.execute_batch(&format!(
+        "DELETE FROM dl.main.{TABLE} WHERE id = 4;"
+    ))?;
+    all_passed &= compare_step("After DELETE id=4", duckdb_conn, runtime, cfg).await?;
+
+    // -------------------------------------------------------------------
+    // Step 4: DELETE all rows → empty result set
+    // -------------------------------------------------------------------
+    header("Step 4: DELETE all rows");
+    duckdb_conn.execute_batch(&format!("DELETE FROM dl.main.{TABLE};"))?;
+    all_passed &= compare_step("After DELETE all", duckdb_conn, runtime, cfg).await?;
+
+    if all_passed {
+        Ok(())
+    } else {
+        Err("at least one lifecycle step mismatched".into())
+    }
+}
+
+fn drop_table(conn: &duckdb::Connection) -> Result<(), Box<dyn Error>> {
+    conn.execute_batch(&format!("DROP TABLE IF EXISTS dl.main.{TABLE};"))?;
+    Ok(())
+}
+
+async fn compare_step(
+    label: &str,
+    duckdb_conn: &duckdb::Connection,
+    runtime: &Arc<RuntimeEnv>,
+    cfg: &Config,
+) -> Result<bool, Box<dyn Error>> {
+    println!("[{label}]");
+
+    // DuckDB read.
+    let duckdb_rows = duckdb_read(duckdb_conn, QUERY)?;
+    println!("  DuckDB:     {} rows", duckdb_rows.len());
+    print_rows("DuckDB", &duckdb_rows);
+
+    // DataFusion read — fresh catalog so we pick up the latest snapshot the
+    // DuckDB writes just produced.
+    let datafusion_rows = datafusion_read(runtime, cfg, QUERY).await?;
+    println!("  DataFusion: {} rows", datafusion_rows.len());
+    print_rows("DataFusion", &datafusion_rows);
+
+    if duckdb_rows == datafusion_rows {
+        println!("  ✅ MATCH");
+        Ok(true)
+    } else {
+        println!("  ❌ MISMATCH");
+        if duckdb_rows.len() != datafusion_rows.len() {
+            println!(
+                "    row count differs: DuckDB={} vs DataFusion={}",
+                duckdb_rows.len(),
+                datafusion_rows.len()
+            );
+        }
+        for (i, (a, b)) in duckdb_rows.iter().zip(datafusion_rows.iter()).enumerate() {
+            if a != b {
+                println!("    diff at row {i}: DuckDB={a:?}  DataFusion={b:?}");
+            }
+        }
+        Ok(false)
+    }
+}
+
+fn setup_duckdb(cfg: &Config) -> Result<duckdb::Connection, Box<dyn Error>> {
+    let conn = duckdb::Connection::open_in_memory()?;
+    conn.execute_batch(
+        "INSTALL ducklake; LOAD ducklake;
+         INSTALL httpfs;   LOAD httpfs;
+         INSTALL postgres; LOAD postgres;",
+    )?;
+    conn.execute_batch(&format!(
+        "CREATE OR REPLACE SECRET tigris (
+             TYPE S3,
+             KEY_ID '{key}',
+             SECRET '{secret}',
+             REGION 'auto',
+             ENDPOINT '{endpoint_host}',
+             URL_STYLE 'path',
+             SCOPE 's3://{bucket}'
+         );",
+        key = cfg.s3_key,
+        secret = cfg.s3_secret,
+        endpoint_host = cfg.s3_endpoint_host,
+        bucket = cfg.s3_bucket,
+    ))?;
+    conn.execute_batch(&format!(
+        "ATTACH 'ducklake:postgres:{pg}' AS dl (DATA_PATH 's3://{bucket}/{data_path}');",
+        pg = cfg.pg_conn,
+        bucket = cfg.s3_bucket,
+        data_path = cfg.data_path,
+    ))?;
+    println!("✓ DuckDB attached to ducklake catalog");
+    Ok(conn)
+}
+
+fn setup_runtime(cfg: &Config) -> Result<Arc<RuntimeEnv>, Box<dyn Error>> {
+    let runtime = Arc::new(RuntimeEnv::default());
+    let s3: Arc<dyn ObjectStore> = Arc::new(
+        AmazonS3Builder::new()
+            .with_endpoint(&cfg.s3_endpoint)
+            .with_bucket_name(&cfg.s3_bucket)
+            .with_access_key_id(&cfg.s3_key)
+            .with_secret_access_key(&cfg.s3_secret)
+            .with_region("auto")
+            .build()?,
+    );
+    runtime.register_object_store(&Url::parse(&format!("s3://{}/", cfg.s3_bucket))?, s3);
+    println!("✓ S3 object store registered");
+    Ok(runtime)
+}
+
+fn duckdb_read(conn: &duckdb::Connection, sql: &str) -> Result<Vec<Row>, Box<dyn Error>> {
+    let mut stmt = conn.prepare(sql)?;
+    let mut rows = stmt.query([])?;
+    let mut out = Vec::new();
+    while let Some(r) = rows.next()? {
+        let rowid: i64 = r.get(0)?;
+        // id was created as INTEGER; DuckDB hands back i32. Canonicalize i64.
+        let id: i64 = if let Ok(v) = r.get::<_, Option<i32>>(1) {
+            v.unwrap_or(0) as i64
+        } else {
+            r.get::<_, Option<i64>>(1)?.unwrap_or(0)
+        };
+        let name: Option<String> = r.get(2)?;
+        out.push(Row { rowid, id, name });
+    }
+    Ok(out)
+}
+
+async fn datafusion_read(
+    runtime: &Arc<RuntimeEnv>,
+    cfg: &Config,
+    sql: &str,
+) -> Result<Vec<Row>, Box<dyn Error>> {
+    // Build a fresh provider + catalog each call so we get the latest
+    // snapshot (the catalog binds snapshot_id at construction time).
+    let provider = PostgresMetadataProvider::new(&cfg.pg_uri).await?;
+    let catalog = DuckLakeCatalog::new(provider)?.with_row_lineage(true);
+    let cfg = SessionConfig::new().with_default_catalog_and_schema("dl", "main");
+    let ctx = SessionContext::new_with_config_rt(cfg, runtime.clone());
+    ctx.register_catalog("dl", Arc::new(catalog));
+
+    let df = ctx.sql(sql).await?;
+    let batches = df.collect().await?;
+    rows_from_batches(&batches)
+}
+
+fn rows_from_batches(batches: &[RecordBatch]) -> Result<Vec<Row>, Box<dyn Error>> {
+    let mut out = Vec::new();
+    for batch in batches {
+        let rowids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .ok_or("rowid column should be Int64")?;
+        let id_col = batch.column(1);
+        let name_col = batch.column(2);
+        for i in 0..batch.num_rows() {
+            if rowids.is_null(i) {
+                return Err("got NULL rowid from DataFusion".into());
+            }
+            let rowid = rowids.value(i);
+
+            // id may come back as Int32 or Int64; coerce to i64.
+            let id: i64 = if let Some(arr) = id_col.as_any().downcast_ref::<Int32Array>() {
+                if arr.is_null(i) { 0 } else { arr.value(i) as i64 }
+            } else if let Some(arr) = id_col.as_any().downcast_ref::<Int64Array>() {
+                if arr.is_null(i) { 0 } else { arr.value(i) }
+            } else {
+                return Err(format!("unexpected id type {:?}", id_col.data_type()).into());
+            };
+
+            let name = if let Some(arr) = name_col.as_any().downcast_ref::<StringArray>() {
+                if arr.is_null(i) {
+                    None
+                } else {
+                    Some(arr.value(i).to_string())
+                }
+            } else {
+                return Err(format!("unexpected name type {:?}", name_col.data_type()).into());
+            };
+
+            out.push(Row { rowid, id, name });
+        }
+    }
+    Ok(out)
+}
+
+fn print_rows(label: &str, rows: &[Row]) {
+    for r in rows {
+        println!(
+            "    [{label:>10}] rowid={:>4}  id={:>4}  name={:?}",
+            r.rowid, r.id, r.name
+        );
+    }
+    if rows.is_empty() {
+        println!("    [{label:>10}] (empty)");
+    }
+}

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -37,6 +37,10 @@ pub struct DuckLakeCatalog {
     object_store_url: Arc<ObjectStoreUrl>,
     /// Catalog base path component for resolving relative schema paths (e.g., /prefix/)
     catalog_path: String,
+    /// When true, expose a virtual `rowid` BIGINT column on every table
+    /// (DuckLake row-lineage feature). Default: false, to preserve existing
+    /// `SELECT *` shape for callers that haven't opted in.
+    row_lineage: bool,
     /// Write configuration (when write feature is enabled)
     #[cfg(feature = "write")]
     write_config: Option<WriteConfig>,
@@ -58,6 +62,7 @@ impl DuckLakeCatalog {
             snapshot_id,
             object_store_url: Arc::new(object_store_url),
             catalog_path,
+            row_lineage: false,
             #[cfg(feature = "write")]
             write_config: None,
         })
@@ -77,6 +82,7 @@ impl DuckLakeCatalog {
             snapshot_id,
             object_store_url: Arc::new(object_store_url),
             catalog_path,
+            row_lineage: false,
             #[cfg(feature = "write")]
             write_config: None,
         })
@@ -119,10 +125,24 @@ impl DuckLakeCatalog {
             snapshot_id,
             object_store_url: Arc::new(object_store_url),
             catalog_path,
+            row_lineage: false,
             write_config: Some(WriteConfig {
                 writer,
             }),
         })
+    }
+
+    /// Enable the DuckLake row-lineage feature: every table will expose a
+    /// virtual `rowid` BIGINT column (assigned from each row's `row_id_start +
+    /// position_in_file`). Off by default to preserve existing `SELECT *`
+    /// shape.
+    ///
+    /// Note: DataFusion has no hidden-column concept, so the `rowid` column
+    /// IS included in `SELECT *` once enabled — this differs from the DuckDB
+    /// extension where `rowid` is hidden unless explicitly referenced.
+    pub fn with_row_lineage(mut self, enabled: bool) -> Self {
+        self.row_lineage = enabled;
+        self
     }
 
     /// Get the metadata provider for this catalog
@@ -199,7 +219,8 @@ impl CatalogProvider for DuckLakeCatalog {
                     self.snapshot_id, // Propagate pinned snapshot_id
                     self.object_store_url.clone(),
                     schema_path,
-                );
+                )
+                .with_row_lineage(self.row_lineage);
 
                 // Configure writer if this catalog is writable
                 #[cfg(feature = "write")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub mod error;
 pub mod information_schema;
 pub mod metadata_provider;
 pub mod path_resolver;
+pub mod row_id;
 pub mod schema;
 pub mod table;
 pub mod table_changes;

--- a/src/metadata_provider.rs
+++ b/src/metadata_provider.rs
@@ -31,6 +31,8 @@ pub const SQL_GET_DATA_FILES: &str = "
         data.file_size_bytes AS data_file_size,
         data.footer_size AS data_footer_size,
         data.encryption_key AS data_encryption_key,
+        data.row_id_start AS data_row_id_start,
+        data.record_count AS data_record_count,
         del.delete_file_id,
         del.path AS delete_file_path,
         del.path_is_relative AS delete_path_is_relative,
@@ -482,11 +484,14 @@ pub struct DuckLakeTableFile {
     pub file: DuckLakeFileData,
     /// Optional associated delete file containing deleted row positions
     pub delete_file: Option<DuckLakeFileData>,
-    /// Starting row ID for this file (reserved for future use)
+    /// Starting row ID for this file. Combined with each row's position in the
+    /// file, this gives a globally unique `rowid` (DuckLake row lineage).
+    /// `None` for files where the metadata column is unset (e.g. older catalogs).
     pub row_id_start: Option<i64>,
     /// Snapshot ID when this file was created (reserved for future use)
     pub snapshot_id: Option<i64>,
-    /// Maximum number of rows in this file (reserved for future use)
+    /// Total rows in this file (`record_count` from the catalog), before any
+    /// delete files are applied. Used for synthetic `rowid` generation.
     pub max_row_count: Option<i64>,
 }
 

--- a/src/metadata_provider_duckdb.rs
+++ b/src/metadata_provider_duckdb.rs
@@ -180,7 +180,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
             .query_map(
                 [table_id, snapshot_id, snapshot_id, table_id, snapshot_id, snapshot_id],
                 |row| {
-                    // Parse data file (columns 0-5)
+                    // Parse data file (columns 0-7)
                     let _data_file_id: i64 = row.get(0)?;
                     let data_file = DuckLakeFileData {
                         path: row.get(1)?,
@@ -189,28 +189,30 @@ impl MetadataProvider for DuckdbMetadataProvider {
                         footer_size: row.get(4)?,
                         encryption_key: row.get(5)?,
                     };
+                    let row_id_start: Option<i64> = row.get(6)?;
+                    let record_count: Option<i64> = row.get(7)?;
 
-                    // Parse delete file (columns 6-12) if exists
-                    let delete_file = if let Ok(Some(_)) = row.get::<_, Option<i64>>(6) {
+                    // Parse delete file (columns 8-14) if exists
+                    let delete_file = if let Ok(Some(_)) = row.get::<_, Option<i64>>(8) {
                         Some(DuckLakeFileData {
-                            path: row.get(7)?,
-                            path_is_relative: row.get(8)?,
-                            file_size_bytes: row.get(9)?,
-                            footer_size: row.get(10)?,
-                            encryption_key: row.get(11)?,
+                            path: row.get(9)?,
+                            path_is_relative: row.get(10)?,
+                            file_size_bytes: row.get(11)?,
+                            footer_size: row.get(12)?,
+                            encryption_key: row.get(13)?,
                         })
                     } else {
                         None
                     };
 
-                    let _delete_count: Option<i64> = row.get(12)?;
+                    let _delete_count: Option<i64> = row.get(14)?;
 
                     Ok(DuckLakeTableFile {
                         file: data_file,
                         delete_file,
-                        row_id_start: None,
+                        row_id_start,
                         snapshot_id: Some(snapshot_id),
-                        max_row_count: None, // Set to None until we have actual row count from data file metadata
+                        max_row_count: record_count,
                     })
                 },
             )?

--- a/src/metadata_provider_mysql.rs
+++ b/src/metadata_provider_mysql.rs
@@ -183,6 +183,8 @@ impl MetadataProvider for MySqlMetadataProvider {
                     data.file_size_bytes AS data_file_size,
                     data.footer_size AS data_footer_size,
                     data.encryption_key AS data_encryption_key,
+                    data.row_id_start AS data_row_id_start,
+                    data.record_count AS data_record_count,
                     del.delete_file_id,
                     del.path AS delete_file_path,
                     del.path_is_relative AS delete_path_is_relative,
@@ -218,14 +220,16 @@ impl MetadataProvider for MySqlMetadataProvider {
                         footer_size: row.try_get(4)?,
                         encryption_key: row.try_get(5)?,
                     };
+                    let row_id_start: Option<i64> = row.try_get(6)?;
+                    let record_count: Option<i64> = row.try_get(7)?;
 
-                    let delete_file = if row.try_get::<Option<i64>, _>(6)?.is_some() {
+                    let delete_file = if row.try_get::<Option<i64>, _>(8)?.is_some() {
                         Some(DuckLakeFileData {
-                            path: row.try_get(7)?,
-                            path_is_relative: row.try_get(8)?,
-                            file_size_bytes: row.try_get(9)?,
-                            footer_size: row.try_get(10)?,
-                            encryption_key: row.try_get(11)?,
+                            path: row.try_get(9)?,
+                            path_is_relative: row.try_get(10)?,
+                            file_size_bytes: row.try_get(11)?,
+                            footer_size: row.try_get(12)?,
+                            encryption_key: row.try_get(13)?,
                         })
                     } else {
                         None
@@ -234,9 +238,9 @@ impl MetadataProvider for MySqlMetadataProvider {
                     Ok(DuckLakeTableFile {
                         file: data_file,
                         delete_file,
-                        row_id_start: None,
-                        snapshot_id: None,
-                        max_row_count: None,
+                        row_id_start,
+                        snapshot_id: Some(snapshot_id),
+                        max_row_count: record_count,
                     })
                 })
                 .collect()

--- a/src/metadata_provider_postgres.rs
+++ b/src/metadata_provider_postgres.rs
@@ -217,6 +217,8 @@ impl MetadataProvider for PostgresMetadataProvider {
                     data.file_size_bytes AS data_file_size,
                     data.footer_size AS data_footer_size,
                     data.encryption_key AS data_encryption_key,
+                    data.row_id_start AS data_row_id_start,
+                    data.record_count AS data_record_count,
                     del.delete_file_id,
                     del.path AS delete_file_path,
                     del.path_is_relative AS delete_path_is_relative,
@@ -252,14 +254,16 @@ impl MetadataProvider for PostgresMetadataProvider {
                         footer_size: row.try_get(4)?,
                         encryption_key: row.try_get(5)?,
                     };
+                    let row_id_start: Option<i64> = row.try_get(6)?;
+                    let record_count: Option<i64> = row.try_get(7)?;
 
-                    let delete_file = if row.try_get::<Option<i64>, _>(6)?.is_some() {
+                    let delete_file = if row.try_get::<Option<i64>, _>(8)?.is_some() {
                         Some(DuckLakeFileData {
-                            path: row.try_get(7)?,
-                            path_is_relative: row.try_get(8)?,
-                            file_size_bytes: row.try_get(9)?,
-                            footer_size: row.try_get(10)?,
-                            encryption_key: row.try_get(11)?,
+                            path: row.try_get(9)?,
+                            path_is_relative: row.try_get(10)?,
+                            file_size_bytes: row.try_get(11)?,
+                            footer_size: row.try_get(12)?,
+                            encryption_key: row.try_get(13)?,
                         })
                     } else {
                         None
@@ -268,9 +272,9 @@ impl MetadataProvider for PostgresMetadataProvider {
                     Ok(DuckLakeTableFile {
                         file: data_file,
                         delete_file,
-                        row_id_start: None,
-                        snapshot_id: None,
-                        max_row_count: None,
+                        row_id_start,
+                        snapshot_id: Some(snapshot_id),
+                        max_row_count: record_count,
                     })
                 })
                 .collect()

--- a/src/metadata_provider_sqlite.rs
+++ b/src/metadata_provider_sqlite.rs
@@ -184,6 +184,8 @@ impl MetadataProvider for SqliteMetadataProvider {
                     data.file_size_bytes AS data_file_size,
                     data.footer_size AS data_footer_size,
                     data.encryption_key AS data_encryption_key,
+                    data.row_id_start AS data_row_id_start,
+                    data.record_count AS data_record_count,
                     del.delete_file_id,
                     del.path AS delete_file_path,
                     del.path_is_relative AS delete_path_is_relative,
@@ -219,14 +221,16 @@ impl MetadataProvider for SqliteMetadataProvider {
                         footer_size: row.try_get(4)?,
                         encryption_key: row.try_get(5)?,
                     };
+                    let row_id_start: Option<i64> = row.try_get(6)?;
+                    let record_count: Option<i64> = row.try_get(7)?;
 
-                    let delete_file = if row.try_get::<Option<i64>, _>(6)?.is_some() {
+                    let delete_file = if row.try_get::<Option<i64>, _>(8)?.is_some() {
                         Some(DuckLakeFileData {
-                            path: row.try_get(7)?,
-                            path_is_relative: row.try_get(8)?,
-                            file_size_bytes: row.try_get(9)?,
-                            footer_size: row.try_get(10)?,
-                            encryption_key: row.try_get(11)?,
+                            path: row.try_get(9)?,
+                            path_is_relative: row.try_get(10)?,
+                            file_size_bytes: row.try_get(11)?,
+                            footer_size: row.try_get(12)?,
+                            encryption_key: row.try_get(13)?,
                         })
                     } else {
                         None
@@ -235,9 +239,9 @@ impl MetadataProvider for SqliteMetadataProvider {
                     Ok(DuckLakeTableFile {
                         file: data_file,
                         delete_file,
-                        row_id_start: None,
-                        snapshot_id: None,
-                        max_row_count: None,
+                        row_id_start,
+                        snapshot_id: Some(snapshot_id),
+                        max_row_count: record_count,
                     })
                 })
                 .collect()

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -69,6 +69,19 @@ CREATE TABLE IF NOT EXISTS ducklake_data_file (
     end_snapshot INTEGER
 );
 
+-- Per-table row-lineage counter (DuckLake spec). `next_row_id` is the
+-- monotonic rowid allocator: a new data file gets its `row_id_start` from
+-- the current value, then we advance by `record_count` in the same
+-- transaction. `record_count` and `file_size_bytes` mirror the currently-
+-- visible totals so DuckDB's `ducklake_table_info` aggregate sees correct
+-- numbers for tables we wrote.
+CREATE TABLE IF NOT EXISTS ducklake_table_stats (
+    table_id INTEGER PRIMARY KEY,
+    record_count INTEGER NOT NULL DEFAULT 0,
+    next_row_id INTEGER NOT NULL DEFAULT 0,
+    file_size_bytes INTEGER NOT NULL DEFAULT 0
+);
+
 CREATE TABLE IF NOT EXISTS ducklake_delete_file (
     delete_file_id INTEGER PRIMARY KEY,
     data_file_id INTEGER NOT NULL,
@@ -254,9 +267,34 @@ impl MetadataWriter for SqliteMetadataWriter {
         file: &DataFileInfo,
     ) -> Result<i64> {
         block_on(async {
-            let row = sqlx::query(
-                "INSERT INTO ducklake_data_file (table_id, path, path_is_relative, file_size_bytes, footer_size, record_count, begin_snapshot)
-                 VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING data_file_id",
+            // Allocate row_id_start from the table's monotonic counter inside
+            // the same transaction so concurrent writers can't hand out
+            // overlapping ranges. Falls back to inserting a fresh stats row
+            // (next_row_id = 0) for tables created before this writer
+            // started maintaining the table_stats table.
+            let mut tx = self.pool.begin().await?;
+
+            sqlx::query(
+                "INSERT OR IGNORE INTO ducklake_table_stats
+                     (table_id, record_count, next_row_id, file_size_bytes)
+                 VALUES (?, 0, 0, 0)",
+            )
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+
+            let stats_row =
+                sqlx::query("SELECT next_row_id FROM ducklake_table_stats WHERE table_id = ?")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
+            let row_id_start: i64 = stats_row.try_get(0)?;
+
+            let data_file_row = sqlx::query(
+                "INSERT INTO ducklake_data_file
+                     (table_id, path, path_is_relative, file_size_bytes,
+                      footer_size, record_count, row_id_start, begin_snapshot)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING data_file_id",
             )
             .bind(table_id)
             .bind(&file.path)
@@ -264,24 +302,62 @@ impl MetadataWriter for SqliteMetadataWriter {
             .bind(file.file_size_bytes)
             .bind(file.footer_size)
             .bind(file.record_count)
+            .bind(row_id_start)
             .bind(snapshot_id)
-            .fetch_one(&self.pool)
+            .fetch_one(&mut *tx)
             .await?;
-            Ok(row.try_get(0)?)
+            let data_file_id: i64 = data_file_row.try_get(0)?;
+
+            // Advance the counter and accumulate stats. `next_row_id`
+            // monotonically increases over the table's lifetime — rowids
+            // are never reused, even after end-snapshot.
+            sqlx::query(
+                "UPDATE ducklake_table_stats
+                 SET next_row_id     = next_row_id + ?,
+                     record_count    = record_count + ?,
+                     file_size_bytes = file_size_bytes + ?
+                 WHERE table_id = ?",
+            )
+            .bind(file.record_count)
+            .bind(file.record_count)
+            .bind(file.file_size_bytes)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+
+            tx.commit().await?;
+            Ok(data_file_id)
         })
     }
 
     fn end_table_files(&self, table_id: i64, snapshot_id: i64) -> Result<u64> {
+        // Used by WriteMode::Replace. End-snapshotting every visible file
+        // drops the table's currently-visible row count and byte total to
+        // zero (the new files written next will rebuild them). `next_row_id`
+        // is deliberately NOT reset: rowids must stay monotonic across the
+        // table's lifetime so historical snapshots still resolve uniquely.
         block_on(async {
+            let mut tx = self.pool.begin().await?;
+
             let result = sqlx::query(
                 "UPDATE ducklake_data_file SET end_snapshot = ?
                  WHERE table_id = ? AND end_snapshot IS NULL",
             )
             .bind(snapshot_id)
             .bind(table_id)
-            .execute(&self.pool)
+            .execute(&mut *tx)
             .await?;
 
+            sqlx::query(
+                "UPDATE ducklake_table_stats
+                 SET record_count = 0, file_size_bytes = 0
+                 WHERE table_id = ?",
+            )
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+
+            tx.commit().await?;
             Ok(result.rows_affected())
         })
     }
@@ -497,6 +573,28 @@ impl MetadataWriter for SqliteMetadataWriter {
                 .bind(table_id)
                 .execute(&mut *tx)
                 .await?;
+
+                // Mirror end_table_files: drop visible row/byte totals to
+                // zero while keeping next_row_id monotonic. INSERT OR IGNORE
+                // first so we don't fall over if this is the first write
+                // (Replace on a brand-new table).
+                sqlx::query(
+                    "INSERT OR IGNORE INTO ducklake_table_stats
+                         (table_id, record_count, next_row_id, file_size_bytes)
+                     VALUES (?, 0, 0, 0)",
+                )
+                .bind(table_id)
+                .execute(&mut *tx)
+                .await?;
+
+                sqlx::query(
+                    "UPDATE ducklake_table_stats
+                     SET record_count = 0, file_size_bytes = 0
+                     WHERE table_id = ?",
+                )
+                .bind(table_id)
+                .execute(&mut *tx)
+                .await?;
             }
 
             tx.commit().await?;
@@ -619,6 +717,142 @@ mod tests {
             .register_data_file(table_id, snapshot_id, &file)
             .unwrap();
         assert_eq!(file_id, 1);
+    }
+
+    /// Helper for the row-lineage tests: read back what `register_data_file`
+    /// wrote into the catalog so we can assert on `row_id_start` and the
+    /// stats counter directly.
+    async fn read_row_id_start(writer: &SqliteMetadataWriter, file_id: i64) -> Option<i64> {
+        let row = sqlx::query("SELECT row_id_start FROM ducklake_data_file WHERE data_file_id = ?")
+            .bind(file_id)
+            .fetch_one(&writer.pool)
+            .await
+            .unwrap();
+        row.try_get(0).ok()
+    }
+
+    async fn read_table_stats(writer: &SqliteMetadataWriter, table_id: i64) -> (i64, i64, i64) {
+        let row = sqlx::query(
+            "SELECT record_count, next_row_id, file_size_bytes
+             FROM ducklake_table_stats WHERE table_id = ?",
+        )
+        .bind(table_id)
+        .fetch_one(&writer.pool)
+        .await
+        .unwrap();
+        (
+            row.try_get(0).unwrap(),
+            row.try_get(1).unwrap(),
+            row.try_get(2).unwrap(),
+        )
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn row_id_start_advances_across_inserts() {
+        // Two INSERTs against the same table should hand out non-overlapping
+        // [row_id_start, row_id_start + record_count) ranges. Counter is
+        // initialized lazily on first register_data_file.
+        let (writer, _temp) = create_test_writer().await;
+        let snapshot_id = writer.create_snapshot().unwrap();
+        let (schema_id, _) = writer
+            .get_or_create_schema("main", None, snapshot_id)
+            .unwrap();
+        let (table_id, _) = writer
+            .get_or_create_table(schema_id, "t", None, snapshot_id)
+            .unwrap();
+
+        let f1_id = writer
+            .register_data_file(
+                table_id,
+                snapshot_id,
+                &DataFileInfo::new("a.parquet", 100, 3),
+            )
+            .unwrap();
+        let f2_id = writer
+            .register_data_file(
+                table_id,
+                snapshot_id,
+                &DataFileInfo::new("b.parquet", 250, 7),
+            )
+            .unwrap();
+
+        assert_eq!(read_row_id_start(&writer, f1_id).await, Some(0));
+        assert_eq!(read_row_id_start(&writer, f2_id).await, Some(3));
+
+        let (records, next, bytes) = read_table_stats(&writer, table_id).await;
+        assert_eq!(records, 10, "record_count = 3 + 7");
+        assert_eq!(next, 10, "next_row_id advances by sum of record_counts");
+        assert_eq!(bytes, 350, "file_size_bytes accumulates");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn end_table_files_preserves_next_row_id() {
+        // Replace must reset record_count and file_size_bytes (those reflect
+        // currently-visible rows) but keep next_row_id monotonic so the next
+        // generation of files gets fresh, non-overlapping rowids.
+        let (writer, _temp) = create_test_writer().await;
+        let snap1 = writer.create_snapshot().unwrap();
+        let (schema_id, _) = writer.get_or_create_schema("main", None, snap1).unwrap();
+        let (table_id, _) = writer
+            .get_or_create_table(schema_id, "t", None, snap1)
+            .unwrap();
+
+        writer
+            .register_data_file(table_id, snap1, &DataFileInfo::new("a.parquet", 100, 5))
+            .unwrap();
+
+        let snap2 = writer.create_snapshot().unwrap();
+        writer.end_table_files(table_id, snap2).unwrap();
+
+        let (records, next, bytes) = read_table_stats(&writer, table_id).await;
+        assert_eq!(records, 0, "record_count cleared after end_table_files");
+        assert_eq!(next, 5, "next_row_id preserved (monotonic across lifetime)");
+        assert_eq!(bytes, 0, "file_size_bytes cleared");
+
+        let f2_id = writer
+            .register_data_file(table_id, snap2, &DataFileInfo::new("b.parquet", 200, 2))
+            .unwrap();
+        assert_eq!(
+            read_row_id_start(&writer, f2_id).await,
+            Some(5),
+            "post-replace files must start at the preserved counter, not 0",
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn row_id_start_works_when_stats_row_missing() {
+        // Defensive path: a table that existed before this writer started
+        // maintaining ducklake_table_stats. First register_data_file must
+        // self-initialize the stats row rather than fail.
+        let (writer, _temp) = create_test_writer().await;
+        let snapshot_id = writer.create_snapshot().unwrap();
+        let (schema_id, _) = writer
+            .get_or_create_schema("main", None, snapshot_id)
+            .unwrap();
+        let (table_id, _) = writer
+            .get_or_create_table(schema_id, "legacy", None, snapshot_id)
+            .unwrap();
+
+        // Simulate a "legacy" table by deleting any stats row that
+        // get_or_create_table may have written (it doesn't today, but be
+        // explicit so the test stays meaningful if that changes).
+        sqlx::query("DELETE FROM ducklake_table_stats WHERE table_id = ?")
+            .bind(table_id)
+            .execute(&writer.pool)
+            .await
+            .unwrap();
+
+        let file_id = writer
+            .register_data_file(
+                table_id,
+                snapshot_id,
+                &DataFileInfo::new("a.parquet", 50, 4),
+            )
+            .unwrap();
+        assert_eq!(read_row_id_start(&writer, file_id).await, Some(0));
+        let (records, next, _) = read_table_stats(&writer, table_id).await;
+        assert_eq!(records, 4);
+        assert_eq!(next, 4);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/row_id.rs
+++ b/src/row_id.rs
@@ -351,6 +351,128 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn rowid_only_projection_empty_input_columns() {
+        // The input has zero columns (count-rows-only mode). RowIdExec
+        // should still emit a single-column batch with the rowid values.
+        // This is the shape that flows from a parquet scan when only rowid
+        // is in the projection.
+        let input_schema = Arc::new(Schema::new(Vec::<Field>::new()));
+        let batch = RecordBatch::try_new_with_options(
+            input_schema.clone(),
+            vec![],
+            &arrow::record_batch::RecordBatchOptions::new().with_row_count(Some(3)),
+        )
+        .unwrap();
+        let mem =
+            MemorySourceConfig::try_new_exec(&[vec![batch]], input_schema.clone(), None)
+                .unwrap();
+
+        let exec = Arc::new(RowIdExec::new(mem, Some(42)));
+        assert_eq!(exec.schema().fields().len(), 1);
+        assert_eq!(exec.schema().field(0).name(), ROWID_COLUMN_NAME);
+
+        let ctx = Arc::new(TaskContext::default());
+        let mut stream = exec.execute(0, ctx).unwrap();
+        use futures::StreamExt;
+        let out = stream.next().await.unwrap().unwrap();
+        assert_eq!(out.num_rows(), 3);
+        assert_eq!(out.num_columns(), 1);
+        let rowids = out
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .values()
+            .to_vec();
+        assert_eq!(rowids, vec![42, 43, 44]);
+    }
+
+    #[tokio::test]
+    async fn empty_batch_passes_through_with_empty_rowid_column() {
+        // A zero-row batch from the input should produce a zero-row batch
+        // out, with the rowid column present and the cursor unchanged so
+        // the next non-empty batch picks up at the right offset.
+        let input_schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int32, false)]));
+        let empty_batch = RecordBatch::try_new(
+            input_schema.clone(),
+            vec![Arc::new(Int32Array::from(Vec::<i32>::new())) as ArrayRef],
+        )
+        .unwrap();
+        let next_batch = small_batch(input_schema.clone(), &[7, 8]);
+        let mem = MemorySourceConfig::try_new_exec(
+            &[vec![empty_batch, next_batch]],
+            input_schema.clone(),
+            None,
+        )
+        .unwrap();
+
+        let exec = Arc::new(RowIdExec::new(mem, Some(100)));
+        let ctx = Arc::new(TaskContext::default());
+        let mut stream = exec.execute(0, ctx).unwrap();
+        use futures::StreamExt;
+
+        let first = stream.next().await.unwrap().unwrap();
+        assert_eq!(first.num_rows(), 0);
+        assert_eq!(first.num_columns(), 2);
+
+        let second = stream.next().await.unwrap().unwrap();
+        let rowids = second
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .values()
+            .to_vec();
+        // Cursor should NOT have advanced past the empty batch — second
+        // batch rows still start at row_id_start + 0.
+        assert_eq!(rowids, vec![100, 101]);
+    }
+
+    #[tokio::test]
+    async fn insert_at_out_of_range_clamps_to_end() {
+        // Caller asks to insert at position 99 when the input has only 1
+        // column. The constructor clamps to input.len() (= 1) so the rowid
+        // ends up appended at the end.
+        let input_schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int32, false)]));
+        let b = small_batch(input_schema.clone(), &[1, 2]);
+        let mem =
+            MemorySourceConfig::try_new_exec(&[vec![b]], input_schema.clone(), None).unwrap();
+
+        let exec = Arc::new(RowIdExec::new_at(mem, Some(10), 99));
+        assert_eq!(exec.schema().fields().len(), 2);
+        assert_eq!(exec.schema().field(0).name(), "v");
+        assert_eq!(exec.schema().field(1).name(), ROWID_COLUMN_NAME);
+    }
+
+    #[test]
+    fn declares_single_partition_input_to_block_repartition() {
+        // Regression guard for the cursor-vs-RepartitionExec hazard: if
+        // either of these defaults reverts, DataFusion's optimizer could
+        // legally insert a RepartitionExec under RowIdExec and break
+        // rowid computation silently. We do not over-assert the exact
+        // Distribution shape — just that it is SinglePartition for the
+        // sole child.
+        let input_schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int32, false)]));
+        let mem =
+            MemorySourceConfig::try_new_exec(&[vec![]], input_schema, None).unwrap();
+        let exec = RowIdExec::new(mem, Some(0));
+
+        let dists = exec.required_input_distribution();
+        assert_eq!(dists.len(), 1);
+        assert!(
+            matches!(dists[0], Distribution::SinglePartition),
+            "RowIdExec must require a single-partition input; got {:?}",
+            dists[0]
+        );
+        assert_eq!(
+            exec.maintains_input_order(),
+            vec![true],
+            "RowIdExec preserves row order — must declare it so DataFusion's \
+             order-aware optimizations can fire",
+        );
+    }
+
+    #[tokio::test]
     async fn emits_null_when_row_id_start_is_none() {
         let input_schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int32, false)]));
         let b = small_batch(input_schema.clone(), &[1, 2]);

--- a/src/row_id.rs
+++ b/src/row_id.rs
@@ -1,16 +1,17 @@
 //! Synthetic `rowid` column injection for DuckLake row lineage.
 //!
-//! DuckLake assigns each row a globally unique `rowid` BIGINT. For files written
-//! by INSERT, the catalog records the file's `row_id_start`, and per-row rowid
-//! is `row_id_start + position_in_file`. This module implements an execution
-//! plan that appends that synthetic column to each batch streaming out of a
-//! per-file Parquet scan, in file order.
+//! DuckLake assigns each row a globally unique `rowid` BIGINT. For files
+//! written by INSERT, the catalog records the file's `row_id_start`, and the
+//! per-row rowid is `row_id_start + position_in_file`. This module implements
+//! an execution plan ([`RowIdExec`]) that appends that synthetic column to
+//! each batch streaming out of a per-file Parquet scan, in file order.
 //!
-//! Limitations vs. the DuckDB extension:
-//! - Files written by UPDATE/compaction store rowids inline in the parquet
-//!   itself (as `_ducklake_internal_row_id`). This is not yet wired up here;
-//!   reads of compacted files will produce computed rowids that no longer
-//!   reflect the original lineage. Tracked as a follow-up.
+//! Files written by `UPDATE` / compaction store the original rowids inline in
+//! the parquet as a column tagged with [`ROW_ID_PARQUET_FIELD_ID`] (typically
+//! named `_ducklake_internal_row_id`). Those files do NOT use this exec —
+//! `DuckLakeTable` reads the embedded column directly via the parquet scan
+//! and renames it; `RowIdExec` is only used when no embedded column is
+//! present. See `table.rs::build_exec_for_file_with_rowid`.
 
 use std::any::Any;
 use std::pin::Pin;
@@ -22,7 +23,7 @@ use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
-use datafusion::physical_expr::EquivalenceProperties;
+use datafusion::physical_expr::{Distribution, EquivalenceProperties};
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
 };
@@ -138,6 +139,23 @@ impl ExecutionPlan for RowIdExec {
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
         vec![&self.input]
+    }
+
+    /// Rowid synthesis relies on rows arriving in file order on a single
+    /// stream — the cursor counts position-in-file. If DataFusion's
+    /// `EnforceDistribution` / `Repartition` rules inserted a `RepartitionExec`
+    /// below us, batches would arrive interleaved across partitions and
+    /// rowid = row_id_start + cursor would no longer correspond to the row's
+    /// real file offset. Pin the child to a single partition to prevent that.
+    fn required_input_distribution(&self) -> Vec<Distribution> {
+        vec![Distribution::SinglePartition]
+    }
+
+    /// Order-preserving wrapper: we do not reorder or drop rows, we only
+    /// append a column. Declaring this lets DataFusion's order-aware
+    /// optimizations (e.g. avoiding sorts after RowIdExec) fire.
+    fn maintains_input_order(&self) -> Vec<bool> {
+        vec![true]
     }
 
     fn with_new_children(

--- a/src/row_id.rs
+++ b/src/row_id.rs
@@ -1,0 +1,357 @@
+//! Synthetic `rowid` column injection for DuckLake row lineage.
+//!
+//! DuckLake assigns each row a globally unique `rowid` BIGINT. For files written
+//! by INSERT, the catalog records the file's `row_id_start`, and per-row rowid
+//! is `row_id_start + position_in_file`. This module implements an execution
+//! plan that appends that synthetic column to each batch streaming out of a
+//! per-file Parquet scan, in file order.
+//!
+//! Limitations vs. the DuckDB extension:
+//! - Files written by UPDATE/compaction store rowids inline in the parquet
+//!   itself (as `_ducklake_internal_row_id`). This is not yet wired up here;
+//!   reads of compacted files will produce computed rowids that no longer
+//!   reflect the original lineage. Tracked as a follow-up.
+
+use std::any::Any;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use arrow::array::{ArrayRef, Int64Array};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use arrow::record_batch::RecordBatch;
+use datafusion::error::{DataFusionError, Result as DataFusionResult};
+use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
+use datafusion::physical_expr::EquivalenceProperties;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
+};
+use futures::Stream;
+
+/// Name of the synthetic rowid column exposed when row lineage is enabled.
+pub const ROWID_COLUMN_NAME: &str = "rowid";
+
+/// Iceberg / DuckLake reserved parquet field-id for the row-id column.
+/// Matches `MultiFileReader::ROW_ID_FIELD_ID` in DuckDB
+/// (`duckdb/src/include/duckdb/common/multi_file/multi_file_reader.hpp`).
+/// Files written by `UPDATE` / compaction embed a column tagged with this
+/// field-id (typically named `_ducklake_internal_row_id`) so original rowids
+/// survive across file rewrites.
+pub const ROW_ID_PARQUET_FIELD_ID: i32 = 2_147_483_540;
+
+/// Build the Arrow Field for the rowid column. Nullable so we can emit NULL
+/// for files whose catalog row_id_start is unrecorded (e.g. older catalogs).
+pub fn rowid_field() -> Field {
+    Field::new(ROWID_COLUMN_NAME, DataType::Int64, true)
+}
+
+/// Execution plan that appends a synthetic `rowid` BIGINT column to each batch.
+///
+/// For a row at position `p` within the file, `rowid = row_id_start + p`. The
+/// row_id_start is supplied per-file at plan construction. If `row_id_start` is
+/// `None`, the column is emitted as all NULL (caller's catalog doesn't track
+/// lineage for this file).
+///
+/// The plan does not change row count or row order, so it composes cleanly with
+/// a downstream `DeleteFilterExec` whose internal position cursor stays aligned.
+#[derive(Debug)]
+pub struct RowIdExec {
+    input: Arc<dyn ExecutionPlan>,
+    /// File's catalog-recorded `row_id_start`. None ⇒ emit NULL rowids.
+    row_id_start: Option<i64>,
+    /// Position in the output schema where the rowid column is inserted.
+    /// Valid range: 0..=input.schema().fields().len().
+    insert_at: usize,
+    /// Output schema = input schema with rowid inserted at `insert_at`.
+    schema: SchemaRef,
+    properties: Arc<PlanProperties>,
+}
+
+impl RowIdExec {
+    /// Append rowid as the last column. Convenience for the common case.
+    pub fn new(input: Arc<dyn ExecutionPlan>, row_id_start: Option<i64>) -> Self {
+        let insert_at = input.schema().fields().len();
+        Self::new_at(input, row_id_start, insert_at)
+    }
+
+    /// Insert rowid at a specific output column position.
+    pub fn new_at(
+        input: Arc<dyn ExecutionPlan>,
+        row_id_start: Option<i64>,
+        insert_at: usize,
+    ) -> Self {
+        let input_schema = input.schema();
+        let input_len = input_schema.fields().len();
+        let insert_at = insert_at.min(input_len);
+
+        let mut fields: Vec<Arc<Field>> = input_schema.fields().iter().cloned().collect();
+        fields.insert(insert_at, Arc::new(rowid_field()));
+        let schema = Arc::new(Schema::new(fields));
+
+        let eq_properties = EquivalenceProperties::new(schema.clone());
+        let properties = Arc::new(PlanProperties::new(
+            eq_properties,
+            input.output_partitioning().clone(),
+            input.pipeline_behavior(),
+            input.boundedness(),
+        ));
+
+        Self {
+            input,
+            row_id_start,
+            insert_at,
+            schema,
+            properties,
+        }
+    }
+}
+
+impl DisplayAs for RowIdExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default
+            | DisplayFormatType::Verbose
+            | DisplayFormatType::TreeRender => {
+                write!(
+                    f,
+                    "RowIdExec: row_id_start={}",
+                    self.row_id_start
+                        .map_or_else(|| "NULL".to_string(), |v| v.to_string())
+                )
+            },
+        }
+    }
+}
+
+impl ExecutionPlan for RowIdExec {
+    fn name(&self) -> &str {
+        "RowIdExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        if children.len() != 1 {
+            return Err(DataFusionError::Internal(
+                "RowIdExec expects exactly one child".into(),
+            ));
+        }
+        Ok(Arc::new(RowIdExec::new_at(
+            children.into_iter().next().unwrap(),
+            self.row_id_start,
+            self.insert_at,
+        )))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        Ok(Box::pin(RowIdStream {
+            input: self.input.execute(partition, context)?,
+            schema: self.schema.clone(),
+            row_id_start: self.row_id_start,
+            insert_at: self.insert_at,
+            cursor: 0,
+        }))
+    }
+}
+
+struct RowIdStream {
+    input: SendableRecordBatchStream,
+    schema: SchemaRef,
+    row_id_start: Option<i64>,
+    insert_at: usize,
+    /// Position in the file of the first row of the next batch (file-order).
+    cursor: i64,
+}
+
+impl Stream for RowIdStream {
+    type Item = DataFusionResult<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match Pin::new(&mut self.input).poll_next(cx) {
+            Poll::Ready(Some(Ok(batch))) => {
+                let n = batch.num_rows();
+                let rowid_col: ArrayRef = match self.row_id_start {
+                    Some(start) => {
+                        let mut builder = Int64Array::builder(n);
+                        for i in 0..n {
+                            builder.append_value(start + self.cursor + i as i64);
+                        }
+                        Arc::new(builder.finish())
+                    },
+                    None => {
+                        let mut builder = Int64Array::builder(n);
+                        for _ in 0..n {
+                            builder.append_null();
+                        }
+                        Arc::new(builder.finish())
+                    },
+                };
+                self.cursor += n as i64;
+
+                let mut cols: Vec<ArrayRef> = batch.columns().to_vec();
+                let pos = self.insert_at.min(cols.len());
+                cols.insert(pos, rowid_col);
+                let out = RecordBatch::try_new(self.schema.clone(), cols)
+                    .map_err(|e| DataFusionError::ArrowError(Box::new(e), None));
+                Poll::Ready(Some(out))
+            },
+            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl RecordBatchStream for RowIdStream {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Array, Int32Array};
+    use datafusion::datasource::memory::MemorySourceConfig;
+
+    fn small_batch(schema: SchemaRef, values: &[i32]) -> RecordBatch {
+        RecordBatch::try_new(
+            schema,
+            vec![Arc::new(Int32Array::from(values.to_vec())) as ArrayRef],
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn appends_sequential_rowids_across_batches() {
+        let input_schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int32, false)]));
+        let b1 = small_batch(input_schema.clone(), &[10, 20, 30]);
+        let b2 = small_batch(input_schema.clone(), &[40, 50]);
+        let mem =
+            MemorySourceConfig::try_new_exec(&[vec![b1, b2]], input_schema.clone(), None)
+                .unwrap();
+
+        let exec = Arc::new(RowIdExec::new(mem, Some(1000)));
+        assert_eq!(exec.schema().field(1).name(), ROWID_COLUMN_NAME);
+
+        let ctx = Arc::new(TaskContext::default());
+        let mut stream = exec.execute(0, ctx).unwrap();
+        use futures::StreamExt;
+
+        let first = stream.next().await.unwrap().unwrap();
+        let rowids = first
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .values()
+            .to_vec();
+        assert_eq!(rowids, vec![1000, 1001, 1002]);
+
+        let second = stream.next().await.unwrap().unwrap();
+        let rowids = second
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .values()
+            .to_vec();
+        assert_eq!(rowids, vec![1003, 1004]);
+    }
+
+    #[tokio::test]
+    async fn inserts_rowid_at_requested_position() {
+        let input_schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            input_schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![10, 20])) as ArrayRef,
+                Arc::new(Int32Array::from(vec![100, 200])) as ArrayRef,
+            ],
+        )
+        .unwrap();
+        let mem =
+            MemorySourceConfig::try_new_exec(&[vec![batch]], input_schema.clone(), None)
+                .unwrap();
+
+        // Insert rowid at position 1 → schema should be [a, rowid, b]
+        let exec = Arc::new(RowIdExec::new_at(mem, Some(500), 1));
+        assert_eq!(exec.schema().field(0).name(), "a");
+        assert_eq!(exec.schema().field(1).name(), ROWID_COLUMN_NAME);
+        assert_eq!(exec.schema().field(2).name(), "b");
+
+        let ctx = Arc::new(TaskContext::default());
+        let mut stream = exec.execute(0, ctx).unwrap();
+        use futures::StreamExt;
+
+        let out = stream.next().await.unwrap().unwrap();
+        let rowids = out
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .values()
+            .to_vec();
+        assert_eq!(rowids, vec![500, 501]);
+        // Verify physical columns still in place around rowid
+        let a = out
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap()
+            .values()
+            .to_vec();
+        let b = out
+            .column(2)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap()
+            .values()
+            .to_vec();
+        assert_eq!(a, vec![10, 20]);
+        assert_eq!(b, vec![100, 200]);
+    }
+
+    #[tokio::test]
+    async fn emits_null_when_row_id_start_is_none() {
+        let input_schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int32, false)]));
+        let b = small_batch(input_schema.clone(), &[1, 2]);
+        let mem =
+            MemorySourceConfig::try_new_exec(&[vec![b]], input_schema.clone(), None).unwrap();
+
+        let exec = Arc::new(RowIdExec::new(mem, None));
+        let ctx = Arc::new(TaskContext::default());
+        let mut stream = exec.execute(0, ctx).unwrap();
+        use futures::StreamExt;
+
+        let batch = stream.next().await.unwrap().unwrap();
+        let rowid_col = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(rowid_col.len(), 2);
+        assert!(rowid_col.is_null(0));
+        assert!(rowid_col.is_null(1));
+    }
+}

--- a/src/row_id.rs
+++ b/src/row_id.rs
@@ -263,8 +263,7 @@ mod tests {
         let b1 = small_batch(input_schema.clone(), &[10, 20, 30]);
         let b2 = small_batch(input_schema.clone(), &[40, 50]);
         let mem =
-            MemorySourceConfig::try_new_exec(&[vec![b1, b2]], input_schema.clone(), None)
-                .unwrap();
+            MemorySourceConfig::try_new_exec(&[vec![b1, b2]], input_schema.clone(), None).unwrap();
 
         let exec = Arc::new(RowIdExec::new(mem, Some(1000)));
         assert_eq!(exec.schema().field(1).name(), ROWID_COLUMN_NAME);
@@ -309,8 +308,7 @@ mod tests {
         )
         .unwrap();
         let mem =
-            MemorySourceConfig::try_new_exec(&[vec![batch]], input_schema.clone(), None)
-                .unwrap();
+            MemorySourceConfig::try_new_exec(&[vec![batch]], input_schema.clone(), None).unwrap();
 
         // Insert rowid at position 1 → schema should be [a, rowid, b]
         let exec = Arc::new(RowIdExec::new_at(mem, Some(500), 1));
@@ -364,8 +362,7 @@ mod tests {
         )
         .unwrap();
         let mem =
-            MemorySourceConfig::try_new_exec(&[vec![batch]], input_schema.clone(), None)
-                .unwrap();
+            MemorySourceConfig::try_new_exec(&[vec![batch]], input_schema.clone(), None).unwrap();
 
         let exec = Arc::new(RowIdExec::new(mem, Some(42)));
         assert_eq!(exec.schema().fields().len(), 1);
@@ -435,8 +432,7 @@ mod tests {
         // ends up appended at the end.
         let input_schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int32, false)]));
         let b = small_batch(input_schema.clone(), &[1, 2]);
-        let mem =
-            MemorySourceConfig::try_new_exec(&[vec![b]], input_schema.clone(), None).unwrap();
+        let mem = MemorySourceConfig::try_new_exec(&[vec![b]], input_schema.clone(), None).unwrap();
 
         let exec = Arc::new(RowIdExec::new_at(mem, Some(10), 99));
         assert_eq!(exec.schema().fields().len(), 2);
@@ -453,8 +449,7 @@ mod tests {
         // Distribution shape — just that it is SinglePartition for the
         // sole child.
         let input_schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int32, false)]));
-        let mem =
-            MemorySourceConfig::try_new_exec(&[vec![]], input_schema, None).unwrap();
+        let mem = MemorySourceConfig::try_new_exec(&[vec![]], input_schema, None).unwrap();
         let exec = RowIdExec::new(mem, Some(0));
 
         let dists = exec.required_input_distribution();
@@ -476,8 +471,7 @@ mod tests {
     async fn emits_null_when_row_id_start_is_none() {
         let input_schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int32, false)]));
         let b = small_batch(input_schema.clone(), &[1, 2]);
-        let mem =
-            MemorySourceConfig::try_new_exec(&[vec![b]], input_schema.clone(), None).unwrap();
+        let mem = MemorySourceConfig::try_new_exec(&[vec![b]], input_schema.clone(), None).unwrap();
 
         let exec = Arc::new(RowIdExec::new(mem, None));
         let ctx = Arc::new(TaskContext::default());

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -58,6 +58,8 @@ pub struct DuckLakeSchema {
     snapshot_id: i64,
     /// Schema path for resolving relative table paths
     schema_path: String,
+    /// Propagated from the catalog: when true, tables expose a `rowid` column.
+    row_lineage: bool,
     /// Metadata writer for write operations (when write feature is enabled)
     #[cfg(feature = "write")]
     writer: Option<Arc<dyn MetadataWriter>>,
@@ -80,9 +82,17 @@ impl DuckLakeSchema {
             snapshot_id,
             object_store_url,
             schema_path,
+            row_lineage: false,
             #[cfg(feature = "write")]
             writer: None,
         }
+    }
+
+    /// Enable the row-lineage virtual `rowid` column for all tables in this
+    /// schema. Set by the parent catalog (see `DuckLakeCatalog::with_row_lineage`).
+    pub fn with_row_lineage(mut self, enabled: bool) -> Self {
+        self.row_lineage = enabled;
+        self
     }
 
     /// Configure this schema for write operations.
@@ -144,7 +154,8 @@ impl SchemaProvider for DuckLakeSchema {
                     self.object_store_url.clone(),
                     table_path,
                 )
-                .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+                .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?
+                .with_row_lineage(self.row_lineage);
 
                 // Configure writer if this schema is writable
                 #[cfg(feature = "write")]

--- a/src/table.rs
+++ b/src/table.rs
@@ -11,6 +11,9 @@ use crate::metadata_provider::{
     DuckLakeFileData, DuckLakeTableColumn, DuckLakeTableFile, MetadataProvider,
 };
 use crate::path_resolver::resolve_path;
+use crate::row_id::{
+    ROW_ID_PARQUET_FIELD_ID, ROWID_COLUMN_NAME, RowIdExec, rowid_field,
+};
 use crate::types::{
     build_arrow_schema, build_read_schema_with_field_id_mapping, extract_parquet_field_ids,
 };
@@ -94,6 +97,27 @@ pub fn delete_file_schema() -> SchemaRef {
 /// Cached schema mapping for renamed columns
 type SchemaMappingCache = (SchemaRef, HashMap<String, String>);
 
+/// Per-file read configuration computed for the row-lineage scan path.
+///
+/// Encapsulates the decision made by `DuckLakeMultiFileReader::GetVirtualColumnExpression`
+/// in the C++ extension: either the parquet file embeds a row-id column
+/// (UPDATE/compaction case — surviving rowids preserved across file rewrite),
+/// or it doesn't (INSERT-only case — synthesize from `row_id_start + position`).
+#[derive(Debug, Clone)]
+struct FileReadConfig {
+    /// Schema we pass to `ParquetSource::new` for this file. When
+    /// `embedded_rowid_parquet_name` is `Some`, this schema has the embedded
+    /// rowid column appended at the end (under its parquet name).
+    read_schema: SchemaRef,
+    /// Parquet-name → user-facing-name renames. Includes the rowid rename
+    /// (parquet column → `"rowid"`) when the file has an embedded column with
+    /// a different name.
+    name_mapping: HashMap<String, String>,
+    /// `Some(parquet_column_name)` if the file embeds the rowid column
+    /// (tagged with [`ROW_ID_PARQUET_FIELD_ID`]); `None` otherwise.
+    embedded_rowid_parquet_name: Option<String>,
+}
+
 /// DuckLake table provider
 ///
 /// Represents a table within a DuckLake schema and provides access to data via Parquet files.
@@ -108,14 +132,25 @@ pub struct DuckLakeTable {
     object_store_url: Arc<ObjectStoreUrl>,
     /// Table path for resolving relative file paths
     table_path: String,
-    /// Current schema with potentially renamed column names
+    /// User-facing schema. Equals `physical_schema` when row lineage is off, or
+    /// `physical_schema` with a `rowid` BIGINT appended at the end when on.
     schema: SchemaRef,
+    /// Schema of the physical (parquet-backed) columns only — no rowid.
+    physical_schema: SchemaRef,
+    /// When true, `schema` includes a trailing `rowid` column and `scan()`
+    /// injects it per-file via [`RowIdExec`].
+    row_lineage: bool,
     /// Column metadata from DuckLake (needed for field_id mapping)
     columns: Vec<DuckLakeTableColumn>,
     /// Table files with paths as stored in metadata (resolved on-the-fly when needed)
     table_files: Vec<DuckLakeTableFile>,
     /// Cached schema mapping (read_schema, name_mapping) - computed once on first scan
     schema_mapping_cache: OnceCell<SchemaMappingCache>,
+    /// Per-file row-lineage read config, populated lazily on the rowid scan
+    /// path. Each file requires its own parquet metadata read to detect an
+    /// embedded `_ducklake_internal_row_id` column; we memoize so repeated
+    /// scans don't re-fetch.
+    file_read_config_cache: std::sync::Mutex<HashMap<String, Arc<FileReadConfig>>>,
     /// Encryption factory for decrypting encrypted Parquet files (when encryption feature is enabled)
     #[cfg(feature = "encryption")]
     encryption_factory: Option<Arc<dyn EncryptionFactory>>,
@@ -152,7 +187,8 @@ impl DuckLakeTable {
     ) -> Result<Self> {
         // Load ALL metadata with this snapshot_id
         let columns = provider.get_table_structure(table_id)?;
-        let schema = Arc::new(build_arrow_schema(&columns)?);
+        let physical_schema = Arc::new(build_arrow_schema(&columns)?);
+        let schema = physical_schema.clone();
         let table_files = provider.get_table_files_for_select(table_id, snapshot_id)?;
 
         // Build encryption factory from file encryption keys (when encryption feature is enabled)
@@ -190,16 +226,40 @@ impl DuckLakeTable {
             object_store_url,
             table_path,
             schema,
+            physical_schema,
+            row_lineage: false,
             columns,
             table_files,
             #[cfg(feature = "encryption")]
             encryption_factory,
             schema_mapping_cache: OnceCell::new(),
+            file_read_config_cache: std::sync::Mutex::new(HashMap::new()),
             #[cfg(feature = "write")]
             schema_name: None,
             #[cfg(feature = "write")]
             writer: None,
         })
+    }
+
+    /// Enable / disable the row-lineage feature. When enabled, the table's
+    /// public schema includes a trailing `rowid` BIGINT column synthesized
+    /// from each row's catalog-recorded `row_id_start + position_in_file`.
+    pub fn with_row_lineage(mut self, enabled: bool) -> Self {
+        self.row_lineage = enabled;
+        self.schema = if enabled {
+            let mut fields: Vec<Arc<Field>> =
+                self.physical_schema.fields().iter().cloned().collect();
+            fields.push(Arc::new(rowid_field()));
+            Arc::new(Schema::new(fields))
+        } else {
+            self.physical_schema.clone()
+        };
+        self
+    }
+
+    /// Index of the synthetic `rowid` column in `self.schema`, when enabled.
+    fn rowid_index(&self) -> Option<usize> {
+        self.row_lineage.then(|| self.physical_schema.fields().len())
     }
 
     /// Resolve a file path (data or delete file) to its absolute path
@@ -525,6 +585,258 @@ impl DuckLakeTable {
             Ok(exec_after_delete)
         }
     }
+
+    /// Inspect a single file's parquet metadata for the row-lineage scan
+    /// path. Mirrors the per-file logic in `DuckLakeMultiFileReader::
+    /// GetVirtualColumnExpression` (ducklake C++): if the file embeds a
+    /// column tagged with [`ROW_ID_PARQUET_FIELD_ID`], project that column;
+    /// otherwise synthesize rowid from `row_id_start + position`.
+    async fn build_file_read_config(
+        &self,
+        state: &dyn Session,
+        file: &DuckLakeFileData,
+    ) -> DataFusionResult<Arc<FileReadConfig>> {
+        let resolved_path = self.resolve_file_path(file)?;
+
+        {
+            let cache = self.file_read_config_cache.lock().unwrap();
+            if let Some(cfg) = cache.get(&resolved_path) {
+                return Ok(cfg.clone());
+            }
+        }
+
+        let object_store = state
+            .runtime_env()
+            .object_store(self.object_store_url.as_ref())?;
+        let object_path = ObjectPath::from(resolved_path.as_str());
+        let reader = ParquetObjectReader::new(object_store, object_path);
+
+        #[cfg(feature = "encryption")]
+        let builder = {
+            use parquet::arrow::arrow_reader::ArrowReaderOptions;
+            let options = if let Some(ref key) = file.encryption_key {
+                if !key.is_empty() {
+                    let key_bytes = crate::encryption::DuckLakeEncryptionFactory::decode_key(key)?;
+                    let decryption_props =
+                        parquet::encryption::decrypt::FileDecryptionProperties::builder(
+                            key_bytes,
+                        )
+                        .build()
+                        .map_err(|e| {
+                            DataFusionError::Execution(format!(
+                                "Failed to create decryption properties: {}",
+                                e
+                            ))
+                        })?;
+                    ArrowReaderOptions::new().with_file_decryption_properties(decryption_props)
+                } else {
+                    ArrowReaderOptions::new()
+                }
+            } else {
+                ArrowReaderOptions::new()
+            };
+            ParquetRecordBatchStreamBuilder::new_with_options(reader, options)
+                .await
+                .map_err(|e| DataFusionError::External(Box::new(e)))?
+        };
+
+        #[cfg(not(feature = "encryption"))]
+        let builder = ParquetRecordBatchStreamBuilder::new(reader)
+            .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+        let field_id_map = extract_parquet_field_ids(builder.metadata());
+
+        // Standard read_schema + name_mapping for physical columns.
+        let (physical_read_schema, mut name_mapping) = if field_id_map.is_empty() {
+            (self.physical_schema.as_ref().clone(), HashMap::new())
+        } else {
+            let (s, m) = build_read_schema_with_field_id_mapping(&self.columns, &field_id_map)
+                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+            (s, m)
+        };
+
+        // Detect the embedded rowid column by reserved field-id.
+        let embedded_rowid_parquet_name = field_id_map.get(&ROW_ID_PARQUET_FIELD_ID).cloned();
+
+        let read_schema = if let Some(ref parquet_name) = embedded_rowid_parquet_name {
+            // Append the embedded rowid column to read_schema under its
+            // parquet name; ParquetExec will project it by name from the
+            // file. We add a `parquet_name → "rowid"` rename so the user
+            // sees the column as `rowid` (only needed if the names differ).
+            let mut fields: Vec<Arc<Field>> =
+                physical_read_schema.fields().iter().cloned().collect();
+            fields.push(Arc::new(Field::new(
+                parquet_name.clone(),
+                DataType::Int64,
+                true,
+            )));
+            if parquet_name != ROWID_COLUMN_NAME {
+                name_mapping.insert(parquet_name.clone(), ROWID_COLUMN_NAME.to_string());
+            }
+            Arc::new(Schema::new(fields))
+        } else {
+            Arc::new(physical_read_schema)
+        };
+
+        let cfg = Arc::new(FileReadConfig {
+            read_schema,
+            name_mapping,
+            embedded_rowid_parquet_name,
+        });
+
+        {
+            let mut cache = self.file_read_config_cache.lock().unwrap();
+            cache
+                .entry(resolved_path)
+                .or_insert_with(|| cfg.clone());
+        }
+
+        Ok(cfg)
+    }
+
+    /// Build a plan for a single file when the synthetic `rowid` column is in
+    /// the projection. Always uses per-file scans because each file may have a
+    /// different layout (embedded rowid vs. synthesized) and a distinct
+    /// `row_id_start`.
+    ///
+    /// Order: ParquetExec(physical_proj [+ rowid if embedded]) →
+    ///   RowIdExec(?) → DeleteFilterExec(?) → ColumnRenameExec(?).
+    async fn build_exec_for_file_with_rowid(
+        &self,
+        state: &dyn Session,
+        table_file: &DuckLakeTableFile,
+        user_proj: &[usize],
+        rowid_idx: usize,
+        limit: Option<usize>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let file_cfg = self.build_file_read_config(state, &table_file.file).await?;
+        let has_embedded = file_cfg.embedded_rowid_parquet_name.is_some();
+
+        // Decompose user projection: which physical columns to read, and where
+        // rowid should appear in the output.
+        let physical_proj: Vec<usize> = user_proj
+            .iter()
+            .filter(|&&i| i != rowid_idx)
+            .copied()
+            .collect();
+        let rowid_insert_pos: usize = user_proj
+            .iter()
+            .position(|&i| i == rowid_idx)
+            .ok_or_else(|| {
+                DataFusionError::Internal(
+                    "build_exec_for_file_with_rowid called without rowid in projection".into(),
+                )
+            })?;
+
+        // Match the C++ extension: if the file embeds no rowid column AND the
+        // catalog didn't record a `row_id_start`, lineage cannot be
+        // reconstructed. Hard-error rather than silently emit NULL/garbage.
+        if !has_embedded && table_file.row_id_start.is_none() {
+            return Err(DataFusionError::Execution(format!(
+                "File \"{}\" has no embedded `_ducklake_internal_row_id` column and no \
+                 `row_id_start` set in the catalog — row lineage cannot be reconstructed",
+                table_file.file.path
+            )));
+        }
+
+        // Build the ParquetExec projection. When the file embeds rowid we
+        // splice it into the projection at `rowid_insert_pos` directly, so
+        // the parquet emits batches already in the user's requested column
+        // order (no extra reorder pass needed).
+        let parquet_projection: Vec<usize> = if has_embedded {
+            let rowid_col_in_read_schema = file_cfg.read_schema.fields().len() - 1;
+            let mut p = physical_proj.clone();
+            p.insert(rowid_insert_pos, rowid_col_in_read_schema);
+            p
+        } else {
+            physical_proj.clone()
+        };
+
+        // Resolve and configure the data file
+        let resolved_path = self.resolve_file_path(&table_file.file)?;
+        let mut pf = PartitionedFile::new(
+            &resolved_path,
+            validated_file_size(table_file.file.file_size_bytes, &resolved_path)?,
+        );
+        if let Some(footer_size) = table_file.file.footer_size
+            && footer_size > 0
+            && let Ok(hint) = usize::try_from(footer_size)
+        {
+            pf = pf.with_metadata_size_hint(hint);
+        }
+
+        let mut builder = FileScanConfigBuilder::new(
+            self.object_store_url.as_ref().clone(),
+            Arc::new(self.create_parquet_source(file_cfg.read_schema.clone())),
+        )
+        .with_limit(limit)
+        .with_file_group(FileGroup::new(vec![pf]));
+        builder = builder.with_projection_indices(Some(parquet_projection))?;
+
+        let parquet_exec: Arc<dyn ExecutionPlan> =
+            DataSourceExec::from_data_source(builder.build());
+
+        // Synthesize rowid only when the file doesn't already supply it.
+        let after_rowid: Arc<dyn ExecutionPlan> = if has_embedded {
+            parquet_exec
+        } else {
+            Arc::new(RowIdExec::new_at(
+                parquet_exec,
+                table_file.row_id_start,
+                rowid_insert_pos,
+            ))
+        };
+
+        // Apply delete filter if needed. DeleteFilterExec tracks file
+        // position, which is preserved through both RowIdExec and an embedded
+        // rowid projection (both leave row order untouched).
+        let after_deletes: Arc<dyn ExecutionPlan> =
+            if let Some(ref delete_file) = table_file.delete_file {
+                let deleted_positions = self.read_delete_file_positions(state, delete_file).await?;
+                if !deleted_positions.is_empty() {
+                    Arc::new(DeleteFilterExec::new(
+                        after_rowid,
+                        table_file.file.path.clone(),
+                        Arc::new(deleted_positions),
+                    ))
+                } else {
+                    after_rowid
+                }
+            } else {
+                after_rowid
+            };
+
+        // Apply column rename. Required when a physical column was renamed in
+        // the catalog, or when the embedded rowid column's parquet name
+        // differs from `"rowid"` (the common case — it's
+        // `_ducklake_internal_row_id`).
+        if !file_cfg.name_mapping.is_empty() {
+            let output_schema = self.output_schema_for_projection(user_proj, rowid_idx);
+            Ok(Arc::new(ColumnRenameExec::new(
+                after_deletes,
+                output_schema,
+                file_cfg.name_mapping.clone(),
+            )))
+        } else {
+            Ok(after_deletes)
+        }
+    }
+
+    /// Output schema for the rowid-projected per-file plan: physical fields
+    /// (using their user-facing renamed names from `self.schema`) interleaved
+    /// with the synthetic `rowid` field at `rowid_idx`.
+    fn output_schema_for_projection(&self, user_proj: &[usize], rowid_idx: usize) -> SchemaRef {
+        let mut fields: Vec<Arc<Field>> = Vec::with_capacity(user_proj.len());
+        for &i in user_proj {
+            if i == rowid_idx {
+                fields.push(Arc::new(rowid_field()));
+            } else {
+                fields.push(self.schema.fields()[i].clone());
+            }
+        }
+        Arc::new(Schema::new(fields))
+    }
 }
 
 #[async_trait]
@@ -608,8 +920,42 @@ impl TableProvider for DuckLakeTable {
         _filters: &[Expr],
         limit: Option<usize>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
-        // Separate files into two groups: with deletes and without deletes
-        // This allows us to create a single efficient exec for files without deletes
+        // Row-lineage detour: when the synthetic `rowid` column is projected,
+        // every file needs its own scan because each has a distinct
+        // `row_id_start`. `projection == None` with row lineage on means "all
+        // columns including rowid", which also routes through this path.
+        let rowid_idx = self.rowid_index();
+        let rowid_in_proj = match (rowid_idx, projection) {
+            (Some(r), Some(p)) => p.contains(&r),
+            (Some(_), None) => true,
+            (None, _) => false,
+        };
+
+        if rowid_in_proj {
+            let rowid_idx = rowid_idx.unwrap();
+            let user_proj: Vec<usize> = projection
+                .cloned()
+                .unwrap_or_else(|| (0..self.schema.fields().len()).collect());
+
+            let mut execs: Vec<Arc<dyn ExecutionPlan>> = Vec::new();
+            for tf in &self.table_files {
+                let exec = self
+                    .build_exec_for_file_with_rowid(state, tf, &user_proj, rowid_idx, limit)
+                    .await?;
+                execs.push(exec);
+            }
+
+            if execs.is_empty() {
+                use datafusion::physical_plan::empty::EmptyExec;
+                let projected_schema = self.output_schema_for_projection(&user_proj, rowid_idx);
+                return Ok(Arc::new(EmptyExec::new(projected_schema)));
+            }
+
+            return combine_execution_plans(execs);
+        }
+
+        // Fast path: rowid not projected. All projection indices refer to
+        // physical columns, so the existing logic works untouched.
         let (files_with_deletes, files_without_deletes): (Vec<_>, Vec<_>) = self
             .table_files
             .iter()

--- a/src/table.rs
+++ b/src/table.rs
@@ -11,9 +11,7 @@ use crate::metadata_provider::{
     DuckLakeFileData, DuckLakeTableColumn, DuckLakeTableFile, MetadataProvider,
 };
 use crate::path_resolver::resolve_path;
-use crate::row_id::{
-    ROW_ID_PARQUET_FIELD_ID, ROWID_COLUMN_NAME, RowIdExec, rowid_field,
-};
+use crate::row_id::{ROW_ID_PARQUET_FIELD_ID, ROWID_COLUMN_NAME, RowIdExec, rowid_field};
 use crate::types::{
     build_arrow_schema, build_read_schema_with_field_id_mapping, extract_parquet_field_ids,
 };
@@ -259,7 +257,8 @@ impl DuckLakeTable {
 
     /// Index of the synthetic `rowid` column in `self.schema`, when enabled.
     fn rowid_index(&self) -> Option<usize> {
-        self.row_lineage.then(|| self.physical_schema.fields().len())
+        self.row_lineage
+            .then(|| self.physical_schema.fields().len())
     }
 
     /// Resolve a file path (data or delete file) to its absolute path
@@ -618,16 +617,14 @@ impl DuckLakeTable {
                 if !key.is_empty() {
                     let key_bytes = crate::encryption::DuckLakeEncryptionFactory::decode_key(key)?;
                     let decryption_props =
-                        parquet::encryption::decrypt::FileDecryptionProperties::builder(
-                            key_bytes,
-                        )
-                        .build()
-                        .map_err(|e| {
-                            DataFusionError::Execution(format!(
-                                "Failed to create decryption properties: {}",
-                                e
-                            ))
-                        })?;
+                        parquet::encryption::decrypt::FileDecryptionProperties::builder(key_bytes)
+                            .build()
+                            .map_err(|e| {
+                                DataFusionError::Execution(format!(
+                                    "Failed to create decryption properties: {}",
+                                    e
+                                ))
+                            })?;
                     ArrowReaderOptions::new().with_file_decryption_properties(decryption_props)
                 } else {
                     ArrowReaderOptions::new()
@@ -687,9 +684,7 @@ impl DuckLakeTable {
 
         {
             let mut cache = self.file_read_config_cache.lock().unwrap();
-            cache
-                .entry(resolved_path)
-                .or_insert_with(|| cfg.clone());
+            cache.entry(resolved_path).or_insert_with(|| cfg.clone());
         }
 
         Ok(cfg)
@@ -720,14 +715,15 @@ impl DuckLakeTable {
             .filter(|&&i| i != rowid_idx)
             .copied()
             .collect();
-        let rowid_insert_pos: usize = user_proj
-            .iter()
-            .position(|&i| i == rowid_idx)
-            .ok_or_else(|| {
-                DataFusionError::Internal(
-                    "build_exec_for_file_with_rowid called without rowid in projection".into(),
-                )
-            })?;
+        let rowid_insert_pos: usize =
+            user_proj
+                .iter()
+                .position(|&i| i == rowid_idx)
+                .ok_or_else(|| {
+                    DataFusionError::Internal(
+                        "build_exec_for_file_with_rowid called without rowid in projection".into(),
+                    )
+                })?;
 
         // Match the C++ extension: if the file embeds no rowid column AND the
         // catalog didn't record a `row_id_start`, lineage cannot be

--- a/tests/row_id_tests.rs
+++ b/tests/row_id_tests.rs
@@ -32,15 +32,9 @@ fn create_catalog_rowid_two_files(catalog_path: &Path) -> Result<()> {
 
     conn.execute("CREATE TABLE c.t(i INTEGER);", [])?;
     // First file: rows 0..3
-    conn.execute(
-        "INSERT INTO c.t SELECT i FROM range(0, 3) t(i);",
-        [],
-    )?;
+    conn.execute("INSERT INTO c.t SELECT i FROM range(0, 3) t(i);", [])?;
     // Second file: rows 10..15
-    conn.execute(
-        "INSERT INTO c.t SELECT i FROM range(10, 15) t(i);",
-        [],
-    )?;
+    conn.execute("INSERT INTO c.t SELECT i FROM range(10, 15) t(i);", [])?;
     Ok(())
 }
 
@@ -131,8 +125,8 @@ fn collect_rowid_i_sorted(batches: &[RecordBatch]) -> Vec<(i64, i32)> {
 
 #[tokio::test]
 async fn rowid_disabled_by_default() -> DataFusionResult<()> {
-    let temp = TempDir::new()
-        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    let temp =
+        TempDir::new().map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
     let path = temp.path().join("rowid_default.ducklake");
     create_catalog_rowid_two_files(&path).map_err(common::to_datafusion_error)?;
 
@@ -168,8 +162,8 @@ async fn rowid_disabled_by_default() -> DataFusionResult<()> {
 
 #[tokio::test]
 async fn rowid_sequential_across_files() -> DataFusionResult<()> {
-    let temp = TempDir::new()
-        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    let temp =
+        TempDir::new().map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
     let path = temp.path().join("rowid_two_files.ducklake");
     create_catalog_rowid_two_files(&path).map_err(common::to_datafusion_error)?;
 
@@ -194,16 +188,7 @@ async fn rowid_sequential_across_files() -> DataFusionResult<()> {
     let pairs = collect_rowid_i_sorted(&batches);
     assert_eq!(
         pairs,
-        vec![
-            (0, 0),
-            (1, 1),
-            (2, 2),
-            (3, 10),
-            (4, 11),
-            (5, 12),
-            (6, 13),
-            (7, 14),
-        ],
+        vec![(0, 0), (1, 1), (2, 2), (3, 10), (4, 11), (5, 12), (6, 13), (7, 14),],
         "rowids should be contiguous 0..8 across the two files",
     );
 
@@ -220,8 +205,8 @@ async fn rowid_sequential_across_files() -> DataFusionResult<()> {
 
 #[tokio::test]
 async fn rowid_preserved_under_deletes() -> DataFusionResult<()> {
-    let temp = TempDir::new()
-        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    let temp =
+        TempDir::new().map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
     let path = temp.path().join("rowid_with_deletes.ducklake");
     create_catalog_rowid_with_deletes(&path).map_err(common::to_datafusion_error)?;
 
@@ -250,8 +235,8 @@ async fn rowid_preserved_under_deletes() -> DataFusionResult<()> {
 async fn rowid_only_projection() -> DataFusionResult<()> {
     // Edge case: physical projection is empty (just rowid). Verifies that
     // RowIdExec works when ParquetExec emits zero-column count batches.
-    let temp = TempDir::new()
-        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    let temp =
+        TempDir::new().map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
     let path = temp.path().join("rowid_only.ducklake");
     create_catalog_rowid_two_files(&path).map_err(common::to_datafusion_error)?;
 
@@ -283,8 +268,8 @@ async fn rowid_preserved_across_update_rewrite() -> DataFusionResult<()> {
     // The critical test: UPDATE rewrites the file with embedded rowids.
     // Our scan must read those embedded values rather than compute
     // `row_id_start + position`, otherwise the rowids drift.
-    let temp = TempDir::new()
-        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    let temp =
+        TempDir::new().map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
     let path = temp.path().join("rowid_update.ducklake");
     create_catalog_rowid_with_update(&path).map_err(common::to_datafusion_error)?;
 
@@ -319,8 +304,8 @@ async fn rowid_preserved_across_update_rewrite() -> DataFusionResult<()> {
 #[tokio::test]
 async fn rowid_count_star_unaffected() -> DataFusionResult<()> {
     // COUNT(*) should not trigger the rowid path (it asks for zero columns).
-    let temp = TempDir::new()
-        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    let temp =
+        TempDir::new().map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
     let path = temp.path().join("rowid_count_star.ducklake");
     create_catalog_rowid_two_files(&path).map_err(common::to_datafusion_error)?;
 

--- a/tests/row_id_tests.rs
+++ b/tests/row_id_tests.rs
@@ -150,8 +150,7 @@ async fn rowid_disabled_by_default() -> DataFusionResult<()> {
     let err = ctx
         .sql("SELECT rowid FROM c.main.t")
         .await
-        .err()
-        .expect("should fail to plan rowid reference with lineage off");
+        .expect_err("should fail to plan rowid reference with lineage off");
     assert!(
         format!("{err}").to_lowercase().contains("rowid"),
         "expected error to mention rowid, got: {err}"

--- a/tests/row_id_tests.rs
+++ b/tests/row_id_tests.rs
@@ -69,18 +69,17 @@ fn create_catalog_rowid_with_deletes(catalog_path: &Path) -> Result<()> {
 /// new data file whose parquet stores `_ducklake_internal_row_id` (field-id
 /// 2147483540) so the original rowids survive the rewrite.
 ///
-/// Trajectory:
-///   INSERT (0..3)    → rowids 0..2, i values [0,1,2]
-///   INSERT (10..15)  → rowids 3..7, i values [10,11,12,13,14]
-///   DELETE WHERE i%2=1 → drops rowids {1,3,5}  (i=1,11,13)
-///   Surviving: (0,0) (2,2) (4,12) wait — let me recompute:
-///     rowid 0 -> i=0;  rowid 1 -> i=1 (del);  rowid 2 -> i=2;
-///     rowid 3 -> i=10; rowid 4 -> i=11 (del); rowid 5 -> i=12;
-///     rowid 6 -> i=13 (del); rowid 7 -> i=14
-///   So surviving = [(0,0),(2,2),(3,10),(5,12),(7,14)]
-///   UPDATE i = i+1000 WHERE i<3 OR i>10:
-///     matches i=0, i=2, i=12, i=14
-///     → [(0,1000),(2,1002),(3,10),(5,1012),(7,1014)]
+/// Trajectory (rowid in parentheses):
+///   INSERT range(0, 3)   → (0,0) (1,1) (2,2)
+///   INSERT range(10, 15) → (3,10) (4,11) (5,12) (6,13) (7,14)
+///   DELETE WHERE i % 2 = 1 → drops rowids {1, 4, 6}
+///     Surviving: (0,0) (2,2) (3,10) (5,12) (7,14)
+///   UPDATE i = i+1000 WHERE i<3 OR i>10 → touches rowids {0, 2, 5, 7}:
+///     → (0,1000) (2,1002) (3,10) (5,1012) (7,1014)
+///
+/// The expected result is only achievable if the rewrite file's embedded
+/// `_ducklake_internal_row_id` column is read; `row_id_start + position`
+/// for the rewrite file would yield a fresh sequential range, not {0,2,5,7}.
 fn create_catalog_rowid_with_update(catalog_path: &Path) -> Result<()> {
     let conn = duckdb::Connection::open_in_memory()?;
     conn.execute("INSTALL ducklake;", [])?;

--- a/tests/row_id_tests.rs
+++ b/tests/row_id_tests.rs
@@ -1,0 +1,342 @@
+#![cfg(feature = "metadata-duckdb")]
+//! End-to-end tests for DuckLake row-lineage (`rowid` virtual column).
+//!
+//! These tests build small DuckLake catalogs via the DuckDB CLI (so the
+//! catalog tables, including `data_file.row_id_start`, are populated by the
+//! official extension) and then query through DataFusion to verify our
+//! injected `rowid` column matches what DuckDB itself would return.
+
+mod common;
+
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::Result;
+use arrow::array::{Array, Int32Array, Int64Array};
+use arrow::record_batch::RecordBatch;
+use datafusion::error::Result as DataFusionResult;
+use datafusion::prelude::*;
+use datafusion_ducklake::{DuckLakeCatalog, DuckdbMetadataProvider};
+use tempfile::TempDir;
+
+/// Build a small two-file catalog: two separate INSERT statements produce two
+/// data files, each with its own `row_id_start`.
+fn create_catalog_rowid_two_files(catalog_path: &Path) -> Result<()> {
+    let conn = duckdb::Connection::open_in_memory()?;
+    conn.execute("INSTALL ducklake;", [])?;
+    conn.execute("INSTALL parquet;", [])?;
+    conn.execute("LOAD ducklake;", [])?;
+
+    let ducklake_path = format!("ducklake:{}", catalog_path.display());
+    conn.execute(&format!("ATTACH '{}' AS c;", ducklake_path), [])?;
+
+    conn.execute("CREATE TABLE c.t(i INTEGER);", [])?;
+    // First file: rows 0..3
+    conn.execute(
+        "INSERT INTO c.t SELECT i FROM range(0, 3) t(i);",
+        [],
+    )?;
+    // Second file: rows 10..15
+    conn.execute(
+        "INSERT INTO c.t SELECT i FROM range(10, 15) t(i);",
+        [],
+    )?;
+    Ok(())
+}
+
+/// Same as the two-file catalog, but DELETE the rows where i is odd.
+/// Verifies that DeleteFilterExec runs after RowIdExec so deleted rowids
+/// are correctly elided from the output.
+fn create_catalog_rowid_with_deletes(catalog_path: &Path) -> Result<()> {
+    let conn = duckdb::Connection::open_in_memory()?;
+    conn.execute("INSTALL ducklake;", [])?;
+    conn.execute("INSTALL parquet;", [])?;
+    conn.execute("LOAD ducklake;", [])?;
+
+    let ducklake_path = format!("ducklake:{}", catalog_path.display());
+    conn.execute(&format!("ATTACH '{}' AS c;", ducklake_path), [])?;
+
+    conn.execute("CREATE TABLE c.t(i INTEGER);", [])?;
+    conn.execute("INSERT INTO c.t SELECT i FROM range(0, 3) t(i);", [])?;
+    conn.execute("INSERT INTO c.t SELECT i FROM range(10, 15) t(i);", [])?;
+    // Same DELETE pattern as the reference DuckLake rowid test.
+    conn.execute("DELETE FROM c.t WHERE i % 2 = 1;", [])?;
+    Ok(())
+}
+
+/// Mirrors the UPDATE portion of test/sql/rowid/ducklake_row_id.test in the
+/// upstream DuckLake extension. The UPDATE rewrites surviving rows into a
+/// new data file whose parquet stores `_ducklake_internal_row_id` (field-id
+/// 2147483540) so the original rowids survive the rewrite.
+///
+/// Trajectory:
+///   INSERT (0..3)    → rowids 0..2, i values [0,1,2]
+///   INSERT (10..15)  → rowids 3..7, i values [10,11,12,13,14]
+///   DELETE WHERE i%2=1 → drops rowids {1,3,5}  (i=1,11,13)
+///   Surviving: (0,0) (2,2) (4,12) wait — let me recompute:
+///     rowid 0 -> i=0;  rowid 1 -> i=1 (del);  rowid 2 -> i=2;
+///     rowid 3 -> i=10; rowid 4 -> i=11 (del); rowid 5 -> i=12;
+///     rowid 6 -> i=13 (del); rowid 7 -> i=14
+///   So surviving = [(0,0),(2,2),(3,10),(5,12),(7,14)]
+///   UPDATE i = i+1000 WHERE i<3 OR i>10:
+///     matches i=0, i=2, i=12, i=14
+///     → [(0,1000),(2,1002),(3,10),(5,1012),(7,1014)]
+fn create_catalog_rowid_with_update(catalog_path: &Path) -> Result<()> {
+    let conn = duckdb::Connection::open_in_memory()?;
+    conn.execute("INSTALL ducklake;", [])?;
+    conn.execute("INSTALL parquet;", [])?;
+    conn.execute("LOAD ducklake;", [])?;
+
+    let ducklake_path = format!("ducklake:{}", catalog_path.display());
+    conn.execute(&format!("ATTACH '{}' AS c;", ducklake_path), [])?;
+
+    conn.execute("CREATE TABLE c.t(i INTEGER);", [])?;
+    conn.execute("INSERT INTO c.t SELECT i FROM range(0, 3) t(i);", [])?;
+    conn.execute("INSERT INTO c.t SELECT i FROM range(10, 15) t(i);", [])?;
+    conn.execute("DELETE FROM c.t WHERE i % 2 = 1;", [])?;
+    // Force a file rewrite that preserves original rowids.
+    conn.execute("UPDATE c.t SET i = i + 1000 WHERE i < 3 OR i > 10;", [])?;
+    Ok(())
+}
+
+fn make_catalog(path: &str, row_lineage: bool) -> DataFusionResult<Arc<DuckLakeCatalog>> {
+    let provider = DuckdbMetadataProvider::new(path)
+        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    let catalog = DuckLakeCatalog::new(provider)
+        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?
+        .with_row_lineage(row_lineage);
+    Ok(Arc::new(catalog))
+}
+
+fn collect_rowid_i_sorted(batches: &[RecordBatch]) -> Vec<(i64, i32)> {
+    let mut out = Vec::new();
+    for batch in batches {
+        let rowids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("first column should be rowid (Int64)");
+        let vals = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .expect("second column should be i (Int32)");
+        for r in 0..batch.num_rows() {
+            assert!(!rowids.is_null(r), "rowid should not be null");
+            out.push((rowids.value(r), vals.value(r)));
+        }
+    }
+    out.sort_by_key(|&(rowid, _)| rowid);
+    out
+}
+
+#[tokio::test]
+async fn rowid_disabled_by_default() -> DataFusionResult<()> {
+    let temp = TempDir::new()
+        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    let path = temp.path().join("rowid_default.ducklake");
+    create_catalog_rowid_two_files(&path).map_err(common::to_datafusion_error)?;
+
+    // Default: row lineage is OFF.
+    let catalog = make_catalog(&path.to_string_lossy(), false)?;
+    let ctx = SessionContext::new();
+    ctx.register_catalog("c", catalog);
+
+    // SELECT * should not expose rowid.
+    let df = ctx.sql("SELECT * FROM c.main.t ORDER BY i").await?;
+    let schema = df.schema().clone();
+    let field_names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+    assert_eq!(
+        field_names,
+        vec!["i"],
+        "rowid must not appear when row lineage is disabled (got {:?})",
+        field_names
+    );
+
+    // Explicitly referencing rowid should fail to plan.
+    let err = ctx
+        .sql("SELECT rowid FROM c.main.t")
+        .await
+        .err()
+        .expect("should fail to plan rowid reference with lineage off");
+    assert!(
+        format!("{err}").to_lowercase().contains("rowid"),
+        "expected error to mention rowid, got: {err}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn rowid_sequential_across_files() -> DataFusionResult<()> {
+    let temp = TempDir::new()
+        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    let path = temp.path().join("rowid_two_files.ducklake");
+    create_catalog_rowid_two_files(&path).map_err(common::to_datafusion_error)?;
+
+    let catalog = make_catalog(&path.to_string_lossy(), true)?;
+    let ctx = SessionContext::new();
+    ctx.register_catalog("c", catalog);
+
+    // Verify rowid IS in the table schema and is BIGINT.
+    let df = ctx.sql("SELECT * FROM c.main.t").await?;
+    let schema = df.schema().clone();
+    let field_names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+    assert_eq!(field_names, vec!["i", "rowid"]);
+
+    // Query rowid + i; rowid values should be globally unique and contiguous
+    // starting at 0 (DuckLake assigns sequentially across files inserted in
+    // order).
+    let df = ctx
+        .sql("SELECT rowid, i FROM c.main.t ORDER BY rowid")
+        .await?;
+    let batches = df.collect().await?;
+
+    let pairs = collect_rowid_i_sorted(&batches);
+    assert_eq!(
+        pairs,
+        vec![
+            (0, 0),
+            (1, 1),
+            (2, 2),
+            (3, 10),
+            (4, 11),
+            (5, 12),
+            (6, 13),
+            (7, 14),
+        ],
+        "rowids should be contiguous 0..8 across the two files",
+    );
+
+    // Spot-check WHERE rowid = N
+    let df = ctx
+        .sql("SELECT rowid, i FROM c.main.t WHERE rowid = 4")
+        .await?;
+    let batches = df.collect().await?;
+    let pairs = collect_rowid_i_sorted(&batches);
+    assert_eq!(pairs, vec![(4, 11)]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn rowid_preserved_under_deletes() -> DataFusionResult<()> {
+    let temp = TempDir::new()
+        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    let path = temp.path().join("rowid_with_deletes.ducklake");
+    create_catalog_rowid_with_deletes(&path).map_err(common::to_datafusion_error)?;
+
+    let catalog = make_catalog(&path.to_string_lossy(), true)?;
+    let ctx = SessionContext::new();
+    ctx.register_catalog("c", catalog);
+
+    let df = ctx
+        .sql("SELECT rowid, i FROM c.main.t ORDER BY rowid")
+        .await?;
+    let batches = df.collect().await?;
+    let pairs = collect_rowid_i_sorted(&batches);
+
+    // Source rows (rowid, i): (0,0) (1,1) (2,2) (3,10) (4,11) (5,12) (6,13) (7,14)
+    // Deleted where i is odd: i ∈ {1, 11, 13}, leaving rowids {0, 2, 3, 5, 7}.
+    assert_eq!(
+        pairs,
+        vec![(0, 0), (2, 2), (3, 10), (5, 12), (7, 14)],
+        "deleted rows' rowids must be elided, surviving rowids unchanged",
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn rowid_only_projection() -> DataFusionResult<()> {
+    // Edge case: physical projection is empty (just rowid). Verifies that
+    // RowIdExec works when ParquetExec emits zero-column count batches.
+    let temp = TempDir::new()
+        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    let path = temp.path().join("rowid_only.ducklake");
+    create_catalog_rowid_two_files(&path).map_err(common::to_datafusion_error)?;
+
+    let catalog = make_catalog(&path.to_string_lossy(), true)?;
+    let ctx = SessionContext::new();
+    ctx.register_catalog("c", catalog);
+
+    let df = ctx.sql("SELECT rowid FROM c.main.t ORDER BY rowid").await?;
+    let batches = df.collect().await?;
+    let mut all = Vec::new();
+    for batch in &batches {
+        let rowids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("rowid column should be Int64");
+        for r in 0..batch.num_rows() {
+            assert!(!rowids.is_null(r));
+            all.push(rowids.value(r));
+        }
+    }
+    all.sort();
+    assert_eq!(all, vec![0, 1, 2, 3, 4, 5, 6, 7]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn rowid_preserved_across_update_rewrite() -> DataFusionResult<()> {
+    // The critical test: UPDATE rewrites the file with embedded rowids.
+    // Our scan must read those embedded values rather than compute
+    // `row_id_start + position`, otherwise the rowids drift.
+    let temp = TempDir::new()
+        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    let path = temp.path().join("rowid_update.ducklake");
+    create_catalog_rowid_with_update(&path).map_err(common::to_datafusion_error)?;
+
+    let catalog = make_catalog(&path.to_string_lossy(), true)?;
+    let ctx = SessionContext::new();
+    ctx.register_catalog("c", catalog);
+
+    let df = ctx
+        .sql("SELECT rowid, i FROM c.main.t ORDER BY rowid")
+        .await?;
+    let batches = df.collect().await?;
+    let pairs = collect_rowid_i_sorted(&batches);
+
+    assert_eq!(
+        pairs,
+        vec![(0, 1000), (2, 1002), (3, 10), (5, 1012), (7, 1014)],
+        "rowids must survive the UPDATE rewrite; values reflect i+1000 \
+         applied to original rowids 0, 2, 5, 7 (file-rewritten rows)",
+    );
+
+    // Also verify per-rowid lookup is correct after the rewrite.
+    let df = ctx
+        .sql("SELECT rowid, i FROM c.main.t WHERE rowid = 5")
+        .await?;
+    let batches = df.collect().await?;
+    let pairs = collect_rowid_i_sorted(&batches);
+    assert_eq!(pairs, vec![(5, 1012)]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn rowid_count_star_unaffected() -> DataFusionResult<()> {
+    // COUNT(*) should not trigger the rowid path (it asks for zero columns).
+    let temp = TempDir::new()
+        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    let path = temp.path().join("rowid_count_star.ducklake");
+    create_catalog_rowid_two_files(&path).map_err(common::to_datafusion_error)?;
+
+    let catalog = make_catalog(&path.to_string_lossy(), true)?;
+    let ctx = SessionContext::new();
+    ctx.register_catalog("c", catalog);
+
+    let df = ctx.sql("SELECT COUNT(*) FROM c.main.t").await?;
+    let batches = df.collect().await?;
+    let total: i64 = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap()
+        .value(0);
+    assert_eq!(total, 8);
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Implements the DuckLake [row lineage](https://ducklake.select/docs/stable/duckdb/advanced_features/row_lineage) feature in datafusion-ducklake: every row gets a stable BIGINT `rowid` that survives file rewrites from `UPDATE` / compaction.

Off by default — opt in via `DuckLakeCatalog::with_row_lineage(true)`. When enabled, the table's public schema gains a trailing `rowid` column; scans synthesize it per-file, matching the upstream DuckDB ducklake extension byte-for-byte (verified against a live Postgres + Tigris catalog and via lifecycle tests covering CREATE → 2× INSERT → UPDATE → DELETE one → DELETE all → DROP).

The scan path mirrors `DuckLakeMultiFileReader::GetVirtualColumnExpression` in the upstream C++ extension:

- **INSERT-only files**: rowid synthesized as `row_id_start + position_in_file` via a new `RowIdExec` execution plan.
- **UPDATE / compaction files**: rowid is read directly from the parquet's embedded `_ducklake_internal_row_id` column (tagged with the Iceberg-reserved field id `2_147_483_540`). Detected per-file at plan time; result cached in `Mutex<HashMap<path, FileReadConfig>>`.
- **Neither**: hard error with the file path, matching the C++ `InvalidInputException` rather than silently emitting NULL/wrong rowids.

`DeleteFilterExec` composes cleanly with both branches: row count and order are preserved upstream of the cursor.

When `rowid` is not in projection (the common case for existing users), `scan()` short-circuits to the original files-without-deletes / files-with-deletes path — zero perf regression on non-rowid reads.

Commit-by-commit breakdown:

1. `feat(metadata)` — plumb `row_id_start` + `record_count` from the catalog through all 4 providers (was already declared on `DuckLakeTableFile`, hardcoded to None).
2. `feat(row_id)` — `RowIdExec` + `ROW_ID_PARQUET_FIELD_ID` constant.
3. `feat` — wire `row_lineage` through catalog/schema/table, scan dispatch, per-file embedded detection.
4. `test(row_id)` — 6 integration tests including the UPDATE-rewrite path.
5. `chore` — enable `sqlx/tls-rustls-ring` for `metadata-postgres` (Neon / RDS sslmode=require previously errored).
6. `examples` — `compare_rowid_against_duckdb` + `rowid_lifecycle` (env-var-configured; no credentials in source).
7. `fix(row_id)` + `test(row_id)` — pin `RowIdExec`'s input to `SinglePartition` so DataFusion's `Repartition` rule can't silently break the cursor; expand unit tests.

Out of scope, called out for follow-up:

- DataFusion has no hidden-column concept, so `rowid` IS in `SELECT *` once enabled (differs from DuckDB where it's hidden). Documented in the `with_row_lineage` docstring.
- `DeleteFilterExec` has the same single-partition assumption as the original `RowIdExec` — same latent reparallelization risk that the fix commit addresses here. Pre-existing in main; should get the same `required_input_distribution = SinglePartition` fix in a separate PR.

## Test plan

- [x] `cargo test` — 260+ tests across 21 suites, no failures, no regressions.
- [x] 7 unit tests in `src/row_id.rs` cover the execution-plan stream behavior, edge cases (empty batch, zero-column input, out-of-range insert position), and a regression guard for `SinglePartition` / `maintains_input_order`.
- [x] 6 integration tests in `tests/row_id_tests.rs` cover: rowid disabled by default + error on reference; sequential rowids across two files; rowid preserved under deletes; **rowid preserved across UPDATE rewrite (embedded path)**; rowid-only projection; COUNT(*) untouched.
- [x] Live verification (`examples/compare_rowid_against_duckdb`) against 6 tables in a real DuckLake — 5 TPCH-shaped tables plus a 17-file 1.2M-row `vectors` stress table. Row-for-row match with DuckDB's native ducklake extension.
- [x] Live lifecycle (`examples/rowid_lifecycle`) against the same catalog: CREATE → INSERT ×2 → UPDATE (file rewrite) → DELETE one → DELETE all → DROP. All four read-after-mutate steps matched DuckDB exactly; UPDATE step specifically exercises the embedded `_ducklake_internal_row_id` path against real storage.
