### PR TITLE
fix(read): derive rowid & delete positions from physical file position

### DIFF
--- a/docs/rowid-lineage-physical-position-plan.md
+++ b/docs/rowid-lineage-physical-position-plan.md
@@ -1,0 +1,345 @@
+# Plan: row-id lineage and deletes must use physical file position
+
+Status: proposed
+Scope: `src/table.rs`, `src/row_id.rs`, `src/delete_filter.rs`, tests
+DataFusion version: 53.0.0
+
+---
+
+## Problem
+
+DuckLake row lineage defines:
+
+```text
+rowid = row_id_start + physical_row_position
+```
+
+`physical_row_position` is the row's 0-based position in the physical Parquet file. Positional
+delete files use the same position in their `pos` column.
+
+The current implementation computes that position with a per-stream counter:
+
+- `RowIdExec` starts `cursor = 0` for the stream and appends `row_id_start + cursor + i`.
+- `DeleteFilterExec` starts `row_offset = 0` for the stream and checks `row_offset + i`.
+
+That only works when one file is read by one ordered stream. DataFusion can split one Parquet file
+into multiple byte-range partitions. `RowIdExec` then forces an unordered `CoalescePartitionsExec`
+because it requires `SinglePartition`, and `DeleteFilterExec` runs once per split partition with its
+counter reset to 0. Both produce silent wrong answers on large files.
+
+Confirmed repro:
+
+- One file from `range(0, 600000)`, `row_id_start = 0`.
+- `target_partitions = 8`, `repartition_file_min_size = 1`.
+- `SELECT rowid, i ...` produces mismatches such as `(rowid=0, i=245760)`.
+- `DELETE WHERE i IN [245760, 245770)` leaves those deleted rows visible.
+
+This is a correctness bug, not a performance bug.
+
+---
+
+## Design Goal
+
+Match DuckDB/DuckLake semantics: derive positions from Parquet physical row order, not from
+DataFusion arrival order.
+
+DataFusion 53 does not expose a reader-level `file_row_number` column like DuckDB, so the pragmatic
+fix is:
+
+1. Control the scan shape for positional paths.
+2. Emit a physical-position column immediately above the scan.
+3. Make rowid synthesis and delete filtering read that column instead of counting stream rows.
+
+The key invariant is:
+
+```text
+FileRowNumberExec is correct only if its input partition emits a complete, contiguous, in-order run
+of physical rows.
+```
+
+Everything below enforces that invariant.
+
+---
+
+## Resolved Decisions
+
+- Use a fixed operator order for the first implementation:
+  `DataSourceExec -> FileRowNumberExec -> DeleteFilterExec -> RowIdExec -> final projection`.
+- Do not rely on `RowIdExec` and `DeleteFilterExec` being freely reorderable.
+- Do not apply `LIMIT` inside per-file positional plans.
+- If an internal limit is ever needed, apply it once above the combined table plan, not once per file.
+- Refuse reader-side filter, sort/reverse, and byte-range repartitioning on positional paths.
+- Preserve row counts when dropping the internal position column to a zero-column output.
+
+---
+
+## Affected Paths
+
+Use the positional path when either condition is true:
+
+- `rowid` is projected.
+- The file has a positional delete file.
+
+Unaffected path:
+
+- Files without deletes when `rowid` is not projected keep the existing grouped Parquet scan and
+  scan-level limit/pushdown behavior.
+
+---
+
+## Plan Shape
+
+For each affected data file:
+
+```text
+Final projection / rename       (drops __ducklake_row_pos, preserves row count for zero columns)
+  RowIdExec                     (if rowid projected; reads row_pos, appends rowid, passes row_pos)
+    DeleteFilterExec            (if deletes; reads row_pos)
+      FileRowNumberExec         (appends __ducklake_row_pos)
+        DataSourceExec          (row-group chunks, no byte re-split, no reader pruning/reordering)
+```
+
+DataFusion's outer plan remains responsible for global query filters, sorts, and limits.
+
+---
+
+## Implementation
+
+### 1. Regression Tests First
+
+Add tests that fail on the current code:
+
+- Large split file: `SELECT rowid, i` must satisfy `rowid == i` when `row_id_start = 0`.
+- Large split file with deletes: deleted physical positions must not appear.
+- Large split file with both rowid and deletes.
+- Filtered rowid query, for example `WHERE i >= K LIMIT 1`, must return the correct rowid.
+- `ORDER BY` on a positional path must not corrupt rowids.
+- `LIMIT 1` with the first physical row deleted must return the next survivor, not zero rows.
+- `COUNT(*)` with deletes must preserve row counts through the internal position column.
+- Single-row-group file remains correct.
+- Multi-file table remains correct.
+- Embedded-rowid file with deletes remains correct.
+- `row_id_start = None`: rowid projection hard-errors as today; delete filtering still works.
+
+### 2. Read Row-Group Metadata
+
+Extend `FileReadConfig` with:
+
+```rust
+row_group_starts: Vec<i64>,
+row_group_count: usize,
+```
+
+Populate these from the `ParquetMetaData` already opened in `build_file_read_config`:
+
+```rust
+row_group_starts[0] = 0
+row_group_starts[i + 1] = row_group_starts[i] + row_groups[i].num_rows()
+```
+
+The catalog does not store per-row-group counts; the Parquet footer is the source of truth.
+
+### 3. Build Row-Group Partitions
+
+Add a helper:
+
+```rust
+fn build_row_group_partitions(
+    file: &DuckLakeFileData,
+    read_cfg: &FileReadConfig,
+    target_partitions: usize,
+) -> DataFusionResult<(Vec<FileGroup>, Vec<i64>)>
+```
+
+Rules:
+
+- Split row groups into `min(target_partitions, row_group_count)` contiguous chunks.
+- Balance chunks by row count where practical.
+- For each chunk `[a, b)`:
+  - Create a `ParquetAccessPlan` of length `row_group_count`.
+  - Mark row groups in `[a, b)` as `Scan`; all others as `Skip`.
+  - Do not use `Selection(RowSelection)`.
+  - Attach the plan to a `PartitionedFile` with the same path, file size, and footer-size hint.
+  - Wrap that one `PartitionedFile` in its own `FileGroup`.
+  - Push `row_group_starts[a]` into `partition_starts`.
+
+DataFusion partitions are `FileGroup`s, not files. The returned vectors must be 1:1:
+
+```text
+file_groups[i] <-> partition_starts[i]
+```
+
+### 4. Wrap ParquetSource For Positional Scans
+
+Create a small `FileSource` wrapper around `ParquetSource` for positional paths.
+
+It must refuse anything that can change row order, row membership, or partition layout:
+
+- `supports_repartitioning() -> false`
+- `repartitioned(...) -> Ok(None)`
+- `try_pushdown_filters(...)`: return all filters as not pushed.
+- `try_pushdown_sort(...)`: return unsupported.
+- `try_reverse_output(...)`: return unsupported.
+
+It may delegate and re-wrap order/cardinality-preserving source-returning methods:
+
+- `with_batch_size`
+- `with_schema_adapter_factory`
+- `try_pushdown_projection`
+
+Read-only accessors delegate normally:
+
+- `create_file_opener`
+- `as_any`
+- `table_schema`
+- `filter`
+- `projection`
+- `metrics`
+- `file_type`
+- `fmt_extra`
+- `schema_adapter_factory`
+
+This wrapper is not an optimization layer. It exists to keep `FileRowNumberExec`'s input as complete,
+contiguous physical rows in physical order.
+
+### 5. Add FileRowNumberExec
+
+Add `FileRowNumberExec` in `src/row_pos.rs` or `src/row_id.rs`.
+
+Behavior:
+
+- Input: row-group-partitioned `DataSourceExec`.
+- State: `partition_starts: Arc<Vec<i64>>`.
+- Output: input columns plus internal `Int64` column `__ducklake_row_pos`.
+- `execute(partition)` starts at `partition_starts[partition]`.
+- For each batch, append values `start + cursor + i`, then increment `cursor` by `batch.num_rows()`.
+
+Plan properties:
+
+- Preserve input partitioning.
+- Preserve input order.
+- Do not require `SinglePartition`.
+
+Add an EXPLAIN assertion that no coalesce/repartition/filter/sort appears between the scan and
+`FileRowNumberExec` on positional paths.
+
+### 6. Rewrite Consumers
+
+`DeleteFilterExec`:
+
+- Stop using `row_offset`.
+- Find `__ducklake_row_pos`.
+- Keep rows whose position is not in the delete set.
+- Preserve the internal row-position column in its output.
+- Preserve zero-column row counts where applicable.
+
+`RowIdExec`:
+
+- Stop using `cursor`.
+- Remove `required_input_distribution = SinglePartition`.
+- Find `__ducklake_row_pos`.
+- Append `rowid = row_id_start + __ducklake_row_pos`.
+- Pass `__ducklake_row_pos` through unchanged.
+- Keep current behavior for missing `row_id_start`: non-embedded files with projected rowid hard-error
+  in `table.rs` before execution.
+
+Embedded rowid files:
+
+- Continue reading the embedded `_ducklake_internal_row_id` column for rowid.
+- If the file also has deletes, still add `FileRowNumberExec` so delete filtering uses physical
+  positions.
+
+### 7. Wire table.rs
+
+For `build_exec_for_file_with_rowid`:
+
+- If the file needs synthetic row positions, use row-group partitions and the positional Parquet
+  source.
+- Pass `None` to the scan builder's limit.
+- Build:
+
+```text
+DataSourceExec
+  -> FileRowNumberExec
+  -> DeleteFilterExec if deletes
+  -> RowIdExec if synthetic rowid is needed
+  -> final projection/rename
+```
+
+For embedded-rowid files with projected rowid:
+
+```text
+DataSourceExec
+  -> FileRowNumberExec if deletes
+  -> DeleteFilterExec if deletes
+  -> final projection/rename
+```
+
+For `build_exec_for_file_with_deletes`:
+
+- Use the same row-group partitioning and positional source.
+- Pass `None` to the scan builder's limit.
+- Build:
+
+```text
+DataSourceExec
+  -> FileRowNumberExec
+  -> DeleteFilterExec
+  -> final projection/rename
+```
+
+For `build_exec_for_files_without_deletes`:
+
+- Leave unchanged.
+
+Limit handling:
+
+- Per-file positional builders must receive/use `None` for scan limit.
+- Do not add a per-file `GlobalLimitExec`.
+- Rely on DataFusion's outer limit, or apply one limit once above `combine_execution_plans` if that
+  becomes necessary.
+
+Final projection:
+
+- Drop `__ducklake_row_pos` before exposing the catalog schema.
+- If dropping to zero output columns, create the output `RecordBatch` with
+  `RecordBatchOptions::with_row_count(Some(batch.num_rows()))`.
+
+---
+
+## Non-Goals
+
+- Do not implement a custom Parquet opener in this fix.
+- Do not preserve reader-side row-group/page/bloom pruning on positional paths.
+- Do not push sort/reverse/filters into the reader on positional paths.
+- Do not refactor unrelated scan paths.
+
+Future improvement: compute a reader-level file-row-number column, DuckDB-style, to recover full
+reader pruning and ordering optimizations.
+
+---
+
+## Verification
+
+Run:
+
+- New large split-file rowid tests.
+- New large split-file delete tests.
+- Existing row lineage tests.
+- Existing delete tests.
+- Full test suite.
+
+Plan assertions for positional paths:
+
+- No `CoalescePartitionsExec` inserted below `FileRowNumberExec`.
+- No reader predicate on the positional `DataSourceExec`.
+- No sort/reverse pushdown in the positional source.
+- No scan-level limit on positional `DataSourceExec`.
+- One `FileGroup` per row-group chunk.
+
+Correctness assertions:
+
+- `rowid == row_id_start + physical_position`.
+- Deleted physical positions are absent.
+- `LIMIT` after deletes returns survivors, not pre-delete rows.
+- `COUNT(*)` with deletes returns the correct count.

--- a/src/column_rename.rs
+++ b/src/column_rename.rs
@@ -138,48 +138,54 @@ impl Stream for ColumnRenameStream {
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match Pin::new(&mut self.input).poll_next(cx) {
             Poll::Ready(Some(Ok(batch))) => {
-                let result: DataFusionResult<RecordBatch> = if batch.num_columns() == 0 {
-                    // COUNT(*) case: preserve row count with empty schema
-                    use arrow::record_batch::RecordBatchOptions;
-                    let options = RecordBatchOptions::new().with_row_count(Some(batch.num_rows()));
-                    RecordBatch::try_new_with_options(
-                        Arc::clone(&self.output_schema),
-                        vec![],
-                        &options,
-                    )
-                    .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
-                } else {
-                    // Build columns by looking up each output field in the input batch
-                    let input_schema = batch.schema();
-                    let columns: DataFusionResult<Vec<_>> = self
-                        .output_schema
-                        .fields()
-                        .iter()
-                        .map(|output_field| {
-                            // Check if this column was renamed (new_name -> old_name)
-                            let input_name = self
-                                .reverse_mapping
-                                .get(output_field.name())
-                                .map(|s| s.as_str())
-                                .unwrap_or_else(|| output_field.name().as_str());
+                let result: DataFusionResult<RecordBatch> =
+                    if self.output_schema.fields().is_empty() {
+                        // Zero OUTPUT columns (e.g. COUNT(*)): preserve the row count
+                        // with an empty schema. This must key off the output schema,
+                        // not the input: on positional paths the input still carries
+                        // the internal `__ducklake_row_pos` column (1 input column),
+                        // yet the output is zero columns and the count must survive.
+                        use arrow::record_batch::RecordBatchOptions;
+                        let options =
+                            RecordBatchOptions::new().with_row_count(Some(batch.num_rows()));
+                        RecordBatch::try_new_with_options(
+                            Arc::clone(&self.output_schema),
+                            vec![],
+                            &options,
+                        )
+                        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+                    } else {
+                        // Build columns by looking up each output field in the input batch
+                        let input_schema = batch.schema();
+                        let columns: DataFusionResult<Vec<_>> = self
+                            .output_schema
+                            .fields()
+                            .iter()
+                            .map(|output_field| {
+                                // Check if this column was renamed (new_name -> old_name)
+                                let input_name = self
+                                    .reverse_mapping
+                                    .get(output_field.name())
+                                    .map(|s| s.as_str())
+                                    .unwrap_or_else(|| output_field.name().as_str());
 
-                            let idx = input_schema
-                                .index_of(input_name)
-                                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-                            // Coerce the column read from the file back to the
-                            // catalog (output) type, keeping the provider
-                            // self-consistent: it advertises and emits the catalog
-                            // schema regardless of the file's physical Arrow type.
-                            // Identical types clone cheaply.
-                            coerce_column(batch.column(idx), output_field.data_type())
+                                let idx = input_schema
+                                    .index_of(input_name)
+                                    .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+                                // Coerce the column read from the file back to the
+                                // catalog (output) type, keeping the provider
+                                // self-consistent: it advertises and emits the catalog
+                                // schema regardless of the file's physical Arrow type.
+                                // Identical types clone cheaply.
+                                coerce_column(batch.column(idx), output_field.data_type())
+                            })
+                            .collect();
+
+                        columns.and_then(|cols| {
+                            RecordBatch::try_new(Arc::clone(&self.output_schema), cols)
+                                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
                         })
-                        .collect();
-
-                    columns.and_then(|cols| {
-                        RecordBatch::try_new(Arc::clone(&self.output_schema), cols)
-                            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
-                    })
-                };
+                    };
 
                 Poll::Ready(Some(result))
             },

--- a/src/delete_filter.rs
+++ b/src/delete_filter.rs
@@ -1,7 +1,12 @@
 //! Custom execution plan for filtering deleted rows
 //!
-//! This module implements a DataFusion execution plan that wraps the Parquet scan
-//! and filters out rows marked as deleted in delete files.
+//! Wraps a positional scan and drops rows whose **physical file position**
+//! appears in a positional delete file. The physical position is read from the
+//! internal [`ROW_POS_COLUMN_NAME`] column materialized by
+//! [`FileRowNumberExec`](crate::row_id::FileRowNumberExec) — never from stream
+//! arrival order — so filtering is correct regardless of how the scan is
+//! partitioned or merged. The position column is passed through unchanged for
+//! any downstream consumer (e.g. `RowIdExec`); the final projection drops it.
 
 use std::any::Any;
 use std::collections::HashSet;
@@ -9,64 +14,64 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
+use arrow::array::Int64Array;
 use arrow::datatypes::SchemaRef;
-use arrow::record_batch::{RecordBatch, RecordBatchOptions};
+use arrow::record_batch::RecordBatch;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
 use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
 use futures::Stream;
 
-/// Custom execution plan that filters out deleted rows
+use crate::row_id::ROW_POS_COLUMN_NAME;
+
+/// Custom execution plan that filters out deleted rows by physical position.
 #[derive(Debug)]
 pub struct DeleteFilterExec {
-    /// The input execution plan (typically ParquetExec)
+    /// The input execution plan (carries [`ROW_POS_COLUMN_NAME`]).
     input: Arc<dyn ExecutionPlan>,
-    /// Path of the file being scanned
+    /// Path of the file being scanned (for display).
     file_path: String,
-    /// Set of deleted row positions for this file (shared across streams)
+    /// Set of deleted physical row positions for this file (shared across streams).
     deleted_positions: Arc<HashSet<i64>>,
-    /// Cached plan properties
+    /// Index of [`ROW_POS_COLUMN_NAME`] in the input schema.
+    pos_index: usize,
+    /// Cached plan properties.
     properties: Arc<PlanProperties>,
 }
 
 impl DeleteFilterExec {
-    pub fn new(
+    /// Build a `DeleteFilterExec`. The input must carry the
+    /// [`ROW_POS_COLUMN_NAME`] column (from `FileRowNumberExec`); errors otherwise.
+    pub fn try_new(
         input: Arc<dyn ExecutionPlan>,
         file_path: String,
         deleted_positions: Arc<HashSet<i64>>,
-    ) -> Self {
-        // Clone properties from input plan
+    ) -> DataFusionResult<Self> {
+        let pos_index = input.schema().index_of(ROW_POS_COLUMN_NAME).map_err(|_| {
+            DataFusionError::Internal(format!(
+                "DeleteFilterExec input is missing the `{ROW_POS_COLUMN_NAME}` column"
+            ))
+        })?;
+        // Filtering only drops rows; partitioning/ordering are preserved.
         let properties = input.properties().clone();
-
-        Self {
+        Ok(Self {
             input,
             file_path,
             deleted_positions,
+            pos_index,
             properties,
-        }
+        })
     }
 }
 
 impl DisplayAs for DeleteFilterExec {
-    fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match t {
-            DisplayFormatType::Default | DisplayFormatType::Verbose => {
-                write!(
-                    f,
-                    "DeleteFilterExec: file={}, deletes={}",
-                    self.file_path,
-                    self.deleted_positions.len()
-                )
-            },
-            DisplayFormatType::TreeRender => {
-                write!(
-                    f,
-                    "DeleteFilterExec: file={}, deletes={}",
-                    self.file_path,
-                    self.deleted_positions.len()
-                )
-            },
-        }
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "DeleteFilterExec: file={}, deletes={}",
+            self.file_path,
+            self.deleted_positions.len()
+        )
     }
 }
 
@@ -87,6 +92,11 @@ impl ExecutionPlan for DeleteFilterExec {
         vec![&self.input]
     }
 
+    /// Order-preserving: drops rows but never reorders them.
+    fn maintains_input_order(&self) -> Vec<bool> {
+        vec![true]
+    }
+
     fn with_new_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
@@ -96,14 +106,11 @@ impl ExecutionPlan for DeleteFilterExec {
                 "DeleteFilterExec expects exactly one child".into(),
             ));
         }
-
-        let deleted_positions = self.deleted_positions.clone();
-
-        Ok(Arc::new(DeleteFilterExec::new(
-            children[0].clone(),
+        Ok(Arc::new(DeleteFilterExec::try_new(
+            children.into_iter().next().unwrap(),
             self.file_path.clone(),
-            deleted_positions,
-        )))
+            self.deleted_positions.clone(),
+        )?))
     }
 
     fn execute(
@@ -111,21 +118,19 @@ impl ExecutionPlan for DeleteFilterExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> DataFusionResult<SendableRecordBatchStream> {
-        let input_stream = self.input.execute(partition, context)?;
-
         Ok(Box::pin(DeleteFilterStream {
-            input: input_stream,
+            input: self.input.execute(partition, context)?,
             deleted_positions: self.deleted_positions.clone(),
-            row_offset: 0,
+            pos_index: self.pos_index,
         }))
     }
 }
 
-/// Stream that filters deleted rows from input batches
+/// Stream that filters deleted rows by reading the physical-position column.
 struct DeleteFilterStream {
     input: SendableRecordBatchStream,
     deleted_positions: Arc<HashSet<i64>>,
-    row_offset: i64,
+    pos_index: usize,
 }
 
 impl Stream for DeleteFilterStream {
@@ -133,17 +138,7 @@ impl Stream for DeleteFilterStream {
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match Pin::new(&mut self.input).poll_next(cx) {
-            Poll::Ready(Some(Ok(batch))) => {
-                // Filter the batch
-                match self.filter_batch(&batch) {
-                    Ok(filtered_batch) => {
-                        // Update row offset for next batch
-                        self.row_offset += batch.num_rows() as i64;
-                        Poll::Ready(Some(Ok(filtered_batch)))
-                    },
-                    Err(e) => Poll::Ready(Some(Err(e))),
-                }
-            },
+            Poll::Ready(Some(Ok(batch))) => Poll::Ready(Some(self.filter_batch(&batch))),
             Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e))),
             Poll::Ready(None) => Poll::Ready(None),
             Poll::Pending => Poll::Pending,
@@ -153,41 +148,34 @@ impl Stream for DeleteFilterStream {
 
 impl DeleteFilterStream {
     fn filter_batch(&self, batch: &RecordBatch) -> DataFusionResult<RecordBatch> {
-        // If no deletes for this file, return batch as-is
         if self.deleted_positions.is_empty() {
             return Ok(batch.clone());
         }
 
-        // Build list of row indices to keep
-        let num_rows = batch.num_rows();
-        let mut keep_indices: Vec<usize> = Vec::with_capacity(num_rows);
+        let pos = batch
+            .column(self.pos_index)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .ok_or_else(|| {
+                DataFusionError::Internal(format!("`{ROW_POS_COLUMN_NAME}` column is not Int64"))
+            })?;
 
+        let num_rows = batch.num_rows();
+        let mut keep_indices: Vec<u32> = Vec::with_capacity(num_rows);
         for i in 0..num_rows {
-            let global_pos = self.row_offset + i as i64;
-            if !self.deleted_positions.contains(&global_pos) {
-                keep_indices.push(i);
+            if !self.deleted_positions.contains(&pos.value(i)) {
+                keep_indices.push(i as u32);
             }
         }
 
-        // If all rows are kept, return original batch
         if keep_indices.len() == num_rows {
             return Ok(batch.clone());
         }
 
-        // Special case: if there are no columns (COUNT(*) case), create an empty batch with the filtered row count
-        if batch.num_columns() == 0 {
-            let mut options = RecordBatchOptions::new();
-            options = options.with_row_count(Some(keep_indices.len()));
-            return RecordBatch::try_new_with_options(batch.schema(), vec![], &options)
-                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None));
-        }
-
-        // Use Arrow's take kernel to select rows
         use arrow::array::UInt32Array;
         use arrow::compute::take;
 
-        let indices = UInt32Array::from(keep_indices.iter().map(|&i| i as u32).collect::<Vec<_>>());
-
+        let indices = UInt32Array::from(keep_indices);
         let filtered_columns: DataFusionResult<Vec<_>> = batch
             .columns()
             .iter()
@@ -211,134 +199,66 @@ impl RecordBatchStream for DeleteFilterStream {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{Array, Int32Array};
+    use arrow::array::{Array, ArrayRef, Int32Array};
     use arrow::datatypes::{DataType, Field, Schema};
     use datafusion::physical_plan::EmptyRecordBatchStream;
 
-    #[test]
-    fn test_filter_batch_ignores_out_of_bounds_positions() {
-        // Create a simple RecordBatch with 4 rows
-        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+    /// Build a batch with a value column and a `__ducklake_row_pos` column.
+    fn batch(values: &[i32], positions: &[i64]) -> (SchemaRef, RecordBatch) {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            crate::row_id::row_pos_field(),
+        ]));
+        let b = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(values.to_vec())) as ArrayRef,
+                Arc::new(Int64Array::from(positions.to_vec())) as ArrayRef,
+            ],
+        )
+        .unwrap();
+        (schema, b)
+    }
 
-        let id_array = Int32Array::from(vec![1, 2, 3, 4]);
-        let batch =
-            RecordBatch::try_new(schema.clone(), vec![Arc::new(id_array) as Arc<dyn Array>])
-                .unwrap();
+    fn stream(schema: SchemaRef, deleted: &[i64]) -> DeleteFilterStream {
+        DeleteFilterStream {
+            input: Box::pin(EmptyRecordBatchStream::new(schema)),
+            deleted_positions: Arc::new(deleted.iter().copied().collect::<HashSet<i64>>()),
+            pos_index: 1,
+        }
+    }
 
-        // Create delete positions: 1 (valid), 1000, 2000, 5000 (all out of bounds)
-        // Only position 1 should actually delete a row (the row with id=2)
-        let deleted_positions: HashSet<i64> = [1, 1000, 2000, 5000].into_iter().collect();
-
-        // Create a DeleteFilterStream with row_offset=0
-        let stream = DeleteFilterStream {
-            input: Box::pin(EmptyRecordBatchStream::new(schema.clone())),
-            deleted_positions: Arc::new(deleted_positions),
-            row_offset: 0,
-        };
-
-        // Apply the filter
-        let filtered_batch = stream.filter_batch(&batch).unwrap();
-
-        // Should have 3 rows (only position 1 was deleted, positions 1000+ are out of bounds)
-        assert_eq!(
-            filtered_batch.num_rows(),
-            3,
-            "Expected 3 rows after filtering (only position 1 is valid)"
-        );
-
-        // Verify the correct rows remain (ids 1, 3, 4)
-        let filtered_ids = filtered_batch
-            .column(0)
+    fn ids(b: &RecordBatch) -> Vec<i32> {
+        b.column(0)
             .as_any()
             .downcast_ref::<Int32Array>()
-            .unwrap();
-
-        let ids: Vec<i32> = filtered_ids.values().to_vec();
-        assert_eq!(
-            ids,
-            vec![1, 3, 4],
-            "Expected ids [1, 3, 4] after deleting position 1 (id=2)"
-        );
+            .unwrap()
+            .values()
+            .to_vec()
     }
 
     #[test]
-    fn test_filter_batch_all_out_of_bounds_positions() {
-        // Test the edge case where ALL delete positions are beyond the file
-        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
-
-        let id_array = Int32Array::from(vec![10, 20, 30]);
-        let batch =
-            RecordBatch::try_new(schema.clone(), vec![Arc::new(id_array) as Arc<dyn Array>])
-                .unwrap();
-
-        // All positions are way beyond the 3-row file
-        let deleted_positions: HashSet<i64> = [1000, 2000, 3000, 9999].into_iter().collect();
-
-        let stream = DeleteFilterStream {
-            input: Box::pin(EmptyRecordBatchStream::new(schema.clone())),
-            deleted_positions: Arc::new(deleted_positions),
-            row_offset: 0,
-        };
-
-        let filtered_batch = stream.filter_batch(&batch).unwrap();
-
-        // Should have all 3 rows (no valid delete positions)
-        assert_eq!(
-            filtered_batch.num_rows(),
-            3,
-            "All rows should remain when delete positions are out of bounds"
-        );
-
-        let filtered_ids = filtered_batch
-            .column(0)
-            .as_any()
-            .downcast_ref::<Int32Array>()
-            .unwrap();
-
-        let ids: Vec<i32> = filtered_ids.values().to_vec();
-        assert_eq!(ids, vec![10, 20, 30]);
+    fn deletes_row_at_listed_position() {
+        // positions [0,1,2,3]; delete position 1 (id=2). 1000 is out of range.
+        let (schema, b) = batch(&[1, 2, 3, 4], &[0, 1, 2, 3]);
+        let filtered = stream(schema, &[1, 1000]).filter_batch(&b).unwrap();
+        assert_eq!(ids(&filtered), vec![1, 3, 4]);
     }
 
     #[test]
-    fn test_filter_batch_with_row_offset() {
-        // Test that row_offset is correctly considered when checking positions
-        let schema = Arc::new(Schema::new(vec![Field::new(
-            "value",
-            DataType::Int32,
-            false,
-        )]));
+    fn keeps_all_when_no_position_matches() {
+        let (schema, b) = batch(&[10, 20, 30], &[0, 1, 2]);
+        let filtered = stream(schema, &[1000, 2000]).filter_batch(&b).unwrap();
+        assert_eq!(ids(&filtered), vec![10, 20, 30]);
+    }
 
-        let array = Int32Array::from(vec![100, 200, 300, 400]);
-        let batch =
-            RecordBatch::try_new(schema.clone(), vec![Arc::new(array) as Arc<dyn Array>]).unwrap();
-
-        // Delete position 11 and 1000 (way out of bounds)
-        // With row_offset=10, this batch contains global positions [10, 11, 12, 13]
-        // So position 11 should delete the second row (value=200)
-        let deleted_positions: HashSet<i64> = [11, 1000].into_iter().collect();
-
-        let stream = DeleteFilterStream {
-            input: Box::pin(EmptyRecordBatchStream::new(schema.clone())),
-            deleted_positions: Arc::new(deleted_positions),
-            row_offset: 10, // This batch starts at global position 10
-        };
-
-        let filtered_batch = stream.filter_batch(&batch).unwrap();
-
-        // Should have 3 rows (position 11 deleted, position 1000 ignored)
-        assert_eq!(filtered_batch.num_rows(), 3);
-
-        let filtered_values = filtered_batch
-            .column(0)
-            .as_any()
-            .downcast_ref::<Int32Array>()
-            .unwrap();
-
-        let values: Vec<i32> = filtered_values.values().to_vec();
-        assert_eq!(
-            values,
-            vec![100, 300, 400],
-            "Position 11 (value=200) should be deleted, 1000 ignored"
-        );
+    #[test]
+    fn deletes_by_physical_position_not_arrival_order() {
+        // Positions are non-contiguous and out of arrival order: this batch
+        // holds physical rows {10, 11, 12, 13}. Deleting position 11 must drop
+        // the row whose pos==11 (value 200), regardless of its index in the batch.
+        let (schema, b) = batch(&[100, 200, 300, 400], &[10, 11, 12, 13]);
+        let filtered = stream(schema, &[11, 1000]).filter_batch(&b).unwrap();
+        assert_eq!(ids(&filtered), vec![100, 300, 400]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub mod error;
 pub mod information_schema;
 pub mod metadata_provider;
 pub mod path_resolver;
+pub(crate) mod positional_source;
 pub mod row_id;
 pub mod schema;
 pub mod table;

--- a/src/positional_source.rs
+++ b/src/positional_source.rs
@@ -1,0 +1,154 @@
+//! [`PositionalFileSource`]: a `FileSource` wrapper for *positional* scan paths
+//! (synthetic rowid and/or positional delete filtering).
+//!
+//! Physical row positions on these paths are reconstructed by
+//! [`FileRowNumberExec`](crate::row_id) from row-group-aligned scan partitions.
+//! That is correct **only** while each partition emits a complete, contiguous,
+//! in-order run of physical rows. This wrapper enforces that by delegating the
+//! actual reading to the inner [`ParquetSource`] while refusing every operation
+//! that would drop, reorder, or re-split rows:
+//!
+//! - byte-range repartitioning (would break row-group alignment),
+//! - reader-side filter pushdown (row-group/page/bloom pruning would emit a
+//!   sparse subset of rows),
+//! - sort / reverse-order pushdown (would read row groups out of physical
+//!   order).
+//!
+//! Order- and cardinality-preserving methods (batch size, column projection)
+//! are delegated and **re-wrapped**, so the wrapper is never silently dropped
+//! and pruning/repartitioning re-enabled.
+//!
+//! [`ParquetSource`]: datafusion::datasource::physical_plan::ParquetSource
+
+use std::any::Any;
+use std::fmt::{self, Formatter};
+use std::sync::Arc;
+
+use datafusion::common::config::ConfigOptions;
+use datafusion::datasource::physical_plan::{FileOpener, FileScanConfig, FileSource};
+use datafusion::datasource::table_schema::TableSchema;
+use datafusion::error::Result as DataFusionResult;
+use datafusion::physical_expr::projection::ProjectionExprs;
+use datafusion::physical_expr::{EquivalenceProperties, LexOrdering, PhysicalExpr};
+use datafusion::physical_expr_common::sort_expr::PhysicalSortExpr;
+use datafusion::physical_plan::filter_pushdown::{FilterPushdownPropagation, PushedDown};
+use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
+use datafusion::physical_plan::{DisplayFormatType, SortOrderPushdownResult};
+use object_store::ObjectStore;
+
+/// Wraps an inner `FileSource` (a configured `ParquetSource`) so DataFusion
+/// cannot repartition, prune, or reorder rows on a positional scan path.
+pub(crate) struct PositionalFileSource {
+    inner: Arc<dyn FileSource>,
+}
+
+impl PositionalFileSource {
+    pub(crate) fn wrap(inner: Arc<dyn FileSource>) -> Arc<dyn FileSource> {
+        Arc::new(Self {
+            inner,
+        })
+    }
+
+    fn rewrap(&self, src: Arc<dyn FileSource>) -> Arc<dyn FileSource> {
+        Arc::new(Self {
+            inner: src,
+        })
+    }
+}
+
+impl FileSource for PositionalFileSource {
+    // ---- delegate: actual file reading and read-only accessors ----
+
+    fn create_file_opener(
+        &self,
+        object_store: Arc<dyn ObjectStore>,
+        base_config: &FileScanConfig,
+        partition: usize,
+    ) -> DataFusionResult<Arc<dyn FileOpener>> {
+        self.inner
+            .create_file_opener(object_store, base_config, partition)
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn table_schema(&self) -> &TableSchema {
+        self.inner.table_schema()
+    }
+
+    fn filter(&self) -> Option<Arc<dyn PhysicalExpr>> {
+        self.inner.filter()
+    }
+
+    fn projection(&self) -> Option<&ProjectionExprs> {
+        self.inner.projection()
+    }
+
+    fn metrics(&self) -> &ExecutionPlanMetricsSet {
+        self.inner.metrics()
+    }
+
+    fn file_type(&self) -> &str {
+        self.inner.file_type()
+    }
+
+    fn fmt_extra(&self, t: DisplayFormatType, f: &mut Formatter) -> fmt::Result {
+        self.inner.fmt_extra(t, f)
+    }
+
+    // ---- delegate + re-wrap: order/cardinality preserving ----
+
+    fn with_batch_size(&self, batch_size: usize) -> Arc<dyn FileSource> {
+        self.rewrap(self.inner.with_batch_size(batch_size))
+    }
+
+    fn try_pushdown_projection(
+        &self,
+        projection: &ProjectionExprs,
+    ) -> DataFusionResult<Option<Arc<dyn FileSource>>> {
+        Ok(self
+            .inner
+            .try_pushdown_projection(projection)?
+            .map(|s| self.rewrap(s)))
+    }
+
+    // ---- refuse: anything that drops, reorders, or re-splits rows ----
+
+    fn supports_repartitioning(&self) -> bool {
+        false
+    }
+
+    fn repartitioned(
+        &self,
+        _target_partitions: usize,
+        _repartition_file_min_size: usize,
+        _output_ordering: Option<LexOrdering>,
+        _config: &FileScanConfig,
+    ) -> DataFusionResult<Option<FileScanConfig>> {
+        Ok(None)
+    }
+
+    fn try_pushdown_filters(
+        &self,
+        filters: Vec<Arc<dyn PhysicalExpr>>,
+        _config: &ConfigOptions,
+    ) -> DataFusionResult<FilterPushdownPropagation<Arc<dyn FileSource>>> {
+        // Refuse all filter pushdown: a pushed predicate enables row-group/page/
+        // bloom pruning, which would emit a sparse subset of rows and corrupt
+        // physical-position synthesis. DataFusion keeps a FilterExec above us.
+        Ok(FilterPushdownPropagation::with_parent_pushdown_result(
+            vec![PushedDown::No; filters.len()],
+        ))
+    }
+
+    fn try_pushdown_sort(
+        &self,
+        _order: &[PhysicalSortExpr],
+        _eq_properties: &EquivalenceProperties,
+    ) -> DataFusionResult<SortOrderPushdownResult<Arc<dyn FileSource>>> {
+        // Refuse sort/reverse pushdown: reading row groups out of physical order
+        // would break position synthesis. DataFusion keeps a SortExec above us.
+        Ok(SortOrderPushdownResult::Unsupported)
+    }
+}

--- a/src/row_id.rs
+++ b/src/row_id.rs
@@ -1,17 +1,36 @@
-//! Synthetic `rowid` column injection for DuckLake row lineage.
+//! Physical row position and synthetic `rowid` column injection for DuckLake
+//! row lineage.
 //!
-//! DuckLake assigns each row a globally unique `rowid` BIGINT. For files
-//! written by INSERT, the catalog records the file's `row_id_start`, and the
-//! per-row rowid is `row_id_start + position_in_file`. This module implements
-//! an execution plan ([`RowIdExec`]) that appends that synthetic column to
-//! each batch streaming out of a per-file Parquet scan, in file order.
+//! DuckLake assigns each row a globally unique `rowid` BIGINT. For files written
+//! by INSERT, the catalog records the file's `row_id_start`, and the per-row
+//! rowid is `row_id_start + physical_row_position`, where `physical_row_position`
+//! is the row's 0-based position in the physical Parquet file. Positional delete
+//! files use the same physical position in their `pos` column.
+//!
+//! The physical position is **not** derivable from stream arrival order: when
+//! DataFusion splits a file across scan partitions and merges them, arrival
+//! order no longer matches file order. Instead we:
+//!
+//! 1. partition the scan on row-group boundaries (so each partition's first
+//!    physical row is known — see `table.rs::build_row_group_partitions`), then
+//! 2. materialize the physical position as an internal column
+//!    ([`ROW_POS_COLUMN_NAME`]) with [`FileRowNumberExec`], seeding each
+//!    partition's counter from that partition's starting row.
+//!
+//! Downstream, [`RowIdExec`] reads that column to compute `rowid`, and
+//! `DeleteFilterExec` reads it to filter deleted positions — neither counts
+//! stream rows, so both are correct regardless of partitioning or merge order.
+//! DataFusion upstream is adding Parquet metadata / virtual-column support
+//! (apache/datafusion#20135, apache/datafusion#22026). If a future DataFusion
+//! release exposes a Parquet physical `row_number` column, prefer that
+//! reader-level source for [`ROW_POS_COLUMN_NAME`]: it can preserve more Parquet
+//! pruning while still producing true physical positions.
 //!
 //! Files written by `UPDATE` / compaction store the original rowids inline in
 //! the parquet as a column tagged with [`ROW_ID_PARQUET_FIELD_ID`] (typically
-//! named `_ducklake_internal_row_id`). Those files do NOT use this exec —
-//! `DuckLakeTable` reads the embedded column directly via the parquet scan
-//! and renames it; `RowIdExec` is only used when no embedded column is
-//! present. See `table.rs::build_exec_for_file_with_rowid`.
+//! named `_ducklake_internal_row_id`). Those files do NOT use [`RowIdExec`] —
+//! `DuckLakeTable` reads the embedded column directly via the parquet scan and
+//! renames it. See `table.rs::build_exec_for_file_with_rowid`.
 
 use std::any::Any;
 use std::pin::Pin;
@@ -23,7 +42,7 @@ use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
-use datafusion::physical_expr::{Distribution, EquivalenceProperties};
+use datafusion::physical_expr::EquivalenceProperties;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
 };
@@ -31,6 +50,13 @@ use futures::Stream;
 
 /// Name of the synthetic rowid column exposed when row lineage is enabled.
 pub const ROWID_COLUMN_NAME: &str = "rowid";
+
+/// Name of the internal physical-row-position column produced by
+/// [`FileRowNumberExec`] and consumed by [`RowIdExec`] / `DeleteFilterExec`.
+/// Projected away before the table's output schema (by `ColumnRenameExec`),
+/// so it never reaches the user. The double-underscore prefix avoids collisions
+/// with real catalog columns.
+pub const ROW_POS_COLUMN_NAME: &str = "__ducklake_row_pos";
 
 /// Iceberg / DuckLake reserved parquet field-id for the row-id column.
 /// Matches `MultiFileReader::ROW_ID_FIELD_ID` in DuckDB
@@ -46,52 +72,44 @@ pub fn rowid_field() -> Field {
     Field::new(ROWID_COLUMN_NAME, DataType::Int64, true)
 }
 
-/// Execution plan that appends a synthetic `rowid` BIGINT column to each batch.
+/// Build the Arrow Field for the internal physical-position column. Non-null:
+/// every row has a well-defined physical position.
+pub fn row_pos_field() -> Field {
+    Field::new(ROW_POS_COLUMN_NAME, DataType::Int64, false)
+}
+
+// ---------------------------------------------------------------------------
+// FileRowNumberExec — materialize the true physical row position as a column
+// ---------------------------------------------------------------------------
+
+/// Execution plan that appends an internal [`ROW_POS_COLUMN_NAME`] BIGINT column
+/// holding each row's **true physical position in the file**.
 ///
-/// For a row at position `p` within the file, `rowid = row_id_start + p`. The
-/// row_id_start is supplied per-file at plan construction. If `row_id_start` is
-/// `None`, the column is emitted as all NULL (caller's catalog doesn't track
-/// lineage for this file).
-///
-/// The plan does not change row count or row order, so it composes cleanly with
-/// a downstream `DeleteFilterExec` whose internal position cursor stays aligned.
+/// Correctness rests on a precondition enforced by its construction in
+/// `table.rs`: the input is a row-group-aligned, non-repartitionable,
+/// non-pruning scan, so partition `p` emits a complete, contiguous, in-order run
+/// of physical rows beginning at `partition_starts[p]`. The per-partition cursor
+/// then equals the physical position. Once materialized, the column travels with
+/// each row, so any reordering above this exec is harmless.
 #[derive(Debug)]
-pub struct RowIdExec {
+pub struct FileRowNumberExec {
     input: Arc<dyn ExecutionPlan>,
-    /// File's catalog-recorded `row_id_start`. None ⇒ emit NULL rowids.
-    row_id_start: Option<i64>,
-    /// Position in the output schema where the rowid column is inserted.
-    /// Valid range: 0..=input.schema().fields().len().
-    insert_at: usize,
-    /// Output schema = input schema with rowid inserted at `insert_at`.
+    /// Starting physical row position for each input partition (1:1 with the
+    /// scan's file groups).
+    partition_starts: Arc<Vec<i64>>,
+    /// Output schema = input schema with [`ROW_POS_COLUMN_NAME`] appended.
     schema: SchemaRef,
     properties: Arc<PlanProperties>,
 }
 
-impl RowIdExec {
-    /// Append rowid as the last column. Convenience for the common case.
-    pub fn new(input: Arc<dyn ExecutionPlan>, row_id_start: Option<i64>) -> Self {
-        let insert_at = input.schema().fields().len();
-        Self::new_at(input, row_id_start, insert_at)
-    }
-
-    /// Insert rowid at a specific output column position.
-    pub fn new_at(
-        input: Arc<dyn ExecutionPlan>,
-        row_id_start: Option<i64>,
-        insert_at: usize,
-    ) -> Self {
-        let input_schema = input.schema();
-        let input_len = input_schema.fields().len();
-        let insert_at = insert_at.min(input_len);
-
-        let mut fields: Vec<Arc<Field>> = input_schema.fields().iter().cloned().collect();
-        fields.insert(insert_at, Arc::new(rowid_field()));
+impl FileRowNumberExec {
+    pub fn new(input: Arc<dyn ExecutionPlan>, partition_starts: Vec<i64>) -> Self {
+        let mut fields: Vec<Arc<Field>> = input.schema().fields().iter().cloned().collect();
+        fields.push(Arc::new(row_pos_field()));
         let schema = Arc::new(Schema::new(fields));
 
-        let eq_properties = EquivalenceProperties::new(schema.clone());
         let properties = Arc::new(PlanProperties::new(
-            eq_properties,
+            EquivalenceProperties::new(schema.clone()),
             input.output_partitioning().clone(),
             input.pipeline_behavior(),
             input.boundedness(),
@@ -99,28 +117,197 @@ impl RowIdExec {
 
         Self {
             input,
-            row_id_start,
-            insert_at,
+            partition_starts: Arc::new(partition_starts),
             schema,
             properties,
         }
     }
 }
 
-impl DisplayAs for RowIdExec {
-    fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match t {
-            DisplayFormatType::Default
-            | DisplayFormatType::Verbose
-            | DisplayFormatType::TreeRender => {
-                write!(
-                    f,
-                    "RowIdExec: row_id_start={}",
-                    self.row_id_start
-                        .map_or_else(|| "NULL".to_string(), |v| v.to_string())
-                )
-            },
+impl DisplayAs for FileRowNumberExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "FileRowNumberExec: starts={:?}",
+            self.partition_starts.as_ref()
+        )
+    }
+}
+
+impl ExecutionPlan for FileRowNumberExec {
+    fn name(&self) -> &str {
+        "FileRowNumberExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    /// Order-preserving: appends a column without reordering or dropping rows.
+    fn maintains_input_order(&self) -> Vec<bool> {
+        vec![true]
+    }
+
+    /// Refuse extra input partitioning. Our per-partition seeds are 1:1 with the
+    /// scan's row-group-aligned file groups; if `EnforceDistribution` inserted a
+    /// round-robin `RepartitionExec` below us to parallelize, the child would
+    /// report more partitions than we have seeds (and rows would be shuffled out
+    /// of physical order). Returning `false` keeps exactly the scan's partitions.
+    fn benefits_from_input_partitioning(&self) -> Vec<bool> {
+        vec![false]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        if children.len() != 1 {
+            return Err(DataFusionError::Internal(
+                "FileRowNumberExec expects exactly one child".into(),
+            ));
         }
+        Ok(Arc::new(FileRowNumberExec::new(
+            children.into_iter().next().unwrap(),
+            self.partition_starts.as_ref().clone(),
+        )))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        let start = *self.partition_starts.get(partition).ok_or_else(|| {
+            DataFusionError::Internal(format!(
+                "FileRowNumberExec: no starting position for partition {partition} \
+                 (have {} partitions)",
+                self.partition_starts.len()
+            ))
+        })?;
+        Ok(Box::pin(FileRowNumberStream {
+            input: self.input.execute(partition, context)?,
+            schema: self.schema.clone(),
+            cursor: start,
+        }))
+    }
+}
+
+struct FileRowNumberStream {
+    input: SendableRecordBatchStream,
+    schema: SchemaRef,
+    /// Physical position of the first row of the next batch.
+    cursor: i64,
+}
+
+impl Stream for FileRowNumberStream {
+    type Item = DataFusionResult<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match Pin::new(&mut self.input).poll_next(cx) {
+            Poll::Ready(Some(Ok(batch))) => {
+                let n = batch.num_rows();
+                let mut builder = Int64Array::builder(n);
+                for i in 0..n {
+                    builder.append_value(self.cursor + i as i64);
+                }
+                self.cursor += n as i64;
+
+                let mut cols: Vec<ArrayRef> = batch.columns().to_vec();
+                cols.push(Arc::new(builder.finish()));
+                let out = RecordBatch::try_new(self.schema.clone(), cols)
+                    .map_err(|e| DataFusionError::ArrowError(Box::new(e), None));
+                Poll::Ready(Some(out))
+            },
+            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl RecordBatchStream for FileRowNumberStream {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RowIdExec — derive rowid from the physical-position column
+// ---------------------------------------------------------------------------
+
+/// Execution plan that appends a synthetic `rowid` BIGINT column computed as
+/// `row_id_start + __ducklake_row_pos`, reading the position column produced by
+/// [`FileRowNumberExec`] (possibly via a `DeleteFilterExec`).
+///
+/// Stateless w.r.t. row order: it reads a per-row value and appends a per-row
+/// value, so it is correct under any partitioning. The position column is passed
+/// through unchanged for any downstream consumer; the final projection
+/// (`ColumnRenameExec`) drops it. If `row_id_start` is `None` the rowid column is
+/// emitted as all-NULL (the per-file plan in `table.rs` hard-errors before
+/// reaching here for non-embedded files with no `row_id_start`, so this is a
+/// defensive fallback only).
+#[derive(Debug)]
+pub struct RowIdExec {
+    input: Arc<dyn ExecutionPlan>,
+    row_id_start: Option<i64>,
+    /// Index of [`ROW_POS_COLUMN_NAME`] in the input schema.
+    pos_index: usize,
+    /// Output schema = input schema with `rowid` appended.
+    schema: SchemaRef,
+    properties: Arc<PlanProperties>,
+}
+
+impl RowIdExec {
+    /// Build a `RowIdExec`. The input must carry the [`ROW_POS_COLUMN_NAME`]
+    /// column (produced by [`FileRowNumberExec`]); errors otherwise.
+    pub fn try_new(
+        input: Arc<dyn ExecutionPlan>,
+        row_id_start: Option<i64>,
+    ) -> DataFusionResult<Self> {
+        let input_schema = input.schema();
+        let pos_index = input_schema.index_of(ROW_POS_COLUMN_NAME).map_err(|_| {
+            DataFusionError::Internal(format!(
+                "RowIdExec input is missing the `{ROW_POS_COLUMN_NAME}` column"
+            ))
+        })?;
+
+        let mut fields: Vec<Arc<Field>> = input_schema.fields().iter().cloned().collect();
+        fields.push(Arc::new(rowid_field()));
+        let schema = Arc::new(Schema::new(fields));
+
+        let properties = Arc::new(PlanProperties::new(
+            EquivalenceProperties::new(schema.clone()),
+            input.output_partitioning().clone(),
+            input.pipeline_behavior(),
+            input.boundedness(),
+        ));
+
+        Ok(Self {
+            input,
+            row_id_start,
+            pos_index,
+            schema,
+            properties,
+        })
+    }
+}
+
+impl DisplayAs for RowIdExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "RowIdExec: row_id_start={}",
+            self.row_id_start
+                .map_or_else(|| "NULL".to_string(), |v| v.to_string())
+        )
     }
 }
 
@@ -141,19 +328,9 @@ impl ExecutionPlan for RowIdExec {
         vec![&self.input]
     }
 
-    /// Rowid synthesis relies on rows arriving in file order on a single
-    /// stream — the cursor counts position-in-file. If DataFusion's
-    /// `EnforceDistribution` / `Repartition` rules inserted a `RepartitionExec`
-    /// below us, batches would arrive interleaved across partitions and
-    /// rowid = row_id_start + cursor would no longer correspond to the row's
-    /// real file offset. Pin the child to a single partition to prevent that.
-    fn required_input_distribution(&self) -> Vec<Distribution> {
-        vec![Distribution::SinglePartition]
-    }
-
-    /// Order-preserving wrapper: we do not reorder or drop rows, we only
-    /// append a column. Declaring this lets DataFusion's order-aware
-    /// optimizations (e.g. avoiding sorts after RowIdExec) fire.
+    /// Order-preserving column append. No distribution requirement: the rowid
+    /// value is computed from the per-row position column, so it is correct
+    /// regardless of how the input is partitioned or merged.
     fn maintains_input_order(&self) -> Vec<bool> {
         vec![true]
     }
@@ -167,11 +344,10 @@ impl ExecutionPlan for RowIdExec {
                 "RowIdExec expects exactly one child".into(),
             ));
         }
-        Ok(Arc::new(RowIdExec::new_at(
+        Ok(Arc::new(RowIdExec::try_new(
             children.into_iter().next().unwrap(),
             self.row_id_start,
-            self.insert_at,
-        )))
+        )?))
     }
 
     fn execute(
@@ -183,8 +359,7 @@ impl ExecutionPlan for RowIdExec {
             input: self.input.execute(partition, context)?,
             schema: self.schema.clone(),
             row_id_start: self.row_id_start,
-            insert_at: self.insert_at,
-            cursor: 0,
+            pos_index: self.pos_index,
         }))
     }
 }
@@ -193,9 +368,7 @@ struct RowIdStream {
     input: SendableRecordBatchStream,
     schema: SchemaRef,
     row_id_start: Option<i64>,
-    insert_at: usize,
-    /// Position in the file of the first row of the next batch (file-order).
-    cursor: i64,
+    pos_index: usize,
 }
 
 impl Stream for RowIdStream {
@@ -207,9 +380,21 @@ impl Stream for RowIdStream {
                 let n = batch.num_rows();
                 let rowid_col: ArrayRef = match self.row_id_start {
                     Some(start) => {
+                        let pos = match batch
+                            .column(self.pos_index)
+                            .as_any()
+                            .downcast_ref::<Int64Array>()
+                        {
+                            Some(p) => p,
+                            None => {
+                                return Poll::Ready(Some(Err(DataFusionError::Internal(format!(
+                                    "`{ROW_POS_COLUMN_NAME}` column is not Int64"
+                                )))));
+                            },
+                        };
                         let mut builder = Int64Array::builder(n);
                         for i in 0..n {
-                            builder.append_value(start + self.cursor + i as i64);
+                            builder.append_value(start + pos.value(i));
                         }
                         Arc::new(builder.finish())
                     },
@@ -221,11 +406,9 @@ impl Stream for RowIdStream {
                         Arc::new(builder.finish())
                     },
                 };
-                self.cursor += n as i64;
 
                 let mut cols: Vec<ArrayRef> = batch.columns().to_vec();
-                let pos = self.insert_at.min(cols.len());
-                cols.insert(pos, rowid_col);
+                cols.push(rowid_col);
                 let out = RecordBatch::try_new(self.schema.clone(), cols)
                     .map_err(|e| DataFusionError::ArrowError(Box::new(e), None));
                 Poll::Ready(Some(out))
@@ -248,244 +431,185 @@ mod tests {
     use super::*;
     use arrow::array::{Array, Int32Array};
     use datafusion::datasource::memory::MemorySourceConfig;
+    use futures::StreamExt;
 
-    fn small_batch(schema: SchemaRef, values: &[i32]) -> RecordBatch {
-        RecordBatch::try_new(
-            schema,
-            vec![Arc::new(Int32Array::from(values.to_vec())) as ArrayRef],
-        )
-        .unwrap()
-    }
-
-    #[tokio::test]
-    async fn appends_sequential_rowids_across_batches() {
-        let input_schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int32, false)]));
-        let b1 = small_batch(input_schema.clone(), &[10, 20, 30]);
-        let b2 = small_batch(input_schema.clone(), &[40, 50]);
-        let mem =
-            MemorySourceConfig::try_new_exec(&[vec![b1, b2]], input_schema.clone(), None).unwrap();
-
-        let exec = Arc::new(RowIdExec::new(mem, Some(1000)));
-        assert_eq!(exec.schema().field(1).name(), ROWID_COLUMN_NAME);
-
-        let ctx = Arc::new(TaskContext::default());
-        let mut stream = exec.execute(0, ctx).unwrap();
-        use futures::StreamExt;
-
-        let first = stream.next().await.unwrap().unwrap();
-        let rowids = first
-            .column(1)
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .unwrap()
-            .values()
-            .to_vec();
-        assert_eq!(rowids, vec![1000, 1001, 1002]);
-
-        let second = stream.next().await.unwrap().unwrap();
-        let rowids = second
-            .column(1)
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .unwrap()
-            .values()
-            .to_vec();
-        assert_eq!(rowids, vec![1003, 1004]);
-    }
-
-    #[tokio::test]
-    async fn inserts_rowid_at_requested_position() {
-        let input_schema = Arc::new(Schema::new(vec![
-            Field::new("a", DataType::Int32, false),
-            Field::new("b", DataType::Int32, false),
+    /// Build an input batch shaped like a `FileRowNumberExec` output: a value
+    /// column `v` plus the internal `__ducklake_row_pos` column.
+    fn batch_with_pos(values: &[i32], positions: &[i64]) -> (SchemaRef, RecordBatch) {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("v", DataType::Int32, false),
+            row_pos_field(),
         ]));
         let batch = RecordBatch::try_new(
-            input_schema.clone(),
+            schema.clone(),
             vec![
-                Arc::new(Int32Array::from(vec![10, 20])) as ArrayRef,
-                Arc::new(Int32Array::from(vec![100, 200])) as ArrayRef,
+                Arc::new(Int32Array::from(values.to_vec())) as ArrayRef,
+                Arc::new(Int64Array::from(positions.to_vec())) as ArrayRef,
             ],
         )
         .unwrap();
-        let mem =
-            MemorySourceConfig::try_new_exec(&[vec![batch]], input_schema.clone(), None).unwrap();
-
-        // Insert rowid at position 1 → schema should be [a, rowid, b]
-        let exec = Arc::new(RowIdExec::new_at(mem, Some(500), 1));
-        assert_eq!(exec.schema().field(0).name(), "a");
-        assert_eq!(exec.schema().field(1).name(), ROWID_COLUMN_NAME);
-        assert_eq!(exec.schema().field(2).name(), "b");
-
-        let ctx = Arc::new(TaskContext::default());
-        let mut stream = exec.execute(0, ctx).unwrap();
-        use futures::StreamExt;
-
-        let out = stream.next().await.unwrap().unwrap();
-        let rowids = out
-            .column(1)
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .unwrap()
-            .values()
-            .to_vec();
-        assert_eq!(rowids, vec![500, 501]);
-        // Verify physical columns still in place around rowid
-        let a = out
-            .column(0)
-            .as_any()
-            .downcast_ref::<Int32Array>()
-            .unwrap()
-            .values()
-            .to_vec();
-        let b = out
-            .column(2)
-            .as_any()
-            .downcast_ref::<Int32Array>()
-            .unwrap()
-            .values()
-            .to_vec();
-        assert_eq!(a, vec![10, 20]);
-        assert_eq!(b, vec![100, 200]);
+        (schema, batch)
     }
 
+    // --- FileRowNumberExec ---
+
     #[tokio::test]
-    async fn rowid_only_projection_empty_input_columns() {
-        // The input has zero columns (count-rows-only mode). RowIdExec
-        // should still emit a single-column batch with the rowid values.
-        // This is the shape that flows from a parquet scan when only rowid
-        // is in the projection.
-        let input_schema = Arc::new(Schema::new(Vec::<Field>::new()));
-        let batch = RecordBatch::try_new_with_options(
-            input_schema.clone(),
-            vec![],
-            &arrow::record_batch::RecordBatchOptions::new().with_row_count(Some(3)),
-        )
-        .unwrap();
-        let mem =
-            MemorySourceConfig::try_new_exec(&[vec![batch]], input_schema.clone(), None).unwrap();
-
-        let exec = Arc::new(RowIdExec::new(mem, Some(42)));
-        assert_eq!(exec.schema().fields().len(), 1);
-        assert_eq!(exec.schema().field(0).name(), ROWID_COLUMN_NAME);
-
-        let ctx = Arc::new(TaskContext::default());
-        let mut stream = exec.execute(0, ctx).unwrap();
-        use futures::StreamExt;
-        let out = stream.next().await.unwrap().unwrap();
-        assert_eq!(out.num_rows(), 3);
-        assert_eq!(out.num_columns(), 1);
-        let rowids = out
-            .column(0)
-            .as_any()
-            .downcast_ref::<Int64Array>()
+    async fn file_row_number_seeds_per_partition() {
+        let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int32, false)]));
+        let mk = |vals: Vec<i32>| {
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![Arc::new(Int32Array::from(vals)) as ArrayRef],
+            )
             .unwrap()
-            .values()
-            .to_vec();
-        assert_eq!(rowids, vec![42, 43, 44]);
-    }
-
-    #[tokio::test]
-    async fn empty_batch_passes_through_with_empty_rowid_column() {
-        // A zero-row batch from the input should produce a zero-row batch
-        // out, with the rowid column present and the cursor unchanged so
-        // the next non-empty batch picks up at the right offset.
-        let input_schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int32, false)]));
-        let empty_batch = RecordBatch::try_new(
-            input_schema.clone(),
-            vec![Arc::new(Int32Array::from(Vec::<i32>::new())) as ArrayRef],
-        )
-        .unwrap();
-        let next_batch = small_batch(input_schema.clone(), &[7, 8]);
+        };
+        // Two partitions: partition 0 starts at 0, partition 1 starts at 100.
         let mem = MemorySourceConfig::try_new_exec(
-            &[vec![empty_batch, next_batch]],
-            input_schema.clone(),
+            &[vec![mk(vec![1, 2, 3])], vec![mk(vec![4, 5])]],
+            schema.clone(),
             None,
         )
         .unwrap();
+        let exec = Arc::new(FileRowNumberExec::new(mem, vec![0, 100]));
+        assert_eq!(exec.schema().field(1).name(), ROW_POS_COLUMN_NAME);
 
-        let exec = Arc::new(RowIdExec::new(mem, Some(100)));
         let ctx = Arc::new(TaskContext::default());
-        let mut stream = exec.execute(0, ctx).unwrap();
-        use futures::StreamExt;
+        let pos_of = |b: &RecordBatch| {
+            b.column(1)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .values()
+                .to_vec()
+        };
 
-        let first = stream.next().await.unwrap().unwrap();
-        assert_eq!(first.num_rows(), 0);
-        assert_eq!(first.num_columns(), 2);
+        let mut s0 = exec.clone().execute(0, ctx.clone()).unwrap();
+        let p0 = s0.next().await.unwrap().unwrap();
+        assert_eq!(pos_of(&p0), vec![0, 1, 2]);
 
-        let second = stream.next().await.unwrap().unwrap();
-        let rowids = second
-            .column(1)
+        let mut s1 = exec.execute(1, ctx).unwrap();
+        let p1 = s1.next().await.unwrap().unwrap();
+        assert_eq!(
+            pos_of(&p1),
+            vec![100, 101],
+            "partition 1 seeds at its start"
+        );
+    }
+
+    #[tokio::test]
+    async fn file_row_number_continues_across_batches() {
+        let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int32, false)]));
+        let mk = |vals: Vec<i32>| {
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![Arc::new(Int32Array::from(vals)) as ArrayRef],
+            )
+            .unwrap()
+        };
+        let mem = MemorySourceConfig::try_new_exec(
+            &[vec![mk(vec![1, 2, 3]), mk(vec![4, 5])]],
+            schema.clone(),
+            None,
+        )
+        .unwrap();
+        let exec = Arc::new(FileRowNumberExec::new(mem, vec![10]));
+        let ctx = Arc::new(TaskContext::default());
+        let mut s = exec.execute(0, ctx).unwrap();
+
+        let pos_of = |b: &RecordBatch| {
+            b.column(1)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .values()
+                .to_vec()
+        };
+        assert_eq!(pos_of(&s.next().await.unwrap().unwrap()), vec![10, 11, 12]);
+        assert_eq!(pos_of(&s.next().await.unwrap().unwrap()), vec![13, 14]);
+    }
+
+    #[tokio::test]
+    async fn file_row_number_zero_column_input() {
+        // COUNT(*)-style input: zero data columns, only a row count.
+        let schema = Arc::new(Schema::new(Vec::<Field>::new()));
+        let batch = RecordBatch::try_new_with_options(
+            schema.clone(),
+            vec![],
+            &arrow::record_batch::RecordBatchOptions::new().with_row_count(Some(4)),
+        )
+        .unwrap();
+        let mem = MemorySourceConfig::try_new_exec(&[vec![batch]], schema, None).unwrap();
+        let exec = Arc::new(FileRowNumberExec::new(mem, vec![7]));
+        let ctx = Arc::new(TaskContext::default());
+        let mut s = exec.execute(0, ctx).unwrap();
+        let out = s.next().await.unwrap().unwrap();
+        assert_eq!(out.num_columns(), 1);
+        assert_eq!(
+            out.column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .values()
+                .to_vec(),
+            vec![7, 8, 9, 10]
+        );
+    }
+
+    // --- RowIdExec ---
+
+    #[tokio::test]
+    async fn rowid_is_start_plus_position() {
+        // Positions deliberately non-contiguous to prove rowid reads the column
+        // rather than counting arrivals.
+        let (schema, batch) = batch_with_pos(&[10, 20, 30], &[5, 6, 9]);
+        let mem = MemorySourceConfig::try_new_exec(&[vec![batch]], schema, None).unwrap();
+        let exec = Arc::new(RowIdExec::try_new(mem, Some(1000)).unwrap());
+
+        // Output appends rowid after the input columns (v, pos, rowid).
+        assert_eq!(exec.schema().field(2).name(), ROWID_COLUMN_NAME);
+
+        let ctx = Arc::new(TaskContext::default());
+        let mut s = exec.execute(0, ctx).unwrap();
+        let out = s.next().await.unwrap().unwrap();
+        let rowids = out
+            .column(2)
             .as_any()
             .downcast_ref::<Int64Array>()
             .unwrap()
             .values()
             .to_vec();
-        // Cursor should NOT have advanced past the empty batch — second
-        // batch rows still start at row_id_start + 0.
-        assert_eq!(rowids, vec![100, 101]);
+        assert_eq!(rowids, vec![1005, 1006, 1009]);
+        // Position column passed through unchanged for downstream consumers.
+        assert_eq!(
+            out.column(1)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .values()
+                .to_vec(),
+            vec![5, 6, 9]
+        );
     }
 
     #[tokio::test]
-    async fn insert_at_out_of_range_clamps_to_end() {
-        // Caller asks to insert at position 99 when the input has only 1
-        // column. The constructor clamps to input.len() (= 1) so the rowid
-        // ends up appended at the end.
-        let input_schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int32, false)]));
-        let b = small_batch(input_schema.clone(), &[1, 2]);
-        let mem = MemorySourceConfig::try_new_exec(&[vec![b]], input_schema.clone(), None).unwrap();
-
-        let exec = Arc::new(RowIdExec::new_at(mem, Some(10), 99));
-        assert_eq!(exec.schema().fields().len(), 2);
-        assert_eq!(exec.schema().field(0).name(), "v");
-        assert_eq!(exec.schema().field(1).name(), ROWID_COLUMN_NAME);
+    async fn rowid_null_when_start_is_none() {
+        let (schema, batch) = batch_with_pos(&[1, 2], &[0, 1]);
+        let mem = MemorySourceConfig::try_new_exec(&[vec![batch]], schema, None).unwrap();
+        let exec = Arc::new(RowIdExec::try_new(mem, None).unwrap());
+        let ctx = Arc::new(TaskContext::default());
+        let mut s = exec.execute(0, ctx).unwrap();
+        let out = s.next().await.unwrap().unwrap();
+        let rowid = out.column(2).as_any().downcast_ref::<Int64Array>().unwrap();
+        assert!(rowid.is_null(0) && rowid.is_null(1));
     }
 
     #[test]
-    fn declares_single_partition_input_to_block_repartition() {
-        // Regression guard for the cursor-vs-RepartitionExec hazard: if
-        // either of these defaults reverts, DataFusion's optimizer could
-        // legally insert a RepartitionExec under RowIdExec and break
-        // rowid computation silently. We do not over-assert the exact
-        // Distribution shape — just that it is SinglePartition for the
-        // sole child.
-        let input_schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int32, false)]));
-        let mem = MemorySourceConfig::try_new_exec(&[vec![]], input_schema, None).unwrap();
-        let exec = RowIdExec::new(mem, Some(0));
-
-        let dists = exec.required_input_distribution();
-        assert_eq!(dists.len(), 1);
+    fn rowid_errors_without_position_column() {
+        let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int32, false)]));
+        let mem = MemorySourceConfig::try_new_exec(&[vec![]], schema, None).unwrap();
         assert!(
-            matches!(dists[0], Distribution::SinglePartition),
-            "RowIdExec must require a single-partition input; got {:?}",
-            dists[0]
+            RowIdExec::try_new(mem, Some(0)).is_err(),
+            "RowIdExec must require the position column"
         );
-        assert_eq!(
-            exec.maintains_input_order(),
-            vec![true],
-            "RowIdExec preserves row order — must declare it so DataFusion's \
-             order-aware optimizations can fire",
-        );
-    }
-
-    #[tokio::test]
-    async fn emits_null_when_row_id_start_is_none() {
-        let input_schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int32, false)]));
-        let b = small_batch(input_schema.clone(), &[1, 2]);
-        let mem = MemorySourceConfig::try_new_exec(&[vec![b]], input_schema.clone(), None).unwrap();
-
-        let exec = Arc::new(RowIdExec::new(mem, None));
-        let ctx = Arc::new(TaskContext::default());
-        let mut stream = exec.execute(0, ctx).unwrap();
-        use futures::StreamExt;
-
-        let batch = stream.next().await.unwrap().unwrap();
-        let rowid_col = batch
-            .column(1)
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .unwrap();
-        assert_eq!(rowid_col.len(), 2);
-        assert!(rowid_col.is_null(0));
-        assert!(rowid_col.is_null(1));
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -11,7 +11,10 @@ use crate::metadata_provider::{
     DuckLakeFileData, DuckLakeTableColumn, DuckLakeTableFile, MetadataProvider,
 };
 use crate::path_resolver::resolve_path;
-use crate::row_id::{ROW_ID_PARQUET_FIELD_ID, ROWID_COLUMN_NAME, RowIdExec, rowid_field};
+use crate::positional_source::PositionalFileSource;
+use crate::row_id::{
+    FileRowNumberExec, ROW_ID_PARQUET_FIELD_ID, ROWID_COLUMN_NAME, RowIdExec, rowid_field,
+};
 use crate::types::{
     build_arrow_schema, build_read_schema_with_field_id_mapping, extract_parquet_field_ids,
 };
@@ -31,6 +34,7 @@ use datafusion::catalog::{Session, TableProvider};
 use datafusion::common::Statistics;
 use datafusion::common::stats::Precision;
 use datafusion::datasource::listing::PartitionedFile;
+use datafusion::datasource::physical_plan::parquet::{ParquetAccessPlan, RowGroupAccess};
 use datafusion::datasource::physical_plan::{FileGroup, FileScanConfigBuilder, ParquetSource};
 use datafusion::datasource::source::DataSourceExec;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
@@ -114,6 +118,17 @@ struct FileReadConfig {
     /// `Some(parquet_column_name)` if the file embeds the rowid column
     /// (tagged with [`ROW_ID_PARQUET_FIELD_ID`]); `None` otherwise.
     embedded_rowid_parquet_name: Option<String>,
+    /// Per-row-group starting physical row position (prefix sums of
+    /// `row_groups[i].num_rows()`). `row_group_starts[i]` is the 0-based file
+    /// position of the first row of row group `i`. Used to build row-group-
+    /// aligned scan partitions whose starting position is known at plan time,
+    /// so `FileRowNumberExec` can synthesize true physical positions instead of
+    /// counting stream arrivals. The Parquet footer is the source of truth; the
+    /// catalog does not store per-row-group counts.
+    row_group_starts: Vec<i64>,
+    /// Number of row groups in the file (`row_group_starts.len()`). Required to
+    /// build a `ParquetAccessPlan` of the correct length.
+    row_group_count: usize,
 }
 
 /// DuckLake table provider
@@ -523,72 +538,86 @@ impl DuckLakeTable {
         projection: Option<&Vec<usize>>,
         limit: Option<usize>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
-        let (read_schema, name_mapping) = self.get_schema_mapping(state).await?;
+        let file_cfg = self.build_file_read_config(state, &table_file.file).await?;
 
-        // Resolve the data file path for scanning
-        let resolved_path = self.resolve_file_path(&table_file.file)?;
+        // Deletes filter by physical row position, so this is a positional path:
+        // it must read the file in row-group-aligned, non-repartitionable,
+        // non-pruning partitions and synthesize positions before filtering.
+        let deleted_positions = if let Some(ref delete_file) = table_file.delete_file {
+            let p = self.read_delete_file_positions(state, delete_file).await?;
+            (!p.is_empty()).then_some(p)
+        } else {
+            None
+        };
 
-        // Create PartitionedFile with footer size hint if available
-        let mut pf = PartitionedFile::new(
-            &resolved_path,
-            validated_file_size(table_file.file.file_size_bytes, &resolved_path)?,
-        );
-        if let Some(footer_size) = table_file.file.footer_size
-            && footer_size > 0
-            && let Ok(hint) = usize::try_from(footer_size)
-        {
-            pf = pf.with_metadata_size_hint(hint);
-        }
-
-        // Use read_schema (with original Parquet names) for reading
-        let mut builder = FileScanConfigBuilder::new(
-            self.object_store_url.as_ref().clone(),
-            Arc::new(self.create_parquet_source(read_schema.clone())),
-        )
-        .with_limit(limit)
-        .with_file_group(FileGroup::new(vec![pf]));
-
-        // Apply projection if provided
-        if let Some(proj) = projection {
-            builder = builder.with_projection_indices(Some(proj.clone()))?;
-        }
-
-        let file_scan_config = builder.build();
-        // Use DataSourceExec directly to preserve our ParquetSource with encryption factory
-        let parquet_exec: Arc<dyn ExecutionPlan> =
-            DataSourceExec::from_data_source(file_scan_config);
-
-        // Wrap with delete filter - we know there's a delete file since we partitioned
-        // The metadata already tells us which delete file goes with this data file
-        let exec_after_delete: Arc<dyn ExecutionPlan> =
-            if let Some(ref delete_file) = table_file.delete_file {
-                let deleted_positions = self.read_delete_file_positions(state, delete_file).await?;
-
-                if !deleted_positions.is_empty() {
-                    Arc::new(DeleteFilterExec::new(
-                        parquet_exec,
-                        table_file.file.path.clone(),
-                        Arc::new(deleted_positions),
-                    ))
-                } else {
-                    parquet_exec
-                }
-            } else {
-                parquet_exec
-            };
-
-        // Wrap with ColumnRenameExec to present the catalog schema (renames, or a
-        // file physical type that differs from the catalog type — see the
-        // no-delete path above). Coerces each column to `output_schema`.
         let output_schema = match projection {
             Some(indices) => Arc::new(self.schema.project(indices)?),
             None => self.schema.clone(),
         };
-        if !name_mapping.is_empty() || exec_after_delete.schema() != output_schema {
+
+        // Explicit parquet projection over `read_schema`. rowid is never
+        // projected on this path, so always read only the physical columns —
+        // for an embedded-rowid file, `read_schema` has a trailing embedded
+        // column we must NOT read here. With `projection = None` that means the
+        // physical columns `0..physical_len` (not "all of read_schema").
+        let proj_indices: Vec<usize> = match projection {
+            Some(indices) => indices.clone(),
+            None => (0..self.physical_schema.fields().len()).collect(),
+        };
+
+        let exec_after_delete: Arc<dyn ExecutionPlan> = if let Some(positions) = deleted_positions {
+            // Positional path: no scan-level limit (would drop rows before the
+            // delete filter); DataFusion enforces LIMIT above the table plan.
+            let target_partitions = state.config().target_partitions();
+            let (file_groups, partition_starts) =
+                self.build_row_group_partitions(&table_file.file, &file_cfg, target_partitions)?;
+
+            let source = PositionalFileSource::wrap(Arc::new(
+                self.create_parquet_source(file_cfg.read_schema.clone()),
+            ));
+            let mut builder =
+                FileScanConfigBuilder::new(self.object_store_url.as_ref().clone(), source)
+                    .with_file_groups(file_groups);
+            builder = builder.with_projection_indices(Some(proj_indices.clone()))?;
+            let scan = DataSourceExec::from_data_source(builder.build());
+
+            let with_pos: Arc<dyn ExecutionPlan> =
+                Arc::new(FileRowNumberExec::new(scan, partition_starts));
+            Arc::new(DeleteFilterExec::try_new(
+                with_pos,
+                table_file.file.path.clone(),
+                Arc::new(positions),
+            )?)
+        } else {
+            // No actual deletes for this file: plain scan, scan-level limit OK.
+            let resolved_path = self.resolve_file_path(&table_file.file)?;
+            let mut pf = PartitionedFile::new(
+                &resolved_path,
+                validated_file_size(table_file.file.file_size_bytes, &resolved_path)?,
+            );
+            if let Some(footer_size) = table_file.file.footer_size
+                && footer_size > 0
+                && let Ok(hint) = usize::try_from(footer_size)
+            {
+                pf = pf.with_metadata_size_hint(hint);
+            }
+            let mut builder = FileScanConfigBuilder::new(
+                self.object_store_url.as_ref().clone(),
+                Arc::new(self.create_parquet_source(file_cfg.read_schema.clone())),
+            )
+            .with_limit(limit)
+            .with_file_group(FileGroup::new(vec![pf]));
+            builder = builder.with_projection_indices(Some(proj_indices.clone()))?;
+            DataSourceExec::from_data_source(builder.build())
+        };
+
+        // ColumnRenameExec presents the catalog schema and, on the positional
+        // path, drops the internal `__ducklake_row_pos` column (by name).
+        if !file_cfg.name_mapping.is_empty() || exec_after_delete.schema() != output_schema {
             Ok(Arc::new(ColumnRenameExec::new(
                 exec_after_delete,
                 output_schema,
-                name_mapping.clone(),
+                file_cfg.name_mapping.clone(),
             )))
         } else {
             Ok(exec_after_delete)
@@ -654,6 +683,18 @@ impl DuckLakeTable {
 
         let field_id_map = extract_parquet_field_ids(builder.metadata());
 
+        // Per-row-group starting positions (prefix sums of num_rows), read from
+        // the footer we already have open. Drives row-group-aligned scan
+        // partitioning on positional paths.
+        let row_groups = builder.metadata().row_groups();
+        let row_group_count = row_groups.len();
+        let mut row_group_starts = Vec::with_capacity(row_group_count);
+        let mut row_acc: i64 = 0;
+        for rg in row_groups {
+            row_group_starts.push(row_acc);
+            row_acc = row_acc.saturating_add(rg.num_rows());
+        }
+
         // Standard read_schema + name_mapping for physical columns.
         let (physical_read_schema, mut name_mapping) = if field_id_map.is_empty() {
             (self.physical_schema.as_ref().clone(), HashMap::new())
@@ -694,6 +735,8 @@ impl DuckLakeTable {
             read_schema,
             name_mapping,
             embedded_rowid_parquet_name,
+            row_group_starts,
+            row_group_count,
         });
 
         {
@@ -704,13 +747,96 @@ impl DuckLakeTable {
         Ok(cfg)
     }
 
+    /// Build row-group-aligned scan partitions for a single file on a
+    /// *positional* path (rowid synthesis and/or delete filtering).
+    ///
+    /// Returns one [`FileGroup`] per contiguous run of row groups (so each is a
+    /// distinct DataFusion partition) together with a `partition_starts` vector
+    /// whose `i`-th entry is the **true physical row position of the first row**
+    /// of `file_groups[i]`. The two vectors are 1:1; `FileRowNumberExec` uses
+    /// `partition_starts[partition]` to seed positions.
+    ///
+    /// Each chunk carries a whole-row-group `Scan`/`Skip` [`ParquetAccessPlan`]
+    /// (never a `RowSelection`), so within a partition the reader emits a
+    /// complete, contiguous, in-order run of physical rows. A single chunk
+    /// (`target_partitions == 1`, or a file with ≤1 row group) carries no access
+    /// plan and reads the whole file in order — identical to the legacy path.
+    fn build_row_group_partitions(
+        &self,
+        file: &DuckLakeFileData,
+        read_cfg: &FileReadConfig,
+        target_partitions: usize,
+    ) -> DataFusionResult<(Vec<FileGroup>, Vec<i64>)> {
+        let resolved_path = self.resolve_file_path(file)?;
+        let file_size = validated_file_size(file.file_size_bytes, &resolved_path)?;
+        let footer_hint = file
+            .footer_size
+            .filter(|&s| s > 0)
+            .and_then(|s| usize::try_from(s).ok());
+
+        let make_pf = |access: Option<ParquetAccessPlan>| {
+            let mut pf = PartitionedFile::new(&resolved_path, file_size);
+            if let Some(hint) = footer_hint {
+                pf = pf.with_metadata_size_hint(hint);
+            }
+            if let Some(plan) = access {
+                pf = pf.with_extensions(Arc::new(plan));
+            }
+            pf
+        };
+
+        let n = read_cfg.row_group_count;
+        let k = target_partitions.max(1).min(n.max(1));
+
+        // Single partition: whole file, in order, no access plan. Covers
+        // target_partitions == 1 and files with 0 or 1 row groups.
+        if k <= 1 {
+            return Ok((vec![FileGroup::new(vec![make_pf(None)])], vec![0]));
+        }
+
+        // Split the n row groups into k contiguous chunks as evenly as possible
+        // (row groups are written near-uniform, so group-count balancing closely
+        // tracks row-count balancing). The first `rem` chunks get one extra group.
+        let base = n / k;
+        let rem = n % k;
+        let mut file_groups = Vec::with_capacity(k);
+        let mut partition_starts = Vec::with_capacity(k);
+        let mut a = 0usize;
+        for chunk in 0..k {
+            let len = base + usize::from(chunk < rem);
+            let b = a + len;
+            debug_assert!(b <= n && len > 0);
+
+            let row_groups: Vec<RowGroupAccess> = (0..n)
+                .map(|rg| {
+                    if rg >= a && rg < b {
+                        RowGroupAccess::Scan
+                    } else {
+                        RowGroupAccess::Skip
+                    }
+                })
+                .collect();
+
+            file_groups.push(FileGroup::new(vec![make_pf(Some(ParquetAccessPlan::new(
+                row_groups,
+            )))]));
+            partition_starts.push(read_cfg.row_group_starts[a]);
+            a = b;
+        }
+        debug_assert_eq!(a, n);
+
+        Ok((file_groups, partition_starts))
+    }
+
     /// Build a plan for a single file when the synthetic `rowid` column is in
     /// the projection. Always uses per-file scans because each file may have a
     /// different layout (embedded rowid vs. synthesized) and a distinct
     /// `row_id_start`.
     ///
-    /// Order: ParquetExec(physical_proj [+ rowid if embedded]) →
-    ///   RowIdExec(?) → DeleteFilterExec(?) → ColumnRenameExec(?).
+    /// Order on the positional path (non-embedded, or any file with deletes):
+    ///   DataSourceExec → FileRowNumberExec → DeleteFilterExec(?) → RowIdExec(?)
+    ///   → ColumnRenameExec. Embedded-rowid files with no deletes keep a plain
+    ///   DataSourceExec → ColumnRenameExec (rowid read from the file).
     async fn build_exec_for_file_with_rowid(
         &self,
         state: &dyn Session,
@@ -722,22 +848,12 @@ impl DuckLakeTable {
         let file_cfg = self.build_file_read_config(state, &table_file.file).await?;
         let has_embedded = file_cfg.embedded_rowid_parquet_name.is_some();
 
-        // Decompose user projection: which physical columns to read, and where
-        // rowid should appear in the output.
+        // Physical columns to read (everything the user asked for except rowid).
         let physical_proj: Vec<usize> = user_proj
             .iter()
             .filter(|&&i| i != rowid_idx)
             .copied()
             .collect();
-        let rowid_insert_pos: usize =
-            user_proj
-                .iter()
-                .position(|&i| i == rowid_idx)
-                .ok_or_else(|| {
-                    DataFusionError::Internal(
-                        "build_exec_for_file_with_rowid called without rowid in projection".into(),
-                    )
-                })?;
 
         // Match the C++ extension: if the file embeds no rowid column AND the
         // catalog didn't record a `row_id_start`, lineage cannot be
@@ -750,72 +866,89 @@ impl DuckLakeTable {
             )));
         }
 
-        // Build the ParquetExec projection. When the file embeds rowid we
-        // splice it into the projection at `rowid_insert_pos` directly, so
-        // the parquet emits batches already in the user's requested column
-        // order (no extra reorder pass needed).
+        // Resolve deletes once.
+        let deleted_positions = if let Some(ref delete_file) = table_file.delete_file {
+            let p = self.read_delete_file_positions(state, delete_file).await?;
+            (!p.is_empty()).then_some(p)
+        } else {
+            None
+        };
+        let has_deletes = deleted_positions.is_some();
+
+        // We need synthesized physical positions when rowid must be synthesized
+        // (non-embedded) or when positional deletes must be applied. Embedded-
+        // rowid files with no deletes keep the legacy plain scan (rowid read from
+        // the file; reader-side pruning and scan-level limit are safe there).
+        let needs_position = !has_embedded || has_deletes;
+
+        // Parquet read projection. For embedded files, also read the embedded
+        // rowid column; `ColumnRenameExec` later maps it to `rowid` by name, so
+        // its position in the read projection is irrelevant.
         let parquet_projection: Vec<usize> = if has_embedded {
             let rowid_col_in_read_schema = file_cfg.read_schema.fields().len() - 1;
             let mut p = physical_proj.clone();
-            p.insert(rowid_insert_pos, rowid_col_in_read_schema);
+            p.push(rowid_col_in_read_schema);
             p
         } else {
             physical_proj.clone()
         };
 
-        // Resolve and configure the data file
-        let resolved_path = self.resolve_file_path(&table_file.file)?;
-        let mut pf = PartitionedFile::new(
-            &resolved_path,
-            validated_file_size(table_file.file.file_size_bytes, &resolved_path)?,
-        );
-        if let Some(footer_size) = table_file.file.footer_size
-            && footer_size > 0
-            && let Ok(hint) = usize::try_from(footer_size)
-        {
-            pf = pf.with_metadata_size_hint(hint);
-        }
+        let after_deletes: Arc<dyn ExecutionPlan> = if needs_position {
+            // Positional path: row-group-aligned partitions + a non-repartition,
+            // non-pruning source, so each partition emits a complete, contiguous,
+            // in-order run of physical rows. No scan-level limit (it would drop
+            // rows before delete filtering); DataFusion enforces LIMIT above.
+            let target_partitions = state.config().target_partitions();
+            let (file_groups, partition_starts) =
+                self.build_row_group_partitions(&table_file.file, &file_cfg, target_partitions)?;
 
-        let mut builder = FileScanConfigBuilder::new(
-            self.object_store_url.as_ref().clone(),
-            Arc::new(self.create_parquet_source(file_cfg.read_schema.clone())),
-        )
-        .with_limit(limit)
-        .with_file_group(FileGroup::new(vec![pf]));
-        builder = builder.with_projection_indices(Some(parquet_projection))?;
+            let source = PositionalFileSource::wrap(Arc::new(
+                self.create_parquet_source(file_cfg.read_schema.clone()),
+            ));
+            let mut builder =
+                FileScanConfigBuilder::new(self.object_store_url.as_ref().clone(), source)
+                    .with_file_groups(file_groups);
+            builder = builder.with_projection_indices(Some(parquet_projection))?;
+            let scan = DataSourceExec::from_data_source(builder.build());
 
-        let parquet_exec: Arc<dyn ExecutionPlan> =
-            DataSourceExec::from_data_source(builder.build());
-
-        // Synthesize rowid only when the file doesn't already supply it.
-        let after_rowid: Arc<dyn ExecutionPlan> = if has_embedded {
-            parquet_exec
+            // Materialize the physical position, then (optionally) filter deletes
+            // by it, then (for non-embedded files) synthesize rowid from it.
+            let mut plan: Arc<dyn ExecutionPlan> =
+                Arc::new(FileRowNumberExec::new(scan, partition_starts));
+            if let Some(p) = deleted_positions {
+                plan = Arc::new(DeleteFilterExec::try_new(
+                    plan,
+                    table_file.file.path.clone(),
+                    Arc::new(p),
+                )?);
+            }
+            if !has_embedded {
+                plan = Arc::new(RowIdExec::try_new(plan, table_file.row_id_start)?);
+            }
+            plan
         } else {
-            Arc::new(RowIdExec::new_at(
-                parquet_exec,
-                table_file.row_id_start,
-                rowid_insert_pos,
-            ))
+            // Embedded rowid, no deletes: legacy plain scan (cardinality-
+            // preserving). Keep scan-level limit and reader pruning.
+            let resolved_path = self.resolve_file_path(&table_file.file)?;
+            let mut pf = PartitionedFile::new(
+                &resolved_path,
+                validated_file_size(table_file.file.file_size_bytes, &resolved_path)?,
+            );
+            if let Some(footer_size) = table_file.file.footer_size
+                && footer_size > 0
+                && let Ok(hint) = usize::try_from(footer_size)
+            {
+                pf = pf.with_metadata_size_hint(hint);
+            }
+            let mut builder = FileScanConfigBuilder::new(
+                self.object_store_url.as_ref().clone(),
+                Arc::new(self.create_parquet_source(file_cfg.read_schema.clone())),
+            )
+            .with_limit(limit)
+            .with_file_group(FileGroup::new(vec![pf]));
+            builder = builder.with_projection_indices(Some(parquet_projection))?;
+            DataSourceExec::from_data_source(builder.build())
         };
-
-        // Apply delete filter if needed. DeleteFilterExec tracks file
-        // position, which is preserved through both RowIdExec and an embedded
-        // rowid projection (both leave row order untouched).
-        let after_deletes: Arc<dyn ExecutionPlan> =
-            if let Some(ref delete_file) = table_file.delete_file {
-                let deleted_positions = self.read_delete_file_positions(state, delete_file).await?;
-                if !deleted_positions.is_empty() {
-                    Arc::new(DeleteFilterExec::new(
-                        after_rowid,
-                        table_file.file.path.clone(),
-                        Arc::new(deleted_positions),
-                    ))
-                } else {
-                    after_rowid
-                }
-            } else {
-                after_rowid
-            };
 
         // Wrap with ColumnRenameExec to present the catalog schema. Required when
         // a physical column was renamed in the catalog, when the embedded rowid

--- a/tests/rowid_physical_position_tests.rs
+++ b/tests/rowid_physical_position_tests.rs
@@ -1,0 +1,461 @@
+#![cfg(feature = "metadata-duckdb")]
+//! Regression tests for row-id lineage & delete filtering using TRUE physical
+//! file position (not stream arrival order).
+//!
+//! These tests use files large enough that DataFusion splits the scan across
+//! multiple byte-range partitions — the condition under which the legacy
+//! arrival-order counters in `RowIdExec` / `DeleteFilterExec` produce wrong
+//! answers. They are the gate for the physical-position fix; several FAIL on
+//! the pre-fix code (documented per-test).
+//!
+//! See docs/rowid-lineage-physical-position-plan.md.
+
+mod common;
+
+use std::path::Path;
+use std::sync::Arc;
+
+use arrow::array::{Array, Int32Array, Int64Array};
+use datafusion::config::ConfigOptions;
+use datafusion::error::Result as DataFusionResult;
+use datafusion::prelude::*;
+use datafusion_ducklake::{DuckLakeCatalog, DuckdbMetadataProvider};
+use tempfile::TempDir;
+
+/// Rows-per-file large enough to span several Parquet row groups (DuckDB's
+/// default row-group size is 122_880).
+const BIG: i64 = 600_000;
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+fn open(catalog_path: &Path) -> anyhow::Result<duckdb::Connection> {
+    let conn = duckdb::Connection::open_in_memory()?;
+    conn.execute("INSTALL ducklake;", [])?;
+    conn.execute("INSTALL parquet;", [])?;
+    conn.execute("LOAD ducklake;", [])?;
+    conn.execute(
+        &format!("ATTACH 'ducklake:{}' AS c;", catalog_path.display()),
+        [],
+    )?;
+    Ok(conn)
+}
+
+fn catalog(path: &str, lineage: bool) -> DataFusionResult<Arc<DuckLakeCatalog>> {
+    let provider = DuckdbMetadataProvider::new(path)
+        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    Ok(Arc::new(
+        DuckLakeCatalog::new(provider)
+            .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?
+            .with_row_lineage(lineage),
+    ))
+}
+
+/// SessionContext that aggressively splits single files into multiple scan
+/// partitions — the configuration that exposes the arrival-order bug.
+fn split_ctx() -> SessionContext {
+    let mut cfg = ConfigOptions::new();
+    cfg.execution.target_partitions = 8;
+    cfg.optimizer.repartition_file_scans = true;
+    cfg.optimizer.repartition_file_min_size = 1;
+    SessionContext::new_with_config(SessionConfig::from(cfg))
+}
+
+fn temp() -> DataFusionResult<TempDir> {
+    TempDir::new().map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))
+}
+
+// ---------------------------------------------------------------------------
+// 1. rowid == i over a large single file (FAILS pre-fix)
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn rowid_matches_physical_position_on_split_file() -> DataFusionResult<()> {
+    let temp = temp()?;
+    let path = temp.path().join("rowid_big.ducklake");
+    {
+        let conn = open(&path).map_err(common::to_datafusion_error)?;
+        conn.execute("CREATE TABLE c.t(i INTEGER);", [])
+            .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+        // Single INSERT => one data file => row_id_start = 0 => rowid must equal i.
+        conn.execute(
+            &format!("INSERT INTO c.t SELECT i FROM range(0, {BIG}) t(i);"),
+            [],
+        )
+        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    }
+
+    let ctx = split_ctx();
+    ctx.register_catalog("c", catalog(&path.to_string_lossy(), true)?);
+
+    let batches = ctx
+        .sql("SELECT rowid, i FROM c.main.t")
+        .await?
+        .collect()
+        .await?;
+    let mut total = 0usize;
+    let mut mismatches = 0usize;
+    for b in &batches {
+        let rid = b.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+        let v = b.column(1).as_any().downcast_ref::<Int32Array>().unwrap();
+        for r in 0..b.num_rows() {
+            total += 1;
+            if rid.value(r) != v.value(r) as i64 {
+                mismatches += 1;
+            }
+        }
+    }
+    assert_eq!(total, BIG as usize, "row count");
+    assert_eq!(mismatches, 0, "{mismatches}/{total} rows have rowid != i");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 2. deleted physical positions are absent over a large file (FAILS pre-fix)
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn deletes_apply_to_correct_physical_rows_on_split_file() -> DataFusionResult<()> {
+    let temp = temp()?;
+    let path = temp.path().join("del_big.ducklake");
+    let (lo, hi) = (245_760i64, 245_770i64); // a block inside a non-first row group
+    {
+        let conn = open(&path).map_err(common::to_datafusion_error)?;
+        for s in [
+            "CREATE TABLE c.t(i INTEGER);".to_string(),
+            format!("INSERT INTO c.t SELECT i FROM range(0, {BIG}) t(i);"),
+            format!("DELETE FROM c.t WHERE i >= {lo} AND i < {hi};"),
+        ] {
+            conn.execute(&s, [])
+                .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+        }
+    }
+
+    let ctx = split_ctx();
+    ctx.register_catalog("c", catalog(&path.to_string_lossy(), false)?);
+
+    let batches = ctx.sql("SELECT i FROM c.main.t").await?.collect().await?;
+    let mut total = 0usize;
+    let mut survived_deleted = 0usize;
+    for b in &batches {
+        let v = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        for r in 0..b.num_rows() {
+            total += 1;
+            let x = v.value(r) as i64;
+            if x >= lo && x < hi {
+                survived_deleted += 1;
+            }
+        }
+    }
+    assert_eq!(
+        survived_deleted, 0,
+        "deleted rows [{lo},{hi}) must not appear"
+    );
+    assert_eq!(total, (BIG - (hi - lo)) as usize, "row count after delete");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 3. rowid + deletes together on a split file (FAILS pre-fix)
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn rowid_and_deletes_together_on_split_file() -> DataFusionResult<()> {
+    let temp = temp()?;
+    let path = temp.path().join("rid_del.ducklake");
+    let (lo, hi) = (300_000i64, 300_005i64);
+    {
+        let conn = open(&path).map_err(common::to_datafusion_error)?;
+        for s in [
+            "CREATE TABLE c.t(i INTEGER);".to_string(),
+            format!("INSERT INTO c.t SELECT i FROM range(0, {BIG}) t(i);"),
+            format!("DELETE FROM c.t WHERE i >= {lo} AND i < {hi};"),
+        ] {
+            conn.execute(&s, [])
+                .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+        }
+    }
+
+    let ctx = split_ctx();
+    ctx.register_catalog("c", catalog(&path.to_string_lossy(), true)?);
+
+    let batches = ctx
+        .sql("SELECT rowid, i FROM c.main.t")
+        .await?
+        .collect()
+        .await?;
+    for b in &batches {
+        let rid = b.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+        let v = b.column(1).as_any().downcast_ref::<Int32Array>().unwrap();
+        for r in 0..b.num_rows() {
+            assert_eq!(rid.value(r), v.value(r) as i64, "rowid must equal i");
+            let x = v.value(r) as i64;
+            assert!(!(x >= lo && x < hi), "deleted row {x} must not appear");
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 4. filtered rowid query keeps correct rowids (guard for piece D)
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn filtered_rowid_query_keeps_correct_rowids() -> DataFusionResult<()> {
+    let temp = temp()?;
+    let path = temp.path().join("filt.ducklake");
+    {
+        let conn = open(&path).map_err(common::to_datafusion_error)?;
+        conn.execute("CREATE TABLE c.t(i INTEGER);", [])
+            .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+        conn.execute(
+            &format!("INSERT INTO c.t SELECT i FROM range(0, {BIG}) t(i);"),
+            [],
+        )
+        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    }
+
+    let ctx = split_ctx();
+    ctx.register_catalog("c", catalog(&path.to_string_lossy(), true)?);
+
+    let batches = ctx
+        .sql("SELECT rowid, i FROM c.main.t WHERE i >= 590000")
+        .await?
+        .collect()
+        .await?;
+    let mut total = 0usize;
+    for b in &batches {
+        let rid = b.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+        let v = b.column(1).as_any().downcast_ref::<Int32Array>().unwrap();
+        for r in 0..b.num_rows() {
+            total += 1;
+            assert!(v.value(r) >= 590000, "filter must hold");
+            assert_eq!(rid.value(r), v.value(r) as i64, "rowid must equal i");
+        }
+    }
+    assert_eq!(total, (BIG - 590000) as usize);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 5. ORDER BY on a positional path must not corrupt rowids
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn order_by_does_not_corrupt_rowids() -> DataFusionResult<()> {
+    let temp = temp()?;
+    let path = temp.path().join("ord.ducklake");
+    {
+        let conn = open(&path).map_err(common::to_datafusion_error)?;
+        conn.execute("CREATE TABLE c.t(i INTEGER);", [])
+            .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+        conn.execute(
+            &format!("INSERT INTO c.t SELECT i FROM range(0, {BIG}) t(i);"),
+            [],
+        )
+        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    }
+
+    let ctx = split_ctx();
+    ctx.register_catalog("c", catalog(&path.to_string_lossy(), true)?);
+
+    let batches = ctx
+        .sql("SELECT rowid, i FROM c.main.t ORDER BY i DESC LIMIT 5")
+        .await?
+        .collect()
+        .await?;
+    for b in &batches {
+        let rid = b.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+        let v = b.column(1).as_any().downcast_ref::<Int32Array>().unwrap();
+        for r in 0..b.num_rows() {
+            assert_eq!(
+                rid.value(r),
+                v.value(r) as i64,
+                "rowid must equal i after ORDER BY"
+            );
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 6. LIMIT over a file whose first physical row is deleted (FAILS pre-fix)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn limit_after_delete_returns_survivor_not_zero() -> DataFusionResult<()> {
+    let temp = temp()?;
+    let path = temp.path().join("lim.ducklake");
+    {
+        let conn = open(&path).map_err(common::to_datafusion_error)?;
+        for s in [
+            "CREATE TABLE c.t(i INTEGER);",
+            "INSERT INTO c.t SELECT i FROM range(0, 10) t(i);",
+            "DELETE FROM c.t WHERE i = 0;", // delete the FIRST physical row
+        ] {
+            conn.execute(s, [])
+                .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+        }
+    }
+
+    let ctx = SessionContext::new();
+    ctx.register_catalog("c", catalog(&path.to_string_lossy(), false)?);
+
+    let batches = ctx
+        .sql("SELECT i FROM c.main.t LIMIT 1")
+        .await?
+        .collect()
+        .await?;
+    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(rows, 1, "LIMIT 1 must return one survivor, not {rows}");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 7. COUNT(*) with deletes on a split file preserves the count
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn count_star_with_deletes_on_split_file() -> DataFusionResult<()> {
+    let temp = temp()?;
+    let path = temp.path().join("cnt.ducklake");
+    let deleted = 7i64;
+    {
+        let conn = open(&path).map_err(common::to_datafusion_error)?;
+        for s in [
+            "CREATE TABLE c.t(i INTEGER);".to_string(),
+            format!("INSERT INTO c.t SELECT i FROM range(0, {BIG}) t(i);"),
+            format!("DELETE FROM c.t WHERE i < {deleted};"),
+        ] {
+            conn.execute(&s, [])
+                .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+        }
+    }
+
+    let ctx = split_ctx();
+    ctx.register_catalog("c", catalog(&path.to_string_lossy(), false)?);
+
+    let batches = ctx
+        .sql("SELECT COUNT(*) FROM c.main.t")
+        .await?
+        .collect()
+        .await?;
+    let cnt = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap()
+        .value(0);
+    assert_eq!(cnt, BIG - deleted, "COUNT(*) must reflect deletes");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 8b. plan-shape invariant: nothing drops/reorders/re-splits rows below
+//     FileRowNumberExec on a positional path.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn positional_plan_shape_is_safe() -> DataFusionResult<()> {
+    let temp = temp()?;
+    let path = temp.path().join("plan.ducklake");
+    {
+        let conn = open(&path).map_err(common::to_datafusion_error)?;
+        conn.execute("CREATE TABLE c.t(i INTEGER);", [])
+            .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+        conn.execute(
+            &format!("INSERT INTO c.t SELECT i FROM range(0, {BIG}) t(i);"),
+            [],
+        )
+        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    }
+
+    let ctx = split_ctx();
+    ctx.register_catalog("c", catalog(&path.to_string_lossy(), true)?);
+
+    let mut plan = String::new();
+    for b in ctx
+        .sql("EXPLAIN SELECT rowid, i FROM c.main.t")
+        .await?
+        .collect()
+        .await?
+    {
+        if let Some(c) = b
+            .column(1)
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+        {
+            for r in 0..b.num_rows() {
+                plan.push_str(c.value(r));
+                plan.push('\n');
+            }
+        }
+    }
+
+    let lines: Vec<&str> = plan.lines().collect();
+    let frn = lines
+        .iter()
+        .position(|l| l.contains("FileRowNumberExec"))
+        .unwrap_or_else(|| panic!("plan has no FileRowNumberExec:\n{plan}"));
+
+    // The file was split into multiple row-group-aligned partitions (parallel).
+    assert!(
+        plan.contains(" groups:"),
+        "scan should be split into >1 group:\n{plan}"
+    );
+
+    // CRITICAL invariant: the scan is *directly* below FileRowNumberExec — nothing
+    // reshuffles, coalesces, or re-splits rows between them (which would break the
+    // per-partition seed). A RepartitionExec ABOVE FileRowNumberExec is fine: the
+    // position is already materialized into the data and travels with each row.
+    assert!(
+        lines
+            .get(frn + 1)
+            .is_some_and(|l| l.contains("DataSourceExec")),
+        "DataSourceExec must be the direct child of FileRowNumberExec:\n{plan}"
+    );
+
+    // No reader-side predicate (would prune rows before position synthesis).
+    assert!(
+        !plan.contains("predicate="),
+        "no reader predicate on positional scan:\n{plan}"
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 8. single-row-group small file stays correct (regression for small files)
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn small_single_row_group_file_unchanged() -> DataFusionResult<()> {
+    let temp = temp()?;
+    let path = temp.path().join("small.ducklake");
+    {
+        let conn = open(&path).map_err(common::to_datafusion_error)?;
+        conn.execute("CREATE TABLE c.t(i INTEGER);", [])
+            .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+        conn.execute("INSERT INTO c.t SELECT i FROM range(0, 5) t(i);", [])
+            .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    }
+
+    let ctx = split_ctx();
+    ctx.register_catalog("c", catalog(&path.to_string_lossy(), true)?);
+
+    let batches = ctx
+        .sql("SELECT rowid, i FROM c.main.t ORDER BY rowid")
+        .await?
+        .collect()
+        .await?;
+    let mut pairs = Vec::new();
+    for b in &batches {
+        let rid = b.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+        let v = b.column(1).as_any().downcast_ref::<Int32Array>().unwrap();
+        for r in 0..b.num_rows() {
+            pairs.push((rid.value(r), v.value(r)));
+        }
+    }
+    assert_eq!(pairs, vec![(0, 0), (1, 1), (2, 2), (3, 3), (4, 4)]);
+    Ok(())
+}


### PR DESCRIPTION
## Problem

Row lineage (`rowid`) and positional deletes both reconstruct a row's **physical file position** with a per-stream counter — `RowIdExec`'s `cursor` and `DeleteFilterExec`'s `row_offset`. That only works when a file is read as a single in-order stream.

When DataFusion splits one Parquet file into multiple byte-range scan partitions (default for files past the repartition threshold):

- `RowIdExec` required `SinglePartition`, which forced an **unordered** `CoalescePartitionsExec` — rowids paired with the wrong rows.
- `DeleteFilterExec` ran once **per split partition** with its counter reset to 0 — deletes applied to the wrong rows (deleted rows reappear in `SELECT`).

Reproduced deterministically on a 600k-row file (`target_partitions=8`): e.g. `(rowid=0, i=245760)`, and `DELETE` leaving deleted rows visible.

A **third, independent** bug surfaced during review: scan-level `LIMIT` was applied *before* `DeleteFilterExec`, so `LIMIT 1` over a file whose leading rows are deleted returned 0 rows. This reproduces even on a tiny single-row-group file.

The existing `SinglePartition` guard didn't help — it guarded the wrong mechanism (a round-robin `RepartitionExec`) and, against a self-splitting source, *caused* the unordered coalesce. The tests only used 3–5 row files (never split), so CI stayed green.

## Fix

Match DuckDB/DuckLake semantics (`rowid = row_id_start + file_row_number`): derive the true physical position from the file's **row-group layout** and carry it as a data column, so partition/merge order no longer matters.

- **`FileReadConfig`** — per-row-group start positions, read from the footer already opened.
- **`build_row_group_partitions`** — one `FileGroup` per contiguous row-group run (`ParquetAccessPlan` Scan/Skip), each with a known starting physical row.
- **`PositionalFileSource`** (new) — wraps `ParquetSource`, refusing repartition / filter pushdown / sort-reverse (which would drop, prune, or reorder rows); re-wraps order-safe methods.
- **`FileRowNumberExec`** (new) — materializes `__ducklake_row_pos`, seeded per partition; `benefits_from_input_partitioning=false` so no round-robin `RepartitionExec` is inserted below it.
- **`RowIdExec` / `DeleteFilterExec`** — rewritten as stateless column readers (`rowid = row_id_start + pos`; filter where `pos ∈ deletes`).
- **`ColumnRenameExec`** — drops the internal position column by name; preserves row count for zero-output-column batches (COUNT(*)).
- Positional paths no longer push scan-level `LIMIT`; DataFusion enforces it above the table plan.

### Tradeoff (deliberate)
Reader-side row-group/page/bloom pruning is disabled on positional paths (rowid-projected queries and scans of files with deletes); the filter is reapplied above the scan. Cross-file and intra-file row-group parallelism are preserved. Upstream `file_row_number` (apache/datafusion#20135) is the future path to recover pruning. Design doc: `docs/rowid-lineage-physical-position-plan.md`.

## Tests

New `tests/rowid_physical_position_tests.rs` (all fail on pre-fix code): large split-file rowid (`rowid==i`), deletes, rowid+deletes, filtered rowid, `ORDER BY`, `LIMIT` after delete, `COUNT(*)` with deletes, single-row-group regression, and a plan-shape assertion (scan directly under `FileRowNumberExec`, no reader predicate).

Full suite: **273 passed, 0 failed**. `clippy -D warnings` and `fmt` clean.