### PR TITLE
fix(read): emit catalog list type for ARRAY-backed columns

### DIFF
--- a/src/column_rename.rs
+++ b/src/column_rename.rs
@@ -138,7 +138,7 @@ impl Stream for ColumnRenameStream {
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match Pin::new(&mut self.input).poll_next(cx) {
             Poll::Ready(Some(Ok(batch))) => {
-                let result = if batch.num_columns() == 0 {
+                let result: DataFusionResult<RecordBatch> = if batch.num_columns() == 0 {
                     // COUNT(*) case: preserve row count with empty schema
                     use arrow::record_batch::RecordBatchOptions;
                     let options = RecordBatchOptions::new().with_row_count(Some(batch.num_rows()));
@@ -147,10 +147,11 @@ impl Stream for ColumnRenameStream {
                         vec![],
                         &options,
                     )
+                    .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
                 } else {
                     // Build columns by looking up each output field in the input batch
                     let input_schema = batch.schema();
-                    let columns: Result<Vec<_>, _> = self
+                    let columns: DataFusionResult<Vec<_>> = self
                         .output_schema
                         .fields()
                         .iter()
@@ -162,24 +163,25 @@ impl Stream for ColumnRenameStream {
                                 .map(|s| s.as_str())
                                 .unwrap_or_else(|| output_field.name().as_str());
 
-                            input_schema
+                            let idx = input_schema
                                 .index_of(input_name)
-                                .map(|idx| batch.column(idx).clone())
+                                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+                            // Coerce the column read from the file back to the
+                            // catalog (output) type, keeping the provider
+                            // self-consistent: it advertises and emits the catalog
+                            // schema regardless of the file's physical Arrow type.
+                            // Identical types clone cheaply.
+                            coerce_column(batch.column(idx), output_field.data_type())
                         })
                         .collect();
 
-                    match columns {
-                        Ok(cols) => RecordBatch::try_new(Arc::clone(&self.output_schema), cols),
-                        Err(e) => Err(e),
-                    }
+                    columns.and_then(|cols| {
+                        RecordBatch::try_new(Arc::clone(&self.output_schema), cols)
+                            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+                    })
                 };
 
-                match result {
-                    Ok(renamed_batch) => Poll::Ready(Some(Ok(renamed_batch))),
-                    Err(e) => {
-                        Poll::Ready(Some(Err(DataFusionError::ArrowError(Box::new(e), None))))
-                    },
-                }
+                Poll::Ready(Some(result))
             },
             Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e))),
             Poll::Ready(None) => Poll::Ready(None),
@@ -192,6 +194,46 @@ impl RecordBatchStream for ColumnRenameStream {
     fn schema(&self) -> SchemaRef {
         Arc::clone(&self.output_schema)
     }
+}
+
+/// Coerce a column read from a parquet file to the catalog's declared type.
+///
+/// The physical Arrow type in a file can differ from the catalog type for list
+/// columns: a DuckDB `ARRAY` may materialise as `FixedSizeList(N)` while the
+/// catalog declares a variable `List`, and externally-written files often carry
+/// an empty list child field name (`""`) where the catalog uses `"item"`.
+///
+/// `arrow::compute::cast` handles the structural value conversion
+/// (`FixedSizeList` ↔ `List`, element-type changes) but leaves the list child
+/// **field name** as-is, so a pure child-name difference round-trips unchanged
+/// and would fail `RecordBatch::try_new`. After casting we therefore re-stamp the
+/// array's `DataType` to the target when only nested field metadata differs —
+/// the buffer layout is identical, so this is a zero-copy metadata swap.
+fn coerce_column(
+    col: &arrow::array::ArrayRef,
+    target: &arrow::datatypes::DataType,
+) -> DataFusionResult<arrow::array::ArrayRef> {
+    use arrow::array::{Array, make_array};
+
+    if col.data_type() == target {
+        return Ok(Arc::clone(col));
+    }
+
+    let casted = arrow::compute::cast(col, target)
+        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+    if casted.data_type() == target {
+        return Ok(casted);
+    }
+
+    // Same physical layout, only nested field metadata (e.g. list child name)
+    // differs. Rebuild the ArrayData with the target DataType.
+    let data = casted
+        .into_data()
+        .into_builder()
+        .data_type(target.clone())
+        .build()
+        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+    Ok(make_array(data))
 }
 
 #[cfg(test)]

--- a/src/table.rs
+++ b/src/table.rs
@@ -344,9 +344,12 @@ impl DuckLakeTable {
                     return Ok((self.schema.clone(), HashMap::new()));
                 }
 
-                let (read_schema, name_mapping) =
-                    build_read_schema_with_field_id_mapping(&self.columns, &field_id_map)
-                        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+                let (read_schema, name_mapping) = build_read_schema_with_field_id_mapping(
+                    &self.columns,
+                    &field_id_map,
+                    Some(builder.schema().as_ref()),
+                )
+                .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
                 Ok((Arc::new(read_schema), name_mapping))
             })
@@ -474,12 +477,17 @@ impl DuckLakeTable {
         let parquet_exec: Arc<dyn ExecutionPlan> =
             DataSourceExec::from_data_source(file_scan_config);
 
-        // Wrap with ColumnRenameExec if column names differ
-        if !name_mapping.is_empty() {
-            let output_schema = match projection {
-                Some(indices) => Arc::new(self.schema.project(indices)?),
-                None => self.schema.clone(),
-            };
+        // Wrap with ColumnRenameExec to present the catalog schema: when columns
+        // were renamed, OR when the file's physical Arrow type differs from the
+        // catalog type (e.g. a DuckDB ARRAY read as FixedSizeList vs the
+        // catalog's List, or a differing list child field name). The wrap coerces
+        // each column to `output_schema`, so the provider's advertised schema and
+        // its scan output stay identical.
+        let output_schema = match projection {
+            Some(indices) => Arc::new(self.schema.project(indices)?),
+            None => self.schema.clone(),
+        };
+        if !name_mapping.is_empty() || parquet_exec.schema() != output_schema {
             Ok(Arc::new(ColumnRenameExec::new(
                 parquet_exec,
                 output_schema,
@@ -569,12 +577,14 @@ impl DuckLakeTable {
                 parquet_exec
             };
 
-        // Wrap with ColumnRenameExec if column names differ
-        if !name_mapping.is_empty() {
-            let output_schema = match projection {
-                Some(indices) => Arc::new(self.schema.project(indices)?),
-                None => self.schema.clone(),
-            };
+        // Wrap with ColumnRenameExec to present the catalog schema (renames, or a
+        // file physical type that differs from the catalog type — see the
+        // no-delete path above). Coerces each column to `output_schema`.
+        let output_schema = match projection {
+            Some(indices) => Arc::new(self.schema.project(indices)?),
+            None => self.schema.clone(),
+        };
+        if !name_mapping.is_empty() || exec_after_delete.schema() != output_schema {
             Ok(Arc::new(ColumnRenameExec::new(
                 exec_after_delete,
                 output_schema,
@@ -648,8 +658,12 @@ impl DuckLakeTable {
         let (physical_read_schema, mut name_mapping) = if field_id_map.is_empty() {
             (self.physical_schema.as_ref().clone(), HashMap::new())
         } else {
-            let (s, m) = build_read_schema_with_field_id_mapping(&self.columns, &field_id_map)
-                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+            let (s, m) = build_read_schema_with_field_id_mapping(
+                &self.columns,
+                &field_id_map,
+                Some(builder.schema().as_ref()),
+            )
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
             (s, m)
         };
 
@@ -803,12 +817,15 @@ impl DuckLakeTable {
                 after_rowid
             };
 
-        // Apply column rename. Required when a physical column was renamed in
-        // the catalog, or when the embedded rowid column's parquet name
-        // differs from `"rowid"` (the common case — it's
-        // `_ducklake_internal_row_id`).
-        if !file_cfg.name_mapping.is_empty() {
-            let output_schema = self.output_schema_for_projection(user_proj, rowid_idx);
+        // Wrap with ColumnRenameExec to present the catalog schema. Required when
+        // a physical column was renamed in the catalog, when the embedded rowid
+        // column's parquet name differs from `"rowid"` (the common case — it's
+        // `_ducklake_internal_row_id`), or when the file's physical Arrow type
+        // differs from the catalog type (e.g. a DuckDB ARRAY read as
+        // FixedSizeList vs the catalog's List). Coerces each column to
+        // `output_schema`.
+        let output_schema = self.output_schema_for_projection(user_proj, rowid_idx);
+        if !file_cfg.name_mapping.is_empty() || after_deletes.schema() != output_schema {
             Ok(Arc::new(ColumnRenameExec::new(
                 after_deletes,
                 output_schema,

--- a/src/types.rs
+++ b/src/types.rs
@@ -461,13 +461,14 @@ pub fn extract_parquet_field_ids(metadata: &ParquetMetaData) -> HashMap<i32, Str
 pub fn build_read_schema_with_field_id_mapping(
     current_columns: &[DuckLakeTableColumn],
     parquet_field_ids: &HashMap<i32, String>,
+    file_schema: Option<&Schema>,
 ) -> Result<(Schema, HashMap<String, String>)> {
     let mut name_mapping: HashMap<String, String> = HashMap::new();
 
     let fields: Result<Vec<Field>> = current_columns
         .iter()
         .map(|col| {
-            let data_type = ducklake_to_arrow_type(&col.column_type)?;
+            let mut data_type = ducklake_to_arrow_type(&col.column_type)?;
             let field_id = i32::try_from(col.column_id).map_err(|_| {
                 DuckLakeError::Internal(format!(
                     "column_id {} for column '{}' exceeds i32 range for Parquet field_id",
@@ -485,6 +486,22 @@ pub fn build_read_schema_with_field_id_mapping(
                 } else {
                     (col.column_name.clone(), false) // No field_id, use current name
                 };
+
+            // For list/nested columns the Parquet reader reproduces the *file's*
+            // child field name (e.g. "" for files our streaming writer produces
+            // vs "item" for files written through the Arrow writer), and
+            // DataFusion's scan validates each batch against the read schema. The
+            // reconstructed name (always "item") may not match, so adopt the
+            // file's actual type for these columns when the file schema is known.
+            // Scalars keep the reconstructed type (precise per the catalog).
+            if matches!(
+                data_type,
+                DataType::List(_) | DataType::LargeList(_) | DataType::FixedSizeList(_, _)
+            ) && let Some(fs) = file_schema
+                && let Ok(file_field) = fs.field_with_name(&read_name)
+            {
+                data_type = file_field.data_type().clone();
+            }
 
             if needs_rename {
                 name_mapping.insert(read_name.clone(), col.column_name.clone());
@@ -525,7 +542,8 @@ mod tests {
         parquet_field_ids.insert(2, "name".to_string()); // Same name
 
         let (read_schema, name_mapping) =
-            build_read_schema_with_field_id_mapping(&current_columns, &parquet_field_ids).unwrap();
+            build_read_schema_with_field_id_mapping(&current_columns, &parquet_field_ids, None)
+                .unwrap();
 
         // Read schema should have original Parquet names
         assert_eq!(read_schema.field(0).name(), "user_id");
@@ -549,7 +567,8 @@ mod tests {
         parquet_field_ids.insert(1, "id".to_string()); // Same name
 
         let (read_schema, name_mapping) =
-            build_read_schema_with_field_id_mapping(&current_columns, &parquet_field_ids).unwrap();
+            build_read_schema_with_field_id_mapping(&current_columns, &parquet_field_ids, None)
+                .unwrap();
 
         assert_eq!(read_schema.field(0).name(), "id");
         assert!(name_mapping.is_empty()); // No rename needed
@@ -568,7 +587,8 @@ mod tests {
         let parquet_field_ids = HashMap::new(); // No field_ids in Parquet
 
         let (read_schema, name_mapping) =
-            build_read_schema_with_field_id_mapping(&current_columns, &parquet_field_ids).unwrap();
+            build_read_schema_with_field_id_mapping(&current_columns, &parquet_field_ids, None)
+                .unwrap();
 
         // Falls back to current column name
         assert_eq!(read_schema.field(0).name(), "id");
@@ -1015,7 +1035,7 @@ mod tests {
         let mut parquet_field_ids = HashMap::new();
         parquet_field_ids.insert(i32::MAX, "id".to_string());
 
-        let result = build_read_schema_with_field_id_mapping(&columns, &parquet_field_ids);
+        let result = build_read_schema_with_field_id_mapping(&columns, &parquet_field_ids, None);
         assert!(result.is_ok(), "column_id = i32::MAX should succeed");
     }
 
@@ -1030,7 +1050,7 @@ mod tests {
 
         let parquet_field_ids = HashMap::new();
 
-        let result = build_read_schema_with_field_id_mapping(&columns, &parquet_field_ids);
+        let result = build_read_schema_with_field_id_mapping(&columns, &parquet_field_ids, None);
         assert!(result.is_err(), "column_id > i32::MAX should fail");
         match result {
             Err(DuckLakeError::Internal(msg)) => {
@@ -1061,7 +1081,7 @@ mod tests {
         let mut parquet_field_ids = HashMap::new();
         parquet_field_ids.insert(-1_i32, "id".to_string());
 
-        let result = build_read_schema_with_field_id_mapping(&columns, &parquet_field_ids);
+        let result = build_read_schema_with_field_id_mapping(&columns, &parquet_field_ids, None);
         assert!(
             result.is_ok(),
             "Negative column_id within i32 range should succeed"


### PR DESCRIPTION
## What

Make the DuckLake table provider **both advertise and emit** the catalog's declared list type for vector/array columns, regardless of how the underlying Parquet file was physically written.

## Why

DuckLake records a vector/array column as a variable-length list (`list<float32>`) in the catalog, but the Parquet files on disk can hold a different physical Arrow shape:

- A DuckDB `ARRAY` materialises as `FixedSizeList(N)`, not a variable `List`.
- Files written by different writers label the list's inner element `"item"` or `""` (empty).

DataFusion's Parquet reader validates every batch against a read schema and reports the **file's** actual shape. When the catalog said `List("item")` but the file held `FixedSizeList` or `List("")`, reads failed with `column types must match schema types`. This broke array/vector reads on externally-written tables, and only worked at all when a downstream consumer happened to coerce the type itself — so the library was not self-consistent for other consumers.

## How

Read each file using its **real** physical list type so the reader's own validation passes, then coerce the result back to the catalog type before returning it:

- **`types.rs`** — `build_read_schema_with_field_id_mapping` takes the file schema and, for list/nested columns, adopts the file's actual physical type. Scalars keep the catalog-reconstructed type.
- **`table.rs`** — all three scan paths (no-delete, after-delete, rowid) wrap in `ColumnRenameExec` whenever the read schema differs from the catalog output schema, not only on column renames. When file and catalog already agree, nothing wraps (no overhead).
- **`column_rename.rs`** — `ColumnRenameStream` coerces each column to the catalog type via a new `coerce_column` helper: identical types clone cheaply; otherwise `arrow::compute::cast` handles `FixedSizeList`↔`List` and element-type conversion; a pure list-child-name difference (which `cast` leaves unchanged) is fixed with a zero-copy `DataType` re-stamp. Error handling unified to `DataFusionResult`.

Net effect: a DuckDB `ARRAY` (`FixedSizeList`) or an externally-written `List("")` both come out as the catalog's `List("item")`.

## Testing

- Library: 220 unit tests pass; `cargo fmt --check` and lib clippy clean.
- Validated downstream against a federated query engine: managed and external DuckLake tables, direct L2/cosine vector kNN, and embedding-backed index create/query/refresh/drop — all behaving identically to the Parquet-backed path.
- No new dependencies; no behavior change when file and catalog schemas already match; `COUNT(*)` (empty-schema) path preserved.