### PR TITLE
ci: use ubuntu-latest instead of ubuntu-latest-m

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest-m
+          - ubuntu-latest
           - macos-latest
         rust: [stable]
     steps:


### PR DESCRIPTION
The `ubuntu-latest-m` larger runner was provisioned in the previous org and isn't available under `datafusion-contrib`, causing the Linux `Check & Build` job to hang waiting for a runner. Switch to the standard `ubuntu-latest` runner.