### PR TITLE
fix(writer): correct footer-size capture for DuckLake spec semantics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ pub mod encryption;
 pub mod error;
 pub mod information_schema;
 pub mod metadata_provider;
+pub(crate) mod parquet_meta;
 pub mod path_resolver;
 pub mod row_id;
 pub mod schema;

--- a/src/parquet_meta.rs
+++ b/src/parquet_meta.rs
@@ -1,0 +1,50 @@
+//! Parquet footer metadata helpers shared between read and write paths.
+
+/// Convert a DuckLake-spec `footer_size` (thrift metadata length only) into the
+/// value to pass to parquet's `with_metadata_size_hint`.
+///
+/// The parquet reader interprets the hint as "bytes to prefetch from end of
+/// file" and needs `thrift_metadata_len + 8` (length field + `PAR1` magic) to
+/// land the entire footer in a single read. Without the +8, the reader has to
+/// issue a second I/O — correctness preserved, but the optimization that
+/// motivated storing the hint is defeated.
+///
+/// The catalog stores the bare thrift length (per DuckLake spec) so that
+/// cross-engine reads via the DuckDB DuckLake extension pass its footer-size
+/// validation. This helper bridges the two semantics.
+///
+/// Returns `None` if the input is missing, non-positive, or its `+ 8` overflows
+/// `usize`. Callers should treat `None` as "no hint" (parquet falls back to a
+/// default probe), not as an error.
+pub(crate) fn metadata_size_hint_from_footer(footer_size: Option<i64>) -> Option<usize> {
+    let size = footer_size?;
+    if size <= 0 {
+        return None;
+    }
+    usize::try_from(size).ok()?.checked_add(8)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn adds_trailer() {
+        // The stored value is the DuckLake-spec thrift metadata length only.
+        // The parquet prefetch hint needs the +8 trailer to land the full
+        // footer in one read.
+        assert_eq!(metadata_size_hint_from_footer(Some(716)), Some(724));
+        assert_eq!(metadata_size_hint_from_footer(Some(1)), Some(9));
+    }
+
+    #[test]
+    fn rejects_invalid() {
+        assert_eq!(metadata_size_hint_from_footer(None), None);
+        assert_eq!(metadata_size_hint_from_footer(Some(0)), None);
+        assert_eq!(metadata_size_hint_from_footer(Some(-1)), None);
+        // On 32-bit targets where `usize::MAX < i64::MAX`, the conversion fails
+        // safely (returns None) rather than wrapping; the `checked_add` defends
+        // against the analogous overflow on any future wider-pointer platform.
+        // On 64-bit `i64::MAX` fits cleanly so we don't assert that boundary.
+    }
+}

--- a/src/table.rs
+++ b/src/table.rs
@@ -374,10 +374,7 @@ impl DuckLakeTable {
             &resolved_delete_path,
             validated_file_size(delete_file.file_size_bytes, &resolved_delete_path)?,
         );
-        if let Some(footer_size) = delete_file.footer_size
-            && footer_size > 0
-            && let Ok(hint) = usize::try_from(footer_size)
-        {
+        if let Some(hint) = crate::parquet_meta::metadata_size_hint_from_footer(delete_file.footer_size) {
             pf = pf.with_metadata_size_hint(hint);
         }
 
@@ -445,10 +442,7 @@ impl DuckLakeTable {
 
                 // Apply footer size hint if available from DuckLake metadata
                 // This reduces I/O from 2 reads to 1 read per file (especially beneficial for S3/MinIO)
-                if let Some(footer_size) = table_file.file.footer_size
-                    && footer_size > 0
-                    && let Ok(hint) = usize::try_from(footer_size)
-                {
+                if let Some(hint) = crate::parquet_meta::metadata_size_hint_from_footer(table_file.file.footer_size) {
                     pf = pf.with_metadata_size_hint(hint);
                 }
 
@@ -525,10 +519,7 @@ impl DuckLakeTable {
             &resolved_path,
             validated_file_size(table_file.file.file_size_bytes, &resolved_path)?,
         );
-        if let Some(footer_size) = table_file.file.footer_size
-            && footer_size > 0
-            && let Ok(hint) = usize::try_from(footer_size)
-        {
+        if let Some(hint) = crate::parquet_meta::metadata_size_hint_from_footer(table_file.file.footer_size) {
             pf = pf.with_metadata_size_hint(hint);
         }
 
@@ -755,10 +746,7 @@ impl DuckLakeTable {
             &resolved_path,
             validated_file_size(table_file.file.file_size_bytes, &resolved_path)?,
         );
-        if let Some(footer_size) = table_file.file.footer_size
-            && footer_size > 0
-            && let Ok(hint) = usize::try_from(footer_size)
-        {
+        if let Some(hint) = crate::parquet_meta::metadata_size_hint_from_footer(table_file.file.footer_size) {
             pf = pf.with_metadata_size_hint(hint);
         }
 

--- a/src/table_changes.rs
+++ b/src/table_changes.rs
@@ -455,10 +455,7 @@ impl TableChangesTable {
             &resolved_path,
             validated_file_size(data_file.file_size_bytes, &resolved_path)?,
         );
-        if let Some(footer_size) = data_file.footer_size
-            && footer_size > 0
-            && let Ok(hint) = usize::try_from(footer_size)
-        {
+        if let Some(hint) = crate::parquet_meta::metadata_size_hint_from_footer(data_file.footer_size) {
             pf = pf.with_metadata_size_hint(hint);
         }
 

--- a/src/table_deletions.rs
+++ b/src/table_deletions.rs
@@ -174,9 +174,7 @@ impl TableDeletionsTable {
             &resolved_path,
             validated_file_size(size_bytes, &resolved_path)?,
         );
-        if footer_size > 0
-            && let Ok(hint) = usize::try_from(footer_size)
-        {
+        if let Some(hint) = crate::parquet_meta::metadata_size_hint_from_footer(Some(footer_size)) {
             pf = pf.with_metadata_size_hint(hint);
         }
 
@@ -197,9 +195,7 @@ impl TableDeletionsTable {
         footer_size: i64,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         let mut pf = PartitionedFile::new(path, validated_file_size(size_bytes, path)?);
-        if footer_size > 0
-            && let Ok(hint) = usize::try_from(footer_size)
-        {
+        if let Some(hint) = crate::parquet_meta::metadata_size_hint_from_footer(Some(footer_size)) {
             pf = pf.with_metadata_size_hint(hint);
         }
 

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -334,7 +334,15 @@ fn calculate_footer_size_from_bytes(buffer: &[u8]) -> Result<i64> {
     let metadata_len =
         i32::from_le_bytes([footer_bytes[0], footer_bytes[1], footer_bytes[2], footer_bytes[3]])
             as i64;
-    Ok(metadata_len + 8)
+    // DuckLake spec / DuckDB-extension semantics: `footer_size` is the thrift
+    // metadata length stored in the last 8 bytes of the file (the i32 LE value),
+    // NOT including the trailing 4-byte length + 4-byte PAR1 magic. Verified by
+    // having the DuckDB DuckLake extension write a file and inspecting the value
+    // it stored in `ducklake_data_file.footer_size` — it equals exactly this i32.
+    // Returning `metadata_len + 8` produced "Parquet footer length stored in
+    // file is not equal to footer length provided" when the DuckDB reader later
+    // validated the persisted hint against its own footer probe.
+    Ok(metadata_len)
 }
 
 #[cfg(test)]
@@ -443,8 +451,18 @@ mod tests {
 
         let footer_size = calculate_footer_size_from_bytes(&buffer).unwrap();
 
-        // Footer should be reasonable size (metadata + 8 bytes)
-        assert!(footer_size >= 8);
+        // `footer_size` must equal exactly the i32 LE value stored in the last
+        // 8 bytes of the file (the thrift metadata length), with no adjustment
+        // for the trailing length + PAR1 magic. The DuckDB DuckLake extension's
+        // reader validates this on open.
+        let expected = i32::from_le_bytes([
+            buffer[buffer.len() - 8],
+            buffer[buffer.len() - 7],
+            buffer[buffer.len() - 6],
+            buffer[buffer.len() - 5],
+        ]) as i64;
+        assert_eq!(footer_size, expected);
+        assert!(footer_size > 0);
         assert!(footer_size < 10000);
     }
 }

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -334,6 +334,11 @@ fn calculate_footer_size_from_bytes(buffer: &[u8]) -> Result<i64> {
     let metadata_len =
         i32::from_le_bytes([footer_bytes[0], footer_bytes[1], footer_bytes[2], footer_bytes[3]])
             as i64;
+    if metadata_len <= 0 {
+        return Err(crate::error::DuckLakeError::Internal(format!(
+            "Invalid Parquet file: non-positive metadata length {metadata_len}"
+        )));
+    }
     // DuckLake spec / DuckDB-extension semantics: `footer_size` is the thrift
     // metadata length stored in the last 8 bytes of the file (the i32 LE value),
     // NOT including the trailing 4-byte length + 4-byte PAR1 magic. Verified by
@@ -342,6 +347,10 @@ fn calculate_footer_size_from_bytes(buffer: &[u8]) -> Result<i64> {
     // Returning `metadata_len + 8` produced "Parquet footer length stored in
     // file is not equal to footer length provided" when the DuckDB reader later
     // validated the persisted hint against its own footer probe.
+    //
+    // Read-side note: callers that want to use the stored value as a parquet
+    // prefetch hint (`with_metadata_size_hint`) must add the 8-byte trailer
+    // back via [`crate::parquet_meta::metadata_size_hint_from_footer`].
     Ok(metadata_len)
 }
 
@@ -465,4 +474,20 @@ mod tests {
         assert!(footer_size > 0);
         assert!(footer_size < 10000);
     }
+
+    #[test]
+    fn test_calculate_footer_size_rejects_negative_metadata_len() {
+        // Craft a trailer with a negative i32 (e.g., 0xFFFFFFFF = -1 LE) + PAR1.
+        // Per the contract, this must Err rather than silently return a negative
+        // size that downstream callers then have to defensively guard against.
+        let mut buffer = vec![0u8; 16]; // arbitrary leading bytes
+        buffer.extend_from_slice(&(-1i32).to_le_bytes());
+        buffer.extend_from_slice(b"PAR1");
+        let err = calculate_footer_size_from_bytes(&buffer).unwrap_err();
+        assert!(
+            format!("{err}").contains("non-positive metadata length"),
+            "unexpected error message: {err}"
+        );
+    }
+
 }


### PR DESCRIPTION
## Summary

`calculate_footer_size_from_bytes` in `src/table_writer.rs` returns `metadata_len + 8`. The DuckLake spec / DuckDB-extension semantics store `footer_size` as the **thrift metadata length only** — the i32 LE value at `file_size - 8` — *excluding* the trailing 4-byte length + 4-byte PAR1 magic. DuckDB's bundled DuckLake extension validates `footer_length_stored_in_file == footer_size_provided` on open and rejects the inflated value with `"Parquet footer length stored in file is not equal to footer length provided"`.

Verified empirically by having the DuckDB DuckLake extension write a file and inspecting `ducklake_data_file.footer_size` — equals exactly the thrift metadata length, no offset. The PR's tightened `test_calculate_footer_size_from_bytes` pins this contract with `assert_eq!(footer_size, expected_i32_le)`.

The trailing two commits handle a perf regression introduced by the bare fix (caught in pre-PR review): the 6 read-side `with_metadata_size_hint` call sites need the `+ 8` *back* to land the prefetch in a single I/O — without it, every Parquet open silently does a second fetch. A new `src/parquet_meta.rs::metadata_size_hint_from_footer` helper bridges the spec-correct stored value to the prefetch-correct hint; the helper replaces 6 hand-rolled `if let Some(footer_size) … && let Ok(hint) = usize::try_from(footer_size)` blocks across `table.rs`, `table_changes.rs`, `table_deletions.rs`. The third commit adds a defensive `Err` in `calculate_footer_size_from_bytes` when the decoded i32 is non-positive (was previously silently returning a negative `i64`).

## Commits

- `01b37b1` fix(writer): correct footer-size capture for DuckLake spec semantics
- `f99e64a` fix(read): restore single-fetch prefetch hint after footer-size correction
- `7374591` fix(writer): reject non-positive metadata length in footer parsing

## Test plan

- [x] `cargo test --features metadata-duckdb,duckdb-bundled --lib parquet_meta` → 2/2 pass
- [x] `cargo test --features metadata-duckdb,duckdb-bundled,write,write-sqlite --lib` → 231/231 pass, zero regressions
- [x] `cargo build --all-features` clean
- [x] `cargo clippy --features metadata-duckdb,duckdb-bundled,write,write-sqlite --lib --tests` clean
- [ ] CI passes

## Context

This is the first of a series of upstream-direction PRs slicing a carry-forward of a long-lived feature branch ([fork audit](https://github.com/zfarrell/datafusion-ducklake/issues/26)). Each PR is scoped to a single concern; this one ships standalone and predates the rest of the queue. Full plan: [zfarrell/datafusion-ducklake meta/upstream-port-plan](https://github.com/zfarrell/datafusion-ducklake/blob/meta/upstream-port-plan/.upstream-port/PLAN.md).

Fork-side trifecta-review record + bug-fix discussion: [zfarrell/datafusion-ducklake#28](https://github.com/zfarrell/datafusion-ducklake/pull/28).