### PR TITLE
  feat(multicatalog): Phase 1 Postgres multi-catalog support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,3 +85,7 @@ required-features = ["metadata-duckdb", "metadata-postgres"]
 [[example]]
 name = "rowid_lifecycle"
 required-features = ["metadata-duckdb", "metadata-postgres"]
+
+[[example]]
+name = "multicatalog_write"
+required-features = ["write-postgres"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,3 +72,6 @@ encryption = ["parquet/encryption", "datafusion/parquet_encryption", "dep:base64
 # Write support
 write = ["dep:uuid"]
 write-sqlite = ["write", "metadata-sqlite"]
+write-postgres = ["write", "metadata-postgres", "multicatalog-postgres"]
+# Multicatalog read provider (independent of write support)
+multicatalog-postgres = ["metadata-postgres"]

--- a/examples/multicatalog_write.rs
+++ b/examples/multicatalog_write.rs
@@ -1,0 +1,380 @@
+//! End-to-end demo of the multicatalog Postgres writer.
+//!
+//! Walks through:
+//! 1. Bootstrapping the catalog tables in Postgres
+//! 2. Creating two catalogs ("pg_prod", "mysql_prod")
+//! 3. Writing real Parquet data through each catalog via DuckLakeTableWriter
+//! 4. Dumping the resulting catalog rows so you can see multi-catalog isolation
+//! 5. Reading the Parquet files back through DataFusion to prove the data is real
+//!
+//! Usage:
+//!   cargo run --example multicatalog_write --no-default-features \
+//!     --features write-postgres,metadata-postgres -- <POSTGRES_URL> <DATA_DIR>
+//!
+//! Example:
+//!   cargo run --example multicatalog_write --no-default-features \
+//!     --features write-postgres,metadata-postgres -- \
+//!     "postgresql://postgres:postgres@127.0.0.1:55432/postgres" /tmp/ducklake-mc
+
+use std::sync::Arc;
+
+use arrow::array::{Float64Array, Int32Array, Int64Array, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use datafusion::execution::runtime_env::RuntimeEnv;
+use datafusion::prelude::*;
+use datafusion_ducklake::{
+    DuckLakeCatalog, DuckLakeTableWriter, MetadataProvider, MetadataWriter, MulticatalogManager,
+    MulticatalogProvider, PostgresMetadataWriter, initialize_multicatalog_schema,
+};
+use object_store::local::LocalFileSystem;
+use sqlx::Row;
+use sqlx::postgres::PgPoolOptions;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 3 {
+        eprintln!("Usage: {} <POSTGRES_URL> <DATA_DIR>", args[0]);
+        std::process::exit(1);
+    }
+    let pg_url = &args[1];
+    let data_dir = std::path::PathBuf::from(&args[2]);
+    std::fs::create_dir_all(&data_dir)?;
+    let data_dir_str = data_dir.canonicalize()?.to_string_lossy().to_string();
+
+    println!("== Multicatalog Postgres writer demo ==");
+    println!("postgres : {}", pg_url);
+    println!("data dir : {}", data_dir_str);
+    println!();
+
+    // ── Step 1: connect + bootstrap schema ────────────────────────────────────
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .connect(pg_url)
+        .await?;
+    initialize_multicatalog_schema(&pool).await?;
+    println!("✓ schema bootstrapped");
+
+    // ── Step 2: create catalogs ───────────────────────────────────────────────
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat_pg = mgr.create_catalog("pg_prod").await?;
+    let cat_mysql = mgr.create_catalog("mysql_prod").await?;
+    println!("✓ catalogs: pg_prod -> {}, mysql_prod -> {}", cat_pg, cat_mysql);
+
+    // ── Step 3: write through each catalog ────────────────────────────────────
+    let object_store: Arc<dyn object_store::ObjectStore> = Arc::new(LocalFileSystem::new());
+
+    // pg_prod.public.users
+    let writer_pg = Arc::new(PostgresMetadataWriter::with_pool(pool.clone(), cat_pg).await?);
+    writer_pg.set_data_path(&data_dir_str)?;
+    let users_batch = build_users_batch();
+    let tw_pg = DuckLakeTableWriter::new(writer_pg.clone(), Arc::clone(&object_store))?;
+    let users_result = tw_pg
+        .write_table("public", "users", std::slice::from_ref(&users_batch))
+        .await?;
+    println!(
+        "✓ wrote pg_prod.public.users — snapshot {}, file count {}, rows {}",
+        users_result.snapshot_id, users_result.files_written, users_result.records_written
+    );
+
+    // pg_prod.public.users again (DML, same schema) — should carry forward schema_version.
+    let users_dml = tw_pg
+        .write_table("public", "users", std::slice::from_ref(&users_batch))
+        .await?;
+    println!(
+        "✓ wrote pg_prod.public.users AGAIN (DML) — snapshot {}",
+        users_dml.snapshot_id
+    );
+
+    // mysql_prod.public.orders
+    let writer_mysql =
+        Arc::new(PostgresMetadataWriter::with_pool(pool.clone(), cat_mysql).await?);
+    let orders_batch = build_orders_batch();
+    let tw_mysql = DuckLakeTableWriter::new(writer_mysql.clone(), Arc::clone(&object_store))?;
+    let orders_result = tw_mysql
+        .write_table("public", "orders", std::slice::from_ref(&orders_batch))
+        .await?;
+    println!(
+        "✓ wrote mysql_prod.public.orders — snapshot {}, file count {}, rows {}",
+        orders_result.snapshot_id, orders_result.files_written, orders_result.records_written
+    );
+
+    // pg_prod.public.users with an added column — DDL, schema_version bumps.
+    let users_v2_batch = build_users_v2_batch();
+    let users_v2 = tw_pg
+        .write_table("public", "users", std::slice::from_ref(&users_v2_batch))
+        .await?;
+    println!(
+        "✓ wrote pg_prod.public.users WITH age column (DDL) — snapshot {}",
+        users_v2.snapshot_id
+    );
+
+    // ── Step 4: dump catalog state ────────────────────────────────────────────
+    println!();
+    println!("== Catalog state ==");
+    dump_query(
+        &pool,
+        "ducklake_catalog",
+        "SELECT catalog_id, catalog_name FROM ducklake_catalog ORDER BY catalog_id",
+    )
+    .await?;
+    dump_query(
+        &pool,
+        "ducklake_catalog_snapshot_map",
+        "SELECT catalog_id, snapshot_id FROM ducklake_catalog_snapshot_map ORDER BY catalog_id, snapshot_id",
+    )
+    .await?;
+    dump_query(
+        &pool,
+        "ducklake_catalog_schema_map",
+        "SELECT catalog_id, schema_id FROM ducklake_catalog_schema_map ORDER BY catalog_id",
+    )
+    .await?;
+    dump_query(
+        &pool,
+        "ducklake_snapshot",
+        "SELECT snapshot_id, schema_version FROM ducklake_snapshot ORDER BY snapshot_id",
+    )
+    .await?;
+    dump_query(
+        &pool,
+        "ducklake_schema",
+        "SELECT schema_id, schema_name, path, begin_snapshot, end_snapshot FROM ducklake_schema ORDER BY schema_id",
+    )
+    .await?;
+    dump_query(
+        &pool,
+        "ducklake_table",
+        "SELECT table_id, schema_id, table_name, begin_snapshot, end_snapshot FROM ducklake_table ORDER BY table_id",
+    )
+    .await?;
+    dump_query(
+        &pool,
+        "ducklake_schema_versions",
+        "SELECT begin_snapshot, schema_version, table_id FROM ducklake_schema_versions ORDER BY begin_snapshot",
+    )
+    .await?;
+    dump_query(
+        &pool,
+        "ducklake_data_file",
+        "SELECT data_file_id, table_id, path, record_count, begin_snapshot, end_snapshot FROM ducklake_data_file ORDER BY data_file_id",
+    )
+    .await?;
+
+    // ── Step 5: read back through the catalog layer ───────────────────────────
+    println!();
+    println!("== Reading via MulticatalogProvider + DuckLakeCatalog ==");
+    println!();
+
+    // Each catalog gets its own MulticatalogProvider and SessionContext, mimicking
+    // how RuntimeDB would isolate per-tenant connections.
+    read_via_multicatalog(&pool, "pg_prod", "users", "SELECT * FROM users ORDER BY id").await?;
+    read_via_multicatalog(
+        &pool,
+        "mysql_prod",
+        "orders",
+        "SELECT * FROM orders ORDER BY order_id",
+    )
+    .await?;
+
+    // Cross-check: pg_prod's catalog should NOT see "orders" (lives in mysql_prod).
+    println!("\n  -- cross-catalog leakage check (pg_prod must NOT see 'orders') --");
+    let cross = pg_prod_sees_orders(&pool).await?;
+    if cross {
+        println!("    LEAK! pg_prod can see mysql_prod's table");
+    } else {
+        println!("    ✓ pg_prod cannot see mysql_prod.orders — isolation works");
+    }
+
+    println!("\n✓ end-to-end demo complete");
+    Ok(())
+}
+
+async fn read_via_multicatalog(
+    pool: &sqlx::PgPool,
+    catalog_name: &str,
+    expected_table: &str,
+    sql: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!("\n  -- {} via MulticatalogProvider --", catalog_name);
+    let provider = MulticatalogProvider::with_pool(pool.clone(), catalog_name).await?;
+    let snapshot = provider.get_current_snapshot()?;
+    println!(
+        "    catalog_id={}, current snapshot={}",
+        provider.catalog_id(),
+        snapshot
+    );
+
+    let catalog = DuckLakeCatalog::with_snapshot(Arc::new(provider), snapshot)?;
+    let runtime = Arc::new(RuntimeEnv::default());
+    let config = SessionConfig::new().with_default_catalog_and_schema(catalog_name, "public");
+    let ctx = SessionContext::new_with_config_rt(config, runtime);
+    ctx.register_catalog(catalog_name, Arc::new(catalog));
+
+    // List what this catalog can see — should be exactly the one table.
+    if let Some(cat) = ctx.catalog(catalog_name) {
+        for schema_name in cat.schema_names() {
+            if schema_name == "information_schema" {
+                continue;
+            }
+            let schema = cat.schema(&schema_name).unwrap();
+            println!("    schema {} -> tables {:?}", schema_name, schema.table_names());
+        }
+    }
+
+    println!("    query: {}", sql);
+    let df = ctx.sql(sql).await?;
+    df.show().await?;
+    let _ = expected_table; // illustrative arg
+    Ok(())
+}
+
+async fn pg_prod_sees_orders(pool: &sqlx::PgPool) -> Result<bool, Box<dyn std::error::Error>> {
+    let provider = MulticatalogProvider::with_pool(pool.clone(), "pg_prod").await?;
+    let sn = provider.get_current_snapshot()?;
+    let catalog = DuckLakeCatalog::with_snapshot(Arc::new(provider), sn)?;
+    let ctx = SessionContext::new();
+    ctx.register_catalog("pg_prod", Arc::new(catalog));
+    let cat = ctx.catalog("pg_prod").unwrap();
+    let schema = match cat.schema("public") {
+        Some(s) => s,
+        None => return Ok(false),
+    };
+    Ok(schema.table_names().iter().any(|n| n == "orders"))
+}
+
+fn build_users_batch() -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("name", DataType::Utf8, true),
+    ]));
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3])),
+            Arc::new(StringArray::from(vec![
+                Some("Alice"),
+                Some("Bob"),
+                Some("Carol"),
+            ])),
+        ],
+    )
+    .unwrap()
+}
+
+fn build_users_v2_batch() -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("name", DataType::Utf8, true),
+        Field::new("age", DataType::Int32, true),
+    ]));
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3])),
+            Arc::new(StringArray::from(vec![
+                Some("Alice"),
+                Some("Bob"),
+                Some("Carol"),
+            ])),
+            Arc::new(Int32Array::from(vec![Some(30), Some(25), None])),
+        ],
+    )
+    .unwrap()
+}
+
+fn build_orders_batch() -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("order_id", DataType::Int64, false),
+        Field::new("amount", DataType::Float64, false),
+    ]));
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(vec![100, 101, 102])),
+            Arc::new(Float64Array::from(vec![19.99, 4.50, 250.00])),
+        ],
+    )
+    .unwrap()
+}
+
+async fn dump_query(
+    pool: &sqlx::PgPool,
+    label: &str,
+    sql: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!("\n  -- {} --", label);
+    let rows = sqlx::query(sql).fetch_all(pool).await?;
+    if rows.is_empty() {
+        println!("    (no rows)");
+        return Ok(());
+    }
+    // Print header from column names of the first row.
+    let header: Vec<String> = rows[0]
+        .columns()
+        .iter()
+        .map(|c| sqlx::Column::name(c).to_string())
+        .collect();
+    println!("    {}", header.join(" | "));
+    println!("    {}", "-".repeat(header.iter().map(|s| s.len()).sum::<usize>() + header.len() * 3));
+    for row in &rows {
+        let cols: Vec<String> = (0..row.len())
+            .map(|i| format_col(row, i))
+            .collect();
+        println!("    {}", cols.join(" | "));
+    }
+    Ok(())
+}
+
+fn format_col(row: &sqlx::postgres::PgRow, i: usize) -> String {
+    // Try a few common types; fall back to "<binary>".
+    if let Ok(v) = row.try_get::<Option<i64>, _>(i) {
+        return v.map(|x| x.to_string()).unwrap_or("NULL".into());
+    }
+    if let Ok(v) = row.try_get::<Option<i32>, _>(i) {
+        return v.map(|x| x.to_string()).unwrap_or("NULL".into());
+    }
+    if let Ok(v) = row.try_get::<Option<bool>, _>(i) {
+        return v.map(|x| x.to_string()).unwrap_or("NULL".into());
+    }
+    if let Ok(v) = row.try_get::<Option<String>, _>(i) {
+        return v.unwrap_or("NULL".into());
+    }
+    "<unprintable>".into()
+}
+
+#[allow(dead_code)]
+async fn visible_files_for_catalog(
+    pool: &sqlx::PgPool,
+    catalog_id: i64,
+    table_name: &str,
+) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    // Current snapshot for the catalog
+    let cur: i64 = sqlx::query(
+        "SELECT COALESCE(MAX(snapshot_id), 0) FROM ducklake_catalog_snapshot_map WHERE catalog_id = $1",
+    )
+    .bind(catalog_id)
+    .fetch_one(pool)
+    .await?
+    .try_get(0)?;
+
+    let rows = sqlx::query(
+        "SELECT f.path FROM ducklake_data_file f
+         JOIN ducklake_table t ON t.table_id = f.table_id
+         JOIN ducklake_schema s ON s.schema_id = t.schema_id
+         JOIN ducklake_catalog_schema_map m ON m.schema_id = s.schema_id
+         WHERE m.catalog_id = $1
+           AND t.table_name = $2
+           AND f.begin_snapshot <= $3
+           AND (f.end_snapshot IS NULL OR f.end_snapshot > $3)
+         ORDER BY f.path",
+    )
+    .bind(catalog_id)
+    .bind(table_name)
+    .bind(cur)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows.into_iter().map(|r| r.try_get(0).unwrap()).collect())
+}

--- a/examples/multicatalog_write.rs
+++ b/examples/multicatalog_write.rs
@@ -60,7 +60,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mgr = MulticatalogManager::new(pool.clone());
     let cat_pg = mgr.create_catalog("pg_prod").await?;
     let cat_mysql = mgr.create_catalog("mysql_prod").await?;
-    println!("✓ catalogs: pg_prod -> {}, mysql_prod -> {}", cat_pg, cat_mysql);
+    println!(
+        "✓ catalogs: pg_prod -> {}, mysql_prod -> {}",
+        cat_pg, cat_mysql
+    );
 
     // ── Step 3: write through each catalog ────────────────────────────────────
     let object_store: Arc<dyn object_store::ObjectStore> = Arc::new(LocalFileSystem::new());
@@ -88,8 +91,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // mysql_prod.public.orders
-    let writer_mysql =
-        Arc::new(PostgresMetadataWriter::with_pool(pool.clone(), cat_mysql).await?);
+    let writer_mysql = Arc::new(PostgresMetadataWriter::with_pool(pool.clone(), cat_mysql).await?);
     let orders_batch = build_orders_batch();
     let tw_mysql = DuckLakeTableWriter::new(writer_mysql.clone(), Arc::clone(&object_store))?;
     let orders_result = tw_mysql
@@ -219,7 +221,11 @@ async fn read_via_multicatalog(
                 continue;
             }
             let schema = cat.schema(&schema_name).unwrap();
-            println!("    schema {} -> tables {:?}", schema_name, schema.table_names());
+            println!(
+                "    schema {} -> tables {:?}",
+                schema_name,
+                schema.table_names()
+            );
         }
     }
 
@@ -317,11 +323,12 @@ async fn dump_query(
         .map(|c| sqlx::Column::name(c).to_string())
         .collect();
     println!("    {}", header.join(" | "));
-    println!("    {}", "-".repeat(header.iter().map(|s| s.len()).sum::<usize>() + header.len() * 3));
+    println!(
+        "    {}",
+        "-".repeat(header.iter().map(|s| s.len()).sum::<usize>() + header.len() * 3)
+    );
     for row in &rows {
-        let cols: Vec<String> = (0..row.len())
-            .map(|i| format_col(row, i))
-            .collect();
+        let cols: Vec<String> = (0..row.len()).map(|i| format_col(row, i)).collect();
         println!("    {}", cols.join(" | "));
     }
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,12 @@ pub mod insert_exec;
 pub mod metadata_writer;
 #[cfg(feature = "write-sqlite")]
 pub mod metadata_writer_sqlite;
+#[cfg(feature = "write-postgres")]
+pub mod metadata_writer_postgres;
+#[cfg(feature = "write-postgres")]
+pub mod multicatalog;
+#[cfg(feature = "multicatalog-postgres")]
+pub mod multicatalog_provider;
 #[cfg(feature = "write")]
 pub mod table_writer;
 
@@ -100,5 +106,11 @@ pub use metadata_writer::{
 };
 #[cfg(feature = "write-sqlite")]
 pub use metadata_writer_sqlite::SqliteMetadataWriter;
+#[cfg(feature = "write-postgres")]
+pub use metadata_writer_postgres::PostgresMetadataWriter;
+#[cfg(feature = "write-postgres")]
+pub use multicatalog::{MulticatalogManager, initialize_multicatalog_schema};
+#[cfg(feature = "multicatalog-postgres")]
+pub use multicatalog_provider::MulticatalogProvider;
 #[cfg(feature = "write")]
 pub use table_writer::{DuckLakeTableWriter, TableWriteSession};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,10 +66,10 @@ pub mod metadata_provider_sqlite;
 pub mod insert_exec;
 #[cfg(feature = "write")]
 pub mod metadata_writer;
-#[cfg(feature = "write-sqlite")]
-pub mod metadata_writer_sqlite;
 #[cfg(feature = "write-postgres")]
 pub mod metadata_writer_postgres;
+#[cfg(feature = "write-sqlite")]
+pub mod metadata_writer_sqlite;
 #[cfg(feature = "write-postgres")]
 pub mod multicatalog;
 #[cfg(feature = "multicatalog-postgres")]
@@ -105,10 +105,10 @@ pub use insert_exec::DuckLakeInsertExec;
 pub use metadata_writer::{
     ColumnDef, DataFileInfo, MetadataWriter, WriteMode, WriteResult, WriteSetupResult,
 };
-#[cfg(feature = "write-sqlite")]
-pub use metadata_writer_sqlite::SqliteMetadataWriter;
 #[cfg(feature = "write-postgres")]
 pub use metadata_writer_postgres::PostgresMetadataWriter;
+#[cfg(feature = "write-sqlite")]
+pub use metadata_writer_sqlite::SqliteMetadataWriter;
 #[cfg(feature = "write-postgres")]
 pub use multicatalog::{MulticatalogManager, initialize_multicatalog_schema};
 #[cfg(feature = "multicatalog-postgres")]

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -500,12 +500,11 @@ impl MetadataWriter for PostgresMetadataWriter {
 
     fn get_data_path(&self) -> Result<String> {
         block_on(async {
-            let row = sqlx::query(
-                "SELECT value FROM ducklake_metadata WHERE key = $1 AND scope IS NULL",
-            )
-            .bind("data_path")
-            .fetch_optional(&self.pool)
-            .await?;
+            let row =
+                sqlx::query("SELECT value FROM ducklake_metadata WHERE key = $1 AND scope IS NULL")
+                    .bind("data_path")
+                    .fetch_optional(&self.pool)
+                    .await?;
 
             match row {
                 Some(r) => Ok(r.try_get(0)?),
@@ -846,10 +845,8 @@ mod tests {
 
     #[test]
     fn test_columns_differ_identical() {
-        let existing = vec![
-            ("id".into(), "int64".into(), false),
-            ("name".into(), "varchar".into(), true),
-        ];
+        let existing =
+            vec![("id".into(), "int64".into(), false), ("name".into(), "varchar".into(), true)];
         let proposed = vec![
             ColumnDef::new("id", "int64", false).unwrap(),
             ColumnDef::new("name", "varchar", true).unwrap(),

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -1,0 +1,907 @@
+//! PostgreSQL implementation of [`MetadataWriter`], multicatalog-aware from day one.
+//!
+//! Each `PostgresMetadataWriter` instance is bound to a single `catalog_id`. All
+//! snapshot and schema inserts are paired with mapping-table inserts in the same
+//! transaction, so cross-catalog isolation is enforced at write time.
+//!
+//! Schema-version allocation is per-catalog dense: a writer computes the next
+//! `schema_version` under `FOR UPDATE` on the catalog's mapping rows, bumps on DDL
+//! (table create or column-set change), and carries forward on DML (Append/Replace
+//! with unchanged columns).
+
+use crate::Result;
+use crate::metadata_provider::block_on;
+use crate::metadata_writer::{
+    ColumnDef, DataFileInfo, MetadataWriter, WriteMode, WriteSetupResult, validate_name,
+};
+use sqlx::Row;
+use sqlx::postgres::{PgPool, PgPoolOptions};
+
+const DEFAULT_MAX_CONNECTIONS: u32 = 5;
+
+pub const DEFAULT_LOCK_TIMEOUT_MS: u32 = 30_000;
+
+/// Each standard DuckLake table as a separate CREATE TABLE IF NOT EXISTS.
+/// sqlx executes each `query()` as a single statement, so we split.
+pub(crate) const SQL_CREATE_STANDARD_TABLES: &[&str] = &[
+    r#"CREATE TABLE IF NOT EXISTS ducklake_metadata (
+        key VARCHAR NOT NULL,
+        value VARCHAR NOT NULL,
+        scope VARCHAR
+    )"#,
+    r#"CREATE TABLE IF NOT EXISTS ducklake_snapshot (
+        snapshot_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+        snapshot_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        schema_version BIGINT NOT NULL DEFAULT 0
+    )"#,
+    r#"CREATE TABLE IF NOT EXISTS ducklake_schema (
+        schema_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+        schema_name VARCHAR NOT NULL,
+        path VARCHAR NOT NULL DEFAULT '',
+        path_is_relative BOOLEAN NOT NULL DEFAULT TRUE,
+        begin_snapshot BIGINT NOT NULL,
+        end_snapshot BIGINT
+    )"#,
+    r#"CREATE TABLE IF NOT EXISTS ducklake_table (
+        table_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+        schema_id BIGINT NOT NULL,
+        table_name VARCHAR NOT NULL,
+        path VARCHAR NOT NULL DEFAULT '',
+        path_is_relative BOOLEAN NOT NULL DEFAULT TRUE,
+        begin_snapshot BIGINT NOT NULL,
+        end_snapshot BIGINT
+    )"#,
+    r#"CREATE TABLE IF NOT EXISTS ducklake_column (
+        column_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+        table_id BIGINT NOT NULL,
+        column_name VARCHAR NOT NULL,
+        column_type VARCHAR NOT NULL,
+        column_order BIGINT NOT NULL,
+        nulls_allowed BOOLEAN DEFAULT TRUE,
+        parent_column BIGINT,
+        begin_snapshot BIGINT NOT NULL,
+        end_snapshot BIGINT
+    )"#,
+    r#"CREATE TABLE IF NOT EXISTS ducklake_data_file (
+        data_file_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+        table_id BIGINT NOT NULL,
+        path VARCHAR NOT NULL,
+        path_is_relative BOOLEAN NOT NULL DEFAULT TRUE,
+        file_size_bytes BIGINT NOT NULL,
+        footer_size BIGINT,
+        encryption_key VARCHAR,
+        record_count BIGINT,
+        row_id_start BIGINT,
+        mapping_id BIGINT,
+        begin_snapshot BIGINT NOT NULL,
+        end_snapshot BIGINT
+    )"#,
+    r#"CREATE TABLE IF NOT EXISTS ducklake_delete_file (
+        delete_file_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+        data_file_id BIGINT NOT NULL,
+        table_id BIGINT NOT NULL,
+        path VARCHAR NOT NULL,
+        path_is_relative BOOLEAN NOT NULL DEFAULT TRUE,
+        file_size_bytes BIGINT NOT NULL,
+        footer_size BIGINT,
+        encryption_key VARCHAR,
+        delete_count BIGINT,
+        begin_snapshot BIGINT NOT NULL,
+        end_snapshot BIGINT
+    )"#,
+    // Idempotent guard: an existing single-catalog Postgres catalog populated by
+    // another tool may not have schema_version on ducklake_snapshot.
+    r#"ALTER TABLE ducklake_snapshot
+        ADD COLUMN IF NOT EXISTS schema_version BIGINT NOT NULL DEFAULT 0"#,
+];
+
+/// Multicatalog scaffolding tables. Always run after the standard tables.
+pub(crate) const SQL_CREATE_MULTICATALOG_TABLES: &[&str] = &[
+    r#"CREATE TABLE IF NOT EXISTS ducklake_catalog (
+        catalog_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+        catalog_name VARCHAR NOT NULL UNIQUE,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )"#,
+    r#"CREATE TABLE IF NOT EXISTS ducklake_catalog_snapshot_map (
+        catalog_id BIGINT NOT NULL,
+        snapshot_id BIGINT NOT NULL,
+        PRIMARY KEY (catalog_id, snapshot_id)
+    )"#,
+    r#"CREATE TABLE IF NOT EXISTS ducklake_catalog_schema_map (
+        catalog_id BIGINT NOT NULL,
+        schema_id BIGINT NOT NULL,
+        PRIMARY KEY (catalog_id, schema_id)
+    )"#,
+    r#"CREATE TABLE IF NOT EXISTS ducklake_schema_versions (
+        begin_snapshot BIGINT NOT NULL,
+        schema_version BIGINT NOT NULL,
+        table_id BIGINT NOT NULL,
+        UNIQUE (table_id, begin_snapshot)
+    )"#,
+    r#"CREATE INDEX IF NOT EXISTS idx_catalog_snapshot_map_snapshot
+        ON ducklake_catalog_snapshot_map(snapshot_id)"#,
+    r#"CREATE INDEX IF NOT EXISTS idx_catalog_schema_map_schema
+        ON ducklake_catalog_schema_map(schema_id)"#,
+    r#"CREATE INDEX IF NOT EXISTS idx_schema_versions_table
+        ON ducklake_schema_versions(table_id, begin_snapshot)"#,
+    // Belt-and-suspenders: app-level lock_catalog should already prevent
+    // duplicates, but a partial unique index catches anyone bypassing the
+    // writer (manual SQL, external migrations).
+    r#"CREATE UNIQUE INDEX IF NOT EXISTS idx_active_table_per_schema
+        ON ducklake_table(schema_id, table_name) WHERE end_snapshot IS NULL"#,
+];
+
+/// Run a slice of DDL statements against the pool. Each statement executes independently.
+pub(crate) async fn execute_ddl_statements(pool: &PgPool, statements: &[&str]) -> Result<()> {
+    for stmt in statements {
+        sqlx::query(stmt).execute(pool).await?;
+    }
+    Ok(())
+}
+
+/// PostgreSQL-based metadata writer for DuckLake catalogs.
+///
+/// Bound to a single `catalog_id` at construction. To write to a different
+/// catalog, construct a new writer with the desired `catalog_id`.
+#[derive(Debug, Clone)]
+pub struct PostgresMetadataWriter {
+    pool: PgPool,
+    catalog_id: i64,
+    lock_timeout_ms: u32,
+}
+
+impl PostgresMetadataWriter {
+    /// Bind a writer to the given pool and catalog id.
+    ///
+    /// Use [`crate::multicatalog::MulticatalogManager::create_catalog`] to obtain
+    /// or create a catalog id by name.
+    pub async fn with_pool(pool: PgPool, catalog_id: i64) -> Result<Self> {
+        Ok(Self {
+            pool,
+            catalog_id,
+            lock_timeout_ms: DEFAULT_LOCK_TIMEOUT_MS,
+        })
+    }
+
+    pub async fn new(connection_string: &str, catalog_id: i64) -> Result<Self> {
+        Self::with_max_connections(connection_string, catalog_id, DEFAULT_MAX_CONNECTIONS).await
+    }
+
+    pub async fn with_max_connections(
+        connection_string: &str,
+        catalog_id: i64,
+        max_connections: u32,
+    ) -> Result<Self> {
+        let pool = PgPoolOptions::new()
+            .max_connections(max_connections)
+            .connect(connection_string)
+            .await?;
+        Ok(Self {
+            pool,
+            catalog_id,
+            lock_timeout_ms: DEFAULT_LOCK_TIMEOUT_MS,
+        })
+    }
+
+    /// Sets the Postgres `lock_timeout` (ms) applied before `FOR UPDATE`.
+    /// `0` disables the timeout — not recommended for production.
+    pub fn with_lock_timeout(mut self, ms: u32) -> Self {
+        self.lock_timeout_ms = ms;
+        self
+    }
+
+    pub fn catalog_id(&self) -> i64 {
+        self.catalog_id
+    }
+}
+
+async fn lock_catalog(
+    catalog_id: i64,
+    lock_timeout_ms: u32,
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+) -> Result<()> {
+    if lock_timeout_ms > 0 {
+        sqlx::query(&format!("SET LOCAL lock_timeout = {}", lock_timeout_ms))
+            .execute(&mut **tx)
+            .await?;
+    }
+    let row =
+        sqlx::query("SELECT catalog_id FROM ducklake_catalog WHERE catalog_id = $1 FOR UPDATE")
+            .bind(catalog_id)
+            .fetch_optional(&mut **tx)
+            .await?;
+    if row.is_none() {
+        return Err(crate::DuckLakeError::CatalogNotFound(format!(
+            "catalog_id {}",
+            catalog_id
+        )));
+    }
+    Ok(())
+}
+
+async fn assert_schema_in_catalog(
+    catalog_id: i64,
+    schema_id: i64,
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+) -> Result<()> {
+    let row = sqlx::query(
+        "SELECT 1 FROM ducklake_catalog_schema_map
+         WHERE catalog_id = $1 AND schema_id = $2",
+    )
+    .bind(catalog_id)
+    .bind(schema_id)
+    .fetch_optional(&mut **tx)
+    .await?;
+    if row.is_none() {
+        return Err(crate::DuckLakeError::InvalidConfig(format!(
+            "schema_id {} does not belong to catalog_id {}",
+            schema_id, catalog_id
+        )));
+    }
+    Ok(())
+}
+
+async fn assert_table_in_catalog(
+    catalog_id: i64,
+    table_id: i64,
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+) -> Result<()> {
+    let row = sqlx::query(
+        "SELECT m.catalog_id FROM ducklake_table t
+         LEFT JOIN ducklake_catalog_schema_map m ON m.schema_id = t.schema_id
+         WHERE t.table_id = $1",
+    )
+    .bind(table_id)
+    .fetch_optional(&mut **tx)
+    .await?;
+    match row {
+        None => Err(crate::DuckLakeError::TableNotFound(format!(
+            "table_id {}",
+            table_id
+        ))),
+        Some(r) => {
+            let owner: Option<i64> = r.try_get(0)?;
+            if owner != Some(catalog_id) {
+                Err(crate::DuckLakeError::InvalidConfig(format!(
+                    "table_id {} does not belong to catalog_id {}",
+                    table_id, catalog_id
+                )))
+            } else {
+                Ok(())
+            }
+        },
+    }
+}
+
+impl MetadataWriter for PostgresMetadataWriter {
+    fn create_snapshot(&self) -> Result<i64> {
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+
+            let row = sqlx::query(
+                "INSERT INTO ducklake_snapshot (snapshot_time, schema_version)
+                 VALUES (CURRENT_TIMESTAMP, 0) RETURNING snapshot_id",
+            )
+            .fetch_one(&mut *tx)
+            .await?;
+            let snapshot_id: i64 = row.try_get(0)?;
+
+            sqlx::query(
+                "INSERT INTO ducklake_catalog_snapshot_map (catalog_id, snapshot_id)
+                 VALUES ($1, $2)",
+            )
+            .bind(self.catalog_id)
+            .bind(snapshot_id)
+            .execute(&mut *tx)
+            .await?;
+
+            tx.commit().await?;
+            Ok(snapshot_id)
+        })
+    }
+
+    fn get_or_create_schema(
+        &self,
+        name: &str,
+        path: Option<&str>,
+        snapshot_id: i64,
+    ) -> Result<(i64, bool)> {
+        validate_name(name, "Schema")?;
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
+
+            let existing = sqlx::query(
+                "SELECT s.schema_id FROM ducklake_schema s
+                 JOIN ducklake_catalog_schema_map m ON m.schema_id = s.schema_id
+                 WHERE m.catalog_id = $1 AND s.schema_name = $2 AND s.end_snapshot IS NULL",
+            )
+            .bind(self.catalog_id)
+            .bind(name)
+            .fetch_optional(&mut *tx)
+            .await?;
+
+            if let Some(row) = existing {
+                let id: i64 = row.try_get(0)?;
+                tx.commit().await?;
+                return Ok((id, false));
+            }
+
+            let schema_path = path.unwrap_or(name);
+            let row = sqlx::query(
+                "INSERT INTO ducklake_schema (schema_name, path, path_is_relative, begin_snapshot)
+                 VALUES ($1, $2, TRUE, $3) RETURNING schema_id",
+            )
+            .bind(name)
+            .bind(schema_path)
+            .bind(snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            let schema_id: i64 = row.try_get(0)?;
+
+            sqlx::query(
+                "INSERT INTO ducklake_catalog_schema_map (catalog_id, schema_id)
+                 VALUES ($1, $2)",
+            )
+            .bind(self.catalog_id)
+            .bind(schema_id)
+            .execute(&mut *tx)
+            .await?;
+
+            tx.commit().await?;
+            Ok((schema_id, true))
+        })
+    }
+
+    fn get_or_create_table(
+        &self,
+        schema_id: i64,
+        name: &str,
+        path: Option<&str>,
+        snapshot_id: i64,
+    ) -> Result<(i64, bool)> {
+        validate_name(name, "Table")?;
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
+            assert_schema_in_catalog(self.catalog_id, schema_id, &mut tx).await?;
+
+            let existing = sqlx::query(
+                "SELECT table_id FROM ducklake_table
+                 WHERE schema_id = $1 AND table_name = $2 AND end_snapshot IS NULL",
+            )
+            .bind(schema_id)
+            .bind(name)
+            .fetch_optional(&mut *tx)
+            .await?;
+
+            if let Some(row) = existing {
+                let id: i64 = row.try_get(0)?;
+                tx.commit().await?;
+                return Ok((id, false));
+            }
+
+            let table_path = path.unwrap_or(name);
+            let row = sqlx::query(
+                "INSERT INTO ducklake_table (schema_id, table_name, path, path_is_relative, begin_snapshot)
+                 VALUES ($1, $2, $3, TRUE, $4) RETURNING table_id",
+            )
+            .bind(schema_id)
+            .bind(name)
+            .bind(table_path)
+            .bind(snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            let id: i64 = row.try_get(0)?;
+
+            tx.commit().await?;
+            Ok((id, true))
+        })
+    }
+
+    fn set_columns(
+        &self,
+        table_id: i64,
+        columns: &[ColumnDef],
+        snapshot_id: i64,
+    ) -> Result<Vec<i64>> {
+        if columns.is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "Table must have at least one column".to_string(),
+            ));
+        }
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
+            assert_table_in_catalog(self.catalog_id, table_id, &mut tx).await?;
+
+            sqlx::query(
+                "UPDATE ducklake_column SET end_snapshot = $1
+                 WHERE table_id = $2 AND end_snapshot IS NULL",
+            )
+            .bind(snapshot_id)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+
+            let mut column_ids = Vec::with_capacity(columns.len());
+            for (order, col) in columns.iter().enumerate() {
+                let row = sqlx::query(
+                    "INSERT INTO ducklake_column (table_id, column_name, column_type, column_order, nulls_allowed, begin_snapshot)
+                     VALUES ($1, $2, $3, $4, $5, $6) RETURNING column_id",
+                )
+                .bind(table_id)
+                .bind(&col.name)
+                .bind(&col.ducklake_type)
+                .bind(order as i64)
+                .bind(col.is_nullable)
+                .bind(snapshot_id)
+                .fetch_one(&mut *tx)
+                .await?;
+                column_ids.push(row.try_get(0)?);
+            }
+
+            tx.commit().await?;
+            Ok(column_ids)
+        })
+    }
+
+    fn register_data_file(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+        file: &DataFileInfo,
+    ) -> Result<i64> {
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
+            assert_table_in_catalog(self.catalog_id, table_id, &mut tx).await?;
+
+            let row = sqlx::query(
+                "INSERT INTO ducklake_data_file (table_id, path, path_is_relative, file_size_bytes, footer_size, record_count, begin_snapshot)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING data_file_id",
+            )
+            .bind(table_id)
+            .bind(&file.path)
+            .bind(file.path_is_relative)
+            .bind(file.file_size_bytes)
+            .bind(file.footer_size)
+            .bind(file.record_count)
+            .bind(snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            let id: i64 = row.try_get(0)?;
+
+            tx.commit().await?;
+            Ok(id)
+        })
+    }
+
+    fn end_table_files(&self, table_id: i64, snapshot_id: i64) -> Result<u64> {
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
+            assert_table_in_catalog(self.catalog_id, table_id, &mut tx).await?;
+
+            let result = sqlx::query(
+                "UPDATE ducklake_data_file SET end_snapshot = $1
+                 WHERE table_id = $2 AND end_snapshot IS NULL",
+            )
+            .bind(snapshot_id)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            let n = result.rows_affected();
+
+            tx.commit().await?;
+            Ok(n)
+        })
+    }
+
+    fn get_data_path(&self) -> Result<String> {
+        block_on(async {
+            let row = sqlx::query(
+                "SELECT value FROM ducklake_metadata WHERE key = $1 AND scope IS NULL",
+            )
+            .bind("data_path")
+            .fetch_optional(&self.pool)
+            .await?;
+
+            match row {
+                Some(r) => Ok(r.try_get(0)?),
+                None => Err(crate::error::DuckLakeError::InvalidConfig(
+                    "Missing required catalog metadata: 'data_path' not configured.".to_string(),
+                )),
+            }
+        })
+    }
+
+    fn set_data_path(&self, path: &str) -> Result<()> {
+        // data_path is global per Phase 1. Reject silent overwrites — if it's
+        // already set to a different value, a concurrent tenant likely set it.
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+
+            let existing: Option<String> = sqlx::query(
+                "SELECT value FROM ducklake_metadata
+                 WHERE key = 'data_path' AND scope IS NULL FOR UPDATE",
+            )
+            .fetch_optional(&mut *tx)
+            .await?
+            .map(|r| r.try_get(0))
+            .transpose()?;
+
+            match existing {
+                Some(cur) if cur == path => {
+                    tx.commit().await?;
+                    return Ok(());
+                },
+                Some(cur) => {
+                    return Err(crate::error::DuckLakeError::InvalidConfig(format!(
+                        "data_path already set to {:?}, refusing to overwrite with {:?}",
+                        cur, path
+                    )));
+                },
+                None => {},
+            }
+
+            sqlx::query(
+                "INSERT INTO ducklake_metadata (key, value, scope)
+                 VALUES ('data_path', $1, NULL)",
+            )
+            .bind(path)
+            .execute(&mut *tx)
+            .await?;
+
+            tx.commit().await?;
+            Ok(())
+        })
+    }
+
+    fn initialize_schema(&self) -> Result<()> {
+        block_on(async {
+            execute_ddl_statements(&self.pool, SQL_CREATE_STANDARD_TABLES).await?;
+            execute_ddl_statements(&self.pool, SQL_CREATE_MULTICATALOG_TABLES).await?;
+            Ok(())
+        })
+    }
+
+    fn begin_write_transaction(
+        &self,
+        schema_name: &str,
+        table_name: &str,
+        columns: &[ColumnDef],
+        mode: WriteMode,
+    ) -> Result<WriteSetupResult> {
+        validate_name(schema_name, "Schema")?;
+        validate_name(table_name, "Table")?;
+        if columns.is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "Table must have at least one column".to_string(),
+            ));
+        }
+        let catalog_id = self.catalog_id;
+        let lock_timeout_ms = self.lock_timeout_ms;
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            lock_catalog(catalog_id, lock_timeout_ms, &mut tx).await?;
+
+            // schema_version is patched in below once we know it.
+            let row = sqlx::query(
+                "INSERT INTO ducklake_snapshot (snapshot_time, schema_version)
+                 VALUES (CURRENT_TIMESTAMP, 0) RETURNING snapshot_id",
+            )
+            .fetch_one(&mut *tx)
+            .await?;
+            let snapshot_id: i64 = row.try_get(0)?;
+
+            sqlx::query(
+                "INSERT INTO ducklake_catalog_snapshot_map (catalog_id, snapshot_id)
+                 VALUES ($1, $2)",
+            )
+            .bind(catalog_id)
+            .bind(snapshot_id)
+            .execute(&mut *tx)
+            .await?;
+
+            let schema_id: i64 = {
+                let existing = sqlx::query(
+                    "SELECT s.schema_id FROM ducklake_schema s
+                     JOIN ducklake_catalog_schema_map m ON m.schema_id = s.schema_id
+                     WHERE m.catalog_id = $1 AND s.schema_name = $2 AND s.end_snapshot IS NULL",
+                )
+                .bind(catalog_id)
+                .bind(schema_name)
+                .fetch_optional(&mut *tx)
+                .await?;
+
+                if let Some(row) = existing {
+                    row.try_get(0)?
+                } else {
+                    let row = sqlx::query(
+                        "INSERT INTO ducklake_schema (schema_name, path, path_is_relative, begin_snapshot)
+                         VALUES ($1, $2, TRUE, $3) RETURNING schema_id",
+                    )
+                    .bind(schema_name)
+                    .bind(schema_name)
+                    .bind(snapshot_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
+                    let id: i64 = row.try_get(0)?;
+
+                    sqlx::query(
+                        "INSERT INTO ducklake_catalog_schema_map (catalog_id, schema_id)
+                         VALUES ($1, $2)",
+                    )
+                    .bind(catalog_id)
+                    .bind(id)
+                    .execute(&mut *tx)
+                    .await?;
+
+                    id
+                }
+            };
+
+            let (table_id, table_was_created): (i64, bool) = {
+                let existing = sqlx::query(
+                    "SELECT table_id FROM ducklake_table
+                     WHERE schema_id = $1 AND table_name = $2 AND end_snapshot IS NULL",
+                )
+                .bind(schema_id)
+                .bind(table_name)
+                .fetch_optional(&mut *tx)
+                .await?;
+
+                if let Some(row) = existing {
+                    (row.try_get(0)?, false)
+                } else {
+                    let row = sqlx::query(
+                        "INSERT INTO ducklake_table (schema_id, table_name, path, path_is_relative, begin_snapshot)
+                         VALUES ($1, $2, $3, TRUE, $4) RETURNING table_id",
+                    )
+                    .bind(schema_id)
+                    .bind(table_name)
+                    .bind(table_name)
+                    .bind(snapshot_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
+                    (row.try_get(0)?, true)
+                }
+            };
+
+            // Fetch existing columns to drive (a) schema-evolution checks for Append,
+            // (b) DDL/DML classification.
+            let existing_column_rows = sqlx::query(
+                "SELECT column_name, column_type, nulls_allowed
+                 FROM ducklake_column
+                 WHERE table_id = $1 AND end_snapshot IS NULL
+                 ORDER BY column_order",
+            )
+            .bind(table_id)
+            .fetch_all(&mut *tx)
+            .await?;
+
+            let existing_columns: Vec<(String, String, bool)> = existing_column_rows
+                .iter()
+                .map(|row| {
+                    let name: String = row.try_get(0)?;
+                    let col_type: String = row.try_get(1)?;
+                    let nullable: bool = row.try_get::<Option<bool>, _>(2)?.unwrap_or(true);
+                    Ok::<_, sqlx::Error>((name, col_type, nullable))
+                })
+                .collect::<std::result::Result<_, _>>()?;
+
+            // Append-mode schema evolution validation (same rules as SQLite writer).
+            if mode == WriteMode::Append && !existing_columns.is_empty() {
+                use std::collections::HashMap;
+                let existing_map: HashMap<&str, (&str, bool)> = existing_columns
+                    .iter()
+                    .map(|(name, col_type, nullable)| {
+                        (name.as_str(), (col_type.as_str(), *nullable))
+                    })
+                    .collect();
+
+                for new_col in columns.iter() {
+                    if let Some((existing_type, _)) = existing_map.get(new_col.name.as_str()) {
+                        if !crate::types::types_compatible(existing_type, &new_col.ducklake_type) {
+                            return Err(crate::error::DuckLakeError::InvalidConfig(format!(
+                                "Schema evolution error: column '{}' has type '{}' in existing table but '{}' in new schema. Type changes are not allowed.",
+                                new_col.name, existing_type, new_col.ducklake_type
+                            )));
+                        }
+                    } else if !new_col.is_nullable {
+                        return Err(crate::error::DuckLakeError::InvalidConfig(format!(
+                            "Schema evolution error: new column '{}' must be nullable. Adding non-nullable columns is not allowed.",
+                            new_col.name
+                        )));
+                    }
+                }
+            }
+
+            // Classify DDL vs DML. DDL = first write (table just created) or the
+            // column set changed from what exists. DML = same schema, just data.
+            let is_ddl = table_was_created || columns_differ(&existing_columns, columns);
+
+            // Allocate schema_version under the catalog lock we already hold.
+            // Per spec: per-catalog dense; DDL bumps, DML carries forward.
+            let max_row = sqlx::query(
+                "SELECT COALESCE(MAX(s.schema_version), 0) FROM ducklake_snapshot s
+                 JOIN ducklake_catalog_snapshot_map m ON m.snapshot_id = s.snapshot_id
+                 WHERE m.catalog_id = $1 AND s.snapshot_id < $2",
+            )
+            .bind(catalog_id)
+            .bind(snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            let prev_max: i64 = max_row.try_get(0)?;
+            let new_schema_version = if is_ddl {
+                prev_max + 1
+            } else if prev_max == 0 {
+                // No prior snapshot for this catalog yet — even a DML-classified
+                // path needs a valid v1.
+                1
+            } else {
+                prev_max
+            };
+
+            sqlx::query("UPDATE ducklake_snapshot SET schema_version = $1 WHERE snapshot_id = $2")
+                .bind(new_schema_version)
+                .bind(snapshot_id)
+                .execute(&mut *tx)
+                .await?;
+
+            // End existing columns and insert the new set.
+            sqlx::query(
+                "UPDATE ducklake_column SET end_snapshot = $1
+                 WHERE table_id = $2 AND end_snapshot IS NULL",
+            )
+            .bind(snapshot_id)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+
+            let mut column_ids = Vec::with_capacity(columns.len());
+            for (order, col) in columns.iter().enumerate() {
+                let row = sqlx::query(
+                    "INSERT INTO ducklake_column (table_id, column_name, column_type, column_order, nulls_allowed, begin_snapshot)
+                     VALUES ($1, $2, $3, $4, $5, $6) RETURNING column_id",
+                )
+                .bind(table_id)
+                .bind(&col.name)
+                .bind(&col.ducklake_type)
+                .bind(order as i64)
+                .bind(col.is_nullable)
+                .bind(snapshot_id)
+                .fetch_one(&mut *tx)
+                .await?;
+                column_ids.push(row.try_get(0)?);
+            }
+
+            // Record a row in ducklake_schema_versions for every DDL — the
+            // UNIQUE(table_id, begin_snapshot) constraint ensures no duplicates.
+            if is_ddl {
+                sqlx::query(
+                    "INSERT INTO ducklake_schema_versions (begin_snapshot, schema_version, table_id)
+                     VALUES ($1, $2, $3)",
+                )
+                .bind(snapshot_id)
+                .bind(new_schema_version)
+                .bind(table_id)
+                .execute(&mut *tx)
+                .await?;
+            }
+
+            if mode == WriteMode::Replace {
+                sqlx::query(
+                    "UPDATE ducklake_data_file SET end_snapshot = $1
+                     WHERE table_id = $2 AND end_snapshot IS NULL",
+                )
+                .bind(snapshot_id)
+                .bind(table_id)
+                .execute(&mut *tx)
+                .await?;
+            }
+
+            tx.commit().await?;
+
+            Ok(WriteSetupResult {
+                snapshot_id,
+                schema_id,
+                table_id,
+                column_ids,
+            })
+        })
+    }
+}
+
+/// Return true when the existing column set differs from the proposed one in a
+/// way that requires a DDL bump: a different number of columns, a renamed
+/// column, a changed type, or a changed nullability.
+///
+/// Columns are compared positionally so a pure reorder counts as DDL — matches
+/// the conservative interpretation of the spec.
+fn columns_differ(existing: &[(String, String, bool)], proposed: &[ColumnDef]) -> bool {
+    if existing.len() != proposed.len() {
+        return true;
+    }
+    for ((ex_name, ex_type, ex_nullable), new_col) in existing.iter().zip(proposed.iter()) {
+        if ex_name != &new_col.name {
+            return true;
+        }
+        if !crate::types::types_compatible(ex_type, &new_col.ducklake_type) {
+            return true;
+        }
+        // Same-name same-compatible-type same-nullability ⇒ no DDL.
+        if *ex_nullable != new_col.is_nullable {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metadata_writer::ColumnDef;
+
+    #[test]
+    fn test_columns_differ_identical() {
+        let existing = vec![
+            ("id".into(), "int64".into(), false),
+            ("name".into(), "varchar".into(), true),
+        ];
+        let proposed = vec![
+            ColumnDef::new("id", "int64", false).unwrap(),
+            ColumnDef::new("name", "varchar", true).unwrap(),
+        ];
+        assert!(!columns_differ(&existing, &proposed));
+    }
+
+    #[test]
+    fn test_columns_differ_added_column() {
+        let existing = vec![("id".into(), "int64".into(), false)];
+        let proposed = vec![
+            ColumnDef::new("id", "int64", false).unwrap(),
+            ColumnDef::new("name", "varchar", true).unwrap(),
+        ];
+        assert!(columns_differ(&existing, &proposed));
+    }
+
+    #[test]
+    fn test_columns_differ_renamed_column() {
+        let existing = vec![("id".into(), "int64".into(), false)];
+        let proposed = vec![ColumnDef::new("user_id", "int64", false).unwrap()];
+        assert!(columns_differ(&existing, &proposed));
+    }
+
+    #[test]
+    fn test_columns_differ_type_change() {
+        let existing = vec![("id".into(), "int32".into(), false)];
+        let proposed = vec![ColumnDef::new("id", "varchar", false).unwrap()];
+        assert!(columns_differ(&existing, &proposed));
+    }
+
+    #[test]
+    fn test_columns_differ_type_widening_is_compatible() {
+        // int32 -> int64 is a safe promotion per types_compatible(); we treat
+        // that as the same column, no DDL bump needed.
+        let existing = vec![("id".into(), "int32".into(), false)];
+        let proposed = vec![ColumnDef::new("id", "int64", false).unwrap()];
+        assert!(!columns_differ(&existing, &proposed));
+    }
+
+    #[test]
+    fn test_columns_differ_nullability_change() {
+        let existing = vec![("id".into(), "int64".into(), false)];
+        let proposed = vec![ColumnDef::new("id", "int64", true).unwrap()];
+        assert!(columns_differ(&existing, &proposed));
+    }
+
+    #[test]
+    fn test_columns_differ_alias_canonical() {
+        // bigint and int64 normalize to the same canonical type.
+        let existing = vec![("id".into(), "bigint".into(), false)];
+        let proposed = vec![ColumnDef::new("id", "int64", false).unwrap()];
+        assert!(!columns_differ(&existing, &proposed));
+    }
+}

--- a/src/multicatalog.rs
+++ b/src/multicatalog.rs
@@ -10,10 +10,16 @@ use sqlx::postgres::PgPool;
 
 /// Bootstrap standard + multicatalog tables. Idempotent.
 pub async fn initialize_multicatalog_schema(pool: &PgPool) -> Result<()> {
-    execute_ddl_statements(pool, crate::metadata_writer_postgres::SQL_CREATE_STANDARD_TABLES)
-        .await?;
-    execute_ddl_statements(pool, crate::metadata_writer_postgres::SQL_CREATE_MULTICATALOG_TABLES)
-        .await?;
+    execute_ddl_statements(
+        pool,
+        crate::metadata_writer_postgres::SQL_CREATE_STANDARD_TABLES,
+    )
+    .await?;
+    execute_ddl_statements(
+        pool,
+        crate::metadata_writer_postgres::SQL_CREATE_MULTICATALOG_TABLES,
+    )
+    .await?;
     Ok(())
 }
 

--- a/src/multicatalog.rs
+++ b/src/multicatalog.rs
@@ -1,0 +1,105 @@
+//! Multicatalog manager: create, look up, and bootstrap DuckLake catalogs.
+//!
+//! See [`crate::metadata_writer_postgres::PostgresMetadataWriter`] for the writer
+//! that binds to a `catalog_id` produced here.
+
+use crate::Result;
+use crate::metadata_writer_postgres::execute_ddl_statements;
+use sqlx::Row;
+use sqlx::postgres::PgPool;
+
+/// Bootstrap standard + multicatalog tables. Idempotent.
+pub async fn initialize_multicatalog_schema(pool: &PgPool) -> Result<()> {
+    execute_ddl_statements(pool, crate::metadata_writer_postgres::SQL_CREATE_STANDARD_TABLES)
+        .await?;
+    execute_ddl_statements(pool, crate::metadata_writer_postgres::SQL_CREATE_MULTICATALOG_TABLES)
+        .await?;
+    Ok(())
+}
+
+/// Manages DuckLake catalogs within a shared metadata database.
+///
+/// `MulticatalogManager` is stateless: it just executes SQL against the pool.
+/// Multiple managers against the same pool are safe.
+#[derive(Debug, Clone)]
+pub struct MulticatalogManager {
+    pool: PgPool,
+}
+
+impl MulticatalogManager {
+    /// Construct a manager bound to a Postgres pool.
+    pub fn new(pool: PgPool) -> Self {
+        Self {
+            pool,
+        }
+    }
+
+    /// Create a catalog with the given name, returning its `catalog_id`.
+    /// Idempotent. Concurrency-safety relies on the `UNIQUE (catalog_name)`
+    /// constraint on `ducklake_catalog`.
+    pub async fn create_catalog(&self, name: &str) -> Result<i64> {
+        if name.trim().is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "Catalog name cannot be empty".to_string(),
+            ));
+        }
+
+        // Fast path: already exists.
+        if let Some(id) = self.find_catalog_id(name).await? {
+            return Ok(id);
+        }
+
+        // Try to insert; if a concurrent writer beat us, fall back to lookup.
+        let insert = sqlx::query(
+            "INSERT INTO ducklake_catalog (catalog_name) VALUES ($1)
+             ON CONFLICT (catalog_name) DO NOTHING
+             RETURNING catalog_id",
+        )
+        .bind(name)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        if let Some(row) = insert {
+            return Ok(row.try_get(0)?);
+        }
+
+        // Conflict: row exists from a concurrent writer. Look it up.
+        self.find_catalog_id(name).await?.ok_or_else(|| {
+            crate::DuckLakeError::Internal(format!(
+                "Catalog '{}' insert conflicted but lookup found nothing — \
+                 the row was inserted and then deleted concurrently",
+                name
+            ))
+        })
+    }
+
+    /// Look up a catalog by name, returning `None` if not found.
+    pub async fn find_catalog_id(&self, name: &str) -> Result<Option<i64>> {
+        let row = sqlx::query("SELECT catalog_id FROM ducklake_catalog WHERE catalog_name = $1")
+            .bind(name)
+            .fetch_optional(&self.pool)
+            .await?;
+
+        match row {
+            Some(r) => Ok(Some(r.try_get(0)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// List all catalogs as (id, name) pairs ordered by id.
+    pub async fn list_catalogs(&self) -> Result<Vec<(i64, String)>> {
+        let rows = sqlx::query(
+            "SELECT catalog_id, catalog_name FROM ducklake_catalog ORDER BY catalog_id",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            let id: i64 = row.try_get(0)?;
+            let name: String = row.try_get(1)?;
+            out.push((id, name));
+        }
+        Ok(out)
+    }
+}

--- a/src/multicatalog.rs
+++ b/src/multicatalog.rs
@@ -108,4 +108,142 @@ impl MulticatalogManager {
         }
         Ok(out)
     }
+
+    /// Drop a catalog and every metadata row owned by it.
+    ///
+    /// Removes the catalog row, its mapping-table entries, and every
+    /// entity reachable through those mappings: snapshots, schemas,
+    /// tables, columns, data and delete file records, schema-version
+    /// history. Idempotent — returns `false` if no catalog by that name
+    /// exists.
+    ///
+    /// # Concurrency
+    ///
+    /// The catalog row is taken with `FOR UPDATE` before any deletion,
+    /// so concurrent writers (which acquire the same lock in
+    /// `lock_catalog`) serialise against the drop. A 30s `lock_timeout`
+    /// bounds how long this waits for an in-progress writer to release
+    /// the lock — matches
+    /// [`crate::metadata_writer_postgres::DEFAULT_LOCK_TIMEOUT_MS`]. The
+    /// entire teardown is one transaction; either everything is gone
+    /// or nothing changes.
+    ///
+    /// # What's NOT cleaned up
+    ///
+    /// Data files on object storage are not removed here. Vacuum
+    /// reclaims them later, matching the crate's drop-without-commit
+    /// convention. Callers needing tighter storage cleanup should list
+    /// the data file paths before calling this and schedule their
+    /// removal externally.
+    pub async fn drop_catalog(&self, name: &str) -> Result<bool> {
+        if name.trim().is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "Catalog name cannot be empty".to_string(),
+            ));
+        }
+
+        let mut tx = self.pool.begin().await?;
+
+        sqlx::query("SET LOCAL lock_timeout = 30000")
+            .execute(&mut *tx)
+            .await?;
+
+        // Resolve catalog_id under FOR UPDATE. Concurrent writers (which
+        // also take FOR UPDATE on this row in `lock_catalog`) serialise
+        // against the drop. If the row has already been deleted by a
+        // parallel drop, we treat this call as a no-op.
+        let row = sqlx::query(
+            "SELECT catalog_id FROM ducklake_catalog
+             WHERE catalog_name = $1 FOR UPDATE",
+        )
+        .bind(name)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let catalog_id: i64 = match row {
+            Some(r) => r.try_get(0)?,
+            None => {
+                tx.commit().await?;
+                return Ok(false);
+            },
+        };
+
+        // Order matters: anything that reads through the catalog mapping
+        // tables must run before we delete those mapping rows. Within
+        // catalog-owned entities the order is rows-that-reference-
+        // `table_id` first, then tables, then schemas, then snapshots.
+
+        // Catalog-scoped child rows that reference `table_id`. Filtered
+        // transitively through the schema map so we only touch rows
+        // owned by this catalog.
+        for child_table in [
+            "ducklake_data_file",
+            "ducklake_delete_file",
+            "ducklake_column",
+            "ducklake_schema_versions",
+        ] {
+            sqlx::query(&format!(
+                "DELETE FROM {} WHERE table_id IN (
+                    SELECT t.table_id FROM ducklake_table t
+                    JOIN ducklake_catalog_schema_map m ON m.schema_id = t.schema_id
+                    WHERE m.catalog_id = $1
+                )",
+                child_table
+            ))
+            .bind(catalog_id)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        // Tables and schemas owned by this catalog.
+        sqlx::query(
+            "DELETE FROM ducklake_table WHERE schema_id IN (
+                SELECT schema_id FROM ducklake_catalog_schema_map WHERE catalog_id = $1
+            )",
+        )
+        .bind(catalog_id)
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "DELETE FROM ducklake_schema WHERE schema_id IN (
+                SELECT schema_id FROM ducklake_catalog_schema_map WHERE catalog_id = $1
+            )",
+        )
+        .bind(catalog_id)
+        .execute(&mut *tx)
+        .await?;
+
+        // Snapshots are catalog-scoped only via the snapshot map; they
+        // carry no catalog_id of their own, so the map is the only path
+        // to locate them.
+        sqlx::query(
+            "DELETE FROM ducklake_snapshot WHERE snapshot_id IN (
+                SELECT snapshot_id FROM ducklake_catalog_snapshot_map WHERE catalog_id = $1
+            )",
+        )
+        .bind(catalog_id)
+        .execute(&mut *tx)
+        .await?;
+
+        // Now safe to remove the mapping rows — nothing reads through
+        // them anymore.
+        sqlx::query("DELETE FROM ducklake_catalog_schema_map WHERE catalog_id = $1")
+            .bind(catalog_id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM ducklake_catalog_snapshot_map WHERE catalog_id = $1")
+            .bind(catalog_id)
+            .execute(&mut *tx)
+            .await?;
+
+        // Finally the catalog row itself.
+        sqlx::query("DELETE FROM ducklake_catalog WHERE catalog_id = $1")
+            .bind(catalog_id)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+        Ok(true)
+    }
 }

--- a/src/multicatalog_provider.rs
+++ b/src/multicatalog_provider.rs
@@ -1,0 +1,722 @@
+//! Catalog-scoped Postgres reader for DuckLake multicatalog.
+//!
+//! Bound to a single `catalog_id` at construction. All queries that touch
+//! catalog-discriminated entities (snapshots, schemas, top-level lists) join
+//! through `ducklake_catalog_snapshot_map` / `ducklake_catalog_schema_map`.
+//! Queries keyed by a globally unique id (`schema_id`, `table_id`) need no
+//! extra scoping because the caller already obtained the id through a
+//! catalog-scoped lookup.
+//!
+//! This implementation is standalone; it does not wrap
+//! [`crate::PostgresMetadataProvider`] — the existing single-catalog provider
+//! is untouched.
+
+use crate::Result;
+use crate::metadata_provider::{
+    ColumnWithTable, DataFileChange, DeleteFileChange, DuckLakeFileData, DuckLakeTableColumn,
+    DuckLakeTableFile, FileWithTable, MetadataProvider, SchemaMetadata, SnapshotMetadata,
+    TableMetadata, TableWithSchema, block_on, reconstruct_list_columns,
+    reconstruct_list_columns_with_table,
+};
+use sqlx::Row;
+use sqlx::postgres::{PgPool, PgPoolOptions};
+use sqlx::types::chrono::NaiveDateTime;
+
+const DEFAULT_MAX_CONNECTIONS: u32 = 5;
+
+/// Catalog-scoped Postgres metadata reader.
+///
+/// Construct with [`Self::with_pool`] (name-keyed; resolves to `catalog_id` once
+/// at construction) or [`Self::with_pool_and_id`] (id-keyed; skip the lookup).
+#[derive(Debug, Clone)]
+pub struct MulticatalogProvider {
+    pool: PgPool,
+    catalog_id: i64,
+}
+
+impl MulticatalogProvider {
+    /// Build a pool from a connection string, then resolve the catalog by name.
+    pub async fn new(connection_string: &str, catalog_name: &str) -> Result<Self> {
+        let pool = PgPoolOptions::new()
+            .max_connections(DEFAULT_MAX_CONNECTIONS)
+            .connect(connection_string)
+            .await?;
+        Self::with_pool(pool, catalog_name).await
+    }
+
+    /// Bind to an existing pool, resolving the catalog by name.
+    ///
+    /// Returns [`crate::DuckLakeError::CatalogNotFound`] if no row in
+    /// `ducklake_catalog` matches `catalog_name`.
+    pub async fn with_pool(pool: PgPool, catalog_name: &str) -> Result<Self> {
+        let row = sqlx::query("SELECT catalog_id FROM ducklake_catalog WHERE catalog_name = $1")
+            .bind(catalog_name)
+            .fetch_optional(&pool)
+            .await?;
+        let catalog_id: i64 = row
+            .ok_or_else(|| crate::DuckLakeError::CatalogNotFound(catalog_name.to_string()))?
+            .try_get(0)?;
+        Ok(Self {
+            pool,
+            catalog_id,
+        })
+    }
+
+    /// Bind to an existing pool with an already-known `catalog_id`. Skips the
+    /// name lookup. Caller is responsible for ensuring the id exists.
+    pub async fn with_pool_and_id(pool: PgPool, catalog_id: i64) -> Result<Self> {
+        Ok(Self {
+            pool,
+            catalog_id,
+        })
+    }
+
+    pub fn catalog_id(&self) -> i64 {
+        self.catalog_id
+    }
+}
+
+impl MetadataProvider for MulticatalogProvider {
+    fn get_current_snapshot(&self) -> Result<i64> {
+        block_on(async {
+            let row = sqlx::query(
+                "SELECT COALESCE(MAX(snapshot_id), 0)
+                 FROM ducklake_catalog_snapshot_map
+                 WHERE catalog_id = $1",
+            )
+            .bind(self.catalog_id)
+            .fetch_one(&self.pool)
+            .await?;
+            Ok(row.try_get(0)?)
+        })
+    }
+
+    fn get_data_path(&self) -> Result<String> {
+        // data_path is global per Phase 1 default.
+        block_on(async {
+            let row =
+                sqlx::query("SELECT value FROM ducklake_metadata WHERE key = $1 AND scope IS NULL")
+                    .bind("data_path")
+                    .fetch_optional(&self.pool)
+                    .await?;
+
+            match row {
+                Some(r) => Ok(r.try_get(0)?),
+                None => Err(crate::error::DuckLakeError::InvalidConfig(
+                    "Missing required catalog metadata: 'data_path' not configured. \
+                     The catalog may be uninitialized or corrupted."
+                        .to_string(),
+                )),
+            }
+        })
+    }
+
+    fn list_snapshots(&self) -> Result<Vec<SnapshotMetadata>> {
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT s.snapshot_id, s.snapshot_time
+                 FROM ducklake_snapshot s
+                 JOIN ducklake_catalog_snapshot_map m ON m.snapshot_id = s.snapshot_id
+                 WHERE m.catalog_id = $1
+                 ORDER BY s.snapshot_id",
+            )
+            .bind(self.catalog_id)
+            .fetch_all(&self.pool)
+            .await?;
+
+            rows.into_iter()
+                .map(|row| {
+                    let snapshot_id: i64 = row.try_get(0)?;
+                    let timestamp: Option<NaiveDateTime> = row.try_get(1)?;
+                    let timestamp_str =
+                        timestamp.map(|ts| ts.format("%Y-%m-%d %H:%M:%S%.6f").to_string());
+                    Ok(SnapshotMetadata {
+                        snapshot_id,
+                        timestamp: timestamp_str,
+                    })
+                })
+                .collect()
+        })
+    }
+
+    fn list_schemas(&self, snapshot_id: i64) -> Result<Vec<SchemaMetadata>> {
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT s.schema_id, s.schema_name, s.path, s.path_is_relative
+                 FROM ducklake_schema s
+                 JOIN ducklake_catalog_schema_map m ON m.schema_id = s.schema_id
+                 WHERE m.catalog_id = $1
+                   AND $2 >= s.begin_snapshot
+                   AND ($3 < s.end_snapshot OR s.end_snapshot IS NULL)",
+            )
+            .bind(self.catalog_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_all(&self.pool)
+            .await?;
+
+            rows.into_iter()
+                .map(|row| {
+                    Ok(SchemaMetadata {
+                        schema_id: row.try_get(0)?,
+                        schema_name: row.try_get(1)?,
+                        path: row.try_get(2)?,
+                        path_is_relative: row.try_get(3)?,
+                    })
+                })
+                .collect()
+        })
+    }
+
+    fn list_tables(&self, schema_id: i64, snapshot_id: i64) -> Result<Vec<TableMetadata>> {
+        // schema_id is globally unique; caller has already resolved it via
+        // get_schema_by_name (catalog-scoped). No additional scoping needed.
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT table_id, table_name, path, path_is_relative
+                 FROM ducklake_table
+                 WHERE schema_id = $1
+                   AND $2 >= begin_snapshot
+                   AND ($3 < end_snapshot OR end_snapshot IS NULL)",
+            )
+            .bind(schema_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_all(&self.pool)
+            .await?;
+
+            rows.into_iter()
+                .map(|row| {
+                    Ok(TableMetadata {
+                        table_id: row.try_get(0)?,
+                        table_name: row.try_get(1)?,
+                        path: row.try_get(2)?,
+                        path_is_relative: row.try_get(3)?,
+                    })
+                })
+                .collect()
+        })
+    }
+
+    fn get_table_structure(&self, table_id: i64) -> Result<Vec<DuckLakeTableColumn>> {
+        // Columns inherit catalog via table_id. No scoping.
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT column_id, column_name, column_type, nulls_allowed, parent_column
+                 FROM ducklake_column
+                 WHERE table_id = $1 AND end_snapshot IS NULL
+                 ORDER BY column_order",
+            )
+            .bind(table_id)
+            .fetch_all(&self.pool)
+            .await?;
+
+            let raw: Result<Vec<(DuckLakeTableColumn, Option<i64>)>> = rows
+                .into_iter()
+                .map(|row| {
+                    let nulls_allowed: Option<bool> = row.try_get(3)?;
+                    let parent_column: Option<i64> = row.try_get(4)?;
+                    Ok((
+                        DuckLakeTableColumn {
+                            column_id: row.try_get(0)?,
+                            column_name: row.try_get(1)?,
+                            column_type: row.try_get(2)?,
+                            is_nullable: nulls_allowed.unwrap_or(true),
+                        },
+                        parent_column,
+                    ))
+                })
+                .collect();
+            Ok(reconstruct_list_columns(raw?))
+        })
+    }
+
+    fn get_table_files_for_select(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+    ) -> Result<Vec<DuckLakeTableFile>> {
+        // Files inherit catalog via table_id. No scoping.
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT
+                    data.data_file_id,
+                    data.path AS data_file_path,
+                    data.path_is_relative AS data_path_is_relative,
+                    data.file_size_bytes AS data_file_size,
+                    data.footer_size AS data_footer_size,
+                    data.encryption_key AS data_encryption_key,
+                    del.delete_file_id,
+                    del.path AS delete_file_path,
+                    del.path_is_relative AS delete_path_is_relative,
+                    del.file_size_bytes AS delete_file_size,
+                    del.footer_size AS delete_footer_size,
+                    del.encryption_key AS delete_encryption_key,
+                    del.delete_count
+                FROM ducklake_data_file AS data
+                LEFT JOIN ducklake_delete_file AS del
+                    ON data.data_file_id = del.data_file_id
+                    AND del.table_id = $1
+                    AND $2 >= del.begin_snapshot
+                    AND ($3 < del.end_snapshot OR del.end_snapshot IS NULL)
+                WHERE data.table_id = $4
+                  AND $5 >= data.begin_snapshot
+                  AND ($6 < data.end_snapshot OR data.end_snapshot IS NULL)",
+            )
+            .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_all(&self.pool)
+            .await?;
+
+            rows.into_iter()
+                .map(|row| {
+                    let data_file = DuckLakeFileData {
+                        path: row.try_get(1)?,
+                        path_is_relative: row.try_get(2)?,
+                        file_size_bytes: row.try_get(3)?,
+                        footer_size: row.try_get(4)?,
+                        encryption_key: row.try_get(5)?,
+                    };
+
+                    let delete_file = if row.try_get::<Option<i64>, _>(6)?.is_some() {
+                        Some(DuckLakeFileData {
+                            path: row.try_get(7)?,
+                            path_is_relative: row.try_get(8)?,
+                            file_size_bytes: row.try_get(9)?,
+                            footer_size: row.try_get(10)?,
+                            encryption_key: row.try_get(11)?,
+                        })
+                    } else {
+                        None
+                    };
+
+                    Ok(DuckLakeTableFile {
+                        file: data_file,
+                        delete_file,
+                        row_id_start: None,
+                        snapshot_id: None,
+                        max_row_count: None,
+                    })
+                })
+                .collect()
+        })
+    }
+
+    fn get_schema_by_name(&self, name: &str, snapshot_id: i64) -> Result<Option<SchemaMetadata>> {
+        block_on(async {
+            let row = sqlx::query(
+                "SELECT s.schema_id, s.schema_name, s.path, s.path_is_relative
+                 FROM ducklake_schema s
+                 JOIN ducklake_catalog_schema_map m ON m.schema_id = s.schema_id
+                 WHERE m.catalog_id = $1
+                   AND s.schema_name = $2
+                   AND $3 >= s.begin_snapshot
+                   AND ($4 < s.end_snapshot OR s.end_snapshot IS NULL)",
+            )
+            .bind(self.catalog_id)
+            .bind(name)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_optional(&self.pool)
+            .await?;
+
+            match row {
+                Some(r) => Ok(Some(SchemaMetadata {
+                    schema_id: r.try_get(0)?,
+                    schema_name: r.try_get(1)?,
+                    path: r.try_get(2)?,
+                    path_is_relative: r.try_get(3)?,
+                })),
+                None => Ok(None),
+            }
+        })
+    }
+
+    fn get_table_by_name(
+        &self,
+        schema_id: i64,
+        name: &str,
+        snapshot_id: i64,
+    ) -> Result<Option<TableMetadata>> {
+        // schema_id catalog-scoped by caller.
+        block_on(async {
+            let row = sqlx::query(
+                "SELECT table_id, table_name, path, path_is_relative
+                 FROM ducklake_table
+                 WHERE schema_id = $1
+                   AND table_name = $2
+                   AND $3 >= begin_snapshot
+                   AND ($4 < end_snapshot OR end_snapshot IS NULL)",
+            )
+            .bind(schema_id)
+            .bind(name)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_optional(&self.pool)
+            .await?;
+
+            match row {
+                Some(r) => Ok(Some(TableMetadata {
+                    table_id: r.try_get(0)?,
+                    table_name: r.try_get(1)?,
+                    path: r.try_get(2)?,
+                    path_is_relative: r.try_get(3)?,
+                })),
+                None => Ok(None),
+            }
+        })
+    }
+
+    fn table_exists(&self, schema_id: i64, name: &str, snapshot_id: i64) -> Result<bool> {
+        block_on(async {
+            let row = sqlx::query(
+                "SELECT EXISTS(
+                    SELECT 1 FROM ducklake_table
+                    WHERE schema_id = $1
+                      AND table_name = $2
+                      AND $3 >= begin_snapshot
+                      AND ($4 < end_snapshot OR end_snapshot IS NULL)
+                 )",
+            )
+            .bind(schema_id)
+            .bind(name)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_one(&self.pool)
+            .await?;
+            Ok(row.try_get(0)?)
+        })
+    }
+
+    fn list_all_tables(&self, snapshot_id: i64) -> Result<Vec<TableWithSchema>> {
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT s.schema_name, t.table_id, t.table_name, t.path, t.path_is_relative
+                 FROM ducklake_schema s
+                 JOIN ducklake_catalog_schema_map m ON m.schema_id = s.schema_id
+                 JOIN ducklake_table t ON s.schema_id = t.schema_id
+                 WHERE m.catalog_id = $1
+                   AND $2 >= s.begin_snapshot
+                   AND ($3 < s.end_snapshot OR s.end_snapshot IS NULL)
+                   AND $4 >= t.begin_snapshot
+                   AND ($5 < t.end_snapshot OR t.end_snapshot IS NULL)
+                 ORDER BY s.schema_name, t.table_name",
+            )
+            .bind(self.catalog_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_all(&self.pool)
+            .await?;
+
+            rows.into_iter()
+                .map(|row| {
+                    let schema_name: String = row.try_get(0)?;
+                    let table = TableMetadata {
+                        table_id: row.try_get(1)?,
+                        table_name: row.try_get(2)?,
+                        path: row.try_get(3)?,
+                        path_is_relative: row.try_get(4)?,
+                    };
+                    Ok(TableWithSchema {
+                        schema_name,
+                        table,
+                    })
+                })
+                .collect()
+        })
+    }
+
+    fn list_all_columns(&self, snapshot_id: i64) -> Result<Vec<ColumnWithTable>> {
+        // Note: unlike the single-catalog PostgresMetadataProvider, this filters
+        // columns by snapshot range as well — needed for multicatalog because we
+        // accumulate column history across catalogs and would otherwise return
+        // ended columns alongside current ones.
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT s.schema_name, t.table_name, c.column_id, c.column_name, c.column_type,
+                        c.nulls_allowed, c.parent_column
+                 FROM ducklake_schema s
+                 JOIN ducklake_catalog_schema_map m ON m.schema_id = s.schema_id
+                 JOIN ducklake_table t ON s.schema_id = t.schema_id
+                 JOIN ducklake_column c ON t.table_id = c.table_id
+                 WHERE m.catalog_id = $1
+                   AND $2 >= s.begin_snapshot
+                   AND ($3 < s.end_snapshot OR s.end_snapshot IS NULL)
+                   AND $4 >= t.begin_snapshot
+                   AND ($5 < t.end_snapshot OR t.end_snapshot IS NULL)
+                   AND $6 >= c.begin_snapshot
+                   AND ($7 < c.end_snapshot OR c.end_snapshot IS NULL)
+                 ORDER BY s.schema_name, t.table_name, c.column_order",
+            )
+            .bind(self.catalog_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_all(&self.pool)
+            .await?;
+
+            let raw: Result<Vec<(ColumnWithTable, Option<i64>)>> = rows
+                .into_iter()
+                .map(|row| {
+                    let schema_name: String = row.try_get(0)?;
+                    let table_name: String = row.try_get(1)?;
+                    let nulls_allowed: Option<bool> = row.try_get(5)?;
+                    let parent_column: Option<i64> = row.try_get(6)?;
+                    let column = DuckLakeTableColumn {
+                        column_id: row.try_get(2)?,
+                        column_name: row.try_get(3)?,
+                        column_type: row.try_get(4)?,
+                        is_nullable: nulls_allowed.unwrap_or(true),
+                    };
+                    Ok((
+                        ColumnWithTable {
+                            schema_name,
+                            table_name,
+                            column,
+                        },
+                        parent_column,
+                    ))
+                })
+                .collect();
+            Ok(reconstruct_list_columns_with_table(raw?))
+        })
+    }
+
+    fn list_all_files(&self, snapshot_id: i64) -> Result<Vec<FileWithTable>> {
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT
+                    s.schema_name,
+                    t.table_name,
+                    data.data_file_id,
+                    data.path AS data_file_path,
+                    data.path_is_relative AS data_path_is_relative,
+                    data.file_size_bytes AS data_file_size,
+                    data.footer_size AS data_footer_size,
+                    data.encryption_key AS data_encryption_key,
+                    del.delete_file_id,
+                    del.path AS delete_file_path,
+                    del.path_is_relative AS delete_path_is_relative,
+                    del.file_size_bytes AS delete_file_size,
+                    del.footer_size AS delete_footer_size,
+                    del.encryption_key AS delete_encryption_key,
+                    del.delete_count
+                FROM ducklake_schema s
+                JOIN ducklake_catalog_schema_map m ON m.schema_id = s.schema_id
+                JOIN ducklake_table t ON s.schema_id = t.schema_id
+                JOIN ducklake_data_file data ON t.table_id = data.table_id
+                LEFT JOIN ducklake_delete_file del
+                    ON data.data_file_id = del.data_file_id
+                    AND del.table_id = t.table_id
+                    AND $1 >= del.begin_snapshot
+                    AND ($2 < del.end_snapshot OR del.end_snapshot IS NULL)
+                WHERE m.catalog_id = $3
+                  AND $4 >= s.begin_snapshot
+                  AND ($5 < s.end_snapshot OR s.end_snapshot IS NULL)
+                  AND $6 >= t.begin_snapshot
+                  AND ($7 < t.end_snapshot OR t.end_snapshot IS NULL)
+                  AND $8 >= data.begin_snapshot
+                  AND ($9 < data.end_snapshot OR data.end_snapshot IS NULL)
+                ORDER BY s.schema_name, t.table_name, data.path",
+            )
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .bind(self.catalog_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_all(&self.pool)
+            .await?;
+
+            rows.into_iter()
+                .map(|row| {
+                    let data_file = DuckLakeFileData {
+                        path: row.try_get(3)?,
+                        path_is_relative: row.try_get(4)?,
+                        file_size_bytes: row.try_get(5)?,
+                        footer_size: row.try_get(6)?,
+                        encryption_key: row.try_get(7)?,
+                    };
+                    let delete_file = if row.try_get::<Option<i64>, _>(8)?.is_some() {
+                        Some(DuckLakeFileData {
+                            path: row.try_get(9)?,
+                            path_is_relative: row.try_get(10)?,
+                            file_size_bytes: row.try_get(11)?,
+                            footer_size: row.try_get(12)?,
+                            encryption_key: row.try_get(13)?,
+                        })
+                    } else {
+                        None
+                    };
+                    Ok(FileWithTable {
+                        schema_name: row.try_get(0)?,
+                        table_name: row.try_get(1)?,
+                        file: DuckLakeTableFile {
+                            file: data_file,
+                            delete_file,
+                            row_id_start: None,
+                            snapshot_id: None,
+                            max_row_count: row.try_get(14)?,
+                        },
+                    })
+                })
+                .collect()
+        })
+    }
+
+    fn get_data_files_added_between_snapshots(
+        &self,
+        table_id: i64,
+        start_snapshot: i64,
+        end_snapshot: i64,
+    ) -> Result<Vec<DataFileChange>> {
+        // CDC inherits catalog via table_id. No additional scoping.
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT
+                    data.begin_snapshot,
+                    data.path,
+                    data.path_is_relative,
+                    data.file_size_bytes,
+                    data.footer_size,
+                    data.encryption_key
+                FROM ducklake_data_file AS data
+                WHERE data.table_id = $1
+                  AND data.begin_snapshot > $2
+                  AND data.begin_snapshot <= $3
+                ORDER BY data.begin_snapshot",
+            )
+            .bind(table_id)
+            .bind(start_snapshot)
+            .bind(end_snapshot)
+            .fetch_all(&self.pool)
+            .await?;
+
+            rows.into_iter()
+                .map(|row| {
+                    Ok(DataFileChange {
+                        begin_snapshot: row.try_get(0)?,
+                        path: row.try_get(1)?,
+                        path_is_relative: row.try_get(2)?,
+                        file_size_bytes: row.try_get(3)?,
+                        footer_size: row.try_get(4)?,
+                        encryption_key: row.try_get(5)?,
+                    })
+                })
+                .collect()
+        })
+    }
+
+    fn get_delete_files_added_between_snapshots(
+        &self,
+        table_id: i64,
+        start_snapshot: i64,
+        end_snapshot: i64,
+    ) -> Result<Vec<DeleteFileChange>> {
+        // Same shape as the single-catalog PostgresMetadataProvider — inherits
+        // catalog via table_id.
+        block_on(async {
+            let rows = sqlx::query(
+                r#"
+WITH current_delete AS (
+    SELECT
+        ddf.data_file_id,
+        ddf.begin_snapshot,
+        ddf.path,
+        ddf.path_is_relative,
+        ddf.file_size_bytes,
+        ddf.footer_size,
+        ddf.encryption_key
+    FROM ducklake_delete_file ddf
+    WHERE ddf.table_id = $1
+      AND ddf.begin_snapshot > $2
+      AND ddf.begin_snapshot <= $3
+),
+data_files AS (
+    SELECT df.*
+    FROM ducklake_data_file df
+    WHERE df.table_id = $1
+)
+SELECT
+    data.path, data.path_is_relative, data.file_size_bytes, data.footer_size,
+    data.row_id_start, data.record_count, data.mapping_id,
+    current_delete.path, current_delete.path_is_relative,
+    current_delete.file_size_bytes, current_delete.footer_size,
+    prev.path, prev.path_is_relative, prev.file_size_bytes, prev.footer_size,
+    current_delete.begin_snapshot
+FROM current_delete
+JOIN data_files data USING (data_file_id)
+LEFT JOIN LATERAL (
+    SELECT ddf.path, ddf.path_is_relative, ddf.file_size_bytes, ddf.footer_size
+    FROM ducklake_delete_file ddf
+    WHERE ddf.table_id = $1
+      AND ddf.data_file_id = current_delete.data_file_id
+      AND ddf.begin_snapshot < current_delete.begin_snapshot
+    ORDER BY ddf.begin_snapshot DESC
+    LIMIT 1
+) prev ON true
+UNION ALL
+SELECT
+    data.path, data.path_is_relative, data.file_size_bytes, data.footer_size,
+    data.row_id_start, data.record_count, data.mapping_id,
+    NULL::VARCHAR, NULL::BOOLEAN, NULL::BIGINT, NULL::BIGINT,
+    prev.path, prev.path_is_relative, prev.file_size_bytes, prev.footer_size,
+    data.end_snapshot
+FROM ducklake_data_file data
+LEFT JOIN LATERAL (
+    SELECT ddf.path, ddf.path_is_relative, ddf.file_size_bytes, ddf.footer_size
+    FROM ducklake_delete_file ddf
+    WHERE ddf.table_id = $1
+      AND ddf.data_file_id = data.data_file_id
+      AND ddf.begin_snapshot < data.end_snapshot
+    ORDER BY ddf.begin_snapshot DESC
+    LIMIT 1
+) prev ON true
+WHERE data.table_id = $1
+  AND data.end_snapshot > $2
+  AND data.end_snapshot <= $3
+"#,
+            )
+            .bind(table_id)
+            .bind(start_snapshot)
+            .bind(end_snapshot)
+            .fetch_all(&self.pool)
+            .await?;
+
+            rows.into_iter()
+                .map(|row| {
+                    Ok(DeleteFileChange {
+                        data_file_path: row.try_get(0)?,
+                        data_file_path_is_relative: row.try_get(1)?,
+                        data_file_size_bytes: row.try_get(2)?,
+                        data_file_footer_size: row.try_get(3)?,
+                        data_row_id_start: row.try_get(4)?,
+                        data_record_count: row.try_get(5)?,
+                        data_mapping_id: row.try_get(6)?,
+                        current_delete_path: row.try_get(7)?,
+                        current_delete_path_is_relative: row.try_get(8)?,
+                        current_delete_file_size_bytes: row.try_get(9)?,
+                        current_delete_footer_size: row.try_get(10)?,
+                        previous_delete_path: row.try_get(11)?,
+                        previous_delete_path_is_relative: row.try_get(12)?,
+                        previous_delete_file_size_bytes: row.try_get(13)?,
+                        previous_delete_footer_size: row.try_get(14)?,
+                        snapshot_id: row.try_get(15)?,
+                    })
+                })
+                .collect()
+        })
+    }
+}

--- a/tests/multicatalog_hardening_tests.rs
+++ b/tests/multicatalog_hardening_tests.rs
@@ -1,0 +1,474 @@
+#![cfg(feature = "write-postgres")]
+//! Hardening tests for the multicatalog Postgres writer.
+//!
+//! Covers the correctness gaps called out in PR review:
+//! - Concurrent `get_or_create_schema` cannot create duplicate schemas
+//! - Concurrent `get_or_create_table` cannot create duplicate tables
+//! - Cross-catalog `register_data_file` is rejected
+//! - Cross-catalog `end_table_files` is rejected
+//! - Cross-catalog `set_columns` is rejected
+//! - `get_or_create_table` rejects schema_id from a different catalog
+//! - All writers serialize per catalog but run in parallel across catalogs
+
+use std::sync::Arc;
+
+use datafusion_ducklake::metadata_writer::{
+    ColumnDef, DataFileInfo, MetadataWriter, WriteMode,
+};
+use datafusion_ducklake::{
+    MulticatalogManager, PostgresMetadataWriter, initialize_multicatalog_schema,
+};
+use sqlx::Row;
+use sqlx::postgres::{PgPool, PgPoolOptions};
+use testcontainers::ContainerAsync;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+async fn spin_up_postgres() -> anyhow::Result<(PgPool, ContainerAsync<Postgres>)> {
+    let container = Postgres::default().start().await?;
+    let port = container.get_host_port_ipv4(5432).await?;
+    let conn = format!("postgresql://postgres:postgres@127.0.0.1:{}/postgres", port);
+    let pool = PgPoolOptions::new()
+        // Need >=N+1 connections for N concurrent writers + this test's queries
+        .max_connections(20)
+        .connect(&conn)
+        .await?;
+    initialize_multicatalog_schema(&pool).await?;
+    Ok((pool, container))
+}
+
+fn users_cols() -> Vec<ColumnDef> {
+    vec![
+        ColumnDef::new("id", "int64", false).unwrap(),
+        ColumnDef::new("name", "varchar", true).unwrap(),
+    ]
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn concurrent_get_or_create_schema_no_duplicates() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let catalog_id = mgr.create_catalog("pg_prod").await.unwrap();
+    let writer = Arc::new(
+        PostgresMetadataWriter::with_pool(pool.clone(), catalog_id)
+            .await
+            .unwrap(),
+    );
+
+    // Allocate a snapshot they all share so the schema row inserts have a valid begin_snapshot.
+    let snapshot_id = writer.create_snapshot().unwrap();
+
+    // 10 concurrent writers all racing to create a schema with the same name.
+    let mut handles = Vec::new();
+    for _ in 0..10 {
+        let w = Arc::clone(&writer);
+        handles.push(tokio::task::spawn_blocking(move || {
+            w.get_or_create_schema("racy", None, snapshot_id)
+        }));
+    }
+
+    let mut ids = Vec::new();
+    let mut created_count = 0;
+    for h in handles {
+        let (id, was_created) = h.await.unwrap().unwrap();
+        ids.push(id);
+        if was_created {
+            created_count += 1;
+        }
+    }
+
+    // All callers should see the SAME schema_id, exactly one should report "created".
+    let first = ids[0];
+    assert!(
+        ids.iter().all(|&x| x == first),
+        "all callers must see the same schema_id, got {:?}",
+        ids
+    );
+    assert_eq!(created_count, 1, "exactly one writer should report was_created");
+
+    // And the catalog only has one schema row.
+    let n: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_schema s
+         JOIN ducklake_catalog_schema_map m ON m.schema_id = s.schema_id
+         WHERE m.catalog_id = $1 AND s.schema_name = 'racy'",
+    )
+    .bind(catalog_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap();
+    assert_eq!(n, 1, "should be exactly one 'racy' schema row");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn concurrent_get_or_create_table_no_duplicates() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let catalog_id = mgr.create_catalog("pg_prod").await.unwrap();
+    let writer = Arc::new(
+        PostgresMetadataWriter::with_pool(pool.clone(), catalog_id)
+            .await
+            .unwrap(),
+    );
+    let snapshot_id = writer.create_snapshot().unwrap();
+    let (schema_id, _) = writer.get_or_create_schema("public", None, snapshot_id).unwrap();
+
+    let mut handles = Vec::new();
+    for _ in 0..10 {
+        let w = Arc::clone(&writer);
+        handles.push(tokio::task::spawn_blocking(move || {
+            w.get_or_create_table(schema_id, "users", None, snapshot_id)
+        }));
+    }
+
+    let mut ids = Vec::new();
+    let mut created_count = 0;
+    for h in handles {
+        let (id, was_created) = h.await.unwrap().unwrap();
+        ids.push(id);
+        if was_created {
+            created_count += 1;
+        }
+    }
+
+    let first = ids[0];
+    assert!(
+        ids.iter().all(|&x| x == first),
+        "all callers must see the same table_id"
+    );
+    assert_eq!(created_count, 1);
+
+    let n: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_table
+         WHERE schema_id = $1 AND table_name = 'users'",
+    )
+    .bind(schema_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap();
+    assert_eq!(n, 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn different_catalogs_proceed_in_parallel_no_serialization() {
+    // The FOR UPDATE lock is per-catalog, so two catalogs writing simultaneously
+    // should both succeed. This test just sanity-checks that we don't accidentally
+    // serialize across catalogs.
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat_a = mgr.create_catalog("cat_a").await.unwrap();
+    let cat_b = mgr.create_catalog("cat_b").await.unwrap();
+
+    let wa = Arc::new(
+        PostgresMetadataWriter::with_pool(pool.clone(), cat_a)
+            .await
+            .unwrap(),
+    );
+    let wb = Arc::new(
+        PostgresMetadataWriter::with_pool(pool.clone(), cat_b)
+            .await
+            .unwrap(),
+    );
+    wa.set_data_path("/data").unwrap();
+
+    // Both writers run a full begin_write_transaction concurrently.
+    let wa_clone = Arc::clone(&wa);
+    let wb_clone = Arc::clone(&wb);
+    let ha = tokio::task::spawn_blocking(move || {
+        wa_clone.begin_write_transaction("public", "users", &users_cols(), WriteMode::Replace)
+    });
+    let hb = tokio::task::spawn_blocking(move || {
+        wb_clone.begin_write_transaction("public", "orders", &users_cols(), WriteMode::Replace)
+    });
+    let res_a = ha.await.unwrap().unwrap();
+    let res_b = hb.await.unwrap().unwrap();
+
+    assert_ne!(res_a.schema_id, res_b.schema_id);
+    assert_ne!(res_a.table_id, res_b.table_id);
+}
+
+// ── cross-catalog ownership checks ────────────────────────────────────────────
+
+async fn seed_two_catalogs(pool: &PgPool) -> (i64, i64, i64, i64) {
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat_a = mgr.create_catalog("cat_a").await.unwrap();
+    let cat_b = mgr.create_catalog("cat_b").await.unwrap();
+    let wa = PostgresMetadataWriter::with_pool(pool.clone(), cat_a).await.unwrap();
+    let wb = PostgresMetadataWriter::with_pool(pool.clone(), cat_b).await.unwrap();
+    wa.set_data_path("/data").unwrap();
+
+    let setup_a = wa
+        .begin_write_transaction("public", "users", &users_cols(), WriteMode::Replace)
+        .unwrap();
+    let setup_b = wb
+        .begin_write_transaction("public", "orders", &users_cols(), WriteMode::Replace)
+        .unwrap();
+    (cat_a, cat_b, setup_a.table_id, setup_b.table_id)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn register_data_file_rejects_cross_catalog_table_id() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let (cat_a, _cat_b, _table_a, table_b) = seed_two_catalogs(&pool).await;
+    let wa = PostgresMetadataWriter::with_pool(pool.clone(), cat_a).await.unwrap();
+    let snap = wa.create_snapshot().unwrap();
+
+    let result = wa.register_data_file(
+        table_b, // ← belongs to cat_b
+        snap,
+        &DataFileInfo::new("evil.parquet", 1024, 1),
+    );
+    let err = result.expect_err("must reject cross-catalog table_id");
+    assert!(
+        err.to_string().contains("does not belong to catalog"),
+        "expected ownership error, got: {}",
+        err
+    );
+
+    // And no row was inserted.
+    let n: i64 =
+        sqlx::query("SELECT COUNT(*) FROM ducklake_data_file WHERE path = 'evil.parquet'")
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
+    assert_eq!(n, 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn end_table_files_rejects_cross_catalog_table_id() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let (cat_a, _cat_b, _table_a, table_b) = seed_two_catalogs(&pool).await;
+    let wa = PostgresMetadataWriter::with_pool(pool.clone(), cat_a).await.unwrap();
+    let snap = wa.create_snapshot().unwrap();
+
+    let result = wa.end_table_files(table_b, snap);
+    let err = result.expect_err("must reject cross-catalog table_id");
+    assert!(
+        err.to_string().contains("does not belong to catalog"),
+        "expected ownership error, got: {}",
+        err
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn set_columns_rejects_cross_catalog_table_id() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let (cat_a, _cat_b, _table_a, table_b) = seed_two_catalogs(&pool).await;
+    let wa = PostgresMetadataWriter::with_pool(pool.clone(), cat_a).await.unwrap();
+    let snap = wa.create_snapshot().unwrap();
+
+    let result = wa.set_columns(table_b, &users_cols(), snap);
+    let err = result.expect_err("must reject cross-catalog table_id");
+    assert!(
+        err.to_string().contains("does not belong to catalog"),
+        "expected ownership error, got: {}",
+        err
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn get_or_create_table_rejects_cross_catalog_schema_id() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat_a = mgr.create_catalog("cat_a").await.unwrap();
+    let cat_b = mgr.create_catalog("cat_b").await.unwrap();
+    let wa = PostgresMetadataWriter::with_pool(pool.clone(), cat_a).await.unwrap();
+    let wb = PostgresMetadataWriter::with_pool(pool.clone(), cat_b).await.unwrap();
+    wa.set_data_path("/data").unwrap();
+
+    // Set up a schema in each catalog.
+    let snap_a = wa.create_snapshot().unwrap();
+    let (schema_a, _) = wa.get_or_create_schema("public", None, snap_a).unwrap();
+    let snap_b = wb.create_snapshot().unwrap();
+    let (schema_b, _) = wb.get_or_create_schema("public", None, snap_b).unwrap();
+
+    // cat_a's writer must reject schema_b.
+    let result = wa.get_or_create_table(schema_b, "users", None, snap_a);
+    let err = result.expect_err("must reject cross-catalog schema_id");
+    assert!(
+        err.to_string().contains("does not belong to catalog"),
+        "expected ownership error, got: {}",
+        err
+    );
+
+    // Own schema works.
+    let ok = wa.get_or_create_table(schema_a, "users", None, snap_a);
+    assert!(ok.is_ok());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn set_data_path_rejects_silent_overwrite() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("pg_prod").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+
+    w.set_data_path("/data/a").unwrap();
+    // Same value is idempotent.
+    w.set_data_path("/data/a").unwrap();
+    // Different value rejected.
+    let err = w.set_data_path("/data/b").expect_err("must reject overwrite");
+    assert!(
+        err.to_string().contains("already set"),
+        "got: {}",
+        err
+    );
+    // Original value is untouched.
+    assert_eq!(w.get_data_path().unwrap(), "/data/a");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn rollback_leaves_no_orphan_rows() {
+    // begin_write_transaction with an invalid column type triggers a rollback
+    // mid-write. The snapshot/mapping/schema rows it would have inserted must
+    // not survive.
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("pg_prod").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path("/data").unwrap();
+
+    let before_snaps: i64 = sqlx::query("SELECT COUNT(*) FROM ducklake_snapshot")
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .try_get(0)
+        .unwrap();
+    let before_map: i64 = sqlx::query("SELECT COUNT(*) FROM ducklake_catalog_snapshot_map")
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .try_get(0)
+        .unwrap();
+
+    let _ok = w
+        .begin_write_transaction("public", "users", &users_cols(), WriteMode::Replace)
+        .unwrap();
+    // Incompatible type change in Append fails after the snapshot is inserted.
+    let bad_cols = vec![
+        ColumnDef::new("id", "varchar", false).unwrap(),
+        ColumnDef::new("name", "varchar", true).unwrap(),
+    ];
+    let snaps_before_fail: i64 = sqlx::query("SELECT COUNT(*) FROM ducklake_snapshot")
+        .fetch_one(&pool).await.unwrap().try_get(0).unwrap();
+    let err =
+        w.begin_write_transaction("public", "users", &bad_cols, WriteMode::Append)
+            .expect_err("incompatible type change must fail");
+    assert!(err.to_string().contains("Schema evolution error"));
+
+    // The failed call must not have left a snapshot behind.
+    let snaps_after_fail: i64 = sqlx::query("SELECT COUNT(*) FROM ducklake_snapshot")
+        .fetch_one(&pool).await.unwrap().try_get(0).unwrap();
+    assert_eq!(
+        snaps_after_fail, snaps_before_fail,
+        "rollback should leave snapshot count unchanged"
+    );
+
+    // And no orphan map rows.
+    let orphans: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_catalog_snapshot_map m
+         LEFT JOIN ducklake_snapshot s ON s.snapshot_id = m.snapshot_id
+         WHERE s.snapshot_id IS NULL",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap();
+    assert_eq!(orphans, 0);
+
+    // And the original write's snapshot/map rows survived.
+    assert!(
+        sqlx::query("SELECT COUNT(*) FROM ducklake_snapshot")
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .try_get::<i64, _>(0)
+            .unwrap()
+            > before_snaps,
+        "the original (good) write should still be in place"
+    );
+    let _ = before_map;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn partial_unique_index_blocks_duplicate_active_table() {
+    // The app-level lock prevents this in normal use; verify the index would
+    // catch it if someone bypasses the writer with raw SQL.
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("pg_prod").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path("/data").unwrap();
+    let setup = w
+        .begin_write_transaction("public", "users", &users_cols(), WriteMode::Replace)
+        .unwrap();
+
+    // Raw SQL insert of a second active row with the same (schema_id, name).
+    let err = sqlx::query(
+        "INSERT INTO ducklake_table (schema_id, table_name, path, path_is_relative, begin_snapshot)
+         VALUES ($1, 'users', 'users', TRUE, $2)",
+    )
+    .bind(setup.schema_id)
+    .bind(setup.snapshot_id)
+    .execute(&pool)
+    .await
+    .expect_err("partial unique index should reject duplicate active table");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("idx_active_table_per_schema")
+            || msg.contains("duplicate key")
+            || msg.contains("unique"),
+        "expected unique-violation error, got: {}",
+        msg
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn unknown_catalog_id_errors_clearly_on_lock() {
+    // Construct a writer with a bogus catalog_id (skip the manager) and ensure
+    // its first mutation surfaces CatalogNotFound rather than a generic SQL error.
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let bogus = PostgresMetadataWriter::with_pool(pool.clone(), 999_999)
+        .await
+        .unwrap();
+    // Snapshot create doesn't take the lock (it's a naked insert + map),
+    // but the map insert will succeed because there's no FK to ducklake_catalog.
+    // The lock-taking methods are the ones that must reject. begin_write_transaction
+    // takes the lock first:
+    let result = bogus.begin_write_transaction(
+        "public",
+        "users",
+        &users_cols(),
+        WriteMode::Replace,
+    );
+    let err = result.expect_err("bogus catalog_id should error");
+    assert!(
+        err.to_string().contains("999999") || err.to_string().contains("not found")
+            || err.to_string().to_lowercase().contains("catalog"),
+        "expected catalog-related error, got: {}",
+        err
+    );
+}

--- a/tests/multicatalog_hardening_tests.rs
+++ b/tests/multicatalog_hardening_tests.rs
@@ -12,9 +12,7 @@
 
 use std::sync::Arc;
 
-use datafusion_ducklake::metadata_writer::{
-    ColumnDef, DataFileInfo, MetadataWriter, WriteMode,
-};
+use datafusion_ducklake::metadata_writer::{ColumnDef, DataFileInfo, MetadataWriter, WriteMode};
 use datafusion_ducklake::{
     MulticatalogManager, PostgresMetadataWriter, initialize_multicatalog_schema,
 };
@@ -85,7 +83,10 @@ async fn concurrent_get_or_create_schema_no_duplicates() {
         "all callers must see the same schema_id, got {:?}",
         ids
     );
-    assert_eq!(created_count, 1, "exactly one writer should report was_created");
+    assert_eq!(
+        created_count, 1,
+        "exactly one writer should report was_created"
+    );
 
     // And the catalog only has one schema row.
     let n: i64 = sqlx::query(
@@ -114,7 +115,9 @@ async fn concurrent_get_or_create_table_no_duplicates() {
             .unwrap(),
     );
     let snapshot_id = writer.create_snapshot().unwrap();
-    let (schema_id, _) = writer.get_or_create_schema("public", None, snapshot_id).unwrap();
+    let (schema_id, _) = writer
+        .get_or_create_schema("public", None, snapshot_id)
+        .unwrap();
 
     let mut handles = Vec::new();
     for _ in 0..10 {
@@ -199,8 +202,12 @@ async fn seed_two_catalogs(pool: &PgPool) -> (i64, i64, i64, i64) {
     let mgr = MulticatalogManager::new(pool.clone());
     let cat_a = mgr.create_catalog("cat_a").await.unwrap();
     let cat_b = mgr.create_catalog("cat_b").await.unwrap();
-    let wa = PostgresMetadataWriter::with_pool(pool.clone(), cat_a).await.unwrap();
-    let wb = PostgresMetadataWriter::with_pool(pool.clone(), cat_b).await.unwrap();
+    let wa = PostgresMetadataWriter::with_pool(pool.clone(), cat_a)
+        .await
+        .unwrap();
+    let wb = PostgresMetadataWriter::with_pool(pool.clone(), cat_b)
+        .await
+        .unwrap();
     wa.set_data_path("/data").unwrap();
 
     let setup_a = wa
@@ -217,7 +224,9 @@ async fn seed_two_catalogs(pool: &PgPool) -> (i64, i64, i64, i64) {
 async fn register_data_file_rejects_cross_catalog_table_id() {
     let (pool, _c) = spin_up_postgres().await.unwrap();
     let (cat_a, _cat_b, _table_a, table_b) = seed_two_catalogs(&pool).await;
-    let wa = PostgresMetadataWriter::with_pool(pool.clone(), cat_a).await.unwrap();
+    let wa = PostgresMetadataWriter::with_pool(pool.clone(), cat_a)
+        .await
+        .unwrap();
     let snap = wa.create_snapshot().unwrap();
 
     let result = wa.register_data_file(
@@ -233,13 +242,12 @@ async fn register_data_file_rejects_cross_catalog_table_id() {
     );
 
     // And no row was inserted.
-    let n: i64 =
-        sqlx::query("SELECT COUNT(*) FROM ducklake_data_file WHERE path = 'evil.parquet'")
-            .fetch_one(&pool)
-            .await
-            .unwrap()
-            .try_get(0)
-            .unwrap();
+    let n: i64 = sqlx::query("SELECT COUNT(*) FROM ducklake_data_file WHERE path = 'evil.parquet'")
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .try_get(0)
+        .unwrap();
     assert_eq!(n, 0);
 }
 
@@ -248,7 +256,9 @@ async fn register_data_file_rejects_cross_catalog_table_id() {
 async fn end_table_files_rejects_cross_catalog_table_id() {
     let (pool, _c) = spin_up_postgres().await.unwrap();
     let (cat_a, _cat_b, _table_a, table_b) = seed_two_catalogs(&pool).await;
-    let wa = PostgresMetadataWriter::with_pool(pool.clone(), cat_a).await.unwrap();
+    let wa = PostgresMetadataWriter::with_pool(pool.clone(), cat_a)
+        .await
+        .unwrap();
     let snap = wa.create_snapshot().unwrap();
 
     let result = wa.end_table_files(table_b, snap);
@@ -265,7 +275,9 @@ async fn end_table_files_rejects_cross_catalog_table_id() {
 async fn set_columns_rejects_cross_catalog_table_id() {
     let (pool, _c) = spin_up_postgres().await.unwrap();
     let (cat_a, _cat_b, _table_a, table_b) = seed_two_catalogs(&pool).await;
-    let wa = PostgresMetadataWriter::with_pool(pool.clone(), cat_a).await.unwrap();
+    let wa = PostgresMetadataWriter::with_pool(pool.clone(), cat_a)
+        .await
+        .unwrap();
     let snap = wa.create_snapshot().unwrap();
 
     let result = wa.set_columns(table_b, &users_cols(), snap);
@@ -284,8 +296,12 @@ async fn get_or_create_table_rejects_cross_catalog_schema_id() {
     let mgr = MulticatalogManager::new(pool.clone());
     let cat_a = mgr.create_catalog("cat_a").await.unwrap();
     let cat_b = mgr.create_catalog("cat_b").await.unwrap();
-    let wa = PostgresMetadataWriter::with_pool(pool.clone(), cat_a).await.unwrap();
-    let wb = PostgresMetadataWriter::with_pool(pool.clone(), cat_b).await.unwrap();
+    let wa = PostgresMetadataWriter::with_pool(pool.clone(), cat_a)
+        .await
+        .unwrap();
+    let wb = PostgresMetadataWriter::with_pool(pool.clone(), cat_b)
+        .await
+        .unwrap();
     wa.set_data_path("/data").unwrap();
 
     // Set up a schema in each catalog.
@@ -322,12 +338,10 @@ async fn set_data_path_rejects_silent_overwrite() {
     // Same value is idempotent.
     w.set_data_path("/data/a").unwrap();
     // Different value rejected.
-    let err = w.set_data_path("/data/b").expect_err("must reject overwrite");
-    assert!(
-        err.to_string().contains("already set"),
-        "got: {}",
-        err
-    );
+    let err = w
+        .set_data_path("/data/b")
+        .expect_err("must reject overwrite");
+    assert!(err.to_string().contains("already set"), "got: {}", err);
     // Original value is untouched.
     assert_eq!(w.get_data_path().unwrap(), "/data/a");
 }
@@ -368,15 +382,23 @@ async fn rollback_leaves_no_orphan_rows() {
         ColumnDef::new("name", "varchar", true).unwrap(),
     ];
     let snaps_before_fail: i64 = sqlx::query("SELECT COUNT(*) FROM ducklake_snapshot")
-        .fetch_one(&pool).await.unwrap().try_get(0).unwrap();
-    let err =
-        w.begin_write_transaction("public", "users", &bad_cols, WriteMode::Append)
-            .expect_err("incompatible type change must fail");
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .try_get(0)
+        .unwrap();
+    let err = w
+        .begin_write_transaction("public", "users", &bad_cols, WriteMode::Append)
+        .expect_err("incompatible type change must fail");
     assert!(err.to_string().contains("Schema evolution error"));
 
     // The failed call must not have left a snapshot behind.
     let snaps_after_fail: i64 = sqlx::query("SELECT COUNT(*) FROM ducklake_snapshot")
-        .fetch_one(&pool).await.unwrap().try_get(0).unwrap();
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .try_get(0)
+        .unwrap();
     assert_eq!(
         snaps_after_fail, snaps_before_fail,
         "rollback should leave snapshot count unchanged"
@@ -458,15 +480,12 @@ async fn unknown_catalog_id_errors_clearly_on_lock() {
     // but the map insert will succeed because there's no FK to ducklake_catalog.
     // The lock-taking methods are the ones that must reject. begin_write_transaction
     // takes the lock first:
-    let result = bogus.begin_write_transaction(
-        "public",
-        "users",
-        &users_cols(),
-        WriteMode::Replace,
-    );
+    let result =
+        bogus.begin_write_transaction("public", "users", &users_cols(), WriteMode::Replace);
     let err = result.expect_err("bogus catalog_id should error");
     assert!(
-        err.to_string().contains("999999") || err.to_string().contains("not found")
+        err.to_string().contains("999999")
+            || err.to_string().contains("not found")
             || err.to_string().to_lowercase().contains("catalog"),
         "expected catalog-related error, got: {}",
         err

--- a/tests/multicatalog_postgres_tests.rs
+++ b/tests/multicatalog_postgres_tests.rs
@@ -389,3 +389,229 @@ async fn register_data_file_records_against_table() {
     assert_eq!(count, 100);
     assert_eq!(begin, setup.snapshot_id);
 }
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn drop_catalog_returns_false_for_unknown_name() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool);
+    let dropped = mgr.drop_catalog("does_not_exist").await.unwrap();
+    assert!(!dropped, "dropping unknown catalog should report false");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn drop_catalog_rejects_empty_name() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool);
+    assert!(mgr.drop_catalog("").await.is_err());
+    assert!(mgr.drop_catalog("   ").await.is_err());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn drop_catalog_removes_empty_catalog() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let _ = mgr.create_catalog("pg_prod").await.unwrap();
+
+    let dropped = mgr.drop_catalog("pg_prod").await.unwrap();
+    assert!(dropped, "first drop should report true");
+
+    // No catalog row left.
+    assert!(mgr.find_catalog_id("pg_prod").await.unwrap().is_none());
+
+    // Second drop is a no-op.
+    let again = mgr.drop_catalog("pg_prod").await.unwrap();
+    assert!(!again, "second drop should report false");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn drop_catalog_removes_populated_catalog() {
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("pg_prod").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path("/data").unwrap();
+
+    // Two tables across one schema, with a data file each + a DDL bump
+    // to populate ducklake_schema_versions.
+    let s1 = w
+        .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
+        .unwrap();
+    w.register_data_file(
+        s1.table_id,
+        s1.snapshot_id,
+        &DataFileInfo::new("u.parquet", 1024, 10),
+    )
+    .unwrap();
+
+    let mut cols_v2 = cols();
+    cols_v2.push(ColumnDef::new("age", "int32", true).unwrap());
+    let _ = w
+        .begin_write_transaction("public", "users", &cols_v2, WriteMode::Replace)
+        .unwrap();
+
+    let s_orders = w
+        .begin_write_transaction("public", "orders", &cols(), WriteMode::Replace)
+        .unwrap();
+    w.register_data_file(
+        s_orders.table_id,
+        s_orders.snapshot_id,
+        &DataFileInfo::new("o.parquet", 2048, 20),
+    )
+    .unwrap();
+
+    // Drop and verify every catalog-scoped table has no rows for this
+    // catalog. Iterate so a future column addition can't quietly skip a
+    // table.
+    let dropped = mgr.drop_catalog("pg_prod").await.unwrap();
+    assert!(dropped);
+
+    // Catalog and mapping rows.
+    for query in [
+        "SELECT COUNT(*) FROM ducklake_catalog",
+        "SELECT COUNT(*) FROM ducklake_catalog_schema_map",
+        "SELECT COUNT(*) FROM ducklake_catalog_snapshot_map",
+    ] {
+        let n: i64 = sqlx::query(query)
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
+        assert_eq!(n, 0, "{} should be empty after drop", query);
+    }
+
+    // Entities owned by the catalog. With only one catalog, "owned by
+    // this catalog" is the same as "any row at all" — global zero is
+    // the right post-condition.
+    for table in [
+        "ducklake_schema",
+        "ducklake_table",
+        "ducklake_column",
+        "ducklake_snapshot",
+        "ducklake_data_file",
+        "ducklake_delete_file",
+        "ducklake_schema_versions",
+    ] {
+        let n: i64 = sqlx::query(&format!("SELECT COUNT(*) FROM {}", table))
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
+        assert_eq!(n, 0, "{} should be empty after drop", table);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn drop_catalog_isolates_other_catalogs() {
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat_a = mgr.create_catalog("pg_prod").await.unwrap();
+    let cat_b = mgr.create_catalog("mysql_prod").await.unwrap();
+    let wa = PostgresMetadataWriter::with_pool(pool.clone(), cat_a)
+        .await
+        .unwrap();
+    let wb = PostgresMetadataWriter::with_pool(pool.clone(), cat_b)
+        .await
+        .unwrap();
+    wa.set_data_path("/data").unwrap();
+
+    // Populate both catalogs.
+    let sa = wa
+        .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
+        .unwrap();
+    wa.register_data_file(
+        sa.table_id,
+        sa.snapshot_id,
+        &DataFileInfo::new("a.parquet", 1024, 10),
+    )
+    .unwrap();
+
+    let sb = wb
+        .begin_write_transaction("public", "orders", &cols(), WriteMode::Replace)
+        .unwrap();
+    wb.register_data_file(
+        sb.table_id,
+        sb.snapshot_id,
+        &DataFileInfo::new("b.parquet", 2048, 20),
+    )
+    .unwrap();
+
+    // Drop catalog A. Catalog B's entities must survive.
+    let dropped = mgr.drop_catalog("pg_prod").await.unwrap();
+    assert!(dropped);
+
+    // Mapping rows: A gone, B intact.
+    for (cat_id, expected, label) in
+        [(cat_a, 0i64, "cat_a schema_map gone"), (cat_b, 1i64, "cat_b schema_map intact")]
+    {
+        let n: i64 =
+            sqlx::query("SELECT COUNT(*) FROM ducklake_catalog_schema_map WHERE catalog_id = $1")
+                .bind(cat_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap()
+                .try_get(0)
+                .unwrap();
+        assert_eq!(n, expected, "{}", label);
+    }
+
+    // Catalog B's entities reachable through its mapping rows must still exist.
+    let b_schema_count: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_schema s
+         JOIN ducklake_catalog_schema_map m ON m.schema_id = s.schema_id
+         WHERE m.catalog_id = $1",
+    )
+    .bind(cat_b)
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap();
+    assert_eq!(b_schema_count, 1, "cat_b schema should survive");
+
+    let b_table_count: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_table t
+         JOIN ducklake_catalog_schema_map m ON m.schema_id = t.schema_id
+         WHERE m.catalog_id = $1",
+    )
+    .bind(cat_b)
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap();
+    assert_eq!(b_table_count, 1, "cat_b table should survive");
+
+    let b_file_count: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_data_file f
+         JOIN ducklake_table t ON t.table_id = f.table_id
+         JOIN ducklake_catalog_schema_map m ON m.schema_id = t.schema_id
+         WHERE m.catalog_id = $1",
+    )
+    .bind(cat_b)
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap();
+    assert_eq!(b_file_count, 1, "cat_b data_file should survive");
+
+    // And the catalog row.
+    assert!(mgr.find_catalog_id("pg_prod").await.unwrap().is_none());
+    assert_eq!(
+        mgr.find_catalog_id("mysql_prod").await.unwrap(),
+        Some(cat_b)
+    );
+}

--- a/tests/multicatalog_postgres_tests.rs
+++ b/tests/multicatalog_postgres_tests.rs
@@ -63,13 +63,12 @@ async fn initialize_multicatalog_schema_is_idempotent() {
         "ducklake_catalog_schema_map",
         "ducklake_schema_versions",
     ] {
-        let row = sqlx::query(
-            "SELECT table_name FROM information_schema.tables WHERE table_name = $1",
-        )
-        .bind(table)
-        .fetch_optional(&pool)
-        .await
-        .unwrap();
+        let row =
+            sqlx::query("SELECT table_name FROM information_schema.tables WHERE table_name = $1")
+                .bind(table)
+                .fetch_optional(&pool)
+                .await
+                .unwrap();
         assert!(row.is_some(), "table {} should exist", table);
     }
 }
@@ -121,34 +120,38 @@ async fn single_catalog_ddl_then_dml_assigns_versions() {
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
         .unwrap();
 
-    let v1: i64 = sqlx::query("SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = $1")
-        .bind(setup1.snapshot_id)
-        .fetch_one(&pool)
-        .await
-        .unwrap()
-        .try_get(0)
-        .unwrap();
-    let v2: i64 = sqlx::query("SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = $1")
-        .bind(setup2.snapshot_id)
-        .fetch_one(&pool)
-        .await
-        .unwrap()
-        .try_get(0)
-        .unwrap();
+    let v1: i64 =
+        sqlx::query("SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = $1")
+            .bind(setup1.snapshot_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
+    let v2: i64 =
+        sqlx::query("SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = $1")
+            .bind(setup2.snapshot_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
     assert_eq!(v1, 1, "first DDL ⇒ v1");
     assert_eq!(v2, 1, "DML carries forward ⇒ still v1");
 
     // ducklake_schema_versions has exactly one row for the DDL commit.
-    let count: i64 = sqlx::query(
-        "SELECT COUNT(*) FROM ducklake_schema_versions WHERE table_id = $1",
-    )
-    .bind(setup1.table_id)
-    .fetch_one(&pool)
-    .await
-    .unwrap()
-    .try_get(0)
-    .unwrap();
-    assert_eq!(count, 1, "only the DDL commit records a schema_versions row");
+    let count: i64 =
+        sqlx::query("SELECT COUNT(*) FROM ducklake_schema_versions WHERE table_id = $1")
+            .bind(setup1.table_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
+    assert_eq!(
+        count, 1,
+        "only the DDL commit records a schema_versions row"
+    );
 
     // Third commit: column added → DDL bump.
     let mut cols_v2 = cols();
@@ -156,13 +159,14 @@ async fn single_catalog_ddl_then_dml_assigns_versions() {
     let setup3 = writer
         .begin_write_transaction("public", "users", &cols_v2, WriteMode::Replace)
         .unwrap();
-    let v3: i64 = sqlx::query("SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = $1")
-        .bind(setup3.snapshot_id)
-        .fetch_one(&pool)
-        .await
-        .unwrap()
-        .try_get(0)
-        .unwrap();
+    let v3: i64 =
+        sqlx::query("SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = $1")
+            .bind(setup3.snapshot_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
     assert_eq!(v3, 2, "column added ⇒ DDL ⇒ v2");
 }
 
@@ -194,41 +198,38 @@ async fn cross_catalog_isolation_same_schema_name() {
     assert_ne!(setup_a.schema_id, setup_b.schema_id);
 
     // Catalog A's mapping points only at A's schema.
-    let schema_ids_a: Vec<i64> = sqlx::query(
-        "SELECT schema_id FROM ducklake_catalog_schema_map WHERE catalog_id = $1",
-    )
-    .bind(cat_a)
-    .fetch_all(&pool)
-    .await
-    .unwrap()
-    .into_iter()
-    .map(|r| r.try_get(0).unwrap())
-    .collect();
+    let schema_ids_a: Vec<i64> =
+        sqlx::query("SELECT schema_id FROM ducklake_catalog_schema_map WHERE catalog_id = $1")
+            .bind(cat_a)
+            .fetch_all(&pool)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|r| r.try_get(0).unwrap())
+            .collect();
     assert_eq!(schema_ids_a, vec![setup_a.schema_id]);
 
-    let schema_ids_b: Vec<i64> = sqlx::query(
-        "SELECT schema_id FROM ducklake_catalog_schema_map WHERE catalog_id = $1",
-    )
-    .bind(cat_b)
-    .fetch_all(&pool)
-    .await
-    .unwrap()
-    .into_iter()
-    .map(|r| r.try_get(0).unwrap())
-    .collect();
+    let schema_ids_b: Vec<i64> =
+        sqlx::query("SELECT schema_id FROM ducklake_catalog_schema_map WHERE catalog_id = $1")
+            .bind(cat_b)
+            .fetch_all(&pool)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|r| r.try_get(0).unwrap())
+            .collect();
     assert_eq!(schema_ids_b, vec![setup_b.schema_id]);
 
     // Each catalog has exactly one snapshot mapping after one write.
     for cat in [cat_a, cat_b] {
-        let n: i64 = sqlx::query(
-            "SELECT COUNT(*) FROM ducklake_catalog_snapshot_map WHERE catalog_id = $1",
-        )
-        .bind(cat)
-        .fetch_one(&pool)
-        .await
-        .unwrap()
-        .try_get(0)
-        .unwrap();
+        let n: i64 =
+            sqlx::query("SELECT COUNT(*) FROM ducklake_catalog_snapshot_map WHERE catalog_id = $1")
+                .bind(cat)
+                .fetch_one(&pool)
+                .await
+                .unwrap()
+                .try_get(0)
+                .unwrap();
         assert_eq!(n, 1, "catalog {} should have 1 snapshot mapping", cat);
     }
 }

--- a/tests/multicatalog_postgres_tests.rs
+++ b/tests/multicatalog_postgres_tests.rs
@@ -1,0 +1,390 @@
+#![cfg(feature = "write-postgres")]
+//! Integration tests for the multicatalog Postgres writer.
+//!
+//! Covers:
+//! - DDL bootstrap idempotency
+//! - `MulticatalogManager::create_catalog` semantics
+//! - Single-catalog write flow on Postgres
+//! - Cross-catalog isolation (writes in catalog A invisible to catalog B)
+//! - Per-catalog dense `schema_version` allocation
+//! - No orphan mapping rows after writes
+
+use datafusion_ducklake::metadata_writer::{ColumnDef, MetadataWriter, WriteMode};
+use datafusion_ducklake::{
+    MulticatalogManager, PostgresMetadataWriter, initialize_multicatalog_schema,
+};
+use sqlx::Row;
+use sqlx::postgres::{PgPool, PgPoolOptions};
+use testcontainers::ContainerAsync;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+async fn spin_up_postgres() -> anyhow::Result<(PgPool, ContainerAsync<Postgres>)> {
+    let container = Postgres::default().start().await?;
+    let port = container.get_host_port_ipv4(5432).await?;
+    let conn_str = format!("postgresql://postgres:postgres@127.0.0.1:{}/postgres", port);
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&conn_str)
+        .await?;
+    initialize_multicatalog_schema(&pool).await?;
+    Ok((pool, container))
+}
+
+fn cols() -> Vec<ColumnDef> {
+    vec![
+        ColumnDef::new("id", "int64", false).unwrap(),
+        ColumnDef::new("name", "varchar", true).unwrap(),
+    ]
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn initialize_multicatalog_schema_is_idempotent() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    // Calling again must not error.
+    initialize_multicatalog_schema(&pool).await.unwrap();
+    initialize_multicatalog_schema(&pool).await.unwrap();
+
+    // schema_version column exists on ducklake_snapshot.
+    let row = sqlx::query(
+        "SELECT column_name FROM information_schema.columns
+         WHERE table_name = 'ducklake_snapshot' AND column_name = 'schema_version'",
+    )
+    .fetch_optional(&pool)
+    .await
+    .unwrap();
+    assert!(row.is_some(), "schema_version column should exist");
+
+    // All catalog tables exist.
+    for table in [
+        "ducklake_catalog",
+        "ducklake_catalog_snapshot_map",
+        "ducklake_catalog_schema_map",
+        "ducklake_schema_versions",
+    ] {
+        let row = sqlx::query(
+            "SELECT table_name FROM information_schema.tables WHERE table_name = $1",
+        )
+        .bind(table)
+        .fetch_optional(&pool)
+        .await
+        .unwrap();
+        assert!(row.is_some(), "table {} should exist", table);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn create_catalog_is_idempotent_by_name() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool);
+
+    let id_a = mgr.create_catalog("pg_prod").await.unwrap();
+    let id_b = mgr.create_catalog("pg_prod").await.unwrap();
+    assert_eq!(id_a, id_b, "same name should yield same id");
+
+    let id_other = mgr.create_catalog("mysql_prod").await.unwrap();
+    assert_ne!(id_a, id_other, "different names get different ids");
+
+    let listed = mgr.list_catalogs().await.unwrap();
+    assert_eq!(listed.len(), 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn create_catalog_rejects_empty_name() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool);
+    assert!(mgr.create_catalog("").await.is_err());
+    assert!(mgr.create_catalog("   ").await.is_err());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn single_catalog_ddl_then_dml_assigns_versions() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let catalog_id = mgr.create_catalog("pg_prod").await.unwrap();
+    let writer = PostgresMetadataWriter::with_pool(pool.clone(), catalog_id)
+        .await
+        .unwrap();
+    writer.set_data_path("/data").unwrap();
+
+    // First commit: DDL (table doesn't exist).
+    let setup1 = writer
+        .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
+        .unwrap();
+
+    // Second commit: same columns -> DML, carry forward schema_version.
+    let setup2 = writer
+        .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
+        .unwrap();
+
+    let v1: i64 = sqlx::query("SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = $1")
+        .bind(setup1.snapshot_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .try_get(0)
+        .unwrap();
+    let v2: i64 = sqlx::query("SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = $1")
+        .bind(setup2.snapshot_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .try_get(0)
+        .unwrap();
+    assert_eq!(v1, 1, "first DDL ⇒ v1");
+    assert_eq!(v2, 1, "DML carries forward ⇒ still v1");
+
+    // ducklake_schema_versions has exactly one row for the DDL commit.
+    let count: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_schema_versions WHERE table_id = $1",
+    )
+    .bind(setup1.table_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap();
+    assert_eq!(count, 1, "only the DDL commit records a schema_versions row");
+
+    // Third commit: column added → DDL bump.
+    let mut cols_v2 = cols();
+    cols_v2.push(ColumnDef::new("age", "int32", true).unwrap());
+    let setup3 = writer
+        .begin_write_transaction("public", "users", &cols_v2, WriteMode::Replace)
+        .unwrap();
+    let v3: i64 = sqlx::query("SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = $1")
+        .bind(setup3.snapshot_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .try_get(0)
+        .unwrap();
+    assert_eq!(v3, 2, "column added ⇒ DDL ⇒ v2");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn cross_catalog_isolation_same_schema_name() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+
+    let cat_a = mgr.create_catalog("pg_prod").await.unwrap();
+    let cat_b = mgr.create_catalog("mysql_prod").await.unwrap();
+
+    let writer_a = PostgresMetadataWriter::with_pool(pool.clone(), cat_a)
+        .await
+        .unwrap();
+    let writer_b = PostgresMetadataWriter::with_pool(pool.clone(), cat_b)
+        .await
+        .unwrap();
+    writer_a.set_data_path("/data").unwrap();
+
+    let setup_a = writer_a
+        .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
+        .unwrap();
+    let setup_b = writer_b
+        .begin_write_transaction("public", "orders", &cols(), WriteMode::Replace)
+        .unwrap();
+
+    // Schemas: two "public" rows, one per catalog, with different schema_ids.
+    assert_ne!(setup_a.schema_id, setup_b.schema_id);
+
+    // Catalog A's mapping points only at A's schema.
+    let schema_ids_a: Vec<i64> = sqlx::query(
+        "SELECT schema_id FROM ducklake_catalog_schema_map WHERE catalog_id = $1",
+    )
+    .bind(cat_a)
+    .fetch_all(&pool)
+    .await
+    .unwrap()
+    .into_iter()
+    .map(|r| r.try_get(0).unwrap())
+    .collect();
+    assert_eq!(schema_ids_a, vec![setup_a.schema_id]);
+
+    let schema_ids_b: Vec<i64> = sqlx::query(
+        "SELECT schema_id FROM ducklake_catalog_schema_map WHERE catalog_id = $1",
+    )
+    .bind(cat_b)
+    .fetch_all(&pool)
+    .await
+    .unwrap()
+    .into_iter()
+    .map(|r| r.try_get(0).unwrap())
+    .collect();
+    assert_eq!(schema_ids_b, vec![setup_b.schema_id]);
+
+    // Each catalog has exactly one snapshot mapping after one write.
+    for cat in [cat_a, cat_b] {
+        let n: i64 = sqlx::query(
+            "SELECT COUNT(*) FROM ducklake_catalog_snapshot_map WHERE catalog_id = $1",
+        )
+        .bind(cat)
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .try_get(0)
+        .unwrap();
+        assert_eq!(n, 1, "catalog {} should have 1 snapshot mapping", cat);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn schema_version_is_per_catalog_dense_under_interleaving() {
+    // Reproduces the spec's working-example scenario:
+    //   cat_a: DDL(v1), DML(v1), DDL(v2)
+    //   cat_b interleaved: DDL(v1), DML(v1)
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat_a = mgr.create_catalog("pg_prod").await.unwrap();
+    let cat_b = mgr.create_catalog("mysql_prod").await.unwrap();
+    let wa = PostgresMetadataWriter::with_pool(pool.clone(), cat_a)
+        .await
+        .unwrap();
+    let wb = PostgresMetadataWriter::with_pool(pool.clone(), cat_b)
+        .await
+        .unwrap();
+    wa.set_data_path("/data").unwrap();
+
+    // cat_a DDL (creates users)
+    let a1 = wa
+        .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
+        .unwrap();
+    // cat_a DML (Replace, same schema)
+    let a2 = wa
+        .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
+        .unwrap();
+    // cat_b DDL (creates orders) — happens in between cat_a's DDLs
+    let b1 = wb
+        .begin_write_transaction("public", "orders", &cols(), WriteMode::Replace)
+        .unwrap();
+    // cat_a DDL: adds age column
+    let mut cols_v2 = cols();
+    cols_v2.push(ColumnDef::new("age", "int32", true).unwrap());
+    let a3 = wa
+        .begin_write_transaction("public", "users", &cols_v2, WriteMode::Replace)
+        .unwrap();
+    // cat_b DML
+    let b2 = wb
+        .begin_write_transaction("public", "orders", &cols(), WriteMode::Replace)
+        .unwrap();
+
+    let get_v = |snap_id: i64| {
+        let pool = pool.clone();
+        async move {
+            sqlx::query("SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = $1")
+                .bind(snap_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap()
+                .try_get::<i64, _>(0)
+                .unwrap()
+        }
+    };
+
+    assert_eq!(get_v(a1.snapshot_id).await, 1, "cat_a first DDL");
+    assert_eq!(get_v(a2.snapshot_id).await, 1, "cat_a DML carries v1");
+    assert_eq!(get_v(b1.snapshot_id).await, 1, "cat_b first DDL");
+    assert_eq!(get_v(a3.snapshot_id).await, 2, "cat_a column-add DDL");
+    assert_eq!(get_v(b2.snapshot_id).await, 1, "cat_b DML carries v1");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn no_orphan_mapping_rows() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("pg_prod").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path("/data").unwrap();
+    let _ = w
+        .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
+        .unwrap();
+    let _ = w
+        .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
+        .unwrap();
+
+    // Every entry in the maps must point at a real row.
+    let orphan_snaps: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_catalog_snapshot_map m
+         LEFT JOIN ducklake_snapshot s ON s.snapshot_id = m.snapshot_id
+         WHERE s.snapshot_id IS NULL",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap();
+    assert_eq!(orphan_snaps, 0);
+
+    let orphan_schemas: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_catalog_schema_map m
+         LEFT JOIN ducklake_schema s ON s.schema_id = m.schema_id
+         WHERE s.schema_id IS NULL",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap();
+    assert_eq!(orphan_schemas, 0);
+
+    // Every snapshot created via a writer must have a mapping.
+    let unmapped_snaps: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_snapshot s
+         LEFT JOIN ducklake_catalog_snapshot_map m ON m.snapshot_id = s.snapshot_id
+         WHERE m.catalog_id IS NULL",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap();
+    assert_eq!(unmapped_snaps, 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn register_data_file_records_against_table() {
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("pg_prod").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path("/data").unwrap();
+    let setup = w
+        .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
+        .unwrap();
+
+    let file = DataFileInfo::new("abc.parquet", 4096, 100).with_footer_size(256);
+    let file_id = w
+        .register_data_file(setup.table_id, setup.snapshot_id, &file)
+        .unwrap();
+    assert!(file_id > 0);
+
+    let row = sqlx::query(
+        "SELECT path, file_size_bytes, record_count, begin_snapshot
+         FROM ducklake_data_file WHERE data_file_id = $1",
+    )
+    .bind(file_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let path: String = row.try_get(0).unwrap();
+    let size: i64 = row.try_get(1).unwrap();
+    let count: i64 = row.try_get(2).unwrap();
+    let begin: i64 = row.try_get(3).unwrap();
+    assert_eq!(path, "abc.parquet");
+    assert_eq!(size, 4096);
+    assert_eq!(count, 100);
+    assert_eq!(begin, setup.snapshot_id);
+}

--- a/tests/multicatalog_provider_tests.rs
+++ b/tests/multicatalog_provider_tests.rs
@@ -1,0 +1,357 @@
+#![cfg(all(feature = "multicatalog-postgres", feature = "write-postgres"))]
+//! Integration tests for the multicatalog Postgres reader.
+//!
+//! These set up a populated catalog via the writer side, then verify the
+//! reader's catalog-scoping with full isolation between catalogs.
+
+use datafusion_ducklake::metadata_provider::MetadataProvider;
+use datafusion_ducklake::metadata_writer::{ColumnDef, DataFileInfo, MetadataWriter, WriteMode};
+use datafusion_ducklake::{
+    MulticatalogManager, MulticatalogProvider, PostgresMetadataWriter,
+    initialize_multicatalog_schema,
+};
+use sqlx::postgres::{PgPool, PgPoolOptions};
+use testcontainers::ContainerAsync;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+async fn spin_up_postgres() -> anyhow::Result<(PgPool, ContainerAsync<Postgres>)> {
+    let container = Postgres::default().start().await?;
+    let port = container.get_host_port_ipv4(5432).await?;
+    let conn = format!("postgresql://postgres:postgres@127.0.0.1:{}/postgres", port);
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&conn)
+        .await?;
+    initialize_multicatalog_schema(&pool).await?;
+    Ok((pool, container))
+}
+
+fn users_cols() -> Vec<ColumnDef> {
+    vec![
+        ColumnDef::new("id", "int64", false).unwrap(),
+        ColumnDef::new("name", "varchar", true).unwrap(),
+    ]
+}
+
+fn orders_cols() -> Vec<ColumnDef> {
+    vec![
+        ColumnDef::new("order_id", "int64", false).unwrap(),
+        ColumnDef::new("amount", "float64", false).unwrap(),
+    ]
+}
+
+/// Set up the working-example world: pg_prod has users (3 snapshots: DDL, DML, DDL),
+/// mysql_prod has orders (1 snapshot: DDL).
+async fn seed_two_catalogs(pool: &PgPool) -> anyhow::Result<(i64, i64)> {
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat_pg = mgr.create_catalog("pg_prod").await?;
+    let cat_mysql = mgr.create_catalog("mysql_prod").await?;
+    let wa = PostgresMetadataWriter::with_pool(pool.clone(), cat_pg).await?;
+    let wb = PostgresMetadataWriter::with_pool(pool.clone(), cat_mysql).await?;
+    wa.set_data_path("/data")?;
+
+    let reg = |w: &PostgresMetadataWriter, setup: datafusion_ducklake::metadata_writer::WriteSetupResult, fname: &str| {
+        w.register_data_file(
+            setup.table_id,
+            setup.snapshot_id,
+            &DataFileInfo::new(fname, 1024, 3),
+        )
+        .unwrap();
+    };
+
+    // pg_prod: DDL, then DML
+    let s1 = wa.begin_write_transaction("public", "users", &users_cols(), WriteMode::Replace)?;
+    reg(&wa, s1, "users-a.parquet");
+    let s2 = wa.begin_write_transaction("public", "users", &users_cols(), WriteMode::Replace)?;
+    reg(&wa, s2, "users-b.parquet");
+    // mysql_prod: DDL
+    let s3 =
+        wb.begin_write_transaction("public", "orders", &orders_cols(), WriteMode::Replace)?;
+    reg(&wb, s3, "orders-a.parquet");
+    // pg_prod: column-add DDL
+    let mut v2 = users_cols();
+    v2.push(ColumnDef::new("age", "int32", true).unwrap());
+    let s4 = wa.begin_write_transaction("public", "users", &v2, WriteMode::Replace)?;
+    reg(&wa, s4, "users-c.parquet");
+    Ok((cat_pg, cat_mysql))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn with_pool_resolves_known_catalog_and_errors_on_unknown() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let _ = seed_two_catalogs(&pool).await.unwrap();
+
+    let p = MulticatalogProvider::with_pool(pool.clone(), "pg_prod")
+        .await
+        .unwrap();
+    assert!(p.catalog_id() > 0);
+
+    let err = MulticatalogProvider::with_pool(pool.clone(), "ghost_catalog").await;
+    assert!(err.is_err(), "unknown catalog should error");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn current_snapshot_is_catalog_scoped() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let (_, _) = seed_two_catalogs(&pool).await.unwrap();
+
+    let pa = MulticatalogProvider::with_pool(pool.clone(), "pg_prod")
+        .await
+        .unwrap();
+    let pb = MulticatalogProvider::with_pool(pool.clone(), "mysql_prod")
+        .await
+        .unwrap();
+
+    // pg_prod has snapshots 1, 2, 4 ⇒ max = 4
+    // mysql_prod has snapshot 3 ⇒ max = 3
+    assert_eq!(pa.get_current_snapshot().unwrap(), 4);
+    assert_eq!(pb.get_current_snapshot().unwrap(), 3);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn list_snapshots_is_catalog_scoped() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let _ = seed_two_catalogs(&pool).await.unwrap();
+
+    let pa = MulticatalogProvider::with_pool(pool.clone(), "pg_prod")
+        .await
+        .unwrap();
+    let pb = MulticatalogProvider::with_pool(pool.clone(), "mysql_prod")
+        .await
+        .unwrap();
+
+    let ids_a: Vec<i64> = pa
+        .list_snapshots()
+        .unwrap()
+        .into_iter()
+        .map(|s| s.snapshot_id)
+        .collect();
+    let ids_b: Vec<i64> = pb
+        .list_snapshots()
+        .unwrap()
+        .into_iter()
+        .map(|s| s.snapshot_id)
+        .collect();
+    assert_eq!(ids_a, vec![1, 2, 4]);
+    assert_eq!(ids_b, vec![3]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn schemas_isolated_by_catalog_despite_same_name() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let _ = seed_two_catalogs(&pool).await.unwrap();
+
+    let pa = MulticatalogProvider::with_pool(pool.clone(), "pg_prod")
+        .await
+        .unwrap();
+    let pb = MulticatalogProvider::with_pool(pool.clone(), "mysql_prod")
+        .await
+        .unwrap();
+
+    let sn_a = pa.get_current_snapshot().unwrap();
+    let sn_b = pb.get_current_snapshot().unwrap();
+
+    // Each catalog sees exactly one schema named "public", with different ids.
+    let schemas_a = pa.list_schemas(sn_a).unwrap();
+    let schemas_b = pb.list_schemas(sn_b).unwrap();
+    assert_eq!(schemas_a.len(), 1);
+    assert_eq!(schemas_b.len(), 1);
+    assert_eq!(schemas_a[0].schema_name, "public");
+    assert_eq!(schemas_b[0].schema_name, "public");
+    assert_ne!(
+        schemas_a[0].schema_id, schemas_b[0].schema_id,
+        "same name, different schema_ids (catalog discrimination)"
+    );
+
+    // get_schema_by_name agrees.
+    let a = pa.get_schema_by_name("public", sn_a).unwrap().unwrap();
+    let b = pb.get_schema_by_name("public", sn_b).unwrap().unwrap();
+    assert_eq!(a.schema_id, schemas_a[0].schema_id);
+    assert_eq!(b.schema_id, schemas_b[0].schema_id);
+
+    // Catalog A should not see a schema from B's snapshot, and vice versa.
+    // pg_prod doesn't have snapshot 3 — its schema lookup should still only
+    // surface schemas it owns.
+    let cross = pa.get_schema_by_name("public", sn_b).unwrap();
+    // At snapshot 3 the pg_prod schema was visible (begin_snapshot=1),
+    // so this returns the pg_prod schema — that's correct behavior.
+    // The catalog scoping prevented us from seeing mysql_prod's schema.
+    assert_eq!(cross.unwrap().schema_id, a.schema_id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn tables_visible_only_through_owning_catalog() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let _ = seed_two_catalogs(&pool).await.unwrap();
+
+    let pa = MulticatalogProvider::with_pool(pool.clone(), "pg_prod")
+        .await
+        .unwrap();
+    let pb = MulticatalogProvider::with_pool(pool.clone(), "mysql_prod")
+        .await
+        .unwrap();
+    let sn_a = pa.get_current_snapshot().unwrap();
+    let sn_b = pb.get_current_snapshot().unwrap();
+
+    let schema_a = pa.get_schema_by_name("public", sn_a).unwrap().unwrap();
+    let schema_b = pb.get_schema_by_name("public", sn_b).unwrap().unwrap();
+
+    // Each catalog's schema only has its own table.
+    let tables_a = pa.list_tables(schema_a.schema_id, sn_a).unwrap();
+    let tables_b = pb.list_tables(schema_b.schema_id, sn_b).unwrap();
+    assert_eq!(tables_a.len(), 1);
+    assert_eq!(tables_a[0].table_name, "users");
+    assert_eq!(tables_b.len(), 1);
+    assert_eq!(tables_b[0].table_name, "orders");
+
+    // get_table_by_name agrees and table_exists confirms.
+    assert!(pa.table_exists(schema_a.schema_id, "users", sn_a).unwrap());
+    assert!(!pa.table_exists(schema_a.schema_id, "orders", sn_a).unwrap());
+    assert!(pb.table_exists(schema_b.schema_id, "orders", sn_b).unwrap());
+    assert!(!pb.table_exists(schema_b.schema_id, "users", sn_b).unwrap());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn table_structure_reflects_latest_columns_after_ddl() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let _ = seed_two_catalogs(&pool).await.unwrap();
+
+    let pa = MulticatalogProvider::with_pool(pool.clone(), "pg_prod")
+        .await
+        .unwrap();
+    let sn = pa.get_current_snapshot().unwrap();
+    let schema = pa.get_schema_by_name("public", sn).unwrap().unwrap();
+    let table = pa
+        .get_table_by_name(schema.schema_id, "users", sn)
+        .unwrap()
+        .unwrap();
+
+    let cols = pa.get_table_structure(table.table_id).unwrap();
+    // After the column-add DDL: id, name, age
+    assert_eq!(cols.len(), 3);
+    assert_eq!(cols[0].column_name, "id");
+    assert_eq!(cols[1].column_name, "name");
+    assert_eq!(cols[2].column_name, "age");
+    assert_eq!(cols[2].column_type, "int32");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn list_all_tables_bulk_is_catalog_scoped() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let _ = seed_two_catalogs(&pool).await.unwrap();
+
+    let pa = MulticatalogProvider::with_pool(pool.clone(), "pg_prod")
+        .await
+        .unwrap();
+    let pb = MulticatalogProvider::with_pool(pool.clone(), "mysql_prod")
+        .await
+        .unwrap();
+
+    let names_a: Vec<String> = pa
+        .list_all_tables(pa.get_current_snapshot().unwrap())
+        .unwrap()
+        .into_iter()
+        .map(|t| t.table.table_name)
+        .collect();
+    let names_b: Vec<String> = pb
+        .list_all_tables(pb.get_current_snapshot().unwrap())
+        .unwrap()
+        .into_iter()
+        .map(|t| t.table.table_name)
+        .collect();
+    assert_eq!(names_a, vec!["users"]);
+    assert_eq!(names_b, vec!["orders"]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn list_all_columns_bulk_is_catalog_scoped() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let _ = seed_two_catalogs(&pool).await.unwrap();
+
+    let pa = MulticatalogProvider::with_pool(pool.clone(), "pg_prod")
+        .await
+        .unwrap();
+    let pb = MulticatalogProvider::with_pool(pool.clone(), "mysql_prod")
+        .await
+        .unwrap();
+
+    let cols_a = pa
+        .list_all_columns(pa.get_current_snapshot().unwrap())
+        .unwrap();
+    let cols_b = pb
+        .list_all_columns(pb.get_current_snapshot().unwrap())
+        .unwrap();
+
+    // pg_prod sees only users (3 cols: id, name, age)
+    assert!(cols_a.iter().all(|c| c.table_name == "users"));
+    assert_eq!(cols_a.len(), 3);
+
+    // mysql_prod sees only orders (2 cols: order_id, amount)
+    assert!(cols_b.iter().all(|c| c.table_name == "orders"));
+    assert_eq!(cols_b.len(), 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn list_all_files_bulk_is_catalog_scoped() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let _ = seed_two_catalogs(&pool).await.unwrap();
+
+    let pa = MulticatalogProvider::with_pool(pool.clone(), "pg_prod")
+        .await
+        .unwrap();
+    let pb = MulticatalogProvider::with_pool(pool.clone(), "mysql_prod")
+        .await
+        .unwrap();
+
+    let files_a = pa
+        .list_all_files(pa.get_current_snapshot().unwrap())
+        .unwrap();
+    let files_b = pb
+        .list_all_files(pb.get_current_snapshot().unwrap())
+        .unwrap();
+
+    // pg_prod sees only users files visible at snapshot 4 (just one)
+    assert!(files_a.iter().all(|f| f.table_name == "users"));
+    assert_eq!(files_a.len(), 1);
+
+    // mysql_prod sees only orders files visible at snapshot 3 (just one)
+    assert!(files_b.iter().all(|f| f.table_name == "orders"));
+    assert_eq!(files_b.len(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn get_table_files_for_select_returns_visible_files_at_snapshot() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let _ = seed_two_catalogs(&pool).await.unwrap();
+
+    let pa = MulticatalogProvider::with_pool(pool.clone(), "pg_prod")
+        .await
+        .unwrap();
+    let sn = pa.get_current_snapshot().unwrap();
+    let schema = pa.get_schema_by_name("public", sn).unwrap().unwrap();
+    let table = pa
+        .get_table_by_name(schema.schema_id, "users", sn)
+        .unwrap()
+        .unwrap();
+
+    let files = pa
+        .get_table_files_for_select(table.table_id, sn)
+        .unwrap();
+    // At snapshot 4 only the latest data file is visible (older ones end_snapshot'd).
+    assert_eq!(files.len(), 1);
+
+    // At snapshot 1, the first file is visible.
+    let files_at_1 = pa.get_table_files_for_select(table.table_id, 1).unwrap();
+    assert_eq!(files_at_1.len(), 1);
+}

--- a/tests/multicatalog_provider_tests.rs
+++ b/tests/multicatalog_provider_tests.rs
@@ -51,7 +51,9 @@ async fn seed_two_catalogs(pool: &PgPool) -> anyhow::Result<(i64, i64)> {
     let wb = PostgresMetadataWriter::with_pool(pool.clone(), cat_mysql).await?;
     wa.set_data_path("/data")?;
 
-    let reg = |w: &PostgresMetadataWriter, setup: datafusion_ducklake::metadata_writer::WriteSetupResult, fname: &str| {
+    let reg = |w: &PostgresMetadataWriter,
+               setup: datafusion_ducklake::metadata_writer::WriteSetupResult,
+               fname: &str| {
         w.register_data_file(
             setup.table_id,
             setup.snapshot_id,
@@ -66,8 +68,7 @@ async fn seed_two_catalogs(pool: &PgPool) -> anyhow::Result<(i64, i64)> {
     let s2 = wa.begin_write_transaction("public", "users", &users_cols(), WriteMode::Replace)?;
     reg(&wa, s2, "users-b.parquet");
     // mysql_prod: DDL
-    let s3 =
-        wb.begin_write_transaction("public", "orders", &orders_cols(), WriteMode::Replace)?;
+    let s3 = wb.begin_write_transaction("public", "orders", &orders_cols(), WriteMode::Replace)?;
     reg(&wb, s3, "orders-a.parquet");
     // pg_prod: column-add DDL
     let mut v2 = users_cols();
@@ -345,9 +346,7 @@ async fn get_table_files_for_select_returns_visible_files_at_snapshot() {
         .unwrap()
         .unwrap();
 
-    let files = pa
-        .get_table_files_for_select(table.table_id, sn)
-        .unwrap();
+    let files = pa.get_table_files_for_select(table.table_id, sn).unwrap();
     // At snapshot 4 only the latest data file is visible (older ones end_snapshot'd).
     assert_eq!(files.len(), 1);
 


### PR DESCRIPTION
  Add per-tenant catalog isolation . Multiple catalogs share one metadata database; each has independent snapshots,schemas, and a dense per-catalog schema_version sequence.

  New public types:
  - MulticatalogManager: create/list catalogs
  - PostgresMetadataWriter: implements MetadataWriter, bound to catalog_id
  - MulticatalogProvider: implements MetadataProvider, bound to catalog_id
  - initialize_multicatalog_schema: idempotent DDL bootstrap

  New tables:
  - ducklake_catalog (name registry)
  - ducklake_catalog_snapshot_map, ducklake_catalog_schema_map
  - ducklake_schema_versions
  - schema_version column on ducklake_snapshot

  Correctness:
  - Per-catalog FOR UPDATE serializes concurrent writers (30s lock_timeout)
  - Cross-catalog table_id/schema_id rejected at write time
  - Partial unique index on (schema_id, table_name) WHERE end_snapshot IS NULL
  - set_data_path rejects silent overwrites

  Tests (testcontainers Postgres):
  - 8 writer + 10 reader + 11 hardening integration tests
  - 7 unit tests for DDL/DML classification

  Existing single-catalog providers and writers untouched.

  Refs #107 Phase 1.


  ## Usage
  
  Enable the feature:

  ```toml
  [dependencies]
  datafusion-ducklake = { version = "0.2", features = ["write-postgres"] }
  # Or read-only:
  # datafusion-ducklake = { version = "0.2", features = ["multicatalog-postgres"] }
  ```
  
  ### Bootstrap and create a catalog

  ```rust
  use datafusion_ducklake::{MulticatalogManager, initialize_multicatalog_schema};
  use sqlx::postgres::PgPoolOptions;
  
  let pool = PgPoolOptions::new()
      .max_connections(5)
      .connect("postgresql://user:pass@host:5432/db")
      .await?; 
  
  // Idempotent — safe to call on every startup.
  initialize_multicatalog_schema(&pool).await?;
  
  // Idempotent by name. Returns the same id for repeat calls.
  let mgr = MulticatalogManager::new(pool.clone());
  let catalog_id = mgr.create_catalog("pg_prod").await?;
  ```
  
  ### Writing (per-catalog)

  ```rust
  use std::sync::Arc;
  use datafusion_ducklake::{
      DuckLakeTableWriter, MetadataWriter, PostgresMetadataWriter,
  };
  use object_store::local::LocalFileSystem;

  let writer = Arc::new(
      PostgresMetadataWriter::with_pool(pool.clone(), catalog_id).await?
  );
  writer.set_data_path("/var/data/ducklake")?;

  let object_store: Arc<dyn object_store::ObjectStore> = Arc::new(LocalFileSystem::new());
  let table_writer = DuckLakeTableWriter::new(writer, object_store)?;
  
  // `batches: &[RecordBatch]`
  table_writer.write_table("public", "users", &batches).await?;
  ```

  ### Reading (per-catalog, via the standard DuckLakeCatalog path)
  
  ```rust
  use std::sync::Arc;
  use datafusion::prelude::*;
  use datafusion_ducklake::{
      DuckLakeCatalog, MetadataProvider, MulticatalogProvider,
  }; 

  let provider = MulticatalogProvider::with_pool(pool.clone(), "pg_prod").await?;
  let snapshot = provider.get_current_snapshot()?;
  let catalog = DuckLakeCatalog::with_snapshot(Arc::new(provider), snapshot)?;

  let ctx = SessionContext::new_with_config(
      SessionConfig::new().with_default_catalog_and_schema("pg_prod", "public"),
  );
  ctx.register_catalog("pg_prod", Arc::new(catalog));

  let df = ctx.sql("SELECT * FROM pg_prod.public.users WHERE id = 42").await?;
  df.show().await?;
  ```
  
  ### Per-tenant isolation in practice

  Each tenant gets its own writer/provider pair against the same pool:
  
  ```rust
  let pg_writer    = PostgresMetadataWriter::with_pool(pool.clone(), mgr.create_catalog("pg_prod").await?).await?;
  let mysql_writer = PostgresMetadataWriter::with_pool(pool.clone(), mgr.create_catalog("mysql_prod").await?).await?;
  // Writes through pg_writer are invisible to mysql_writer's reader, and vice versa.
  ```
  
  ### Configuration knobs

  ```rust
  // Bound how long a writer waits for the catalog row lock (default 30s).
  let writer = PostgresMetadataWriter::with_pool(pool, catalog_id)
      .await?
      .with_lock_timeout(10_000);  // 10 seconds
  ```
