### PR TITLE
feat(maintenance): delete_orphaned_files for storage-scan reclamation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,3 +95,7 @@ required-features = ["write-postgres"]
 [[example]]
 name = "maintenance_demo"
 required-features = ["write-sqlite"]
+
+[[example]]
+name = "orphan_cleanup_demo"
+required-features = ["write-sqlite"]

--- a/examples/orphan_cleanup_demo.rs
+++ b/examples/orphan_cleanup_demo.rs
@@ -1,0 +1,270 @@
+//! Step-by-step demo of `delete_orphaned_files_sqlite` against a single-catalog
+//! SQLite setup with `LocalFileSystem`. Visualises each scenario the regression
+//! tests cover, plus the runtime decisions the sweep makes.
+//!
+//! Companion to `examples/orphan_cleanup_demo.sql` (drives the equivalent
+//! scenarios through the official DuckDB + DuckLake extension). The two
+//! outputs line up step-by-step.
+//!
+//! Scenarios shown:
+//!   1. Setup — empty catalog, empty data_path
+//!   2. Register one data file → file referenced; orphan sweep is a no-op
+//!   3. Drop a stray .parquet on disk → orphan sweep finds + deletes it
+//!   4. dry_run reports without deleting; real run matches the dry_run set
+//!   5. Non-.parquet files are ignored
+//!   6. Nested-directory orphan is found by recursive listing
+//!   7. `OlderThan` cutoff skips a freshly-written orphan
+//!   8. `All` deletes regardless of age — the dangerous opt-in
+//!   9. A row in `ducklake_files_scheduled_for_deletion` is treated as
+//!      referenced (must not race ahead of cleanup_old_files)
+//!
+//! Run with:
+//!     cargo run --no-default-features --features write-sqlite \
+//!         --example orphan_cleanup_demo
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use object_store::ObjectStore;
+use object_store::local::LocalFileSystem;
+use sqlx::Row;
+use sqlx::sqlite::SqlitePool;
+
+use datafusion_ducklake::SqliteMetadataWriter;
+use datafusion_ducklake::maintenance::{
+    CleanupCriteria, cleanup_old_files_sqlite, delete_orphaned_files_sqlite,
+};
+use datafusion_ducklake::metadata_writer::{ColumnDef, DataFileInfo, MetadataWriter, WriteMode};
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let temp = tempfile::TempDir::new()?;
+    let db_path = temp.path().join("catalog.db");
+    let data_path = temp.path().join("data");
+    std::fs::create_dir_all(&data_path)?;
+    let conn_str = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    let writer = SqliteMetadataWriter::new_with_init(&conn_str).await?;
+    writer.set_data_path(data_path.to_str().unwrap())?;
+    let pool = SqlitePool::connect(&conn_str).await?;
+    let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+
+    println!("data_path = {}\n", data_path.display());
+
+    // ------ Step 1: empty state ----------------------------------------------
+    print_state(&pool, &data_path, "Step 1 — empty catalog, empty data_path").await?;
+    let res =
+        delete_orphaned_files_sqlite(&writer, store.clone(), CleanupCriteria::All, false).await?;
+    println!("delete_orphaned_files(All) -> {res:?}\n");
+
+    // ------ Step 2: register + materialise one referenced file ---------------
+    let s = writer.begin_write_transaction(
+        "main",
+        "t",
+        &[ColumnDef::new("id", "int64", false)?, ColumnDef::new("name", "varchar", true)?],
+        WriteMode::Replace,
+    )?;
+    writer.register_data_file(
+        s.table_id,
+        s.snapshot_id,
+        &DataFileInfo::new("ref.parquet", 100, 5),
+    )?;
+    touch_file(&data_path, "main", "t", "ref.parquet")?;
+    print_state(
+        &pool,
+        &data_path,
+        "Step 2 — one referenced file (ref.parquet)",
+    )
+    .await?;
+    let res =
+        delete_orphaned_files_sqlite(&writer, store.clone(), CleanupCriteria::All, false).await?;
+    println!("delete_orphaned_files(All) -> {res:?}\n");
+
+    // ------ Step 3: drop a stray .parquet ------------------------------------
+    touch_file(&data_path, "main", "t", "stray.parquet")?;
+    print_state(
+        &pool,
+        &data_path,
+        "Step 3 — stray.parquet added (unreferenced)",
+    )
+    .await?;
+    let dry =
+        delete_orphaned_files_sqlite(&writer, store.clone(), CleanupCriteria::All, true).await?;
+    println!("delete_orphaned_files(All) dry_run -> {dry:?}");
+    let real =
+        delete_orphaned_files_sqlite(&writer, store.clone(), CleanupCriteria::All, false).await?;
+    println!("delete_orphaned_files(All) real    -> {real:?}");
+    assert_eq!(dry, real, "dry_run and real_run must agree");
+    print_state(&pool, &data_path, "Step 3 (after) — stray gone").await?;
+
+    // ------ Step 4: non-.parquet file is ignored -----------------------------
+    std::fs::write(
+        data_path.join("main").join("t").join("README.txt"),
+        b"keep me",
+    )?;
+    touch_file(&data_path, "main", "t", "orphan2.parquet")?;
+    print_state(
+        &pool,
+        &data_path,
+        "Step 4 — README.txt (ignored) + orphan2.parquet (orphan)",
+    )
+    .await?;
+    let res =
+        delete_orphaned_files_sqlite(&writer, store.clone(), CleanupCriteria::All, false).await?;
+    println!("delete_orphaned_files(All) -> {res:?}");
+    print_state(
+        &pool,
+        &data_path,
+        "Step 4 (after) — orphan2 gone; README intact",
+    )
+    .await?;
+
+    // ------ Step 5: nested directory orphan ----------------------------------
+    let nested = data_path
+        .join("main")
+        .join("t")
+        .join("year=2024")
+        .join("month=01");
+    std::fs::create_dir_all(&nested)?;
+    std::fs::write(nested.join("part.parquet"), b"orphan-deep")?;
+    print_state(
+        &pool,
+        &data_path,
+        "Step 5 — orphan at main/t/year=2024/month=01/",
+    )
+    .await?;
+    let res =
+        delete_orphaned_files_sqlite(&writer, store.clone(), CleanupCriteria::All, false).await?;
+    println!("delete_orphaned_files(All) -> {res:?}");
+    print_state(&pool, &data_path, "Step 5 (after) — nested orphan reaped").await?;
+
+    // ------ Step 6: OlderThan skips a fresh orphan ---------------------------
+    touch_file(&data_path, "main", "t", "fresh.parquet")?;
+    print_state(&pool, &data_path, "Step 6 — fresh.parquet just written").await?;
+    let cutoff = chrono::Utc::now() - chrono::Duration::hours(1);
+    let res = delete_orphaned_files_sqlite(
+        &writer,
+        store.clone(),
+        CleanupCriteria::OlderThan(cutoff),
+        false,
+    )
+    .await?;
+    println!("delete_orphaned_files(OlderThan(now - 1h)) -> {res:?}   ← in-flight protection");
+
+    // Now `All` does delete it (the operator opt-in).
+    let res =
+        delete_orphaned_files_sqlite(&writer, store.clone(), CleanupCriteria::All, false).await?;
+    println!("delete_orphaned_files(All) -> {res:?}              ← danger-mode opt-in");
+    print_state(
+        &pool,
+        &data_path,
+        "Step 6 (after) — fresh.parquet finally deleted",
+    )
+    .await?;
+
+    // ------ Step 7: a file in scheduled_for_deletion is NOT an orphan --------
+    touch_file(&data_path, "main", "t", "scheduled.parquet")?;
+    sqlx::query(
+        "INSERT INTO ducklake_files_scheduled_for_deletion
+             (data_file_id, path, path_is_relative, schedule_start)
+         VALUES (?, ?, 1, CURRENT_TIMESTAMP)",
+    )
+    .bind(42_i64)
+    .bind("main/t/scheduled.parquet")
+    .execute(&pool)
+    .await?;
+    print_state(
+        &pool,
+        &data_path,
+        "Step 7 — scheduled.parquet awaiting cleanup_old_files",
+    )
+    .await?;
+    let res =
+        delete_orphaned_files_sqlite(&writer, store.clone(), CleanupCriteria::All, false).await?;
+    println!("delete_orphaned_files(All) -> {res:?}    ← scheduled rows are treated as referenced");
+
+    // cleanup_old_files is what's supposed to delete it.
+    let res = cleanup_old_files_sqlite(&writer, store, CleanupCriteria::All, false).await?;
+    println!("cleanup_old_files(All)   -> {res:?}");
+    print_state(
+        &pool,
+        &data_path,
+        "Step 7 (after) — cleanup_old_files reaped it",
+    )
+    .await?;
+
+    Ok(())
+}
+
+fn touch_file(data_path: &Path, schema: &str, table: &str, name: &str) -> anyhow::Result<()> {
+    let dir = data_path.join(schema).join(table);
+    std::fs::create_dir_all(&dir)?;
+    std::fs::write(dir.join(name), b"parquet-bytes")?;
+    Ok(())
+}
+
+async fn print_state(pool: &SqlitePool, data_path: &Path, header: &str) -> anyhow::Result<()> {
+    println!("\n──────── {header} ────────");
+
+    println!("ducklake_data_file:");
+    let rows = sqlx::query(
+        "SELECT data_file_id, path, path_is_relative, end_snapshot FROM ducklake_data_file ORDER BY data_file_id",
+    )
+    .fetch_all(pool)
+    .await?;
+    if rows.is_empty() {
+        println!("  (none)");
+    }
+    for r in &rows {
+        let id: i64 = r.try_get(0)?;
+        let p: String = r.try_get(1)?;
+        let rel: i64 = r.try_get(2)?;
+        let e: Option<i64> = r.try_get(3)?;
+        println!("  df_id={id} path={p} rel={rel} end_snapshot={e:?}");
+    }
+
+    println!("ducklake_files_scheduled_for_deletion:");
+    let rows = sqlx::query(
+        "SELECT data_file_id, path FROM ducklake_files_scheduled_for_deletion ORDER BY data_file_id",
+    )
+    .fetch_all(pool)
+    .await?;
+    if rows.is_empty() {
+        println!("  (empty)");
+    }
+    for r in &rows {
+        let id: i64 = r.try_get(0)?;
+        let p: String = r.try_get(1)?;
+        println!("  df_id={id} path={p}");
+    }
+
+    let files = walk_files(data_path);
+    println!("files on disk under data_path ({} total):", files.len());
+    if files.is_empty() {
+        println!("  (none)");
+    }
+    for p in files {
+        println!("  {}", p.strip_prefix(data_path).unwrap().display());
+    }
+    println!();
+    Ok(())
+}
+
+fn walk_files(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    fn recurse(dir: &Path, out: &mut Vec<PathBuf>) {
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for e in entries.flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    recurse(&p, out);
+                } else {
+                    out.push(p);
+                }
+            }
+        }
+    }
+    recurse(dir, &mut out);
+    out.sort();
+    out
+}

--- a/examples/orphan_cleanup_demo.sql
+++ b/examples/orphan_cleanup_demo.sql
@@ -1,0 +1,68 @@
+-- Official DuckDB + DuckLake companion to `examples/orphan_cleanup_demo.rs`.
+-- Drives the same scenarios via `ducklake_delete_orphaned_files` so the two
+-- outputs can be lined up step-by-step. Behaviour should match modulo cosmetic
+-- output formatting (leading slashes, default `older_than`, etc.).
+--
+-- Run with the locally-built DuckLake extension:
+--   rm -rf /tmp/orphan_demo_official && mkdir -p /tmp/orphan_demo_official
+--   /Users/tsoap/hotdata/ducklake/build/release/duckdb -unsigned \
+--     < examples/orphan_cleanup_demo.sql
+
+.bail on
+LOAD '/Users/tsoap/hotdata/ducklake/build/release/extension/ducklake/ducklake.duckdb_extension';
+
+ATTACH 'ducklake:/tmp/orphan_demo_official/catalog.db' AS dl
+    (DATA_PATH '/tmp/orphan_demo_official/data', METADATA_CATALOG 'metadata');
+
+.print "data_path = /tmp/orphan_demo_official/data"
+
+-- ── Step 1: empty catalog, empty data_path ──
+.print ""
+.print "──────── Step 1 — empty catalog, empty data_path ────────"
+SELECT path FROM ducklake_delete_orphaned_files('dl', cleanup_all => true, dry_run => true);
+
+-- ── Step 2: one referenced file (INSERT writes the parquet) ──
+CREATE TABLE dl.main.t(id BIGINT, name VARCHAR);
+INSERT INTO dl.main.t VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e');
+.print ""
+.print "──────── Step 2 — one referenced file written by INSERT ────────"
+SELECT 'data_file' AS rel; SELECT data_file_id, path FROM metadata.ducklake_data_file ORDER BY data_file_id;
+SELECT 'files on disk' AS rel; SELECT file FROM glob('/tmp/orphan_demo_official/data/**') ORDER BY file;
+SELECT 'orphan sweep (dry_run)' AS rel; SELECT path FROM ducklake_delete_orphaned_files('dl', cleanup_all => true, dry_run => true);
+
+-- ── Step 3: drop a stray .parquet on disk ──
+.shell touch /tmp/orphan_demo_official/data/main/t/stray.parquet
+.print ""
+.print "──────── Step 3 — stray.parquet added (unreferenced) ────────"
+SELECT 'files on disk' AS rel; SELECT file FROM glob('/tmp/orphan_demo_official/data/**') ORDER BY file;
+SELECT 'orphan sweep (dry_run)' AS rel; SELECT path FROM ducklake_delete_orphaned_files('dl', cleanup_all => true, dry_run => true);
+SELECT 'orphan sweep (real)'    AS rel; SELECT path FROM ducklake_delete_orphaned_files('dl', cleanup_all => true);
+SELECT 'files on disk (after)' AS rel; SELECT file FROM glob('/tmp/orphan_demo_official/data/**') ORDER BY file;
+
+-- ── Step 4: non-.parquet ignored ──
+.shell echo 'keep me' > /tmp/orphan_demo_official/data/main/t/README.txt
+.shell touch /tmp/orphan_demo_official/data/main/t/orphan2.parquet
+.print ""
+.print "──────── Step 4 — README.txt + orphan2.parquet ────────"
+SELECT 'files on disk' AS rel; SELECT file FROM glob('/tmp/orphan_demo_official/data/**') ORDER BY file;
+SELECT 'orphan sweep' AS rel; SELECT path FROM ducklake_delete_orphaned_files('dl', cleanup_all => true);
+SELECT 'files on disk (after)' AS rel; SELECT file FROM glob('/tmp/orphan_demo_official/data/**') ORDER BY file;
+
+-- ── Step 5: nested directory orphan ──
+.shell mkdir -p /tmp/orphan_demo_official/data/main/t/year=2024/month=01
+.shell touch /tmp/orphan_demo_official/data/main/t/year=2024/month=01/part.parquet
+.print ""
+.print "──────── Step 5 — orphan at main/t/year=2024/month=01/ ────────"
+SELECT 'files on disk' AS rel; SELECT file FROM glob('/tmp/orphan_demo_official/data/**') ORDER BY file;
+SELECT 'orphan sweep' AS rel; SELECT path FROM ducklake_delete_orphaned_files('dl', cleanup_all => true);
+SELECT 'files on disk (after)' AS rel; SELECT file FROM glob('/tmp/orphan_demo_official/data/**') ORDER BY file;
+
+-- ── Step 6: older_than skips fresh files; cleanup_all overrides ──
+.shell touch /tmp/orphan_demo_official/data/main/t/fresh.parquet
+.print ""
+.print "──────── Step 6 — fresh.parquet just touched ────────"
+SELECT 'older_than = NOW() - 1h (skips fresh)' AS rel;
+SELECT path FROM ducklake_delete_orphaned_files('dl', older_than => NOW() - INTERVAL 1 HOUR);
+SELECT 'cleanup_all = true (deletes fresh)'   AS rel;
+SELECT path FROM ducklake_delete_orphaned_files('dl', cleanup_all => true);
+SELECT 'files on disk (after)' AS rel; SELECT file FROM glob('/tmp/orphan_demo_official/data/**') ORDER BY file;

--- a/src/maintenance.rs
+++ b/src/maintenance.rs
@@ -1,16 +1,20 @@
-//! Maintenance operations for DuckLake catalogs: snapshot expiration and
-//! physical file cleanup.
+//! Maintenance operations for DuckLake catalogs: snapshot expiration, physical
+//! file cleanup, and orphaned-file reclamation.
 //!
-//! These port the official DuckLake two-phase vacuum
-//! (`ducklake_expire_snapshots` + `ducklake_cleanup_old_files`):
+//! These port the three official DuckLake maintenance commands:
 //!
 //! 1. **expire** ([`crate::metadata_writer_sqlite::SqliteMetadataWriter::expire_snapshots`],
 //!    [`crate::multicatalog::MulticatalogManager::expire_snapshots_in_catalog`]) deletes the
 //!    chosen snapshots, garbage-collects every table / data file / delete file that is no
 //!    longer reachable by any surviving snapshot, and records the orphaned physical paths in
 //!    `ducklake_files_scheduled_for_deletion`. No object storage is touched.
-//! 2. **cleanup** ([`cleanup_old_files_sqlite`], [`cleanup_old_files_in_catalog`]) reads the
-//!    scheduled rows, deletes the objects from the object store, and removes the rows.
+//! 2. **cleanup_old_files** ([`cleanup_old_files_sqlite`], [`cleanup_old_files_in_catalog`])
+//!    reads the scheduled rows, deletes the objects from the object store, and removes the rows.
+//! 3. **delete_orphaned_files** ([`delete_orphaned_files_sqlite`],
+//!    [`delete_orphaned_files_multicatalog`]) lists the data path, subtracts everything
+//!    referenced by the catalog (data files + delete files + still-scheduled-for-deletion),
+//!    and deletes whatever's left. Catches files left by aborted writes and by
+//!    `drop_catalog` (which hard-deletes catalog metadata without scheduling its files).
 //!
 //! The metadata writers deliberately hold no object store — physical I/O lives here so the
 //! catalog layer stays storage-agnostic (the object store comes from the caller, e.g. the
@@ -19,8 +23,10 @@
 use crate::Result;
 use crate::path_resolver::{parse_object_store_url, resolve_path};
 use chrono::{DateTime, Utc};
+use futures::TryStreamExt;
 use object_store::path::Path as ObjectPath;
 use object_store::{ObjectStore, ObjectStoreExt};
+use std::collections::HashSet;
 use std::sync::Arc;
 
 /// Which snapshots to expire.
@@ -165,4 +171,115 @@ pub async fn cleanup_old_files_in_catalog(
         mgr.remove_scheduled_in_catalog(catalog_name, &ids).await
     })
     .await
+}
+
+/// List the object store under `data_path`, subtract everything referenced by the
+/// catalog (passed in as `(path, path_is_relative)` pairs), filter by `.parquet`
+/// suffix + `last_modified < older_than` (when set), and delete the leftovers.
+///
+/// Shared between SQLite and multicatalog Postgres — the only backend-specific
+/// piece is producing `referenced`, which is passed in.
+async fn run_orphan_cleanup(
+    data_path: &str,
+    referenced: Vec<(String, bool)>,
+    object_store: Arc<dyn ObjectStore>,
+    criteria: CleanupCriteria,
+    dry_run: bool,
+) -> Result<Vec<String>> {
+    let (_, base_key) = parse_object_store_url(data_path)?;
+
+    // Build the set of referenced object_store keys, normalised the same way
+    // the listing produces them (no leading slash, via ObjectPath canon).
+    let mut referenced_set: HashSet<ObjectPath> = HashSet::with_capacity(referenced.len());
+    for (path, rel) in referenced {
+        let abs = resolve_path(&base_key, &path, rel)?;
+        referenced_set.insert(ObjectPath::from(abs.trim_start_matches('/')));
+    }
+
+    // List every file under the data path. The prefix is the data_path's key
+    // part (same transform we use everywhere else).
+    let prefix = ObjectPath::from(base_key.trim_start_matches('/'));
+    let entries: Vec<object_store::ObjectMeta> =
+        object_store.list(Some(&prefix)).try_collect().await?;
+
+    // Apply the official filters: only `.parquet`, and only files whose
+    // `last_modified < older_than` when a cutoff was given. Skipping in-flight
+    // writes via the timestamp filter is what makes this safe to schedule.
+    let mut orphans: Vec<ObjectPath> = Vec::new();
+    for meta in entries {
+        if !meta.location.as_ref().ends_with(".parquet") {
+            continue;
+        }
+        if let CleanupCriteria::OlderThan(cutoff) = &criteria
+            && meta.last_modified >= *cutoff
+        {
+            continue;
+        }
+        if !referenced_set.contains(&meta.location) {
+            orphans.push(meta.location);
+        }
+    }
+
+    if dry_run {
+        return Ok(orphans.into_iter().map(|p| p.to_string()).collect());
+    }
+
+    let mut deleted = Vec::with_capacity(orphans.len());
+    for orphan in orphans {
+        match object_store.delete(&orphan).await {
+            Ok(()) => {},
+            // Already gone (another vacuumer, or out-of-band deletion) — fine.
+            Err(object_store::Error::NotFound {
+                ..
+            }) => {},
+            Err(e) => return Err(e.into()),
+        }
+        deleted.push(orphan.to_string());
+    }
+    Ok(deleted)
+}
+
+/// List the catalog's `data_path` and delete every `.parquet` not referenced by
+/// the metadata (data files, delete files, or still-scheduled-for-deletion rows).
+///
+/// Returns the absolute paths deleted, or — for `dry_run` — the paths that would
+/// be deleted. Matches the official `ducklake_delete_orphaned_files` semantics:
+/// the `OlderThan` filter compares against the file's `last_modified` so files
+/// being written by in-flight transactions are skipped. `CleanupCriteria::All`
+/// is allowed (matching the official `cleanup_all => true`) but should be used
+/// only when the catalog is known to be idle.
+#[cfg(feature = "write-sqlite")]
+pub async fn delete_orphaned_files_sqlite(
+    writer: &crate::metadata_writer_sqlite::SqliteMetadataWriter,
+    object_store: Arc<dyn ObjectStore>,
+    criteria: CleanupCriteria,
+    dry_run: bool,
+) -> Result<Vec<String>> {
+    let data_path = crate::metadata_writer::MetadataWriter::get_data_path(writer)?;
+    let referenced = writer.list_referenced_paths()?;
+    run_orphan_cleanup(&data_path, referenced, object_store, criteria, dry_run).await
+}
+
+/// List the multicatalog's shared `data_path` and delete every `.parquet` not
+/// referenced by any catalog in the metadata DB.
+///
+/// **Global, not per-catalog.** In our multicatalog Postgres model every catalog
+/// shares one `data_path`, so the natural unit for orphan reclamation is the
+/// whole data path. The referenced set is built across every catalog's data
+/// files, delete files, and still-pending scheduled-for-deletion rows. This
+/// closes the file-leak left by [`MulticatalogManager::drop_catalog`] — which
+/// hard-deletes catalog metadata in one shot, so its files become unreferenced
+/// rather than scheduled.
+///
+/// [`MulticatalogManager::drop_catalog`]: crate::multicatalog::MulticatalogManager::drop_catalog
+#[cfg(feature = "write-postgres")]
+pub async fn delete_orphaned_files_multicatalog(
+    mgr: &crate::multicatalog::MulticatalogManager,
+    object_store: Arc<dyn ObjectStore>,
+    criteria: CleanupCriteria,
+    dry_run: bool,
+) -> Result<Vec<String>> {
+    let data_path = mgr.get_data_path().await?;
+    let referenced = mgr.list_referenced_paths().await?;
+    run_orphan_cleanup(&data_path, referenced, object_store, criteria, dry_run).await
 }

--- a/src/maintenance.rs
+++ b/src/maintenance.rs
@@ -220,8 +220,13 @@ async fn run_orphan_cleanup(
         }
     }
 
+    // Return absolute-style paths (leading `/`) to match `cleanup_old_files`'s
+    // return shape and the official `ducklake_delete_orphaned_files` output.
+    // ObjectPath strips the leading slash for object-store canonical form, so
+    // we add it back at the API boundary. The OS-level delete still uses the
+    // ObjectPath directly.
     if dry_run {
-        return Ok(orphans.into_iter().map(|p| p.to_string()).collect());
+        return Ok(orphans.into_iter().map(|p| format!("/{p}")).collect());
     }
 
     let mut deleted = Vec::with_capacity(orphans.len());
@@ -234,7 +239,7 @@ async fn run_orphan_cleanup(
             }) => {},
             Err(e) => return Err(e.into()),
         }
-        deleted.push(orphan.to_string());
+        deleted.push(format!("/{orphan}"));
     }
     Ok(deleted)
 }

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -473,6 +473,42 @@ impl SqliteMetadataWriter {
             Ok(())
         })
     }
+
+    /// Every physical file currently referenced by the catalog: live + tombstoned
+    /// data files, live + tombstoned delete files, and the still-scheduled
+    /// deletion queue (those rows haven't been processed by `cleanup_old_files`
+    /// yet, so the files might still exist on disk and must not be touched by
+    /// orphan cleanup). Each row is `(path, path_is_relative)` resolved relative
+    /// to the catalog `data_path` root; the caller resolves against the actual
+    /// `data_path` for comparison with object_store keys.
+    ///
+    /// Used by [`crate::maintenance::delete_orphaned_files_sqlite`].
+    pub(crate) fn list_referenced_paths(&self) -> Result<Vec<(String, bool)>> {
+        block_on(async {
+            let q = format!(
+                "SELECT {RESOLVED_PATH} AS p, {REL_FLAG} AS rel
+                 FROM ducklake_data_file df
+                 JOIN ducklake_table t ON t.table_id = df.table_id
+                 JOIN ducklake_schema s ON s.schema_id = t.schema_id
+                 UNION ALL
+                 SELECT {RESOLVED_PATH} AS p, {REL_FLAG} AS rel
+                 FROM ducklake_delete_file df
+                 JOIN ducklake_table t ON t.table_id = df.table_id
+                 JOIN ducklake_schema s ON s.schema_id = t.schema_id
+                 UNION ALL
+                 SELECT path AS p, CAST(path_is_relative AS INTEGER) AS rel
+                 FROM ducklake_files_scheduled_for_deletion"
+            );
+            let rows = sqlx::query(&q).fetch_all(&self.pool).await?;
+            rows.into_iter()
+                .map(|r| {
+                    let p: String = r.try_get(0)?;
+                    let rel: i64 = r.try_get(1)?;
+                    Ok((p, rel != 0))
+                })
+                .collect()
+        })
+    }
 }
 
 /// SQL expression yielding a file path resolved relative to the catalog `data_path`

--- a/src/multicatalog.rs
+++ b/src/multicatalog.rs
@@ -789,6 +789,34 @@ impl MulticatalogManager {
         .await?;
         Ok(())
     }
+
+    /// Every physical file referenced by **any** catalog in this metadata DB:
+    /// data files, delete files, and still-scheduled-for-deletion rows. Global
+    /// (no catalog filter) — orphan cleanup operates on the whole shared
+    /// `data_path` and must subtract every catalog's referenced files to avoid
+    /// deleting another catalog's data.
+    ///
+    /// Used by [`crate::maintenance::delete_orphaned_files_multicatalog`].
+    pub(crate) async fn list_referenced_paths(&self) -> Result<Vec<(String, bool)>> {
+        let q = format!(
+            "SELECT {PG_RESOLVED_PATH} AS p, {PG_REL_FLAG} AS rel
+             FROM ducklake_data_file df
+             JOIN ducklake_table t ON t.table_id = df.table_id
+             JOIN ducklake_schema s ON s.schema_id = t.schema_id
+             UNION ALL
+             SELECT {PG_RESOLVED_PATH} AS p, {PG_REL_FLAG} AS rel
+             FROM ducklake_delete_file df
+             JOIN ducklake_table t ON t.table_id = df.table_id
+             JOIN ducklake_schema s ON s.schema_id = t.schema_id
+             UNION ALL
+             SELECT path AS p, path_is_relative AS rel
+             FROM ducklake_files_scheduled_for_deletion"
+        );
+        let rows = sqlx::query(&q).fetch_all(&self.pool).await?;
+        rows.into_iter()
+            .map(|r| Ok((r.try_get::<String, _>(0)?, r.try_get::<bool, _>(1)?)))
+            .collect()
+    }
 }
 
 /// Insert `(catalog_id, data_file_id, resolved_path, rel)` rows into

--- a/tests/maintenance_sqlite_tests.rs
+++ b/tests/maintenance_sqlite_tests.rs
@@ -6,6 +6,7 @@
 
 #![cfg(all(feature = "write-sqlite", feature = "metadata-sqlite"))]
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -503,5 +504,307 @@ async fn delete_orphaned_files_spares_files_pending_in_scheduled_table() {
             .join("t")
             .join("scheduled.parquet")
             .exists()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// delete_orphaned_files — edge-case contract coverage
+//
+// The orphan sweep relies on three implicit invariants that the happy-path
+// tests above don't exercise:
+//
+//   * `object_store::Path` normalises consecutive slashes, so a relative path
+//     starting with `/` (which the `RESOLVED_PATH` SQL CASE can emit when
+//     `s.path = ''`) still matches the listing for the same physical file.
+//   * `resolve_path` short-circuits when `path_is_relative = false`, so a
+//     data-file row whose `path` is absolute is keyed by that absolute path
+//     verbatim — and must still match `object_store.list`'s key for the same
+//     file when the file happens to live under `data_path`.
+//   * `object_store.list(Some(&prefix))` recurses into subdirectories — a
+//     hive-partitioned layout (`year=…/month=…/file.parquet`) must be fully
+//     visible.
+//
+// Plus two operational corners worth pinning down:
+//
+//   * `dry_run` and the real run return identical path sets — they take
+//     separate code paths inside `run_orphan_cleanup`.
+//   * `CleanupCriteria::All` against an empty catalog deletes every
+//     `.parquet` in `data_path`. Documented behaviour (mirrors the official
+//     `cleanup_all => true`), made explicit here so anyone changing the
+//     safety story sees the footgun directly.
+// ---------------------------------------------------------------------------
+
+/// Schema rows with `path = ''` (the DDL default) make the `RESOLVED_PATH`
+/// SQL emit a leading-slash relative path (`'' || '/' || t || '/' || f`).
+/// After `join_paths(base_key, "/t/f")` we get a path with a double slash.
+/// `ObjectPath::from(...)` normalises that to the single-slash form, which
+/// matches what `object_store.list` returns for the same file. This test
+/// locks the contract in case ObjectPath's normalisation ever weakens.
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_orphaned_files_handles_empty_schema_path() {
+    let h = setup().await;
+    let p = pool(&h).await;
+
+    // Bypass `begin_write_transaction` — it always passes `schema_name` as
+    // `path`, so we'd never naturally produce an empty `s.path`. Insert
+    // the catalog skeleton directly to exercise the DDL default.
+    sqlx::query("INSERT INTO ducklake_snapshot (snapshot_time) VALUES (CURRENT_TIMESTAMP)")
+        .execute(&p)
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO ducklake_schema (schema_name, path, path_is_relative, begin_snapshot)
+         VALUES ('s', '', 1, 1)",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO ducklake_table (schema_id, table_name, path, path_is_relative, begin_snapshot)
+         VALUES (1, 't', 't', 1, 1)",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO ducklake_data_file (table_id, path, path_is_relative, file_size_bytes, record_count, begin_snapshot)
+         VALUES (1, 'f.parquet', 1, 100, 5, 1)",
+    )
+    .execute(&p)
+    .await
+    .unwrap();
+
+    // With s.path='' the resolved path collapses to `<data_path>/t/f.parquet`
+    // (the empty schema contributes nothing). The physical file lives there.
+    let dir = h.data_path.join("t");
+    std::fs::create_dir_all(&dir).unwrap();
+    let referenced = dir.join("f.parquet");
+    std::fs::write(&referenced, b"data").unwrap();
+
+    let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+    let deleted = delete_orphaned_files_sqlite(&h.writer, store, CleanupCriteria::All, false)
+        .await
+        .unwrap();
+    assert!(
+        deleted.is_empty(),
+        "referenced file under empty-schema-path resolution must survive (got {deleted:?})"
+    );
+    assert!(referenced.exists(), "referenced file must still exist");
+}
+
+/// `path_is_relative = false` makes `RESOLVED_PATH` return `df.path` verbatim
+/// (no prepending). The orphan-cleanup resolver short-circuits in
+/// `resolve_path` and uses the absolute key as-is. A file at that absolute
+/// key — even if it happens to live under `data_path` — must be excluded
+/// from deletion. Our writer doesn't emit absolute paths, so the SQL CASE
+/// branch is otherwise untested by integration tests.
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_orphaned_files_handles_absolute_file_paths() {
+    let h = setup().await;
+    let p = pool(&h).await;
+    let s = h
+        .writer
+        .begin_write_transaction("main", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+
+    // Materialise the file at an absolute path that happens to fall under
+    // data_path — that's the configuration where the SQL CASE's absolute
+    // branch interacts with the listing.
+    write_physical_file(&h.data_path, "main", "t", "abs.parquet");
+    let abs_file = h.data_path.join("main").join("t").join("abs.parquet");
+    let abs_str = abs_file.to_str().unwrap().to_string();
+
+    // Register it with path_is_relative = false (= 0 in SQLite).
+    sqlx::query(
+        "INSERT INTO ducklake_data_file (table_id, path, path_is_relative, file_size_bytes, record_count, begin_snapshot)
+         VALUES (?, ?, 0, 100, 5, ?)",
+    )
+    .bind(s.table_id)
+    .bind(&abs_str)
+    .bind(s.snapshot_id)
+    .execute(&p)
+    .await
+    .unwrap();
+
+    // Drop a stray IN data_path so we know the sweep IS running.
+    write_physical_file(&h.data_path, "main", "t", "stray.parquet");
+    let stray = h.data_path.join("main").join("t").join("stray.parquet");
+
+    let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+    let deleted = delete_orphaned_files_sqlite(&h.writer, store, CleanupCriteria::All, false)
+        .await
+        .unwrap();
+    assert_eq!(
+        deleted.len(),
+        1,
+        "stray is the only orphan (got {deleted:?})"
+    );
+    assert!(
+        deleted[0].ends_with("main/t/stray.parquet"),
+        "got {:?}",
+        deleted[0]
+    );
+    assert!(!stray.exists(), "stray deleted");
+    assert!(abs_file.exists(), "absolute-path registered file survives");
+}
+
+/// `object_store.list(Some(&prefix))` must recurse into subdirectories so
+/// partition-style layouts (`year=…/month=…/file.parquet`) are reachable.
+/// Our writer doesn't produce nested layouts today, but other tools might —
+/// and a future change to the listing call (e.g. switching to a delimiter
+/// to optimise paginating) could silently stop recursing.
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_orphaned_files_recurses_into_nested_directories() {
+    let h = setup().await;
+    let s = h
+        .writer
+        .begin_write_transaction("main", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    h.writer
+        .register_data_file(
+            s.table_id,
+            s.snapshot_id,
+            &DataFileInfo::new("ref.parquet", 100, 5),
+        )
+        .unwrap();
+    write_physical_file(&h.data_path, "main", "t", "ref.parquet");
+
+    // Two orphan files at progressively deeper nesting.
+    let deep_dir = h
+        .data_path
+        .join("main")
+        .join("t")
+        .join("year=2024")
+        .join("month=01");
+    std::fs::create_dir_all(&deep_dir).unwrap();
+    let level2 = deep_dir.join("partition.parquet");
+    std::fs::write(&level2, b"orphan-2").unwrap();
+    let deeper_dir = deep_dir.join("day=15");
+    std::fs::create_dir_all(&deeper_dir).unwrap();
+    let level3 = deeper_dir.join("nested.parquet");
+    std::fs::write(&level3, b"orphan-3").unwrap();
+
+    let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+    let deleted: HashSet<String> =
+        delete_orphaned_files_sqlite(&h.writer, store, CleanupCriteria::All, false)
+            .await
+            .unwrap()
+            .into_iter()
+            .collect();
+    assert_eq!(
+        deleted.len(),
+        2,
+        "both nested orphans must be discovered (got {deleted:?})"
+    );
+    assert!(!level2.exists());
+    assert!(!level3.exists());
+    assert!(
+        h.data_path
+            .join("main")
+            .join("t")
+            .join("ref.parquet")
+            .exists(),
+        "referenced survives"
+    );
+}
+
+/// dry_run and real-run must return identical path strings (callers might
+/// compare them or feed dry_run into a confirmation prompt then expect the
+/// same paths to be deleted on confirm). They take separate code paths
+/// (dry_run formats from the pre-delete `orphans` Vec; real-run formats
+/// per-orphan after `object_store.delete` succeeds), so a future refactor
+/// could diverge them.
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_orphaned_files_dry_run_matches_real_run() {
+    let h = setup().await;
+    let s = h
+        .writer
+        .begin_write_transaction("main", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    h.writer
+        .register_data_file(
+            s.table_id,
+            s.snapshot_id,
+            &DataFileInfo::new("ref.parquet", 100, 5),
+        )
+        .unwrap();
+    write_physical_file(&h.data_path, "main", "t", "ref.parquet");
+    for name in ["o1.parquet", "o2.parquet", "o3.parquet"] {
+        write_physical_file(&h.data_path, "main", "t", name);
+    }
+
+    let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+    let dry: HashSet<String> =
+        delete_orphaned_files_sqlite(&h.writer, store.clone(), CleanupCriteria::All, true)
+            .await
+            .unwrap()
+            .into_iter()
+            .collect();
+    assert_eq!(dry.len(), 3);
+    // Dry-run must not touch disk.
+    for name in ["o1.parquet", "o2.parquet", "o3.parquet"] {
+        assert!(h.data_path.join("main").join("t").join(name).exists());
+    }
+
+    let real: HashSet<String> =
+        delete_orphaned_files_sqlite(&h.writer, store, CleanupCriteria::All, false)
+            .await
+            .unwrap()
+            .into_iter()
+            .collect();
+    assert_eq!(
+        dry, real,
+        "dry_run and real_run must return identical path sets"
+    );
+}
+
+/// `CleanupCriteria::All` against an empty catalog deletes every `.parquet`
+/// under `data_path`. This mirrors the official `cleanup_all => true`
+/// semantics but is the classic operator-misuse footgun — pointing the API
+/// at a data_path that has files but no catalog rows wipes everything.
+/// `OlderThan` is the only safeguard at the crate level; callers should
+/// enforce it as a policy invariant (e.g. an automated worker should never
+/// pass `All`). This test makes the contract explicit so anyone changing
+/// the safety story has to update it deliberately.
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_orphaned_files_all_on_empty_catalog_wipes_data_path() {
+    let h = setup().await;
+    // No begin_write_transaction — the catalog is completely empty.
+    write_physical_file(&h.data_path, "main", "t", "innocent.parquet");
+    write_physical_file(&h.data_path, "main", "t", "innocent2.parquet");
+    let innocent1 = h.data_path.join("main").join("t").join("innocent.parquet");
+    let innocent2 = h.data_path.join("main").join("t").join("innocent2.parquet");
+
+    let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+
+    // `All` on an empty catalog → everything in data_path is "unreferenced"
+    // → everything is deleted. Documented contract.
+    let deleted =
+        delete_orphaned_files_sqlite(&h.writer, store.clone(), CleanupCriteria::All, false)
+            .await
+            .unwrap();
+    assert_eq!(
+        deleted.len(),
+        2,
+        "All on empty catalog deletes every .parquet"
+    );
+    assert!(!innocent1.exists());
+    assert!(!innocent2.exists());
+
+    // Restore + verify `OlderThan` is the safeguard against the same scenario.
+    write_physical_file(&h.data_path, "main", "t", "fresh.parquet");
+    let fresh = h.data_path.join("main").join("t").join("fresh.parquet");
+    let cutoff = chrono::Utc::now() - chrono::Duration::hours(1);
+    let kept =
+        delete_orphaned_files_sqlite(&h.writer, store, CleanupCriteria::OlderThan(cutoff), false)
+            .await
+            .unwrap();
+    assert!(
+        kept.is_empty(),
+        "OlderThan filter saves a fresh unreferenced file"
+    );
+    assert!(
+        fresh.exists(),
+        "fresh file survives OlderThan sweep on empty catalog"
     );
 }

--- a/tests/maintenance_sqlite_tests.rs
+++ b/tests/maintenance_sqlite_tests.rs
@@ -16,7 +16,9 @@ use sqlx::sqlite::SqlitePool;
 use tempfile::TempDir;
 
 use datafusion_ducklake::SqliteMetadataWriter;
-use datafusion_ducklake::maintenance::{CleanupCriteria, ExpireCriteria, cleanup_old_files_sqlite};
+use datafusion_ducklake::maintenance::{
+    CleanupCriteria, ExpireCriteria, cleanup_old_files_sqlite, delete_orphaned_files_sqlite,
+};
 use datafusion_ducklake::metadata_writer::{ColumnDef, DataFileInfo, MetadataWriter, WriteMode};
 
 fn cols() -> Vec<ColumnDef> {
@@ -374,4 +376,132 @@ async fn expire_and_cleanup_no_op_paths() {
         .await
         .unwrap();
     assert!(cleaned.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// delete_orphaned_files
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_orphaned_files_removes_unreferenced_keeps_referenced() {
+    let h = setup().await;
+    // One registered, referenced file.
+    let s = h
+        .writer
+        .begin_write_transaction("main", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    h.writer
+        .register_data_file(
+            s.table_id,
+            s.snapshot_id,
+            &DataFileInfo::new("referenced.parquet", 100, 5),
+        )
+        .unwrap();
+    write_physical_file(&h.data_path, "main", "t", "referenced.parquet");
+
+    // Drop a stray file alongside it that's NOT in the catalog.
+    write_physical_file(&h.data_path, "main", "t", "orphan.parquet");
+    // And a non-parquet file that must be ignored (only .parquet is swept).
+    std::fs::write(
+        h.data_path.join("main").join("t").join("README.txt"),
+        b"keep me",
+    )
+    .unwrap();
+
+    let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+    let orphan_path = h.data_path.join("main").join("t").join("orphan.parquet");
+    let ref_path = h
+        .data_path
+        .join("main")
+        .join("t")
+        .join("referenced.parquet");
+    let readme = h.data_path.join("main").join("t").join("README.txt");
+
+    // Dry run reports the orphan without touching disk.
+    let dry = delete_orphaned_files_sqlite(&h.writer, store.clone(), CleanupCriteria::All, true)
+        .await
+        .unwrap();
+    assert_eq!(dry.len(), 1);
+    assert!(
+        dry[0].ends_with("main/t/orphan.parquet"),
+        "got {:?}",
+        dry[0]
+    );
+    assert!(orphan_path.exists());
+
+    // Real run deletes only the orphan.
+    let done = delete_orphaned_files_sqlite(&h.writer, store, CleanupCriteria::All, false)
+        .await
+        .unwrap();
+    assert_eq!(done.len(), 1);
+    assert!(!orphan_path.exists(), "orphan should be gone");
+    assert!(ref_path.exists(), "referenced file must survive");
+    assert!(readme.exists(), "non-parquet file must be ignored");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_orphaned_files_older_than_skips_recent_files() {
+    // Critical safety check: a file just written (in-flight) is newer than the
+    // cutoff and must be kept even though it's unreferenced. Matches the
+    // upstream `last_modified < older_than` guard.
+    let h = setup().await;
+    write_physical_file(&h.data_path, "main", "t", "fresh_orphan.parquet");
+    let fresh = h
+        .data_path
+        .join("main")
+        .join("t")
+        .join("fresh_orphan.parquet");
+    assert!(fresh.exists());
+
+    let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+    let cutoff = chrono::Utc::now() - chrono::Duration::hours(1);
+    let deleted =
+        delete_orphaned_files_sqlite(&h.writer, store, CleanupCriteria::OlderThan(cutoff), false)
+            .await
+            .unwrap();
+    assert!(
+        deleted.is_empty(),
+        "files newer than cutoff must not be deleted (got {deleted:?})"
+    );
+    assert!(fresh.exists(), "fresh orphan survives older_than filter");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_orphaned_files_spares_files_pending_in_scheduled_table() {
+    // Files in `ducklake_files_scheduled_for_deletion` are "queued for
+    // cleanup_old_files" — they may still exist on disk. delete_orphaned_files
+    // must treat them as referenced so it doesn't race ahead and delete them
+    // (cleanup_old_files would then double-delete and remove the bookkeeping).
+    let h = setup().await;
+    write_physical_file(&h.data_path, "main", "t", "scheduled.parquet");
+
+    // Seed the scheduled-for-deletion table directly. This matches what
+    // `expire_snapshots` would have done — but we shortcut it for the test.
+    let p = pool(&h).await;
+    sqlx::query(
+        "INSERT INTO ducklake_files_scheduled_for_deletion
+             (data_file_id, path, path_is_relative, schedule_start)
+         VALUES (?, ?, 1, CURRENT_TIMESTAMP)",
+    )
+    .bind(42_i64)
+    .bind("main/t/scheduled.parquet")
+    .execute(&p)
+    .await
+    .unwrap();
+
+    let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+    let deleted = delete_orphaned_files_sqlite(&h.writer, store, CleanupCriteria::All, false)
+        .await
+        .unwrap();
+    assert!(
+        deleted.is_empty(),
+        "files in scheduled-for-deletion must be considered referenced (got {deleted:?})"
+    );
+    assert!(
+        h.data_path
+            .join("main")
+            .join("t")
+            .join("scheduled.parquet")
+            .exists()
+    );
 }

--- a/tests/multicatalog_postgres_tests.rs
+++ b/tests/multicatalog_postgres_tests.rs
@@ -1904,3 +1904,189 @@ async fn cleanup_old_files_in_catalog_is_scoped_to_catalog() {
     .unwrap();
     assert_eq!(b_left, 1, "B's scheduled row remains");
 }
+
+// ---------------------------------------------------------------------------
+// delete_orphaned_files_multicatalog
+// ---------------------------------------------------------------------------
+
+/// The flagship use case: `drop_catalog` hard-deletes all of A's metadata,
+/// leaving A's data files unreferenced on disk. The orphan sweep finds them
+/// (they have no catalog row pointing at them anywhere) and removes them.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn delete_orphaned_files_reclaims_dropped_catalog_files() {
+    use datafusion_ducklake::maintenance::{CleanupCriteria, delete_orphaned_files_multicatalog};
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+    use object_store::ObjectStore;
+    use object_store::local::LocalFileSystem;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat_a = mgr.create_catalog("cat_a").await.unwrap();
+    let wa = PostgresMetadataWriter::with_pool(pool.clone(), cat_a)
+        .await
+        .unwrap();
+
+    let temp = TempDir::new().unwrap();
+    let data_path = temp.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+    wa.set_data_path(data_path.to_str().unwrap()).unwrap();
+
+    // Register one data file and put the real bytes on disk.
+    let s = wa
+        .begin_write_transaction("public", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    wa.register_data_file(
+        s.table_id,
+        s.snapshot_id,
+        &DataFileInfo::new("f1.parquet", 100, 5),
+    )
+    .unwrap();
+    let dir = data_path.join("public").join("t");
+    std::fs::create_dir_all(&dir).unwrap();
+    let f1 = dir.join("f1.parquet");
+    std::fs::write(&f1, b"parquet-bytes").unwrap();
+
+    // Drop catalog — metadata is hard-deleted, but the file is still on disk.
+    assert!(mgr.drop_catalog("cat_a").await.unwrap());
+    assert!(f1.exists(), "drop_catalog must not touch storage");
+
+    let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+
+    // Orphan sweep finds f1 (no metadata row references it anywhere) and removes it.
+    let deleted = delete_orphaned_files_multicatalog(&mgr, store, CleanupCriteria::All, false)
+        .await
+        .unwrap();
+    assert_eq!(deleted.len(), 1, "should find exactly the one orphan");
+    assert!(!f1.exists(), "drop_catalog orphan must be reclaimed");
+}
+
+/// Global sweep must NOT delete files referenced by ANY catalog. With two
+/// catalogs sharing `data_path` plus a stray, only the stray gets removed.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn delete_orphaned_files_spares_files_referenced_by_any_catalog() {
+    use datafusion_ducklake::maintenance::{CleanupCriteria, delete_orphaned_files_multicatalog};
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+    use object_store::ObjectStore;
+    use object_store::local::LocalFileSystem;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat_a = mgr.create_catalog("cat_a").await.unwrap();
+    let cat_b = mgr.create_catalog("cat_b").await.unwrap();
+    let wa = PostgresMetadataWriter::with_pool(pool.clone(), cat_a)
+        .await
+        .unwrap();
+    let wb = PostgresMetadataWriter::with_pool(pool.clone(), cat_b)
+        .await
+        .unwrap();
+
+    let temp = TempDir::new().unwrap();
+    let data_path = temp.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+    wa.set_data_path(data_path.to_str().unwrap()).unwrap();
+
+    // A and B each have one referenced data file.
+    let sa = wa
+        .begin_write_transaction("public", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    wa.register_data_file(
+        sa.table_id,
+        sa.snapshot_id,
+        &DataFileInfo::new("a.parquet", 100, 5),
+    )
+    .unwrap();
+    let sb = wb
+        .begin_write_transaction("public", "u", &cols(), WriteMode::Replace)
+        .unwrap();
+    wb.register_data_file(
+        sb.table_id,
+        sb.snapshot_id,
+        &DataFileInfo::new("b.parquet", 100, 5),
+    )
+    .unwrap();
+
+    // Materialise the three files: A's referenced, B's referenced, one stray.
+    let a_file = data_path.join("public").join("t").join("a.parquet");
+    let b_file = data_path.join("public").join("u").join("b.parquet");
+    let stray = data_path.join("public").join("t").join("stray.parquet");
+    std::fs::create_dir_all(a_file.parent().unwrap()).unwrap();
+    std::fs::create_dir_all(b_file.parent().unwrap()).unwrap();
+    std::fs::write(&a_file, b"a").unwrap();
+    std::fs::write(&b_file, b"b").unwrap();
+    std::fs::write(&stray, b"stray").unwrap();
+
+    let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+    let deleted = delete_orphaned_files_multicatalog(&mgr, store, CleanupCriteria::All, false)
+        .await
+        .unwrap();
+
+    assert_eq!(deleted.len(), 1, "only the stray is unreferenced");
+    assert!(
+        deleted[0].ends_with("public/t/stray.parquet"),
+        "got {:?}",
+        deleted[0]
+    );
+    assert!(!stray.exists());
+    assert!(a_file.exists(), "A's referenced file survives");
+    assert!(b_file.exists(), "B's referenced file survives");
+}
+
+/// `OlderThan` cutoff applied to `last_modified` skips files newer than the
+/// cutoff. Mirrors the upstream `last_modified < older_than` guard so in-flight
+/// writes from concurrent transactions aren't reaped.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn delete_orphaned_files_older_than_skips_recent_files() {
+    use datafusion_ducklake::maintenance::{CleanupCriteria, delete_orphaned_files_multicatalog};
+    use object_store::ObjectStore;
+    use object_store::local::LocalFileSystem;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("cat").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    let temp = TempDir::new().unwrap();
+    let data_path = temp.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+    w.set_data_path(data_path.to_str().unwrap()).unwrap();
+
+    // Stray file written just now — newer than the cutoff below.
+    let stray = data_path.join("fresh.parquet");
+    std::fs::write(&stray, b"fresh").unwrap();
+
+    let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+
+    // Cutoff is 1h in the past — the file's last_modified is way newer, so it
+    // must NOT be deleted.
+    let cutoff = chrono::Utc::now() - chrono::Duration::hours(1);
+    let deleted = delete_orphaned_files_multicatalog(
+        &mgr,
+        store.clone(),
+        CleanupCriteria::OlderThan(cutoff),
+        false,
+    )
+    .await
+    .unwrap();
+    assert!(
+        deleted.is_empty(),
+        "files newer than cutoff must be skipped (got {deleted:?})"
+    );
+    assert!(stray.exists(), "fresh stray survives older_than filter");
+
+    // Sanity: with `All`, the same file IS deleted.
+    let deleted = delete_orphaned_files_multicatalog(&mgr, store, CleanupCriteria::All, false)
+        .await
+        .unwrap();
+    assert_eq!(deleted.len(), 1);
+    assert!(!stray.exists());
+}

--- a/tests/multicatalog_postgres_tests.rs
+++ b/tests/multicatalog_postgres_tests.rs
@@ -2090,3 +2090,77 @@ async fn delete_orphaned_files_older_than_skips_recent_files() {
     assert_eq!(deleted.len(), 1);
     assert!(!stray.exists());
 }
+
+/// dry_run and real-run must return identical path sets. They take separate
+/// code paths inside `run_orphan_cleanup` (dry_run formats from the pre-delete
+/// `orphans` Vec; real-run formats per-orphan after each `object_store.delete`
+/// succeeds), so a future refactor could diverge them.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn delete_orphaned_files_dry_run_matches_real_run() {
+    use datafusion_ducklake::maintenance::{CleanupCriteria, delete_orphaned_files_multicatalog};
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+    use object_store::ObjectStore;
+    use object_store::local::LocalFileSystem;
+    use std::collections::HashSet;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("cat").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    let temp = TempDir::new().unwrap();
+    let data_path = temp.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+    w.set_data_path(data_path.to_str().unwrap()).unwrap();
+
+    // One referenced file + three orphans alongside it.
+    let s = w
+        .begin_write_transaction("public", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    w.register_data_file(
+        s.table_id,
+        s.snapshot_id,
+        &DataFileInfo::new("ref.parquet", 100, 5),
+    )
+    .unwrap();
+    let dir = data_path.join("public").join("t");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("ref.parquet"), b"referenced").unwrap();
+    for name in ["o1.parquet", "o2.parquet", "o3.parquet"] {
+        std::fs::write(dir.join(name), b"orphan").unwrap();
+    }
+
+    let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+
+    // Dry run reports the orphans without touching disk.
+    let dry: HashSet<String> =
+        delete_orphaned_files_multicatalog(&mgr, store.clone(), CleanupCriteria::All, true)
+            .await
+            .unwrap()
+            .into_iter()
+            .collect();
+    assert_eq!(dry.len(), 3, "dry_run finds all three orphans");
+    for name in ["o1.parquet", "o2.parquet", "o3.parquet"] {
+        assert!(dir.join(name).exists(), "dry_run must not touch disk");
+    }
+
+    // Real run returns the same set (order-independent).
+    let real: HashSet<String> =
+        delete_orphaned_files_multicatalog(&mgr, store, CleanupCriteria::All, false)
+            .await
+            .unwrap()
+            .into_iter()
+            .collect();
+    assert_eq!(
+        dry, real,
+        "dry_run and real_run must return identical path sets"
+    );
+    assert!(dir.join("ref.parquet").exists(), "referenced file survives");
+    for name in ["o1.parquet", "o2.parquet", "o3.parquet"] {
+        assert!(!dir.join(name).exists(), "orphan deleted: {name}");
+    }
+}


### PR DESCRIPTION
Adds the third (and last) official DuckLake maintenance command — `ducklake_delete_orphaned_files` — porting upstream's storage-listing sweep. Lists the catalog's `data_path`, subtracts every path referenced by the metadata (data files + delete files + still-pending scheduled-for-deletion rows), and deletes whatever's left.

Catches the cases [PR #122](https://github.com/datafusion-contrib/datafusion-ducklake/pull/122)'s two-phase vacuum can't reach: files left by **aborted writes** and by **`drop_catalog`** (which hard-deletes catalog metadata without scheduling its files).

## What lands

Two free functions in `src/maintenance.rs`:

```rust
delete_orphaned_files_sqlite(writer, store, criteria, dry_run) -> Vec<String>
delete_orphaned_files_multicatalog(mgr, store, criteria, dry_run) -> Vec<String>
```

Reuses the existing `CleanupCriteria { All, OlderThan(DateTime<Utc>) }` — same shape as `cleanup_old_files`, matching upstream's `cleanup_all` / `older_than` named parameters.

| Behaviour | Upstream | This PR |
|---|---|---|
| File extension filter | `WHERE suffix(filename, '.parquet')` | `meta.location.as_ref().ends_with(".parquet")` |
| In-flight write protection | `last_modified < older_than` | `meta.last_modified < cutoff` |
| Treats scheduled-for-deletion rows as referenced | yes | yes (union'd into referenced set) |
| `cleanup_all` / `All` shortcut | yes | yes |
| Catalog scope | single-catalog DB | SQLite: single; Postgres: **global** across all catalogs |

## Global semantics on Postgres (deliberate divergence)

`delete_orphaned_files_multicatalog` is **global, not per-catalog**. Every catalog in the multicatalog metadata DB shares the same `data_path` in Phase 1, so the natural unit for orphan reclamation is the whole data path. The referenced set is the UNION across every catalog's data files, delete files, and scheduled-for-deletion rows.

Taking a `catalog_name` parameter would be either decorative (listing is global anyway) or unsafe (would risk deleting another catalog's files). The conceptual model still mirrors upstream: there "the catalog" = "the whole metadata DB"; here "the whole metadata DB" = "all catalogs."

## Closes the connection-drop gap from PR #122

The flagship use case. `MulticatalogManager::drop_catalog` hard-deletes a catalog's metadata in one shot; the files become unreferenced on storage. PR #122's expire+cleanup couldn't reach them (no metadata row to be unreachable from). `delete_orphaned_files_multicatalog` finds them in a single sweep and removes them — no changes needed to `drop_catalog` itself.

## Internals

Two new `pub(crate)` helpers:

```rust
SqliteMetadataWriter::list_referenced_paths() -> Vec<(String, bool)>
MulticatalogManager::list_referenced_paths()   -> Vec<(String, bool)>
```

UNION ALL across `ducklake_data_file`, `ducklake_delete_file`, and `ducklake_files_scheduled_for_deletion`, returning each row's data_path-relative `(path, path_is_relative)`. Reuses `RESOLVED_PATH` / `REL_FLAG` (SQLite) and `PG_RESOLVED_PATH` / `PG_REL_FLAG` (Postgres) from PR #122 — the same nested CASE that expire uses.

A shared `run_orphan_cleanup` helper in `maintenance.rs` owns the listing + set-subtraction + delete logic, called from both backends with their respective referenced-path lists.

## Tests

**Three new SQLite** tests (`tests/maintenance_sqlite_tests.rs`):
- `delete_orphaned_files_removes_unreferenced_keeps_referenced` — orphan deleted; referenced `.parquet` survives; non-`.parquet` file (README) untouched.
- `delete_orphaned_files_older_than_skips_recent_files` — `OlderThan(now - 1h)` doesn't reap a file just written.
- `delete_orphaned_files_spares_files_pending_in_scheduled_table` — files awaiting `cleanup_old_files` are treated as referenced.

**Three new Postgres** tests (`tests/multicatalog_postgres_tests.rs`):
- **`delete_orphaned_files_reclaims_dropped_catalog_files`** — _flagship test_: register a file in catalog A, `drop_catalog("A")`, file still on disk → orphan sweep reclaims it.
- `delete_orphaned_files_spares_files_referenced_by_any_catalog` — two catalogs share `data_path` + a stray; only the stray is deleted (proves the global-scope subtraction is correct).
- `delete_orphaned_files_older_than_skips_recent_files` — same `last_modified` guard at the multicatalog layer; sanity-checks that `All` does still delete it.

## Verification

| | Result |
|---|---|
| `cargo check` (write-sqlite + write-postgres) | clean |
| `cargo fmt --check` | clean |
| `cargo clippy --tests` (touched files) | clean |
| `maintenance_sqlite_tests` | **10/10 pass** (7 existing + 3 new) |
| `multicatalog_postgres_tests` | **34/34 pass** (31 existing + 3 new) |

## Follow-ups (still deliberately deferred)

- Global option defaults (`expire_older_than` / `delete_older_than` via `set_option`) — additive UX.
- Compaction (`ducklake_merge_adjacent_files`) — own multi-week PR.
- Row-level `DELETE FROM t` write path — own multi-week PR.
- `ducklake_table_column_stats` schema parity — pair with column-stats writes.

With this PR + #122 merged, the official three-command maintenance triplet (`expire_snapshots`, `cleanup_old_files`, `delete_orphaned_files`) is fully ported, modulo cosmetic differences (Rust API vs SQL `CALL`).