### PR TITLE
feat(multicatalog): project row_id_start on data-file reads

### DIFF
--- a/src/multicatalog_provider.rs
+++ b/src/multicatalog_provider.rs
@@ -246,6 +246,8 @@ impl MetadataProvider for MulticatalogProvider {
                     data.file_size_bytes AS data_file_size,
                     data.footer_size AS data_footer_size,
                     data.encryption_key AS data_encryption_key,
+                    data.row_id_start AS data_row_id_start,
+                    data.record_count AS data_record_count,
                     del.delete_file_id,
                     del.path AS delete_file_path,
                     del.path_is_relative AS delete_path_is_relative,
@@ -281,14 +283,16 @@ impl MetadataProvider for MulticatalogProvider {
                         footer_size: row.try_get(4)?,
                         encryption_key: row.try_get(5)?,
                     };
+                    let row_id_start: Option<i64> = row.try_get(6)?;
+                    let record_count: Option<i64> = row.try_get(7)?;
 
-                    let delete_file = if row.try_get::<Option<i64>, _>(6)?.is_some() {
+                    let delete_file = if row.try_get::<Option<i64>, _>(8)?.is_some() {
                         Some(DuckLakeFileData {
-                            path: row.try_get(7)?,
-                            path_is_relative: row.try_get(8)?,
-                            file_size_bytes: row.try_get(9)?,
-                            footer_size: row.try_get(10)?,
-                            encryption_key: row.try_get(11)?,
+                            path: row.try_get(9)?,
+                            path_is_relative: row.try_get(10)?,
+                            file_size_bytes: row.try_get(11)?,
+                            footer_size: row.try_get(12)?,
+                            encryption_key: row.try_get(13)?,
                         })
                     } else {
                         None
@@ -297,9 +301,9 @@ impl MetadataProvider for MulticatalogProvider {
                     Ok(DuckLakeTableFile {
                         file: data_file,
                         delete_file,
-                        row_id_start: None,
-                        snapshot_id: None,
-                        max_row_count: None,
+                        row_id_start,
+                        snapshot_id: Some(snapshot_id),
+                        max_row_count: record_count,
                     })
                 })
                 .collect()

--- a/tests/multicatalog_provider_tests.rs
+++ b/tests/multicatalog_provider_tests.rs
@@ -354,3 +354,38 @@ async fn get_table_files_for_select_returns_visible_files_at_snapshot() {
     let files_at_1 = pa.get_table_files_for_select(table.table_id, 1).unwrap();
     assert_eq!(files_at_1.len(), 1);
 }
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn get_table_files_for_select_returns_row_id_start_and_record_count() {
+    // The DuckLake row-lineage read path (RowIdExec) needs row_id_start to
+    // reconstruct rowids. The multicatalog reader used to drop these columns
+    // on the floor, so any consumer using row lineage saw the file as if no
+    // row_id_start were set — matching the single-catalog reader closes the
+    // gap.
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let (cat_pg, _) = seed_two_catalogs(&pool).await.unwrap();
+
+    let pa = MulticatalogProvider::with_pool_and_id(pool.clone(), cat_pg)
+        .await
+        .unwrap();
+    let sn = pa.get_current_snapshot().unwrap();
+    let schema = pa.get_schema_by_name("public", sn).unwrap().unwrap();
+    let table = pa
+        .get_table_by_name(schema.schema_id, "users", sn)
+        .unwrap()
+        .unwrap();
+
+    let files = pa.get_table_files_for_select(table.table_id, sn).unwrap();
+    assert_eq!(files.len(), 1);
+    let f = &files[0];
+    // Three appends of 3 rows each (users-a, -b, -c) → the latest visible
+    // file (users-c) starts at offset 6 and carries 3 rows.
+    assert_eq!(f.row_id_start, Some(6), "row_id_start must be projected");
+    assert_eq!(
+        f.max_row_count,
+        Some(3),
+        "record_count must surface as max_row_count"
+    );
+    assert_eq!(f.snapshot_id, Some(sn), "snapshot_id is the query snapshot");
+}


### PR DESCRIPTION
PR #121 taught the Postgres writer to populate `row_id_start` and `ducklake_table_stats` on every file it writes, and the single-catalog readers (Postgres/MySQL/DuckDB) have been projecting that column for the row-lineage read path (`RowIdExec`) since #115. The multicatalog reader was the odd one out — its `get_table_files_for_select` was hard-coding `row_id_start`, `snapshot_id`, and `max_row_count` to `None`, so any consumer using multicatalog + row lineage saw files as if `row_id_start` were unset and fell over.

Two changes:

* SELECT in `MulticatalogProvider::get_table_files_for_select` now projects `data.row_id_start` and `data.record_count` at positions 6 and 7; delete-file column indices shift by +2.

* The returned `DuckLakeTableFile` carries the real `row_id_start`, `snapshot_id: Some(snapshot_id)`, and `max_row_count: record_count` instead of three `None`s. SQL, indices, and mapping now mirror the single-catalog Postgres reader verbatim.

The new integration test reuses `seed_two_catalogs` — three Replace generations on `pg_prod.public.users` leave only `users-c` visible with `row_id_start = 6` (0 + 3 + 3 preserved across each Replace). The assertions pin all three previously-`None` fields and rely on the monotonic-across-Replace contract #121 introduced.