### PR TITLE
fix(writer): align ducklake_column / ducklake_data_file schema with the DuckLake spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,12 +83,9 @@ jobs:
         run: cargo clippy --all-targets --all-features --no-deps -- -D warnings
 
       - name: Run tests
-        # `--features write-sqlite` is required to make the writer + sqlite-
-        # provider test suites visible to `cargo test`. Both test files are
-        # gated with `#![cfg(feature = "write-sqlite")]` /
-        # `#![cfg(feature = "metadata-sqlite")]`, so without these features
-        # cargo silently compiles them to zero-test binaries and any
-        # writer-schema regression slips through CI unnoticed.
+        # `write-sqlite` pulls in the writer and sqlite-provider tests,
+        # which are `#![cfg]`-gated; without it cargo compiles them to
+        # zero-test binaries.
         run: |
           if [[ "$RUNNER_OS" == "macOS" ]]; then
             cargo test --features "skip-tests-with-docker write-sqlite"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,10 +84,15 @@ jobs:
 
       - name: Run tests
         run: |
+          # Enable write-sqlite so tests/sql_write_tests.rs (gated on
+          # write-sqlite + metadata-sqlite) actually runs in CI. Without
+          # this, the file compiles to a zero-test binary and any
+          # writer-schema regression is invisible — see PR #115's
+          # post-merge debugging for the prior consequence.
           if [[ "$RUNNER_OS" == "macOS" ]]; then
-            cargo test --features skip-tests-with-docker
+            cargo test --features "skip-tests-with-docker write-sqlite"
           else
-            cargo test
+            cargo test --features "write-sqlite"
           fi
 
       - name: Check documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,12 +83,13 @@ jobs:
         run: cargo clippy --all-targets --all-features --no-deps -- -D warnings
 
       - name: Run tests
+        # `--features write-sqlite` is required to make the writer + sqlite-
+        # provider test suites visible to `cargo test`. Both test files are
+        # gated with `#![cfg(feature = "write-sqlite")]` /
+        # `#![cfg(feature = "metadata-sqlite")]`, so without these features
+        # cargo silently compiles them to zero-test binaries and any
+        # writer-schema regression slips through CI unnoticed.
         run: |
-          # Enable write-sqlite so tests/sql_write_tests.rs (gated on
-          # write-sqlite + metadata-sqlite) actually runs in CI. Without
-          # this, the file compiles to a zero-test binary and any
-          # writer-schema regression is invisible — see PR #115's
-          # post-merge debugging for the prior consequence.
           if [[ "$RUNNER_OS" == "macOS" ]]; then
             cargo test --features "skip-tests-with-docker write-sqlite"
           else

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -50,14 +50,11 @@ CREATE TABLE IF NOT EXISTS ducklake_column (
     column_type VARCHAR NOT NULL,
     column_order INTEGER NOT NULL,
     nulls_allowed BOOLEAN DEFAULT 1,
-    -- Columns below match the DuckLake spec (see
-    -- ducklake_metadata_manager.cpp upstream). We don't populate them
-    -- today (our writer doesn't support nested types or column defaults)
-    -- but their PRESENCE in the schema is required so the reader's
-    -- SQL_GET_TABLE_COLUMNS query — which projects `parent_column` —
-    -- doesn't fail on tables we wrote. Leaving the other four in for
-    -- compatibility with anything DuckDB or future reader code may
-    -- project from the same row.
+    -- Mirror the upstream DuckLake spec (ducklake_metadata_manager.cpp):
+    -- `parent_column` is projected by our reader's SQL_GET_TABLE_COLUMNS;
+    -- the four `*default*` columns are projected by DuckDB when it reads
+    -- catalogs we produce. We leave them NULL — no nested-type or
+    -- column-default writes yet.
     initial_default VARCHAR,
     default_value VARCHAR,
     parent_column INTEGER,

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -50,6 +50,19 @@ CREATE TABLE IF NOT EXISTS ducklake_column (
     column_type VARCHAR NOT NULL,
     column_order INTEGER NOT NULL,
     nulls_allowed BOOLEAN DEFAULT 1,
+    -- Columns below match the DuckLake spec (see
+    -- ducklake_metadata_manager.cpp upstream). We don't populate them
+    -- today (our writer doesn't support nested types or column defaults)
+    -- but their PRESENCE in the schema is required so the reader's
+    -- SQL_GET_TABLE_COLUMNS query — which projects `parent_column` —
+    -- doesn't fail on tables we wrote. Leaving the other four in for
+    -- compatibility with anything DuckDB or future reader code may
+    -- project from the same row.
+    initial_default VARCHAR,
+    default_value VARCHAR,
+    parent_column INTEGER,
+    default_value_type VARCHAR,
+    default_value_dialect VARCHAR,
     begin_snapshot INTEGER NOT NULL,
     end_snapshot INTEGER
 );

--- a/tests/sqlite_metadata_provider_test.rs
+++ b/tests/sqlite_metadata_provider_test.rs
@@ -68,10 +68,7 @@ async fn init_schema(pool: &SqlitePool) -> anyhow::Result<()> {
     .execute(pool)
     .await?;
 
-    // The five non-`column_id`/`table_id`/etc. columns below mirror the
-    // upstream DuckLake spec. The reader's SQL_GET_TABLE_COLUMNS query
-    // projects `parent_column`, so this fixture has to provide it or the
-    // metadata provider errors with "no such column".
+    // Schema must match SQL_CREATE_SCHEMA in metadata_writer_sqlite.rs.
     sqlx::query(
         "CREATE TABLE IF NOT EXISTS ducklake_column (
             column_id INTEGER PRIMARY KEY,
@@ -93,9 +90,6 @@ async fn init_schema(pool: &SqlitePool) -> anyhow::Result<()> {
     .execute(pool)
     .await?;
 
-    // `row_id_start` and `record_count` are projected by SQL_GET_DATA_FILES
-    // since the row-lineage work in PR #115. The fixture must surface them
-    // so the provider can hydrate `DuckLakeTableFile`.
     sqlx::query(
         "CREATE TABLE IF NOT EXISTS ducklake_data_file (
             data_file_id INTEGER PRIMARY KEY,

--- a/tests/sqlite_metadata_provider_test.rs
+++ b/tests/sqlite_metadata_provider_test.rs
@@ -68,6 +68,10 @@ async fn init_schema(pool: &SqlitePool) -> anyhow::Result<()> {
     .execute(pool)
     .await?;
 
+    // The five non-`column_id`/`table_id`/etc. columns below mirror the
+    // upstream DuckLake spec. The reader's SQL_GET_TABLE_COLUMNS query
+    // projects `parent_column`, so this fixture has to provide it or the
+    // metadata provider errors with "no such column".
     sqlx::query(
         "CREATE TABLE IF NOT EXISTS ducklake_column (
             column_id INTEGER PRIMARY KEY,
@@ -76,6 +80,11 @@ async fn init_schema(pool: &SqlitePool) -> anyhow::Result<()> {
             column_type TEXT NOT NULL,
             column_order INTEGER NOT NULL,
             nulls_allowed INTEGER,
+            initial_default TEXT,
+            default_value TEXT,
+            parent_column INTEGER,
+            default_value_type TEXT,
+            default_value_dialect TEXT,
             begin_snapshot INTEGER NOT NULL DEFAULT 1,
             end_snapshot INTEGER,
             FOREIGN KEY (table_id) REFERENCES ducklake_table(table_id)
@@ -84,6 +93,9 @@ async fn init_schema(pool: &SqlitePool) -> anyhow::Result<()> {
     .execute(pool)
     .await?;
 
+    // `row_id_start` and `record_count` are projected by SQL_GET_DATA_FILES
+    // since the row-lineage work in PR #115. The fixture must surface them
+    // so the provider can hydrate `DuckLakeTableFile`.
     sqlx::query(
         "CREATE TABLE IF NOT EXISTS ducklake_data_file (
             data_file_id INTEGER PRIMARY KEY,
@@ -93,6 +105,9 @@ async fn init_schema(pool: &SqlitePool) -> anyhow::Result<()> {
             file_size_bytes INTEGER NOT NULL,
             footer_size INTEGER,
             encryption_key TEXT,
+            record_count INTEGER,
+            row_id_start INTEGER,
+            mapping_id INTEGER,
             begin_snapshot INTEGER NOT NULL DEFAULT 1,
             end_snapshot INTEGER,
             FOREIGN KEY (table_id) REFERENCES ducklake_table(table_id)


### PR DESCRIPTION
## Summary

`SqliteMetadataWriter` was creating a `ducklake_column` table missing five columns the upstream DuckLake spec defines (notably `parent_column`). Since PR #89 added `parent_column` to the reader's `SQL_GET_TABLE_COLUMNS` query, any catalog written by `SqliteMetadataWriter` has been unreadable through the metadata provider, panicking with `no such column: parent_column`.

This shipped to main because CI ran `cargo test` without enabling `write-sqlite` / `metadata-sqlite`, so the two test suites that would have caught it (`tests/sql_write_tests.rs`, `tests/sqlite_metadata_provider_test.rs`) compiled to zero-test binaries.

## Changes

1. **`src/metadata_writer_sqlite.rs::SQL_CREATE_SCHEMA`** — add `parent_column`, `initial_default`, `default_value`, `default_value_type`, `default_value_dialect` to the `ducklake_column` CREATE TABLE. Matches the upstream schema in `ducklake_metadata_manager.cpp`. We don't populate the four `*_default*` columns today (we don't write nested types or column defaults), but they have to exist so the reader's query doesn't error.

2. **`tests/sqlite_metadata_provider_test.rs::init_schema`** — bring the in-test fixture in line with the same spec. Also adds `row_id_start`, `record_count`, and `mapping_id` on `ducklake_data_file` since `SQL_GET_DATA_FILES` projects them after the row-lineage work in PR #115.

3. **`.github/workflows/ci.yml`** — enable `write-sqlite` on the test step. Without this, the next analogous schema drift ships invisibly again.

## Test plan

- [x] `cargo test --features "skip-tests-with-docker write-sqlite"` — green across all suites. The 7 `sql_write_tests` (including the previously-broken `test_insert_into_read_only_fails`) and the 18 `sqlite_metadata_provider_test` cases all pass.
- [x] `cargo clippy --all-targets --all-features --no-deps -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.

## Out of scope (followups)

The encryption, postgres, and mysql test fixtures (`tests/encryption_tests.rs`, `tests/postgres_metadata_provider_test.rs`, `tests/mysql_metadata_provider_test.rs`) have analogous spec gaps — same missing columns on `ducklake_column`. They aren't blocking CI today because their features are still not enabled there. Worth a follow-up once those backends are set up in CI.
