### PR TITLE
feat(maintenance): single-catalog DROP TABLE + expire_snapshots / cleanup_old_files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1830,6 +1830,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sdk-s3",
  "base64 0.22.1",
+ "chrono",
  "datafusion",
  "duckdb",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ hex = { version = "0.4", optional = true }
 
 # Write support (optional)
 uuid = { version = "1.0", features = ["v4"], optional = true }
+# Used by the maintenance API (ExpireCriteria/CleanupCriteria OlderThan).
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"], optional = true }
 
 # Metadata providers (optional)
 duckdb = { version = "1.4.1", optional = true }
@@ -70,7 +72,7 @@ duckdb-bundled = ["metadata-duckdb", "duckdb/bundled"]
 encryption = ["parquet/encryption", "datafusion/parquet_encryption", "dep:base64", "dep:hex"]
 
 # Write support
-write = ["dep:uuid"]
+write = ["dep:uuid", "dep:chrono"]
 write-sqlite = ["write", "metadata-sqlite"]
 write-postgres = ["write", "metadata-postgres", "multicatalog-postgres"]
 # Multicatalog read provider (independent of write support)
@@ -89,3 +91,7 @@ required-features = ["metadata-duckdb", "metadata-postgres"]
 [[example]]
 name = "multicatalog_write"
 required-features = ["write-postgres"]
+
+[[example]]
+name = "maintenance_demo"
+required-features = ["write-sqlite"]

--- a/examples/maintenance_demo.rs
+++ b/examples/maintenance_demo.rs
@@ -1,0 +1,222 @@
+//! Side-by-side comparable demo of the new maintenance flow on the single-catalog
+//! (SQLite + LocalFS) write path.
+//!
+//! Mirrors the scenario in `examples/maintenance_demo.sql` (which drives the same
+//! logical sequence through the official DuckDB+DuckLake extension), so the two
+//! outputs can be lined up step-by-step.
+//!
+//! Scenario:
+//!   snap 1   CREATE TABLE main.t(id int64, name varchar)   -- DDL
+//!   snap 2   write data file f1                            -- INSERT
+//!   snap 3   Replace: end-snapshot f1, write f2            -- "DELETE FROM t" + reinsert
+//!   snap 4   DROP TABLE main.t                              -- tombstone
+//!   expire   versions [2, 3]                                -- snap 4 is most-recent, kept
+//!   cleanup  cleanup_all                                    -- physically delete scheduled
+//!
+//! Run with:
+//!     cargo run --no-default-features --features write-sqlite \
+//!         --example maintenance_demo
+
+use std::path::Path;
+use std::sync::Arc;
+
+use object_store::ObjectStore;
+use object_store::local::LocalFileSystem;
+use sqlx::Row;
+use sqlx::sqlite::SqlitePool;
+
+use datafusion_ducklake::SqliteMetadataWriter;
+use datafusion_ducklake::maintenance::{CleanupCriteria, ExpireCriteria, cleanup_old_files_sqlite};
+use datafusion_ducklake::metadata_writer::{ColumnDef, DataFileInfo, MetadataWriter, WriteMode};
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    // --- temp catalog + data path ----------------------------------------------------
+    let temp = tempfile::TempDir::new()?;
+    let db_path = temp.path().join("catalog.db");
+    let data_path = temp.path().join("data");
+    std::fs::create_dir_all(&data_path)?;
+    let conn_str = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    let writer = SqliteMetadataWriter::new_with_init(&conn_str).await?;
+    writer.set_data_path(data_path.to_str().unwrap())?;
+    let pool = SqlitePool::connect(&conn_str).await?;
+
+    println!("data_path = {}\n", data_path.display());
+
+    // --- snap 1: CREATE TABLE (DDL only — no files yet) ------------------------------
+    // begin_write_transaction allocates a snapshot and creates the schema/table/columns.
+    // We don't register a data file at this snapshot, so it's purely DDL.
+    let s1 = writer.begin_write_transaction(
+        "main",
+        "t",
+        &[ColumnDef::new("id", "int64", false)?, ColumnDef::new("name", "varchar", true)?],
+        WriteMode::Replace,
+    )?;
+    print_state(&pool, &data_path, "Step 1 — CREATE TABLE main.t").await?;
+
+    // --- snap 2: write data file f1 ("INSERT") ---------------------------------------
+    let s2 = writer.begin_write_transaction(
+        "main",
+        "t",
+        &cols(),
+        WriteMode::Replace, // Replace at snap2 ends nothing (nothing live), then writes f1.
+    )?;
+    writer.register_data_file(
+        s2.table_id,
+        s2.snapshot_id,
+        &DataFileInfo::new("f1.parquet", 100, 5),
+    )?;
+    touch_file(&data_path, "main", "t", "f1.parquet")?;
+    print_state(&pool, &data_path, "Step 2 — write f1 (INSERT)").await?;
+
+    // --- snap 3: Replace — end-snapshot f1, write f2 ("DELETE FROM t" + reinsert) ----
+    let s3 = writer.begin_write_transaction("main", "t", &cols(), WriteMode::Replace)?;
+    writer.register_data_file(
+        s3.table_id,
+        s3.snapshot_id,
+        &DataFileInfo::new("f2.parquet", 100, 5),
+    )?;
+    touch_file(&data_path, "main", "t", "f2.parquet")?;
+    print_state(&pool, &data_path, "Step 3 — Replace: end f1, write f2").await?;
+
+    // --- snap 4: DROP TABLE ---------------------------------------------------------
+    let dropped = writer.drop_table("main", "t")?;
+    println!("drop_table -> {dropped}");
+    print_state(&pool, &data_path, "Step 4 — DROP TABLE main.t").await?;
+
+    // --- expire snapshots [2, 3] (snap 4 is most-recent, always kept) ----------------
+    let expired = writer.expire_snapshots(ExpireCriteria::Versions(vec![
+        s2.snapshot_id,
+        s3.snapshot_id,
+    ]))?;
+    println!("expire_snapshots -> {expired:#?}");
+    print_state(&pool, &data_path, "Step 5 — expire versions [2, 3]").await?;
+
+    // --- cleanup: physically delete scheduled files ----------------------------------
+    let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+    let dry = cleanup_old_files_sqlite(&writer, store.clone(), CleanupCriteria::All, true).await?;
+    println!("cleanup dry_run -> {dry:#?}");
+    let done = cleanup_old_files_sqlite(&writer, store, CleanupCriteria::All, false).await?;
+    println!("cleanup real    -> {done:#?}");
+    print_state(&pool, &data_path, "Step 6 — cleanup_old_files(all)").await?;
+
+    // The s1 binding exists only so the table's first snapshot stays readable in the
+    // narrative; it's unused after that.
+    let _ = s1;
+    Ok(())
+}
+
+fn cols() -> Vec<ColumnDef> {
+    vec![
+        ColumnDef::new("id", "int64", false).unwrap(),
+        ColumnDef::new("name", "varchar", true).unwrap(),
+    ]
+}
+
+fn touch_file(data_path: &Path, schema: &str, table: &str, name: &str) -> anyhow::Result<()> {
+    let dir = data_path.join(schema).join(table);
+    std::fs::create_dir_all(&dir)?;
+    std::fs::write(dir.join(name), b"parquet-bytes")?;
+    Ok(())
+}
+
+/// Dump everything that's interesting at this point: snapshots, the table row(s),
+/// data files, scheduled-for-deletion queue, and what's physically on disk.
+async fn print_state(pool: &SqlitePool, data_path: &Path, header: &str) -> anyhow::Result<()> {
+    println!("\n──────── {header} ────────");
+
+    println!("ducklake_snapshot:");
+    let rows = sqlx::query(
+        "SELECT snapshot_id, snapshot_time FROM ducklake_snapshot ORDER BY snapshot_id",
+    )
+    .fetch_all(pool)
+    .await?;
+    for r in &rows {
+        let id: i64 = r.try_get(0)?;
+        let t: String = r.try_get(1)?;
+        println!("  snap {id} @ {t}");
+    }
+
+    println!("ducklake_table:");
+    let rows = sqlx::query(
+        "SELECT table_id, table_name, begin_snapshot, end_snapshot FROM ducklake_table",
+    )
+    .fetch_all(pool)
+    .await?;
+    for r in &rows {
+        let id: i64 = r.try_get(0)?;
+        let n: String = r.try_get(1)?;
+        let b: i64 = r.try_get(2)?;
+        let e: Option<i64> = r.try_get(3)?;
+        println!("  table_id={id} name={n} begin={b} end={e:?}");
+    }
+
+    println!("ducklake_data_file:");
+    let rows = sqlx::query(
+        "SELECT data_file_id, path, begin_snapshot, end_snapshot FROM ducklake_data_file ORDER BY data_file_id",
+    ).fetch_all(pool).await?;
+    if rows.is_empty() {
+        println!("  (none)");
+    }
+    for r in &rows {
+        let id: i64 = r.try_get(0)?;
+        let p: String = r.try_get(1)?;
+        let b: i64 = r.try_get(2)?;
+        let e: Option<i64> = r.try_get(3)?;
+        println!("  df_id={id} path={p} begin={b} end={e:?}");
+    }
+
+    println!("ducklake_files_scheduled_for_deletion:");
+    let rows = sqlx::query(
+        "SELECT data_file_id, path, schedule_start FROM ducklake_files_scheduled_for_deletion ORDER BY data_file_id",
+    ).fetch_all(pool).await?;
+    if rows.is_empty() {
+        println!("  (empty)");
+    }
+    for r in &rows {
+        let id: i64 = r.try_get(0)?;
+        let p: String = r.try_get(1)?;
+        let t: String = r.try_get(2)?;
+        println!("  df_id={id} path={p} scheduled_at={t}");
+    }
+
+    println!("ducklake_table_stats:");
+    let rows = sqlx::query("SELECT table_id, record_count, next_row_id FROM ducklake_table_stats")
+        .fetch_all(pool)
+        .await?;
+    if rows.is_empty() {
+        println!("  (none)");
+    }
+    for r in &rows {
+        let id: i64 = r.try_get(0)?;
+        let rc: i64 = r.try_get(1)?;
+        let nr: i64 = r.try_get(2)?;
+        println!("  table_id={id} record_count={rc} next_row_id={nr}");
+    }
+
+    println!("files on disk under data_path:");
+    let mut found = Vec::new();
+    walk_files(data_path, &mut found);
+    if found.is_empty() {
+        println!("  (none)");
+    }
+    for p in found {
+        println!("  {}", p.strip_prefix(data_path).unwrap().display());
+    }
+    println!();
+    Ok(())
+}
+
+fn walk_files(dir: &Path, out: &mut Vec<std::path::PathBuf>) {
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for e in entries.flatten() {
+            let p = e.path();
+            if p.is_dir() {
+                walk_files(&p, out);
+            } else {
+                out.push(p);
+            }
+        }
+    }
+}

--- a/examples/maintenance_demo.sql
+++ b/examples/maintenance_demo.sql
@@ -1,0 +1,86 @@
+-- Side-by-side comparable demo of the official DuckDB+DuckLake maintenance flow.
+-- Mirrors `examples/maintenance_demo.rs` (which drives the same logical sequence
+-- through our Rust port), so the two outputs can be lined up step-by-step.
+--
+-- Hardcoded paths under /tmp/maint_demo_official — caller must `rm -rf` first.
+-- Run with the locally-built DuckLake extension (HEAD of the ported repo):
+--   rm -rf /tmp/maint_demo_official && mkdir -p /tmp/maint_demo_official/data
+--   /Users/tsoap/hotdata/ducklake/build/release/duckdb -unsigned \
+--     -c "LOAD '/Users/tsoap/hotdata/ducklake/build/release/extension/ducklake/ducklake.duckdb_extension';" \
+--     < examples/maintenance_demo.sql
+
+.bail on
+LOAD '/Users/tsoap/hotdata/ducklake/build/release/extension/ducklake/ducklake.duckdb_extension';
+
+ATTACH 'ducklake:/tmp/maint_demo_official/catalog.db' AS dl
+    (DATA_PATH '/tmp/maint_demo_official/data', METADATA_CATALOG 'metadata');
+
+.print "data_path = /tmp/maint_demo_official/data"
+.print ""
+
+-- ── Step 1: CREATE TABLE (DDL only) ──
+CREATE TABLE dl.main.t(id BIGINT, name VARCHAR);
+.print "──────── Step 1 — CREATE TABLE main.t ────────"
+SELECT 'ducklake_snapshot' AS rel; SELECT snapshot_id, snapshot_time FROM metadata.ducklake_snapshot ORDER BY snapshot_id;
+SELECT 'ducklake_table' AS rel;    SELECT table_id, table_name, begin_snapshot, end_snapshot FROM metadata.ducklake_table;
+SELECT 'ducklake_data_file' AS rel; SELECT data_file_id, path, begin_snapshot, end_snapshot FROM metadata.ducklake_data_file ORDER BY data_file_id;
+SELECT 'ducklake_files_scheduled_for_deletion' AS rel; SELECT data_file_id, path, schedule_start FROM metadata.ducklake_files_scheduled_for_deletion ORDER BY data_file_id;
+SELECT 'files on disk' AS rel; SELECT file FROM glob('/tmp/maint_demo_official/data/**') ORDER BY file;
+.print ""
+
+-- ── Step 2: INSERT rows → writes f1 ──
+INSERT INTO dl.main.t VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e');
+.print "──────── Step 2 — INSERT 5 rows (f1) ────────"
+SELECT snapshot_id, snapshot_time FROM metadata.ducklake_snapshot ORDER BY snapshot_id;
+SELECT table_id, table_name, begin_snapshot, end_snapshot FROM metadata.ducklake_table;
+SELECT data_file_id, path, begin_snapshot, end_snapshot FROM metadata.ducklake_data_file ORDER BY data_file_id;
+SELECT data_file_id, path, schedule_start FROM metadata.ducklake_files_scheduled_for_deletion ORDER BY data_file_id;
+SELECT file FROM glob('/tmp/maint_demo_official/data/**') ORDER BY file;
+.print ""
+
+-- ── Step 3: DELETE all + INSERT more → ends f1, writes f2 (parallels our Replace) ──
+DELETE FROM dl.main.t;
+INSERT INTO dl.main.t VALUES (6, 'f'), (7, 'g'), (8, 'h'), (9, 'i'), (10, 'j');
+.print "──────── Step 3 — DELETE all + INSERT (f2) ────────"
+SELECT snapshot_id, snapshot_time FROM metadata.ducklake_snapshot ORDER BY snapshot_id;
+SELECT table_id, table_name, begin_snapshot, end_snapshot FROM metadata.ducklake_table;
+SELECT data_file_id, path, begin_snapshot, end_snapshot FROM metadata.ducklake_data_file ORDER BY data_file_id;
+SELECT data_file_id, path, schedule_start FROM metadata.ducklake_files_scheduled_for_deletion ORDER BY data_file_id;
+SELECT file FROM glob('/tmp/maint_demo_official/data/**') ORDER BY file;
+.print ""
+
+-- ── Step 4: DROP TABLE ──
+DROP TABLE dl.main.t;
+.print "──────── Step 4 — DROP TABLE main.t ────────"
+SELECT snapshot_id, snapshot_time FROM metadata.ducklake_snapshot ORDER BY snapshot_id;
+SELECT table_id, table_name, begin_snapshot, end_snapshot FROM metadata.ducklake_table;
+SELECT data_file_id, path, begin_snapshot, end_snapshot FROM metadata.ducklake_data_file ORDER BY data_file_id;
+SELECT data_file_id, path, schedule_start FROM metadata.ducklake_files_scheduled_for_deletion ORDER BY data_file_id;
+SELECT file FROM glob('/tmp/maint_demo_official/data/**') ORDER BY file;
+.print ""
+
+-- ── Step 5: expire snapshots [2, 3] (snap 4 is most-recent, kept) ──
+.print "── expire_snapshots(versions => [2, 3]) ──"
+CALL ducklake_expire_snapshots('dl', versions => [2, 3]);
+.print ""
+.print "──────── Step 5 — after expire ────────"
+SELECT snapshot_id, snapshot_time FROM metadata.ducklake_snapshot ORDER BY snapshot_id;
+SELECT table_id, table_name, begin_snapshot, end_snapshot FROM metadata.ducklake_table;
+SELECT data_file_id, path, begin_snapshot, end_snapshot FROM metadata.ducklake_data_file ORDER BY data_file_id;
+SELECT data_file_id, path, schedule_start FROM metadata.ducklake_files_scheduled_for_deletion ORDER BY data_file_id;
+SELECT file FROM glob('/tmp/maint_demo_official/data/**') ORDER BY file;
+.print ""
+
+-- ── Step 6: cleanup ──
+.print "── cleanup_old_files dry_run=true, cleanup_all=true ──"
+SELECT path FROM ducklake_cleanup_old_files('dl', cleanup_all => true, dry_run => true);
+.print ""
+.print "── cleanup_old_files(cleanup_all => true) [real] ──"
+CALL ducklake_cleanup_old_files('dl', cleanup_all => true);
+.print ""
+.print "──────── Step 6 — after cleanup_old_files ────────"
+SELECT snapshot_id, snapshot_time FROM metadata.ducklake_snapshot ORDER BY snapshot_id;
+SELECT table_id, table_name, begin_snapshot, end_snapshot FROM metadata.ducklake_table;
+SELECT data_file_id, path, begin_snapshot, end_snapshot FROM metadata.ducklake_data_file ORDER BY data_file_id;
+SELECT data_file_id, path, schedule_start FROM metadata.ducklake_files_scheduled_for_deletion ORDER BY data_file_id;
+SELECT file FROM glob('/tmp/maint_demo_official/data/**') ORDER BY file;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,8 @@ pub mod metadata_provider_sqlite;
 #[cfg(feature = "write")]
 pub mod insert_exec;
 #[cfg(feature = "write")]
+pub mod maintenance;
+#[cfg(feature = "write")]
 pub mod metadata_writer;
 #[cfg(feature = "write-postgres")]
 pub mod metadata_writer_postgres;

--- a/src/maintenance.rs
+++ b/src/maintenance.rs
@@ -1,0 +1,168 @@
+//! Maintenance operations for DuckLake catalogs: snapshot expiration and
+//! physical file cleanup.
+//!
+//! These port the official DuckLake two-phase vacuum
+//! (`ducklake_expire_snapshots` + `ducklake_cleanup_old_files`):
+//!
+//! 1. **expire** ([`crate::metadata_writer_sqlite::SqliteMetadataWriter::expire_snapshots`],
+//!    [`crate::multicatalog::MulticatalogManager::expire_snapshots_in_catalog`]) deletes the
+//!    chosen snapshots, garbage-collects every table / data file / delete file that is no
+//!    longer reachable by any surviving snapshot, and records the orphaned physical paths in
+//!    `ducklake_files_scheduled_for_deletion`. No object storage is touched.
+//! 2. **cleanup** ([`cleanup_old_files_sqlite`], [`cleanup_old_files_in_catalog`]) reads the
+//!    scheduled rows, deletes the objects from the object store, and removes the rows.
+//!
+//! The metadata writers deliberately hold no object store — physical I/O lives here so the
+//! catalog layer stays storage-agnostic (the object store comes from the caller, e.g. the
+//! same one a [`crate::table_writer::DuckLakeTableWriter`] was built with).
+
+use crate::Result;
+use crate::path_resolver::{parse_object_store_url, resolve_path};
+use chrono::{DateTime, Utc};
+use object_store::path::Path as ObjectPath;
+use object_store::{ObjectStore, ObjectStoreExt};
+use std::sync::Arc;
+
+/// Which snapshots to expire.
+#[derive(Debug, Clone)]
+pub enum ExpireCriteria {
+    /// Expire exactly these snapshot ids (the most recent snapshot is always kept,
+    /// even if listed here).
+    Versions(Vec<i64>),
+    /// Expire every snapshot older than this timestamp. The most recent snapshot
+    /// is always kept regardless.
+    OlderThan(DateTime<Utc>),
+}
+
+/// Which scheduled files to physically delete.
+#[derive(Debug, Clone)]
+pub enum CleanupCriteria {
+    /// Delete every scheduled file regardless of when it was scheduled.
+    All,
+    /// Delete only files scheduled before this timestamp.
+    OlderThan(DateTime<Utc>),
+}
+
+/// Render a UTC timestamp as a SQL literal both backends parse and compare correctly.
+///
+/// SQLite stores `CURRENT_TIMESTAMP` as `'YYYY-MM-DD HH:MM:SS'` text — lexicographic
+/// comparison with this format works because the components are zero-padded and in
+/// big-endian order. Postgres parses the same text into both `TIMESTAMP` and
+/// `TIMESTAMPTZ` (we explicitly cast at the bind site).
+pub(crate) fn format_sql_timestamp(dt: &DateTime<Utc>) -> String {
+    dt.format("%Y-%m-%d %H:%M:%S%.6f").to_string()
+}
+
+/// A snapshot that was expired, as returned by the expire operations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExpiredSnapshot {
+    /// The expired snapshot id.
+    pub snapshot_id: i64,
+    /// The snapshot timestamp, as stored in `ducklake_snapshot.snapshot_time`.
+    pub snapshot_time: String,
+}
+
+/// A row of `ducklake_files_scheduled_for_deletion`. `path` is relative to the
+/// catalog `data_path` root when `path_is_relative` is set (see the table docs).
+#[derive(Debug, Clone)]
+pub struct ScheduledFile {
+    /// The `data_file_id` of the (already-deleted) data/delete file row.
+    pub data_file_id: i64,
+    /// Physical path, relative to `data_path` when `path_is_relative`.
+    pub path: String,
+    /// Whether `path` is relative to the catalog `data_path` root.
+    pub path_is_relative: bool,
+}
+
+/// Resolve scheduled rows against `data_path`, delete the objects (unless `dry_run`),
+/// and return the resolved absolute paths that were (or would be) deleted. Shared
+/// by both backends; the row listing / row removal is backend-specific and passed in.
+async fn run_cleanup<RemoveFut>(
+    data_path: &str,
+    files: Vec<ScheduledFile>,
+    object_store: Arc<dyn ObjectStore>,
+    dry_run: bool,
+    remove_rows: impl FnOnce(Vec<i64>) -> RemoveFut,
+) -> Result<Vec<String>>
+where
+    RemoveFut: std::future::Future<Output = Result<()>>,
+{
+    if files.is_empty() {
+        return Ok(Vec::new());
+    }
+    let (_, base_key) = parse_object_store_url(data_path)?;
+
+    let mut resolved = Vec::with_capacity(files.len());
+    let mut ids = Vec::with_capacity(files.len());
+    for file in &files {
+        let abs = resolve_path(&base_key, &file.path, file.path_is_relative)?;
+        resolved.push(abs);
+        ids.push(file.data_file_id);
+    }
+
+    if dry_run {
+        return Ok(resolved);
+    }
+
+    for abs in &resolved {
+        // object_store keys are relative (no leading slash) — same transform the
+        // writer uses when it puts a file (see table_writer.rs).
+        let key = ObjectPath::from(abs.trim_start_matches('/'));
+        match object_store.delete(&key).await {
+            Ok(()) => {},
+            // A missing object means a prior partial cleanup already removed it —
+            // idempotent, so we still drop the scheduled row.
+            Err(object_store::Error::NotFound {
+                ..
+            }) => {},
+            Err(e) => return Err(e.into()),
+        }
+    }
+
+    remove_rows(ids).await?;
+    Ok(resolved)
+}
+
+/// Physically delete files scheduled by [`SqliteMetadataWriter::expire_snapshots`] and
+/// remove their bookkeeping rows. Returns the resolved absolute paths deleted (or, for
+/// `dry_run`, the paths that would be deleted).
+///
+/// [`SqliteMetadataWriter::expire_snapshots`]: crate::metadata_writer_sqlite::SqliteMetadataWriter::expire_snapshots
+#[cfg(feature = "write-sqlite")]
+pub async fn cleanup_old_files_sqlite(
+    writer: &crate::metadata_writer_sqlite::SqliteMetadataWriter,
+    object_store: Arc<dyn ObjectStore>,
+    criteria: CleanupCriteria,
+    dry_run: bool,
+) -> Result<Vec<String>> {
+    let data_path = crate::metadata_writer::MetadataWriter::get_data_path(writer)?;
+    let files = writer.list_scheduled_for_deletion(&criteria)?;
+    run_cleanup(&data_path, files, object_store, dry_run, |ids| async move {
+        writer.remove_scheduled(&ids)
+    })
+    .await
+}
+
+/// Physically delete files scheduled by
+/// [`MulticatalogManager::expire_snapshots_in_catalog`] for `catalog_name` and remove their
+/// bookkeeping rows. Returns the resolved absolute paths deleted (or, for `dry_run`, the
+/// paths that would be deleted).
+///
+/// [`MulticatalogManager::expire_snapshots_in_catalog`]: crate::multicatalog::MulticatalogManager::expire_snapshots_in_catalog
+#[cfg(feature = "write-postgres")]
+pub async fn cleanup_old_files_in_catalog(
+    mgr: &crate::multicatalog::MulticatalogManager,
+    catalog_name: &str,
+    object_store: Arc<dyn ObjectStore>,
+    criteria: CleanupCriteria,
+    dry_run: bool,
+) -> Result<Vec<String>> {
+    let data_path = mgr.get_data_path().await?;
+    let files = mgr
+        .list_scheduled_for_deletion_in_catalog(catalog_name, &criteria)
+        .await?;
+    run_cleanup(&data_path, files, object_store, dry_run, |ids| async move {
+        mgr.remove_scheduled_in_catalog(catalog_name, &ids).await
+    })
+    .await
+}

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -118,6 +118,26 @@ pub(crate) const SQL_CREATE_MULTICATALOG_TABLES: &[&str] = &[
         table_id BIGINT NOT NULL,
         UNIQUE (table_id, begin_snapshot)
     )"#,
+    // Files queued for physical deletion by the two-phase vacuum (DuckLake
+    // spec). `expire_snapshots_in_catalog` GCs unreachable catalog rows and
+    // records the orphaned physical paths here; `cleanup_old_files` deletes
+    // the objects and removes these rows. `path` is stored relative to the
+    // catalog `data_path` root (already resolved through schema/table) so
+    // cleanup needs only a single-level join with `data_path`.
+    //
+    // Deviation from the single-catalog upstream schema: `catalog_id` scopes
+    // each scheduled file to its catalog. Without it cleanup couldn't tell
+    // catalogs apart — the data-file rows it would otherwise join against are
+    // already deleted by the time the file is scheduled.
+    r#"CREATE TABLE IF NOT EXISTS ducklake_files_scheduled_for_deletion (
+        catalog_id BIGINT NOT NULL,
+        data_file_id BIGINT NOT NULL,
+        path VARCHAR NOT NULL,
+        path_is_relative BOOLEAN NOT NULL DEFAULT TRUE,
+        schedule_start TIMESTAMPTZ DEFAULT NOW()
+    )"#,
+    r#"CREATE INDEX IF NOT EXISTS idx_scheduled_for_deletion_catalog
+        ON ducklake_files_scheduled_for_deletion(catalog_id)"#,
     r#"CREATE INDEX IF NOT EXISTS idx_catalog_snapshot_map_snapshot
         ON ducklake_catalog_snapshot_map(snapshot_id)"#,
     r#"CREATE INDEX IF NOT EXISTS idx_catalog_schema_map_schema

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -3,6 +3,9 @@
 //! Requires multi-threaded Tokio runtime (`#[tokio::test(flavor = "multi_thread")]`).
 
 use crate::Result;
+use crate::maintenance::{
+    CleanupCriteria, ExpireCriteria, ExpiredSnapshot, ScheduledFile, format_sql_timestamp,
+};
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
     ColumnDef, DataFileInfo, MetadataWriter, WriteMode, WriteSetupResult, validate_name,
@@ -11,6 +14,16 @@ use sqlx::Row;
 use sqlx::sqlite::{SqlitePool, SqlitePoolOptions};
 
 const DEFAULT_MAX_CONNECTIONS: u32 = 5;
+
+/// Render a slice of ids as a SQL `IN (...)` body. Safe to interpolate because
+/// the values are `i64` (no injection surface) — same approach the upstream
+/// DuckLake C++ takes, and the only option since SQLite lacks array binds.
+fn id_list(ids: &[i64]) -> String {
+    ids.iter()
+        .map(|id| id.to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
 
 const SQL_CREATE_SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS ducklake_metadata (
@@ -105,6 +118,20 @@ CREATE TABLE IF NOT EXISTS ducklake_delete_file (
     begin_snapshot INTEGER NOT NULL,
     end_snapshot INTEGER
 );
+
+-- Files queued for physical deletion by the two-phase vacuum (DuckLake spec).
+-- `expire_snapshots` GCs unreachable catalog rows and records the orphaned
+-- physical paths here; `cleanup_old_files` deletes the objects and removes
+-- these rows. `path` is stored relative to the catalog `data_path` root
+-- (i.e. already resolved through schema/table) so cleanup needs only a
+-- single-level join with `data_path`. Mirrors the upstream
+-- `ducklake_files_scheduled_for_deletion` table.
+CREATE TABLE IF NOT EXISTS ducklake_files_scheduled_for_deletion (
+    data_file_id INTEGER NOT NULL,
+    path VARCHAR NOT NULL,
+    path_is_relative BOOLEAN NOT NULL DEFAULT 1,
+    schedule_start TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
 "#;
 
 /// SQLite-based metadata writer for DuckLake catalogs.
@@ -136,6 +163,370 @@ impl SqliteMetadataWriter {
         writer.initialize_schema()?;
         Ok(writer)
     }
+
+    /// Tombstone a live table at a new "drop snapshot".
+    ///
+    /// Allocates a fresh snapshot and sets `end_snapshot = <drop snapshot>` on the
+    /// currently-live rows for the named table in `ducklake_table`,
+    /// `ducklake_column`, `ducklake_data_file`, and `ducklake_delete_file`. Reads at
+    /// any snapshot `>=` the drop snapshot no longer see the table; earlier snapshots
+    /// are unaffected (time travel preserved). This is the single-catalog mirror of
+    /// [`crate::multicatalog::MulticatalogManager::drop_table_in_catalog`].
+    ///
+    /// Idempotent: returns `Ok(false)` (no snapshot allocated) when no live
+    /// `(schema, table)` pair exists. Physical data files are not removed — that is
+    /// the job of [`Self::expire_snapshots`] + [`crate::maintenance::cleanup_old_files_sqlite`].
+    ///
+    /// The table's `ducklake_table_stats` row is intentionally left in place:
+    /// `next_row_id` must stay monotonic across the table's lifetime, and a
+    /// recreate-after-drop gets a fresh `table_id`. The orphaned stats row is
+    /// reclaimed by [`Self::expire_snapshots`] once the table is fully expired.
+    pub fn drop_table(&self, schema_name: &str, table_name: &str) -> Result<bool> {
+        validate_name(schema_name, "Schema")?;
+        validate_name(table_name, "Table")?;
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+
+            // Resolve the live table_id. `end_snapshot IS NULL` on both schema and
+            // table makes an already-dropped table a no-op (idempotent).
+            let table_id: i64 = match sqlx::query(
+                "SELECT t.table_id FROM ducklake_table t
+                 JOIN ducklake_schema s ON s.schema_id = t.schema_id
+                 WHERE s.schema_name = ? AND s.end_snapshot IS NULL
+                   AND t.table_name = ? AND t.end_snapshot IS NULL",
+            )
+            .bind(schema_name)
+            .bind(table_name)
+            .fetch_optional(&mut *tx)
+            .await?
+            {
+                Some(r) => r.try_get(0)?,
+                None => {
+                    tx.commit().await?;
+                    return Ok(false);
+                },
+            };
+
+            let drop_snapshot: i64 = sqlx::query(
+                "INSERT INTO ducklake_snapshot (snapshot_time) VALUES (CURRENT_TIMESTAMP) RETURNING snapshot_id",
+            )
+            .fetch_one(&mut *tx)
+            .await?
+            .try_get(0)?;
+
+            for child in
+                ["ducklake_table", "ducklake_column", "ducklake_data_file", "ducklake_delete_file"]
+            {
+                sqlx::query(&format!(
+                    "UPDATE {child} SET end_snapshot = ?
+                     WHERE table_id = ? AND end_snapshot IS NULL"
+                ))
+                .bind(drop_snapshot)
+                .bind(table_id)
+                .execute(&mut *tx)
+                .await?;
+            }
+
+            tx.commit().await?;
+            Ok(true)
+        })
+    }
+
+    /// Expire snapshots and garbage-collect the catalog metadata they leave behind.
+    ///
+    /// Ports the official `ducklake_expire_snapshots` / `DuckLakeMetadataManager::DeleteSnapshots`.
+    /// The most recent snapshot is never expired. After deleting the chosen snapshot
+    /// rows, every table / data file / delete file no longer reachable by any surviving
+    /// snapshot is removed from the catalog and its physical path is recorded in
+    /// `ducklake_files_scheduled_for_deletion` for later physical deletion via
+    /// [`crate::maintenance::cleanup_old_files_sqlite`]. Returns the expired snapshots.
+    ///
+    /// Reachability is global here — correct for a single-catalog SQLite metadata DB.
+    /// The whole operation runs in one transaction, so a crash can't leave scheduled
+    /// rows out of sync with the catalog.
+    pub fn expire_snapshots(&self, criteria: ExpireCriteria) -> Result<Vec<ExpiredSnapshot>> {
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+
+            // The most recent snapshot is never expirable.
+            let most_recent: Option<i64> =
+                sqlx::query("SELECT MAX(snapshot_id) FROM ducklake_snapshot")
+                    .fetch_one(&mut *tx)
+                    .await?
+                    .try_get(0)?;
+            let most_recent = match most_recent {
+                Some(id) => id,
+                None => {
+                    tx.commit().await?;
+                    return Ok(Vec::new());
+                },
+            };
+
+            // 1. Resolve the snapshots to expire (excluding the most recent).
+            let candidates: Vec<ExpiredSnapshot> = match &criteria {
+                ExpireCriteria::Versions(versions) => {
+                    let ids: Vec<i64> = versions
+                        .iter()
+                        .copied()
+                        .filter(|&v| v != most_recent)
+                        .collect();
+                    if ids.is_empty() {
+                        tx.commit().await?;
+                        return Ok(Vec::new());
+                    }
+                    let rows = sqlx::query(&format!(
+                        "SELECT snapshot_id, snapshot_time FROM ducklake_snapshot
+                         WHERE snapshot_id IN ({}) ORDER BY snapshot_id",
+                        id_list(&ids)
+                    ))
+                    .fetch_all(&mut *tx)
+                    .await?;
+                    rows_to_snapshots(rows)?
+                },
+                ExpireCriteria::OlderThan(ts) => {
+                    let rows = sqlx::query(
+                        "SELECT snapshot_id, snapshot_time FROM ducklake_snapshot
+                         WHERE snapshot_id != ? AND snapshot_time < ? ORDER BY snapshot_id",
+                    )
+                    .bind(most_recent)
+                    .bind(format_sql_timestamp(ts))
+                    .fetch_all(&mut *tx)
+                    .await?;
+                    rows_to_snapshots(rows)?
+                },
+            };
+            if candidates.is_empty() {
+                tx.commit().await?;
+                return Ok(Vec::new());
+            }
+            let expire_ids: Vec<i64> = candidates.iter().map(|s| s.snapshot_id).collect();
+
+            // 2. Delete the snapshot rows themselves.
+            sqlx::query(&format!(
+                "DELETE FROM ducklake_snapshot WHERE snapshot_id IN ({})",
+                id_list(&expire_ids)
+            ))
+            .execute(&mut *tx)
+            .await?;
+
+            // 3. Tables whose lifetime is no longer covered by any surviving snapshot
+            //    AND which have no surviving live version.
+            let dead_tables: Vec<i64> = sqlx::query(
+                "SELECT t.table_id FROM ducklake_table t
+                 WHERE t.end_snapshot IS NOT NULL AND NOT EXISTS (
+                     SELECT 1 FROM ducklake_snapshot
+                     WHERE snapshot_id >= t.begin_snapshot AND snapshot_id < t.end_snapshot)
+                 AND NOT EXISTS (
+                     SELECT 1 FROM ducklake_table t2
+                     WHERE t2.table_id = t.table_id
+                       AND (t2.end_snapshot IS NULL OR EXISTS (
+                           SELECT 1 FROM ducklake_snapshot
+                           WHERE snapshot_id >= t2.begin_snapshot
+                             AND snapshot_id < t2.end_snapshot)))",
+            )
+            .fetch_all(&mut *tx)
+            .await?
+            .into_iter()
+            .map(|r| r.try_get::<i64, _>(0))
+            .collect::<std::result::Result<_, _>>()?;
+            let dead_table_filter = if dead_tables.is_empty() {
+                "0".to_string()
+            } else {
+                format!("df.table_id IN ({})", id_list(&dead_tables))
+            };
+
+            // 4. Data files no longer referenced by any surviving snapshot (or belonging
+            //    to a dead table): schedule their physical paths, then drop the rows.
+            let dead_data_files = sqlx::query(&format!(
+                "SELECT df.data_file_id, {RESOLVED_PATH} AS resolved_path, {REL_FLAG} AS rel
+                 FROM ducklake_data_file df
+                 JOIN ducklake_table t ON t.table_id = df.table_id
+                 JOIN ducklake_schema s ON s.schema_id = t.schema_id
+                 WHERE ({dead_table_filter}) OR (df.end_snapshot IS NOT NULL AND NOT EXISTS (
+                     SELECT 1 FROM ducklake_snapshot
+                     WHERE snapshot_id >= df.begin_snapshot AND snapshot_id < df.end_snapshot))"
+            ))
+            .fetch_all(&mut *tx)
+            .await?;
+            let data_file_ids = schedule_files(&mut tx, dead_data_files).await?;
+            if !data_file_ids.is_empty() {
+                sqlx::query(&format!(
+                    "DELETE FROM ducklake_data_file WHERE data_file_id IN ({})",
+                    id_list(&data_file_ids)
+                ))
+                .execute(&mut *tx)
+                .await?;
+            }
+
+            // 5. Delete files orphaned by the data files above, by a dead table, or no
+            //    longer referenced by any surviving snapshot. (Our writer does not emit
+            //    delete files yet, so this is a no-op for catalogs we produce.)
+            let dead_data_filter = if data_file_ids.is_empty() {
+                "0".to_string()
+            } else {
+                format!("df.data_file_id IN ({})", id_list(&data_file_ids))
+            };
+            let dead_delete_table_filter = if dead_tables.is_empty() {
+                "0".to_string()
+            } else {
+                format!("df.table_id IN ({})", id_list(&dead_tables))
+            };
+            let dead_delete_files = sqlx::query(&format!(
+                "SELECT df.delete_file_id, {RESOLVED_PATH} AS resolved_path, {REL_FLAG} AS rel
+                 FROM ducklake_delete_file df
+                 JOIN ducklake_table t ON t.table_id = df.table_id
+                 JOIN ducklake_schema s ON s.schema_id = t.schema_id
+                 WHERE ({dead_data_filter}) OR ({dead_delete_table_filter})
+                    OR (df.end_snapshot IS NOT NULL AND NOT EXISTS (
+                        SELECT 1 FROM ducklake_snapshot
+                        WHERE snapshot_id >= df.begin_snapshot AND snapshot_id < df.end_snapshot))"
+            ))
+            .fetch_all(&mut *tx)
+            .await?;
+            let delete_file_ids = schedule_files(&mut tx, dead_delete_files).await?;
+            if !delete_file_ids.is_empty() {
+                sqlx::query(&format!(
+                    "DELETE FROM ducklake_delete_file WHERE delete_file_id IN ({})",
+                    id_list(&delete_file_ids)
+                ))
+                .execute(&mut *tx)
+                .await?;
+            }
+
+            // 6. Reclaim per-table metadata for fully-expired tables (this is where a
+            //    dropped table's orphaned ducklake_table_stats row is removed).
+            if !dead_tables.is_empty() {
+                let dead = id_list(&dead_tables);
+                for table in ["ducklake_table", "ducklake_table_stats", "ducklake_column"] {
+                    sqlx::query(&format!("DELETE FROM {table} WHERE table_id IN ({dead})"))
+                        .execute(&mut *tx)
+                        .await?;
+                }
+            }
+
+            // 7. Reclaim schemas no longer covered by any surviving snapshot.
+            sqlx::query(
+                "DELETE FROM ducklake_schema
+                 WHERE end_snapshot IS NOT NULL AND NOT EXISTS (
+                     SELECT 1 FROM ducklake_snapshot
+                     WHERE snapshot_id >= ducklake_schema.begin_snapshot
+                       AND snapshot_id < ducklake_schema.end_snapshot)",
+            )
+            .execute(&mut *tx)
+            .await?;
+
+            tx.commit().await?;
+            Ok(candidates)
+        })
+    }
+
+    /// List files scheduled for physical deletion, optionally filtered by schedule time.
+    pub(crate) fn list_scheduled_for_deletion(
+        &self,
+        criteria: &CleanupCriteria,
+    ) -> Result<Vec<ScheduledFile>> {
+        block_on(async {
+            let rows = match criteria {
+                CleanupCriteria::All => {
+                    sqlx::query(
+                        "SELECT data_file_id, path, path_is_relative
+                     FROM ducklake_files_scheduled_for_deletion",
+                    )
+                    .fetch_all(&self.pool)
+                    .await?
+                },
+                CleanupCriteria::OlderThan(ts) => {
+                    sqlx::query(
+                        "SELECT data_file_id, path, path_is_relative
+                     FROM ducklake_files_scheduled_for_deletion
+                     WHERE schedule_start < ?",
+                    )
+                    .bind(format_sql_timestamp(ts))
+                    .fetch_all(&self.pool)
+                    .await?
+                },
+            };
+            rows.into_iter()
+                .map(|r| {
+                    Ok(ScheduledFile {
+                        data_file_id: r.try_get(0)?,
+                        path: r.try_get(1)?,
+                        path_is_relative: r.try_get::<i64, _>(2)? != 0,
+                    })
+                })
+                .collect()
+        })
+    }
+
+    /// Remove scheduled-deletion bookkeeping rows after their objects are gone.
+    pub(crate) fn remove_scheduled(&self, ids: &[i64]) -> Result<()> {
+        if ids.is_empty() {
+            return Ok(());
+        }
+        block_on(async {
+            sqlx::query(&format!(
+                "DELETE FROM ducklake_files_scheduled_for_deletion WHERE data_file_id IN ({})",
+                id_list(ids)
+            ))
+            .execute(&self.pool)
+            .await?;
+            Ok(())
+        })
+    }
+}
+
+/// SQL expression yielding a file path resolved relative to the catalog `data_path`
+/// root, mirroring the read-side hierarchical resolution (file → table → schema →
+/// data_path). An absolute path anywhere in the chain short-circuits to that absolute
+/// path. Assumes `/`-joined relative names (everything our writer produces).
+const RESOLVED_PATH: &str = "CASE
+    WHEN NOT df.path_is_relative THEN df.path
+    WHEN NOT t.path_is_relative THEN t.path || '/' || df.path
+    ELSE s.path || '/' || t.path || '/' || df.path
+END";
+
+/// Companion to [`RESOLVED_PATH`]: 1 only when the whole chain is relative (so the
+/// resolved path is relative to `data_path`), else 0 (the resolved path is absolute).
+const REL_FLAG: &str =
+    "(CASE WHEN df.path_is_relative AND t.path_is_relative AND s.path_is_relative
+           THEN 1 ELSE 0 END)";
+
+/// Map `(snapshot_id, snapshot_time)` rows to [`ExpiredSnapshot`]s.
+fn rows_to_snapshots(rows: Vec<sqlx::sqlite::SqliteRow>) -> Result<Vec<ExpiredSnapshot>> {
+    rows.into_iter()
+        .map(|r| {
+            Ok(ExpiredSnapshot {
+                snapshot_id: r.try_get(0)?,
+                snapshot_time: r.try_get(1)?,
+            })
+        })
+        .collect()
+}
+
+/// Insert `(id, resolved_path, rel)` rows (as produced by [`RESOLVED_PATH`]/[`REL_FLAG`])
+/// into `ducklake_files_scheduled_for_deletion` and return the ids scheduled.
+async fn schedule_files(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    rows: Vec<sqlx::sqlite::SqliteRow>,
+) -> Result<Vec<i64>> {
+    let mut ids = Vec::with_capacity(rows.len());
+    for row in rows {
+        let id: i64 = row.try_get(0)?;
+        let path: String = row.try_get(1)?;
+        let rel: i64 = row.try_get(2)?;
+        sqlx::query(
+            "INSERT INTO ducklake_files_scheduled_for_deletion
+                 (data_file_id, path, path_is_relative, schedule_start)
+             VALUES (?, ?, ?, CURRENT_TIMESTAMP)",
+        )
+        .bind(id)
+        .bind(&path)
+        .bind(rel)
+        .execute(&mut **tx)
+        .await?;
+        ids.push(id);
+    }
+    Ok(ids)
 }
 
 impl MetadataWriter for SqliteMetadataWriter {

--- a/src/multicatalog.rs
+++ b/src/multicatalog.rs
@@ -4,9 +4,24 @@
 //! that binds to a `catalog_id` produced here.
 
 use crate::Result;
+use crate::maintenance::{
+    CleanupCriteria, ExpireCriteria, ExpiredSnapshot, ScheduledFile, format_sql_timestamp,
+};
 use crate::metadata_writer_postgres::execute_ddl_statements;
 use sqlx::Row;
-use sqlx::postgres::PgPool;
+use sqlx::postgres::{PgPool, PgRow};
+
+/// SQL expression yielding a file path resolved relative to the catalog `data_path`
+/// root (file → table → schema → data_path). An absolute path anywhere in the chain
+/// short-circuits to that absolute path. Mirrors the SQLite writer's `RESOLVED_PATH`.
+const PG_RESOLVED_PATH: &str = "CASE
+    WHEN NOT df.path_is_relative THEN df.path
+    WHEN NOT t.path_is_relative THEN t.path || '/' || df.path
+    ELSE s.path || '/' || t.path || '/' || df.path
+END";
+
+/// Companion to [`PG_RESOLVED_PATH`]: true only when the whole chain is relative.
+const PG_REL_FLAG: &str = "(df.path_is_relative AND t.path_is_relative AND s.path_is_relative)";
 
 /// Bootstrap standard + multicatalog tables. Idempotent.
 pub async fn initialize_multicatalog_schema(pool: &PgPool) -> Result<()> {
@@ -437,4 +452,369 @@ impl MulticatalogManager {
         tx.commit().await?;
         Ok(true)
     }
+
+    /// Read the global `data_path` (Phase 1: one `data_path` shared by all catalogs).
+    pub async fn get_data_path(&self) -> Result<String> {
+        let row =
+            sqlx::query("SELECT value FROM ducklake_metadata WHERE key = $1 AND scope IS NULL")
+                .bind("data_path")
+                .fetch_optional(&self.pool)
+                .await?;
+        match row {
+            Some(r) => Ok(r.try_get(0)?),
+            None => Err(crate::DuckLakeError::InvalidConfig(
+                "Missing required catalog metadata: 'data_path' not configured.".to_string(),
+            )),
+        }
+    }
+
+    /// Expire snapshots within a single catalog and GC the metadata they leave behind.
+    ///
+    /// The multicatalog mirror of [`crate::metadata_writer_sqlite::SqliteMetadataWriter::expire_snapshots`].
+    /// The most recent snapshot *of this catalog* is never expired. After deleting the
+    /// chosen snapshot rows (and their `ducklake_catalog_snapshot_map` rows), every table /
+    /// data file / delete file no longer reachable by any surviving snapshot of this catalog
+    /// is removed and its physical path recorded in `ducklake_files_scheduled_for_deletion`
+    /// (tagged with `catalog_id`) for later deletion via
+    /// [`crate::maintenance::cleanup_old_files_in_catalog`]. Returns the expired snapshots.
+    ///
+    /// # Concurrency
+    ///
+    /// Takes the catalog row `FOR UPDATE` (30s `lock_timeout`) before any work, serialising
+    /// against in-flight writers and other maintenance — same discipline as
+    /// [`Self::drop_table_in_catalog`].
+    ///
+    /// # Catalog scoping
+    ///
+    /// Because Postgres is multi-catalog (one shared `ducklake_snapshot` /
+    /// `ducklake_data_file`, partitioned by the `*_map` tables), every reachability check
+    /// is restricted to *this* catalog's snapshots. Otherwise another catalog's snapshot
+    /// sitting in the `[begin_snapshot, end_snapshot)` range of a file would wrongly keep it
+    /// alive forever.
+    pub async fn expire_snapshots_in_catalog(
+        &self,
+        catalog_name: &str,
+        criteria: ExpireCriteria,
+    ) -> Result<Vec<ExpiredSnapshot>> {
+        let mut tx = self.pool.begin().await?;
+        sqlx::query("SET LOCAL lock_timeout = 30000")
+            .execute(&mut *tx)
+            .await?;
+
+        let catalog_id: i64 = match sqlx::query(
+            "SELECT catalog_id FROM ducklake_catalog WHERE catalog_name = $1 FOR UPDATE",
+        )
+        .bind(catalog_name)
+        .fetch_optional(&mut *tx)
+        .await?
+        {
+            Some(r) => r.try_get(0)?,
+            None => {
+                tx.commit().await?;
+                return Ok(Vec::new());
+            },
+        };
+
+        // Most recent snapshot OF THIS CATALOG — never expirable.
+        let most_recent: Option<i64> = sqlx::query(
+            "SELECT MAX(s.snapshot_id) FROM ducklake_snapshot s
+             JOIN ducklake_catalog_snapshot_map m ON m.snapshot_id = s.snapshot_id
+             WHERE m.catalog_id = $1",
+        )
+        .bind(catalog_id)
+        .fetch_one(&mut *tx)
+        .await?
+        .try_get(0)?;
+        let most_recent = match most_recent {
+            Some(id) => id,
+            None => {
+                tx.commit().await?;
+                return Ok(Vec::new());
+            },
+        };
+
+        // 1. Resolve the candidate snapshots (catalog-scoped, never the most recent).
+        let candidate_rows: Vec<PgRow> = match &criteria {
+            ExpireCriteria::Versions(versions) => {
+                let ids: Vec<i64> = versions
+                    .iter()
+                    .copied()
+                    .filter(|&v| v != most_recent)
+                    .collect();
+                sqlx::query(
+                    "SELECT s.snapshot_id, s.snapshot_time::text FROM ducklake_snapshot s
+                     JOIN ducklake_catalog_snapshot_map m
+                       ON m.snapshot_id = s.snapshot_id AND m.catalog_id = $1
+                     WHERE s.snapshot_id <> $2 AND s.snapshot_id = ANY($3)
+                     ORDER BY s.snapshot_id",
+                )
+                .bind(catalog_id)
+                .bind(most_recent)
+                .bind(&ids)
+                .fetch_all(&mut *tx)
+                .await?
+            },
+            ExpireCriteria::OlderThan(ts) => {
+                sqlx::query(
+                    "SELECT s.snapshot_id, s.snapshot_time::text FROM ducklake_snapshot s
+                     JOIN ducklake_catalog_snapshot_map m
+                       ON m.snapshot_id = s.snapshot_id AND m.catalog_id = $1
+                     WHERE s.snapshot_id <> $2 AND s.snapshot_time < $3::timestamp
+                     ORDER BY s.snapshot_id",
+                )
+                .bind(catalog_id)
+                .bind(most_recent)
+                .bind(format_sql_timestamp(ts))
+                .fetch_all(&mut *tx)
+                .await?
+            },
+        };
+        let candidates: Vec<ExpiredSnapshot> = candidate_rows
+            .into_iter()
+            .map(|r| {
+                Ok(ExpiredSnapshot {
+                    snapshot_id: r.try_get(0)?,
+                    snapshot_time: r.try_get(1)?,
+                })
+            })
+            .collect::<Result<_>>()?;
+        if candidates.is_empty() {
+            tx.commit().await?;
+            return Ok(Vec::new());
+        }
+        let expire_ids: Vec<i64> = candidates.iter().map(|s| s.snapshot_id).collect();
+
+        // 2. Delete the snapshots: map rows first, then the (now catalog-private) rows.
+        sqlx::query(
+            "DELETE FROM ducklake_catalog_snapshot_map
+             WHERE catalog_id = $1 AND snapshot_id = ANY($2)",
+        )
+        .bind(catalog_id)
+        .bind(&expire_ids)
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query("DELETE FROM ducklake_snapshot WHERE snapshot_id = ANY($1)")
+            .bind(&expire_ids)
+            .execute(&mut *tx)
+            .await?;
+
+        // 3. Tables in this catalog no longer covered by any surviving snapshot and with
+        //    no surviving live version.
+        let dead_tables: Vec<i64> = sqlx::query(
+            "SELECT t.table_id FROM ducklake_table t
+             JOIN ducklake_catalog_schema_map csm
+               ON csm.schema_id = t.schema_id AND csm.catalog_id = $1
+             WHERE t.end_snapshot IS NOT NULL AND NOT EXISTS (
+                 SELECT 1 FROM ducklake_snapshot s
+                 JOIN ducklake_catalog_snapshot_map m
+                   ON m.snapshot_id = s.snapshot_id AND m.catalog_id = $1
+                 WHERE s.snapshot_id >= t.begin_snapshot AND s.snapshot_id < t.end_snapshot)
+             AND NOT EXISTS (
+                 SELECT 1 FROM ducklake_table t2
+                 WHERE t2.table_id = t.table_id
+                   AND (t2.end_snapshot IS NULL OR EXISTS (
+                       SELECT 1 FROM ducklake_snapshot s
+                       JOIN ducklake_catalog_snapshot_map m
+                         ON m.snapshot_id = s.snapshot_id AND m.catalog_id = $1
+                       WHERE s.snapshot_id >= t2.begin_snapshot
+                         AND s.snapshot_id < t2.end_snapshot)))",
+        )
+        .bind(catalog_id)
+        .fetch_all(&mut *tx)
+        .await?
+        .into_iter()
+        .map(|r| r.try_get::<i64, _>(0))
+        .collect::<std::result::Result<_, _>>()?;
+
+        // 4. Data files orphaned (in this catalog): schedule paths, then drop the rows.
+        //    `= ANY($2)` with an empty array is simply false — no special-casing needed.
+        let dead_data_files = sqlx::query(&format!(
+            "SELECT df.data_file_id, {PG_RESOLVED_PATH} AS resolved_path, {PG_REL_FLAG} AS rel
+             FROM ducklake_data_file df
+             JOIN ducklake_table t ON t.table_id = df.table_id
+             JOIN ducklake_schema s ON s.schema_id = t.schema_id
+             JOIN ducklake_catalog_schema_map csm
+               ON csm.schema_id = s.schema_id AND csm.catalog_id = $1
+             WHERE (df.table_id = ANY($2)) OR (df.end_snapshot IS NOT NULL AND NOT EXISTS (
+                 SELECT 1 FROM ducklake_snapshot ss
+                 JOIN ducklake_catalog_snapshot_map m
+                   ON m.snapshot_id = ss.snapshot_id AND m.catalog_id = $1
+                 WHERE ss.snapshot_id >= df.begin_snapshot AND ss.snapshot_id < df.end_snapshot))"
+        ))
+        .bind(catalog_id)
+        .bind(&dead_tables)
+        .fetch_all(&mut *tx)
+        .await?;
+        let data_file_ids = schedule_pg_files(&mut tx, catalog_id, dead_data_files).await?;
+        sqlx::query("DELETE FROM ducklake_data_file WHERE data_file_id = ANY($1)")
+            .bind(&data_file_ids)
+            .execute(&mut *tx)
+            .await?;
+
+        // 5. Delete files orphaned by the data files above, a dead table, or no surviving
+        //    snapshot. (Our writer does not emit delete files yet — no-op for our catalogs.)
+        let dead_delete_files = sqlx::query(&format!(
+            "SELECT df.delete_file_id, {PG_RESOLVED_PATH} AS resolved_path, {PG_REL_FLAG} AS rel
+             FROM ducklake_delete_file df
+             JOIN ducklake_table t ON t.table_id = df.table_id
+             JOIN ducklake_schema s ON s.schema_id = t.schema_id
+             JOIN ducklake_catalog_schema_map csm
+               ON csm.schema_id = s.schema_id AND csm.catalog_id = $1
+             WHERE (df.data_file_id = ANY($2)) OR (df.table_id = ANY($3))
+                OR (df.end_snapshot IS NOT NULL AND NOT EXISTS (
+                    SELECT 1 FROM ducklake_snapshot ss
+                    JOIN ducklake_catalog_snapshot_map m
+                      ON m.snapshot_id = ss.snapshot_id AND m.catalog_id = $1
+                    WHERE ss.snapshot_id >= df.begin_snapshot AND ss.snapshot_id < df.end_snapshot))"
+        ))
+        .bind(catalog_id)
+        .bind(&data_file_ids)
+        .bind(&dead_tables)
+        .fetch_all(&mut *tx)
+        .await?;
+        let delete_file_ids = schedule_pg_files(&mut tx, catalog_id, dead_delete_files).await?;
+        sqlx::query("DELETE FROM ducklake_delete_file WHERE delete_file_id = ANY($1)")
+            .bind(&delete_file_ids)
+            .execute(&mut *tx)
+            .await?;
+
+        // 6. Reclaim per-table metadata for fully-expired tables. (No ducklake_table_stats
+        //    on Postgres — that table is maintained only by the SQLite writer.)
+        for table in ["ducklake_table", "ducklake_column", "ducklake_schema_versions"] {
+            sqlx::query(&format!("DELETE FROM {table} WHERE table_id = ANY($1)"))
+                .bind(&dead_tables)
+                .execute(&mut *tx)
+                .await?;
+        }
+
+        // 7. Reclaim schemas no longer covered by a surviving snapshot of this catalog,
+        //    along with their catalog_schema_map rows (no orphan maps).
+        let dead_schemas: Vec<i64> = sqlx::query(
+            "SELECT s.schema_id FROM ducklake_schema s
+             JOIN ducklake_catalog_schema_map csm
+               ON csm.schema_id = s.schema_id AND csm.catalog_id = $1
+             WHERE s.end_snapshot IS NOT NULL AND NOT EXISTS (
+                 SELECT 1 FROM ducklake_snapshot ss
+                 JOIN ducklake_catalog_snapshot_map m
+                   ON m.snapshot_id = ss.snapshot_id AND m.catalog_id = $1
+                 WHERE ss.snapshot_id >= s.begin_snapshot AND ss.snapshot_id < s.end_snapshot)",
+        )
+        .bind(catalog_id)
+        .fetch_all(&mut *tx)
+        .await?
+        .into_iter()
+        .map(|r| r.try_get::<i64, _>(0))
+        .collect::<std::result::Result<_, _>>()?;
+        sqlx::query(
+            "DELETE FROM ducklake_catalog_schema_map WHERE catalog_id = $1 AND schema_id = ANY($2)",
+        )
+        .bind(catalog_id)
+        .bind(&dead_schemas)
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query("DELETE FROM ducklake_schema WHERE schema_id = ANY($1)")
+            .bind(&dead_schemas)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+        Ok(candidates)
+    }
+
+    /// List files scheduled for physical deletion for `catalog_name`, optionally filtered
+    /// by schedule time. Unknown catalog ⇒ empty list.
+    pub(crate) async fn list_scheduled_for_deletion_in_catalog(
+        &self,
+        catalog_name: &str,
+        criteria: &CleanupCriteria,
+    ) -> Result<Vec<ScheduledFile>> {
+        let catalog_id = match self.find_catalog_id(catalog_name).await? {
+            Some(id) => id,
+            None => return Ok(Vec::new()),
+        };
+        let rows = match criteria {
+            CleanupCriteria::All => {
+                sqlx::query(
+                    "SELECT data_file_id, path, path_is_relative
+                 FROM ducklake_files_scheduled_for_deletion WHERE catalog_id = $1",
+                )
+                .bind(catalog_id)
+                .fetch_all(&self.pool)
+                .await?
+            },
+            CleanupCriteria::OlderThan(ts) => {
+                sqlx::query(
+                    "SELECT data_file_id, path, path_is_relative
+                 FROM ducklake_files_scheduled_for_deletion
+                 WHERE catalog_id = $1 AND schedule_start < $2::timestamptz",
+                )
+                .bind(catalog_id)
+                .bind(format_sql_timestamp(ts))
+                .fetch_all(&self.pool)
+                .await?
+            },
+        };
+        rows.into_iter()
+            .map(|r| {
+                Ok(ScheduledFile {
+                    data_file_id: r.try_get(0)?,
+                    path: r.try_get(1)?,
+                    path_is_relative: r.try_get(2)?,
+                })
+            })
+            .collect()
+    }
+
+    /// Remove scheduled-deletion bookkeeping rows for `catalog_name` after their objects
+    /// are gone. Unknown catalog ⇒ no-op.
+    pub(crate) async fn remove_scheduled_in_catalog(
+        &self,
+        catalog_name: &str,
+        ids: &[i64],
+    ) -> Result<()> {
+        if ids.is_empty() {
+            return Ok(());
+        }
+        let catalog_id = match self.find_catalog_id(catalog_name).await? {
+            Some(id) => id,
+            None => return Ok(()),
+        };
+        sqlx::query(
+            "DELETE FROM ducklake_files_scheduled_for_deletion
+             WHERE catalog_id = $1 AND data_file_id = ANY($2)",
+        )
+        .bind(catalog_id)
+        .bind(ids)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+}
+
+/// Insert `(catalog_id, data_file_id, resolved_path, rel)` rows into
+/// `ducklake_files_scheduled_for_deletion` and return the scheduled ids.
+async fn schedule_pg_files(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    catalog_id: i64,
+    rows: Vec<PgRow>,
+) -> Result<Vec<i64>> {
+    let mut ids = Vec::with_capacity(rows.len());
+    for row in rows {
+        let id: i64 = row.try_get(0)?;
+        let path: String = row.try_get(1)?;
+        let rel: bool = row.try_get(2)?;
+        sqlx::query(
+            "INSERT INTO ducklake_files_scheduled_for_deletion
+                 (catalog_id, data_file_id, path, path_is_relative, schedule_start)
+             VALUES ($1, $2, $3, $4, NOW())",
+        )
+        .bind(catalog_id)
+        .bind(id)
+        .bind(&path)
+        .bind(rel)
+        .execute(&mut **tx)
+        .await?;
+        ids.push(id);
+    }
+    Ok(ids)
 }

--- a/tests/maintenance_sqlite_tests.rs
+++ b/tests/maintenance_sqlite_tests.rs
@@ -1,0 +1,377 @@
+//! Integration tests for single-catalog maintenance on the SQLite writer:
+//! `drop_table`, `expire_snapshots`, and `cleanup_old_files_sqlite`.
+//!
+//! Mirrors the upstream DuckLake suite
+//! (`test/sql/catalog/drop_table.test`, `test/sql/compaction/expire_snapshots*.test`).
+
+#![cfg(all(feature = "write-sqlite", feature = "metadata-sqlite"))]
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use object_store::ObjectStore;
+use object_store::local::LocalFileSystem;
+use sqlx::Row;
+use sqlx::sqlite::SqlitePool;
+use tempfile::TempDir;
+
+use datafusion_ducklake::SqliteMetadataWriter;
+use datafusion_ducklake::maintenance::{CleanupCriteria, ExpireCriteria, cleanup_old_files_sqlite};
+use datafusion_ducklake::metadata_writer::{ColumnDef, DataFileInfo, MetadataWriter, WriteMode};
+
+fn cols() -> Vec<ColumnDef> {
+    vec![
+        ColumnDef::new("id", "int64", false).unwrap(),
+        ColumnDef::new("name", "varchar", true).unwrap(),
+    ]
+}
+
+/// A writable single-catalog SQLite environment plus the bits needed to assert on it.
+struct Harness {
+    writer: SqliteMetadataWriter,
+    conn_str: String,
+    data_path: PathBuf,
+    _temp: TempDir,
+}
+
+async fn setup() -> Harness {
+    let temp = TempDir::new().unwrap();
+    let db_path = temp.path().join("test.db");
+    let data_path = temp.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+    let conn_str = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    let writer = SqliteMetadataWriter::new_with_init(&conn_str)
+        .await
+        .unwrap();
+    writer.set_data_path(data_path.to_str().unwrap()).unwrap();
+
+    Harness {
+        writer,
+        conn_str,
+        data_path,
+        _temp: temp,
+    }
+}
+
+/// Open a fresh read connection to the metadata DB for raw assertions.
+async fn pool(h: &Harness) -> SqlitePool {
+    SqlitePool::connect(&h.conn_str).await.unwrap()
+}
+
+async fn scalar_i64(pool: &SqlitePool, sql: &str) -> i64 {
+    sqlx::query(sql)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+        .try_get::<i64, _>(0)
+        .unwrap()
+}
+
+/// Register a data file in the catalog AND create the matching physical file on disk
+/// at `<data_path>/<schema>/<table>/<name>`, mirroring the real write layout.
+fn write_physical_file(data_path: &Path, schema: &str, table: &str, name: &str) {
+    let dir = data_path.join(schema).join(table);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join(name), b"parquet-bytes").unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn drop_table_tombstones_children_and_is_idempotent() {
+    let h = setup().await;
+    let s = h
+        .writer
+        .begin_write_transaction("main", "users", &cols(), WriteMode::Replace)
+        .unwrap();
+    h.writer
+        .register_data_file(
+            s.table_id,
+            s.snapshot_id,
+            &DataFileInfo::new("f1.parquet", 100, 5),
+        )
+        .unwrap();
+
+    let dropped = h.writer.drop_table("main", "users").unwrap();
+    assert!(dropped, "live table should drop");
+
+    let p = pool(&h).await;
+    // No live rows remain for the table; children carry the drop snapshot.
+    for tbl in ["ducklake_table", "ducklake_column", "ducklake_data_file"] {
+        let live = scalar_i64(
+            &p,
+            &format!(
+                "SELECT COUNT(*) FROM {tbl} WHERE table_id = {} AND end_snapshot IS NULL",
+                s.table_id
+            ),
+        )
+        .await;
+        assert_eq!(live, 0, "no live rows in {tbl} after drop");
+    }
+
+    // The stats row is intentionally preserved (monotonic next_row_id).
+    let stats = scalar_i64(
+        &p,
+        &format!(
+            "SELECT COUNT(*) FROM ducklake_table_stats WHERE table_id = {}",
+            s.table_id
+        ),
+    )
+    .await;
+    assert_eq!(stats, 1, "table_stats row preserved across drop");
+    let next_row_id = scalar_i64(
+        &p,
+        &format!(
+            "SELECT next_row_id FROM ducklake_table_stats WHERE table_id = {}",
+            s.table_id
+        ),
+    )
+    .await;
+    assert_eq!(next_row_id, 5, "next_row_id preserved");
+
+    // Second drop is a no-op.
+    let dropped_again = h.writer.drop_table("main", "users").unwrap();
+    assert!(!dropped_again, "second drop returns false");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn drop_table_unknown_and_empty_names() {
+    let h = setup().await;
+    assert!(
+        !h.writer.drop_table("main", "ghost").unwrap(),
+        "unknown table -> false"
+    );
+    assert!(
+        h.writer.drop_table("", "users").is_err(),
+        "empty schema rejected"
+    );
+    assert!(
+        h.writer.drop_table("main", "").is_err(),
+        "empty table rejected"
+    );
+}
+
+/// Write three Replace generations of one table so the first two data files become
+/// superseded (end-snapshotted), then return the writer + snapshot ids.
+fn three_generations(writer: &SqliteMetadataWriter) -> (i64, i64, i64, i64) {
+    let s1 = writer
+        .begin_write_transaction("main", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    writer
+        .register_data_file(
+            s1.table_id,
+            s1.snapshot_id,
+            &DataFileInfo::new("f1.parquet", 100, 5),
+        )
+        .unwrap();
+    let s2 = writer
+        .begin_write_transaction("main", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    writer
+        .register_data_file(
+            s2.table_id,
+            s2.snapshot_id,
+            &DataFileInfo::new("f2.parquet", 100, 5),
+        )
+        .unwrap();
+    let s3 = writer
+        .begin_write_transaction("main", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    writer
+        .register_data_file(
+            s3.table_id,
+            s3.snapshot_id,
+            &DataFileInfo::new("f3.parquet", 100, 5),
+        )
+        .unwrap();
+    (s1.table_id, s1.snapshot_id, s2.snapshot_id, s3.snapshot_id)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn expire_by_version_schedules_orphaned_file() {
+    let h = setup().await;
+    let (_tid, s1, _s2, _s3) = three_generations(&h.writer);
+
+    // f1 lives in [s1, s2); expiring s1 leaves no surviving snapshot in that range.
+    let expired = h
+        .writer
+        .expire_snapshots(ExpireCriteria::Versions(vec![s1]))
+        .unwrap();
+    assert_eq!(expired.len(), 1);
+    assert_eq!(expired[0].snapshot_id, s1);
+
+    let p = pool(&h).await;
+    assert_eq!(
+        scalar_i64(
+            &p,
+            &format!("SELECT COUNT(*) FROM ducklake_snapshot WHERE snapshot_id = {s1}")
+        )
+        .await,
+        0,
+        "expired snapshot row removed"
+    );
+    // Exactly f1 is scheduled, with the data_path-relative resolved path.
+    let scheduled: Vec<(String, i64)> =
+        sqlx::query("SELECT path, path_is_relative FROM ducklake_files_scheduled_for_deletion")
+            .fetch_all(&p)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|r| {
+                (
+                    r.try_get::<String, _>(0).unwrap(),
+                    r.try_get::<i64, _>(1).unwrap(),
+                )
+            })
+            .collect();
+    assert_eq!(scheduled.len(), 1);
+    assert_eq!(scheduled[0].0, "main/t/f1.parquet");
+    assert_eq!(scheduled[0].1, 1, "path is relative to data_path");
+    // f1's catalog row is gone; f2/f3 remain.
+    assert_eq!(
+        scalar_i64(&p, "SELECT COUNT(*) FROM ducklake_data_file").await,
+        2
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn expire_full_after_drop_reclaims_all_table_metadata() {
+    let h = setup().await;
+    let s = h
+        .writer
+        .begin_write_transaction("main", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    h.writer
+        .register_data_file(
+            s.table_id,
+            s.snapshot_id,
+            &DataFileInfo::new("f1.parquet", 100, 5),
+        )
+        .unwrap();
+    // Drop allocates snapshot 2; the table is now fully tombstoned in [1, 2).
+    assert!(h.writer.drop_table("main", "t").unwrap());
+
+    // Expire snapshot 1 (the drop snapshot 2 is the most recent and is kept).
+    let expired = h
+        .writer
+        .expire_snapshots(ExpireCriteria::Versions(vec![s.snapshot_id]))
+        .unwrap();
+    assert_eq!(expired.len(), 1);
+
+    let p = pool(&h).await;
+    let tid = s.table_id;
+    for tbl in ["ducklake_table", "ducklake_column", "ducklake_data_file", "ducklake_table_stats"] {
+        let cnt = scalar_i64(
+            &p,
+            &format!("SELECT COUNT(*) FROM {tbl} WHERE table_id = {tid}"),
+        )
+        .await;
+        assert_eq!(cnt, 0, "{tbl} fully reclaimed after expire");
+    }
+    // The orphaned file was scheduled for physical deletion.
+    assert_eq!(
+        scalar_i64(
+            &p,
+            "SELECT COUNT(*) FROM ducklake_files_scheduled_for_deletion"
+        )
+        .await,
+        1
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cleanup_old_files_deletes_physical_file() {
+    let h = setup().await;
+    let (_tid, s1, _s2, _s3) = three_generations(&h.writer);
+    // Materialize the physical files referenced by the catalog.
+    for name in ["f1.parquet", "f2.parquet", "f3.parquet"] {
+        write_physical_file(&h.data_path, "main", "t", name);
+    }
+
+    h.writer
+        .expire_snapshots(ExpireCriteria::Versions(vec![s1]))
+        .unwrap();
+
+    let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+    let f1 = h.data_path.join("main").join("t").join("f1.parquet");
+
+    // Dry run reports the path without deleting.
+    let dry = cleanup_old_files_sqlite(&h.writer, store.clone(), CleanupCriteria::All, true)
+        .await
+        .unwrap();
+    assert_eq!(dry.len(), 1);
+    assert!(f1.exists(), "dry run must not delete");
+
+    // Real run deletes the object and clears the bookkeeping row.
+    let done = cleanup_old_files_sqlite(&h.writer, store.clone(), CleanupCriteria::All, false)
+        .await
+        .unwrap();
+    assert_eq!(done.len(), 1);
+    assert!(!f1.exists(), "f1 physically removed");
+    assert!(
+        h.data_path
+            .join("main")
+            .join("t")
+            .join("f2.parquet")
+            .exists(),
+        "live file f2 untouched"
+    );
+
+    let p = pool(&h).await;
+    assert_eq!(
+        scalar_i64(
+            &p,
+            "SELECT COUNT(*) FROM ducklake_files_scheduled_for_deletion"
+        )
+        .await,
+        0,
+        "scheduled rows cleared"
+    );
+
+    // Idempotent: nothing left to clean.
+    let again = cleanup_old_files_sqlite(&h.writer, store, CleanupCriteria::All, false)
+        .await
+        .unwrap();
+    assert!(again.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn expire_older_than_uses_datetime_utc() {
+    // Cover the OlderThan public API (chrono::DateTime<Utc>) end-to-end: a
+    // far-future cutoff means every non-most-recent snapshot is expirable.
+    let h = setup().await;
+    let (_tid, _s1, _s2, _s3) = three_generations(&h.writer);
+
+    let cutoff = chrono::Utc::now() + chrono::Duration::days(1);
+    let expired = h
+        .writer
+        .expire_snapshots(ExpireCriteria::OlderThan(cutoff))
+        .unwrap();
+    // three_generations creates s1, s2, s3. s3 is most-recent and kept;
+    // the other two are expired.
+    assert_eq!(expired.len(), 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn expire_and_cleanup_no_op_paths() {
+    let h = setup().await;
+    // Single snapshot: nothing is expirable (the most recent is always kept).
+    let s = h
+        .writer
+        .begin_write_transaction("main", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    let expired = h
+        .writer
+        .expire_snapshots(ExpireCriteria::Versions(vec![s.snapshot_id]))
+        .unwrap();
+    assert!(
+        expired.is_empty(),
+        "cannot expire the only/most-recent snapshot"
+    );
+
+    // Nothing scheduled -> cleanup returns empty.
+    let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+    let cleaned = cleanup_old_files_sqlite(&h.writer, store, CleanupCriteria::All, false)
+        .await
+        .unwrap();
+    assert!(cleaned.is_empty());
+}

--- a/tests/multicatalog_postgres_tests.rs
+++ b/tests/multicatalog_postgres_tests.rs
@@ -1275,3 +1275,455 @@ async fn drop_table_in_catalog_isolates_other_catalogs() {
         "drop snapshot must be registered only under the dropping catalog"
     );
 }
+
+// ---------------------------------------------------------------------------
+// expire_snapshots_in_catalog / cleanup_old_files_in_catalog
+// ---------------------------------------------------------------------------
+
+/// Write three Replace generations of one table for `writer`, returning the table id and
+/// the three snapshot ids. The first two data files end up superseded (end-snapshotted).
+fn three_generations(
+    writer: &PostgresMetadataWriter,
+    schema: &str,
+    table: &str,
+) -> (i64, i64, i64, i64) {
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+    let s1 = writer
+        .begin_write_transaction(schema, table, &cols(), WriteMode::Replace)
+        .unwrap();
+    writer
+        .register_data_file(
+            s1.table_id,
+            s1.snapshot_id,
+            &DataFileInfo::new("f1.parquet", 100, 5),
+        )
+        .unwrap();
+    let s2 = writer
+        .begin_write_transaction(schema, table, &cols(), WriteMode::Replace)
+        .unwrap();
+    writer
+        .register_data_file(
+            s2.table_id,
+            s2.snapshot_id,
+            &DataFileInfo::new("f2.parquet", 100, 5),
+        )
+        .unwrap();
+    let s3 = writer
+        .begin_write_transaction(schema, table, &cols(), WriteMode::Replace)
+        .unwrap();
+    writer
+        .register_data_file(
+            s3.table_id,
+            s3.snapshot_id,
+            &DataFileInfo::new("f3.parquet", 100, 5),
+        )
+        .unwrap();
+    (s1.table_id, s1.snapshot_id, s2.snapshot_id, s3.snapshot_id)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn expire_in_catalog_empty_for_most_recent_and_unknown() {
+    use datafusion_ducklake::maintenance::ExpireCriteria;
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("pg_prod").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path("/data").unwrap();
+    let s = w
+        .begin_write_transaction("public", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    w.register_data_file(
+        s.table_id,
+        s.snapshot_id,
+        &DataFileInfo::new("f1.parquet", 100, 5),
+    )
+    .unwrap();
+
+    // The only snapshot is the most recent — never expirable.
+    let expired = mgr
+        .expire_snapshots_in_catalog("pg_prod", ExpireCriteria::Versions(vec![s.snapshot_id]))
+        .await
+        .unwrap();
+    assert!(expired.is_empty());
+
+    // Unknown catalog is a no-op.
+    let none = mgr
+        .expire_snapshots_in_catalog("ghost", ExpireCriteria::Versions(vec![1]))
+        .await
+        .unwrap();
+    assert!(none.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn expire_in_catalog_by_version_schedules_orphaned_file() {
+    use datafusion_ducklake::maintenance::ExpireCriteria;
+
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("pg_prod").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path("/data").unwrap();
+    let (_tid, s1, _s2, _s3) = three_generations(&w, "public", "t");
+
+    let expired = mgr
+        .expire_snapshots_in_catalog("pg_prod", ExpireCriteria::Versions(vec![s1]))
+        .await
+        .unwrap();
+    assert_eq!(expired.len(), 1);
+    assert_eq!(expired[0].snapshot_id, s1);
+
+    // Snapshot row and its catalog map row are both gone.
+    let snap_rows: i64 =
+        sqlx::query("SELECT COUNT(*) FROM ducklake_snapshot WHERE snapshot_id = $1")
+            .bind(s1)
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
+    assert_eq!(snap_rows, 0);
+    let map_rows: i64 =
+        sqlx::query("SELECT COUNT(*) FROM ducklake_catalog_snapshot_map WHERE snapshot_id = $1")
+            .bind(s1)
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
+    assert_eq!(map_rows, 0, "no orphan snapshot-map row");
+
+    // f1 was scheduled, tagged with this catalog and the data_path-relative path.
+    let scheduled: Vec<(i64, String, bool)> = sqlx::query(
+        "SELECT catalog_id, path, path_is_relative FROM ducklake_files_scheduled_for_deletion",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap()
+    .into_iter()
+    .map(|r| {
+        (
+            r.try_get::<i64, _>(0).unwrap(),
+            r.try_get::<String, _>(1).unwrap(),
+            r.try_get::<bool, _>(2).unwrap(),
+        )
+    })
+    .collect();
+    assert_eq!(scheduled.len(), 1);
+    assert_eq!(scheduled[0].0, cat);
+    assert_eq!(scheduled[0].1, "public/t/f1.parquet");
+    assert!(scheduled[0].2);
+
+    // f1's catalog row is gone; f2/f3 remain.
+    let live_files: i64 = sqlx::query("SELECT COUNT(*) FROM ducklake_data_file")
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .try_get(0)
+        .unwrap();
+    assert_eq!(live_files, 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn expire_in_catalog_full_after_drop_removes_table_metadata() {
+    use datafusion_ducklake::maintenance::ExpireCriteria;
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("pg_prod").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path("/data").unwrap();
+    let s = w
+        .begin_write_transaction("public", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    w.register_data_file(
+        s.table_id,
+        s.snapshot_id,
+        &DataFileInfo::new("f1.parquet", 100, 5),
+    )
+    .unwrap();
+
+    // Drop allocates a second snapshot; expire the first (the drop snapshot is kept).
+    assert!(
+        mgr.drop_table_in_catalog("pg_prod", "public", "t")
+            .await
+            .unwrap()
+    );
+    let expired = mgr
+        .expire_snapshots_in_catalog("pg_prod", ExpireCriteria::Versions(vec![s.snapshot_id]))
+        .await
+        .unwrap();
+    assert_eq!(expired.len(), 1);
+
+    for tbl in
+        ["ducklake_table", "ducklake_column", "ducklake_data_file", "ducklake_schema_versions"]
+    {
+        let cnt: i64 = sqlx::query(&format!("SELECT COUNT(*) FROM {tbl} WHERE table_id = $1"))
+            .bind(s.table_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
+        assert_eq!(cnt, 0, "{tbl} fully reclaimed after expire");
+    }
+    let scheduled: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_files_scheduled_for_deletion WHERE catalog_id = $1",
+    )
+    .bind(cat)
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap();
+    assert_eq!(
+        scheduled, 1,
+        "the table's data file was scheduled for deletion"
+    );
+}
+
+/// The critical scoping regression: a data file in catalog A whose `[begin, end)` global
+/// snapshot range *contains* a snapshot belonging to catalog B must still be GC'd when A
+/// expires — a globally-scoped reachability check would wrongly keep it alive.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn expire_in_catalog_is_scoped_to_catalog() {
+    use datafusion_ducklake::maintenance::ExpireCriteria;
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat_a = mgr.create_catalog("cat_a").await.unwrap();
+    let cat_b = mgr.create_catalog("cat_b").await.unwrap();
+    let wa = PostgresMetadataWriter::with_pool(pool.clone(), cat_a)
+        .await
+        .unwrap();
+    let wb = PostgresMetadataWriter::with_pool(pool.clone(), cat_b)
+        .await
+        .unwrap();
+    wa.set_data_path("/data").unwrap();
+
+    // Interleave so B's snapshot sits between A's two snapshots:
+    //   a1 (A) < b1 (B) < a2 (A)  → A/f1 lives in [a1, a2), which contains b1.
+    let a1 = wa
+        .begin_write_transaction("public", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    wa.register_data_file(
+        a1.table_id,
+        a1.snapshot_id,
+        &DataFileInfo::new("f1.parquet", 100, 5),
+    )
+    .unwrap();
+    let b1 = wb
+        .begin_write_transaction("public", "u", &cols(), WriteMode::Replace)
+        .unwrap();
+    wb.register_data_file(
+        b1.table_id,
+        b1.snapshot_id,
+        &DataFileInfo::new("g1.parquet", 100, 5),
+    )
+    .unwrap();
+    let a2 = wa
+        .begin_write_transaction("public", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    wa.register_data_file(
+        a2.table_id,
+        a2.snapshot_id,
+        &DataFileInfo::new("f2.parquet", 100, 5),
+    )
+    .unwrap();
+    assert!(
+        b1.snapshot_id > a1.snapshot_id && b1.snapshot_id < a2.snapshot_id,
+        "test setup: B's snapshot must fall inside A/f1's lifetime range"
+    );
+
+    let expired = mgr
+        .expire_snapshots_in_catalog("cat_a", ExpireCriteria::Versions(vec![a1.snapshot_id]))
+        .await
+        .unwrap();
+    assert_eq!(expired.len(), 1);
+
+    // A/f1 was scheduled despite B's snapshot being in its global range (proves scoping).
+    let a_scheduled: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_files_scheduled_for_deletion WHERE catalog_id = $1",
+    )
+    .bind(cat_a)
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap();
+    assert_eq!(
+        a_scheduled, 1,
+        "A/f1 must be GC'd — catalog-scoped reachability"
+    );
+
+    // Catalog B is entirely untouched.
+    let b_snap: i64 = sqlx::query("SELECT COUNT(*) FROM ducklake_snapshot WHERE snapshot_id = $1")
+        .bind(b1.snapshot_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .try_get(0)
+        .unwrap();
+    assert_eq!(b_snap, 1, "B's snapshot survives");
+    let b_files: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_data_file WHERE table_id = $1 AND end_snapshot IS NULL",
+    )
+    .bind(b1.table_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap();
+    assert_eq!(b_files, 1, "B's data file untouched");
+    let b_scheduled: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_files_scheduled_for_deletion WHERE catalog_id = $1",
+    )
+    .bind(cat_b)
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap();
+    assert_eq!(b_scheduled, 0, "nothing scheduled for B");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn cleanup_old_files_in_catalog_is_scoped_to_catalog() {
+    use datafusion_ducklake::maintenance::{
+        CleanupCriteria, ExpireCriteria, cleanup_old_files_in_catalog,
+    };
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+    use object_store::ObjectStore;
+    use object_store::local::LocalFileSystem;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat_a = mgr.create_catalog("cat_a").await.unwrap();
+    let cat_b = mgr.create_catalog("cat_b").await.unwrap();
+    let wa = PostgresMetadataWriter::with_pool(pool.clone(), cat_a)
+        .await
+        .unwrap();
+    let wb = PostgresMetadataWriter::with_pool(pool.clone(), cat_b)
+        .await
+        .unwrap();
+
+    let temp = TempDir::new().unwrap();
+    let data_path = temp.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+    wa.set_data_path(data_path.to_str().unwrap()).unwrap();
+
+    // A: two generations of public.t (f1 superseded by f2). B: two of public.u.
+    let a1 = wa
+        .begin_write_transaction("public", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    wa.register_data_file(
+        a1.table_id,
+        a1.snapshot_id,
+        &DataFileInfo::new("f1.parquet", 100, 5),
+    )
+    .unwrap();
+    let a2 = wa
+        .begin_write_transaction("public", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    wa.register_data_file(
+        a2.table_id,
+        a2.snapshot_id,
+        &DataFileInfo::new("f2.parquet", 100, 5),
+    )
+    .unwrap();
+    let b1 = wb
+        .begin_write_transaction("public", "u", &cols(), WriteMode::Replace)
+        .unwrap();
+    wb.register_data_file(
+        b1.table_id,
+        b1.snapshot_id,
+        &DataFileInfo::new("g1.parquet", 100, 5),
+    )
+    .unwrap();
+    let b2 = wb
+        .begin_write_transaction("public", "u", &cols(), WriteMode::Replace)
+        .unwrap();
+    wb.register_data_file(
+        b2.table_id,
+        b2.snapshot_id,
+        &DataFileInfo::new("g2.parquet", 100, 5),
+    )
+    .unwrap();
+
+    // Materialize the physical files.
+    for (sch, tbl, name) in [
+        ("public", "t", "f1.parquet"),
+        ("public", "t", "f2.parquet"),
+        ("public", "u", "g1.parquet"),
+        ("public", "u", "g2.parquet"),
+    ] {
+        let dir = data_path.join(sch).join(tbl);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(name), b"parquet-bytes").unwrap();
+    }
+
+    // Expire the first snapshot of each catalog so each has one scheduled file.
+    mgr.expire_snapshots_in_catalog("cat_a", ExpireCriteria::Versions(vec![a1.snapshot_id]))
+        .await
+        .unwrap();
+    mgr.expire_snapshots_in_catalog("cat_b", ExpireCriteria::Versions(vec![b1.snapshot_id]))
+        .await
+        .unwrap();
+
+    let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+    let a_f1 = data_path.join("public").join("t").join("f1.parquet");
+    let b_g1 = data_path.join("public").join("u").join("g1.parquet");
+
+    // Dry run for A reports its one file without deleting.
+    let dry =
+        cleanup_old_files_in_catalog(&mgr, "cat_a", store.clone(), CleanupCriteria::All, true)
+            .await
+            .unwrap();
+    assert_eq!(dry.len(), 1);
+    assert!(a_f1.exists());
+
+    // Real cleanup for A removes only A's file + bookkeeping row.
+    let done = cleanup_old_files_in_catalog(&mgr, "cat_a", store, CleanupCriteria::All, false)
+        .await
+        .unwrap();
+    assert_eq!(done.len(), 1);
+    assert!(!a_f1.exists(), "A/f1 deleted");
+    assert!(b_g1.exists(), "B/g1 untouched by A's cleanup");
+
+    let a_left: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_files_scheduled_for_deletion WHERE catalog_id = $1",
+    )
+    .bind(cat_a)
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap();
+    assert_eq!(a_left, 0, "A's scheduled row cleared");
+    let b_left: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_files_scheduled_for_deletion WHERE catalog_id = $1",
+    )
+    .bind(cat_b)
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap();
+    assert_eq!(b_left, 1, "B's scheduled row remains");
+}


### PR DESCRIPTION
Ports the official DuckLake two-phase vacuum (`expire_snapshots` + `cleanup_old_files`) and extends `DROP TABLE` to the single-catalog (SQLite) write path. Mirrors upstream behaviour at the catalog level — only the physical I/O differs (DuckDB uses `FileSystem::RemoveFiles`, we use `object_store`).

Closes the gap left by #120's docstring: _"future expire-snapshots / cleanup-files vacuum."_

## What's in this PR

### New public API (Rust methods, both backends)

```rust
SqliteMetadataWriter::drop_table(schema, table) -> Result<bool>
SqliteMetadataWriter::expire_snapshots(criteria) -> Result<Vec<ExpiredSnapshot>>
MulticatalogManager::expire_snapshots_in_catalog(catalog, criteria) -> Result<Vec<ExpiredSnapshot>>
maintenance::cleanup_old_files_sqlite(writer, store, criteria, dry_run) -> Result<Vec<String>>
maintenance::cleanup_old_files_in_catalog(mgr, catalog, store, criteria, dry_run) -> Result<Vec<String>>

ExpireCriteria::{ Versions(Vec<i64>), OlderThan(DateTime<Utc>) }
CleanupCriteria::{ All, OlderThan(DateTime<Utc>) }
```

### Three-phase delete philosophy (matches official)

| Phase | Operations | What it touches |
|---|---|---|
| `DROP TABLE` | `UPDATE`s only | `ducklake_{table, column, data_file, delete_file}` end_snapshot. Soft-delete; time travel preserved. |
| `expire_snapshots` | `DELETE`s + `INSERT`s | Removes unreachable metadata; **schedules** orphaned physical paths into `ducklake_files_scheduled_for_deletion`. Catalog-wide; never deletes the most recent snapshot. |
| `cleanup_old_files` | `object_store.delete()` + `DELETE` | Physically removes scheduled files; clears bookkeeping. |

### Postgres multicatalog scoping (critical correctness point)

`ducklake_snapshot` / `ducklake_table` / `ducklake_data_file` are shared across catalogs in the Phase 1 multicatalog design, partitioned by `ducklake_catalog_{snapshot,schema}_map`. Every reachability subquery is joined to `ducklake_catalog_snapshot_map` so another catalog's snapshot can't keep this catalog's files alive forever. Tests include a regression where catalog A's file has a `[begin, end)` range that contains a catalog B snapshot and is still correctly GC'd (`expire_in_catalog_is_scoped_to_catalog`).

`ducklake_files_scheduled_for_deletion` adds a `catalog_id` column on Postgres (documented divergence from the official single-catalog schema). Without it, `cleanup_old_files` can't tell catalogs apart — the data-file rows it would otherwise join against are already deleted by expire time. SQLite uses the official schema unchanged.

### Schema additions

Both additive and idempotent (`CREATE TABLE IF NOT EXISTS`):
- **SQLite** (`SQL_CREATE_SCHEMA`): `ducklake_files_scheduled_for_deletion(data_file_id, path, path_is_relative, schedule_start)`.
- **Postgres** (`SQL_CREATE_MULTICATALOG_TABLES`): same plus `catalog_id BIGINT NOT NULL` + index on `catalog_id`.

### Tests (35 total)

- `tests/maintenance_sqlite_tests.rs` (**new, 7**): drop tombstone + idempotency + `next_row_id` preserved; drop unknown/empty names; expire-by-version schedules orphaned file; expire-after-drop reclaims `ducklake_table` / `ducklake_column` / `ducklake_data_file` / `ducklake_table_stats`; cleanup end-to-end with `LocalFileSystem` (dry_run + real + idempotent); no-op paths; `OlderThan(DateTime<Utc>)` end-to-end.
- `tests/multicatalog_postgres_tests.rs` (**extended, 5 new**): empty + unknown catalog; expire-by-version schedules with `catalog_id` and resolved path; expire-full-after-drop; **catalog-scoping regression**; `cleanup_old_files_in_catalog` scoped to one catalog with real `LocalFileSystem` files.

### Side-by-side validation

- `examples/maintenance_demo.rs` drives our Rust API through CREATE → INSERT → Replace → DROP → expire → cleanup.
- `examples/maintenance_demo.sql` runs the equivalent against the official `duckdb` + `ducklake` extension.

Behavioural outcomes match (modulo official's `DELETE FROM + INSERT` being two snapshots while our `Replace` is one).

## Not in scope (each a clean follow-up)

- `ducklake_delete_orphaned_files` (storage-scan based; catches files from aborted writes).
- Global option defaults (`expire_older_than` / `delete_older_than` via `set_option`).
- Compaction (`ducklake_merge_adjacent_files`) — would also schedule files.
- Row-level `DELETE FROM t` write path (delete file emission).
- `ducklake_table_column_stats` schema parity (pair with column-stats writes).

## How to verify locally

```bash
# Single-catalog (SQLite, no docker)
cargo test --no-default-features --features write-sqlite --test maintenance_sqlite_tests

# Multicatalog (Postgres, needs docker)
cargo test --no-default-features --features write-postgres --test multicatalog_postgres_tests

# Side-by-side demo
cargo run --no-default-features --features write-sqlite --example maintenance_demo

rm -rf /tmp/maint_demo_official && mkdir -p /tmp/maint_demo_official
duckdb -unsigned < examples/maintenance_demo.sql
```