### PR TITLE
feat(postgres): populate row_id_start on data-file registration

### DIFF
--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -76,6 +76,19 @@ pub(crate) const SQL_CREATE_STANDARD_TABLES: &[&str] = &[
         begin_snapshot BIGINT NOT NULL,
         end_snapshot BIGINT
     )"#,
+    // Per-table running counters maintained inside the writer's transaction
+    // so concurrent writes hand out non-overlapping rowid ranges. `next_row_id`
+    // increases monotonically over the table's lifetime (rowids are never
+    // reused, even after end-snapshot); `record_count` and `file_size_bytes`
+    // mirror the currently-visible totals so DuckDB's `ducklake_table_info`
+    // aggregate sees correct numbers for tables this writer produced. Mirrors
+    // the sqlite writer's `ducklake_table_stats`.
+    r#"CREATE TABLE IF NOT EXISTS ducklake_table_stats (
+        table_id BIGINT PRIMARY KEY,
+        record_count BIGINT NOT NULL DEFAULT 0,
+        next_row_id BIGINT NOT NULL DEFAULT 0,
+        file_size_bytes BIGINT NOT NULL DEFAULT 0
+    )"#,
     r#"CREATE TABLE IF NOT EXISTS ducklake_delete_file (
         delete_file_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
         data_file_id BIGINT NOT NULL,
@@ -453,13 +466,39 @@ impl MetadataWriter for PostgresMetadataWriter {
         file: &DataFileInfo,
     ) -> Result<i64> {
         block_on(async {
+            // Allocate row_id_start from the table's monotonic counter inside
+            // the same transaction so concurrent writers can't hand out
+            // overlapping ranges. The DuckLake row-lineage read path
+            // (RowIdExec) hard-errors on files where row_id_start is NULL and
+            // no embedded `_ducklake_internal_row_id` column is present, so
+            // every file we write must carry a value. Falls back to inserting
+            // a fresh stats row (next_row_id = 0) for tables created before
+            // this writer started maintaining `ducklake_table_stats`.
             let mut tx = self.pool.begin().await?;
             lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
             assert_table_in_catalog(self.catalog_id, table_id, &mut tx).await?;
 
+            sqlx::query(
+                "INSERT INTO ducklake_table_stats (table_id, record_count, next_row_id, file_size_bytes)
+                 VALUES ($1, 0, 0, 0)
+                 ON CONFLICT (table_id) DO NOTHING",
+            )
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+
+            let stats_row =
+                sqlx::query("SELECT next_row_id FROM ducklake_table_stats WHERE table_id = $1")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
+            let row_id_start: i64 = stats_row.try_get(0)?;
+
             let row = sqlx::query(
-                "INSERT INTO ducklake_data_file (table_id, path, path_is_relative, file_size_bytes, footer_size, record_count, begin_snapshot)
-                 VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING data_file_id",
+                "INSERT INTO ducklake_data_file
+                     (table_id, path, path_is_relative, file_size_bytes,
+                      footer_size, record_count, row_id_start, begin_snapshot)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING data_file_id",
             )
             .bind(table_id)
             .bind(&file.path)
@@ -467,10 +506,28 @@ impl MetadataWriter for PostgresMetadataWriter {
             .bind(file.file_size_bytes)
             .bind(file.footer_size)
             .bind(file.record_count)
+            .bind(row_id_start)
             .bind(snapshot_id)
             .fetch_one(&mut *tx)
             .await?;
             let id: i64 = row.try_get(0)?;
+
+            // Advance the counter and accumulate stats. `next_row_id`
+            // monotonically increases over the table's lifetime — rowids
+            // are never reused, even after end-snapshot.
+            sqlx::query(
+                "UPDATE ducklake_table_stats
+                 SET next_row_id     = next_row_id + $1,
+                     record_count    = record_count + $2,
+                     file_size_bytes = file_size_bytes + $3
+                 WHERE table_id = $4",
+            )
+            .bind(file.record_count)
+            .bind(file.record_count)
+            .bind(file.file_size_bytes)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
 
             tx.commit().await?;
             Ok(id)
@@ -478,6 +535,11 @@ impl MetadataWriter for PostgresMetadataWriter {
     }
 
     fn end_table_files(&self, table_id: i64, snapshot_id: i64) -> Result<u64> {
+        // Used by WriteMode::Replace. End-snapshotting every visible file
+        // drops the table's currently-visible row count and byte total to
+        // zero (the new files written next will rebuild them). `next_row_id`
+        // is deliberately NOT reset: rowids must stay monotonic across the
+        // table's lifetime so historical snapshots still resolve uniquely.
         block_on(async {
             let mut tx = self.pool.begin().await?;
             lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
@@ -492,6 +554,15 @@ impl MetadataWriter for PostgresMetadataWriter {
             .execute(&mut *tx)
             .await?;
             let n = result.rows_affected();
+
+            sqlx::query(
+                "UPDATE ducklake_table_stats
+                 SET record_count = 0, file_size_bytes = 0
+                 WHERE table_id = $1",
+            )
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
 
             tx.commit().await?;
             Ok(n)
@@ -796,6 +867,28 @@ impl MetadataWriter for PostgresMetadataWriter {
                      WHERE table_id = $2 AND end_snapshot IS NULL",
                 )
                 .bind(snapshot_id)
+                .bind(table_id)
+                .execute(&mut *tx)
+                .await?;
+
+                // Mirror end_table_files: drop visible row/byte totals to
+                // zero while keeping next_row_id monotonic. Seed the row
+                // first in case this is a Replace on a brand-new table.
+                sqlx::query(
+                    "INSERT INTO ducklake_table_stats
+                         (table_id, record_count, next_row_id, file_size_bytes)
+                     VALUES ($1, 0, 0, 0)
+                     ON CONFLICT (table_id) DO NOTHING",
+                )
+                .bind(table_id)
+                .execute(&mut *tx)
+                .await?;
+
+                sqlx::query(
+                    "UPDATE ducklake_table_stats
+                     SET record_count = 0, file_size_bytes = 0
+                     WHERE table_id = $1",
+                )
                 .bind(table_id)
                 .execute(&mut *tx)
                 .await?;

--- a/tests/multicatalog_postgres_tests.rs
+++ b/tests/multicatalog_postgres_tests.rs
@@ -1275,3 +1275,180 @@ async fn drop_table_in_catalog_isolates_other_catalogs() {
         "drop snapshot must be registered only under the dropping catalog"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Row lineage / row_id_start coverage for the postgres writer. The read path
+// (RowIdExec) hard-errors on data files whose row_id_start is NULL and have
+// no embedded `_ducklake_internal_row_id` column, so the writer must populate
+// the column on every file it produces. These tests pin that contract.
+// ---------------------------------------------------------------------------
+
+async fn read_row_id_start(pool: &PgPool, file_id: i64) -> Option<i64> {
+    sqlx::query("SELECT row_id_start FROM ducklake_data_file WHERE data_file_id = $1")
+        .bind(file_id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+        .try_get(0)
+        .unwrap()
+}
+
+async fn read_table_stats(pool: &PgPool, table_id: i64) -> (i64, i64, i64) {
+    let row = sqlx::query(
+        "SELECT record_count, next_row_id, file_size_bytes
+         FROM ducklake_table_stats WHERE table_id = $1",
+    )
+    .bind(table_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    (
+        row.try_get(0).unwrap(),
+        row.try_get(1).unwrap(),
+        row.try_get(2).unwrap(),
+    )
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn register_data_file_assigns_non_overlapping_row_id_start() {
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("pg_rowid").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path("/data").unwrap();
+    let setup = w
+        .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
+        .unwrap();
+
+    // Three files of 100, 50, 200 rows -> row_id_start = 0, 100, 150;
+    // next_row_id = 350 after all three.
+    let f1 = w
+        .register_data_file(
+            setup.table_id,
+            setup.snapshot_id,
+            &DataFileInfo::new("f1.parquet", 4096, 100),
+        )
+        .unwrap();
+    let f2 = w
+        .register_data_file(
+            setup.table_id,
+            setup.snapshot_id,
+            &DataFileInfo::new("f2.parquet", 2048, 50),
+        )
+        .unwrap();
+    let f3 = w
+        .register_data_file(
+            setup.table_id,
+            setup.snapshot_id,
+            &DataFileInfo::new("f3.parquet", 8192, 200),
+        )
+        .unwrap();
+
+    assert_eq!(read_row_id_start(&pool, f1).await, Some(0));
+    assert_eq!(read_row_id_start(&pool, f2).await, Some(100));
+    assert_eq!(read_row_id_start(&pool, f3).await, Some(150));
+
+    let (records, next, bytes) = read_table_stats(&pool, setup.table_id).await;
+    assert_eq!(records, 350);
+    assert_eq!(next, 350);
+    assert_eq!(bytes, 4096 + 2048 + 8192);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn replace_preserves_next_row_id_monotonic() {
+    // rowids must never be reused, even across WriteMode::Replace cycles.
+    // begin_write_transaction(Replace) end-snapshots the prior generation's
+    // files and clears record_count / file_size_bytes, but next_row_id stays
+    // put — so the first file of the new generation continues where the old
+    // generation left off.
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("pg_replace").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path("/data").unwrap();
+    let s1 = w
+        .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
+        .unwrap();
+
+    w.register_data_file(
+        s1.table_id,
+        s1.snapshot_id,
+        &DataFileInfo::new("g1.parquet", 1024, 5),
+    )
+    .unwrap();
+    let (rc1, next1, _) = read_table_stats(&pool, s1.table_id).await;
+    assert_eq!(rc1, 5);
+    assert_eq!(next1, 5);
+
+    // Second Replace ends the first generation's files and resets visible
+    // totals to zero while preserving next_row_id.
+    let s2 = w
+        .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
+        .unwrap();
+    let (rc2, next2, bytes2) = read_table_stats(&pool, s2.table_id).await;
+    assert_eq!(rc2, 0, "record_count must reset on Replace");
+    assert_eq!(next2, 5, "next_row_id must NOT reset on Replace");
+    assert_eq!(bytes2, 0);
+
+    // The first file of the new generation picks up at 5.
+    let f2_id = w
+        .register_data_file(
+            s2.table_id,
+            s2.snapshot_id,
+            &DataFileInfo::new("g2.parquet", 2048, 2),
+        )
+        .unwrap();
+    assert_eq!(
+        read_row_id_start(&pool, f2_id).await,
+        Some(5),
+        "post-replace files must start at the preserved counter, not 0",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn register_data_file_self_initialises_stats_for_legacy_tables() {
+    // Defensive path: a table that existed before this writer maintained
+    // ducklake_table_stats. The first register_data_file must self-initialise
+    // the stats row at 0 rather than fail with "no row".
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("pg_legacy").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path("/data").unwrap();
+    let setup = w
+        .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
+        .unwrap();
+
+    // Simulate "legacy" state by removing whatever stats row may have been
+    // pre-populated. begin_write_transaction doesn't currently insert one,
+    // but being explicit keeps the test meaningful if that changes.
+    sqlx::query("DELETE FROM ducklake_table_stats WHERE table_id = $1")
+        .bind(setup.table_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let file_id = w
+        .register_data_file(
+            setup.table_id,
+            setup.snapshot_id,
+            &DataFileInfo::new("a.parquet", 50, 4),
+        )
+        .unwrap();
+    assert_eq!(read_row_id_start(&pool, file_id).await, Some(0));
+    let (records, next, _) = read_table_stats(&pool, setup.table_id).await;
+    assert_eq!(records, 4);
+    assert_eq!(next, 4);
+}


### PR DESCRIPTION
Bring the Postgres metadata writer up to parity with the SQLite writer so the virtual `rowid` column resolves to a unique, stable identifier across the table's lifetime.

Three changes:

* Bootstrap `ducklake_table_stats(table_id PK, record_count, next_row_id, file_size_bytes)` in `SQL_CREATE_STANDARD_TABLES`. Legacy catalogs that pre-date this table are self-healed on first `register_data_file` via `INSERT ... ON CONFLICT (table_id) DO NOTHING`.

* `register_data_file` reads `next_row_id`, writes it as the new file's `row_id_start`, then bumps `next_row_id += record_count` and accumulates `record_count` / `file_size_bytes`. All inside the same transaction so concurrent writers don't hand out overlapping ranges.

* `WriteMode::Replace` (both standalone `end_table_files` and the inline branch of `begin_write_transaction`) clears `record_count` and `file_size_bytes` but leaves `next_row_id` untouched — rowids must stay monotonic across the table's whole lifetime, not per generation.

Three integration tests cover the contract: non-overlapping ranges across appends, monotonic counter across Replace cycles, and self- initialisation for legacy tables that boot without a stats row.