### PR TITLE
feat(metadata): add get_table_row_count respecting delete files

### DIFF
--- a/src/metadata_provider.rs
+++ b/src/metadata_provider.rs
@@ -493,6 +493,11 @@ pub struct DuckLakeTableFile {
     /// Total rows in this file (`record_count` from the catalog), before any
     /// delete files are applied. Used for synthetic `rowid` generation.
     pub max_row_count: Option<i64>,
+    /// Number of rows removed by the associated `delete_file` visible at the
+    /// queried snapshot (`delete_count` from `ducklake_delete_file`). `None`
+    /// when there is no visible delete file. Net live rows for this file are
+    /// `max_row_count - delete_count`.
+    pub delete_count: Option<i64>,
 }
 
 impl DuckLakeTableFile {
@@ -503,6 +508,7 @@ impl DuckLakeTableFile {
             row_id_start: None,
             snapshot_id: None,
             max_row_count: None,
+            delete_count: None,
         }
     }
 }
@@ -572,6 +578,27 @@ pub trait MetadataProvider: Send + Sync + std::fmt::Debug {
         snapshot_id: i64,
     ) -> Result<Vec<DuckLakeTableFile>>;
     //     todo: support select with file pruning
+
+    /// Net number of live rows in a table at a snapshot, accounting for delete
+    /// files: `SUM(record_count) - SUM(delete_count)` over the files visible at
+    /// `snapshot_id`. This matches a `SELECT COUNT(*)` against the table at that
+    /// snapshot without scanning any data — the counts come from catalog
+    /// metadata.
+    ///
+    /// The default implementation derives the count from
+    /// [`get_table_files_for_select`](Self::get_table_files_for_select), so it
+    /// is computed from exactly the file set a scan would read and stays correct
+    /// across deletes, replacements, and compaction. A file whose
+    /// `max_row_count` is unset (foreign catalogs that omit `record_count`)
+    /// contributes 0 and cannot be counted from metadata alone.
+    fn get_table_row_count(&self, table_id: i64, snapshot_id: i64) -> Result<u64> {
+        let files = self.get_table_files_for_select(table_id, snapshot_id)?;
+        let net: i64 = files
+            .iter()
+            .map(|f| f.max_row_count.unwrap_or(0) - f.delete_count.unwrap_or(0))
+            .sum();
+        Ok(net.max(0) as u64)
+    }
 
     // Dynamic lookup methods for on-demand metadata retrieval
 

--- a/src/metadata_provider_duckdb.rs
+++ b/src/metadata_provider_duckdb.rs
@@ -193,19 +193,21 @@ impl MetadataProvider for DuckdbMetadataProvider {
                     let record_count: Option<i64> = row.get(7)?;
 
                     // Parse delete file (columns 8-14) if exists
-                    let delete_file = if let Ok(Some(_)) = row.get::<_, Option<i64>>(8) {
-                        Some(DuckLakeFileData {
-                            path: row.get(9)?,
-                            path_is_relative: row.get(10)?,
-                            file_size_bytes: row.get(11)?,
-                            footer_size: row.get(12)?,
-                            encryption_key: row.get(13)?,
-                        })
-                    } else {
-                        None
-                    };
-
-                    let _delete_count: Option<i64> = row.get(14)?;
+                    let (delete_file, delete_count) =
+                        if let Ok(Some(_)) = row.get::<_, Option<i64>>(8) {
+                            (
+                                Some(DuckLakeFileData {
+                                    path: row.get(9)?,
+                                    path_is_relative: row.get(10)?,
+                                    file_size_bytes: row.get(11)?,
+                                    footer_size: row.get(12)?,
+                                    encryption_key: row.get(13)?,
+                                }),
+                                row.get(14)?,
+                            )
+                        } else {
+                            (None, None)
+                        };
 
                     Ok(DuckLakeTableFile {
                         file: data_file,
@@ -213,6 +215,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
                         row_id_start,
                         snapshot_id: Some(snapshot_id),
                         max_row_count: record_count,
+                        delete_count,
                     })
                 },
             )?
@@ -397,6 +400,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
                             row_id_start: None,
                             snapshot_id: None,
                             max_row_count,
+                            delete_count: None,
                         },
                     })
                 },

--- a/src/metadata_provider_mysql.rs
+++ b/src/metadata_provider_mysql.rs
@@ -223,16 +223,20 @@ impl MetadataProvider for MySqlMetadataProvider {
                     let row_id_start: Option<i64> = row.try_get(6)?;
                     let record_count: Option<i64> = row.try_get(7)?;
 
-                    let delete_file = if row.try_get::<Option<i64>, _>(8)?.is_some() {
-                        Some(DuckLakeFileData {
-                            path: row.try_get(9)?,
-                            path_is_relative: row.try_get(10)?,
-                            file_size_bytes: row.try_get(11)?,
-                            footer_size: row.try_get(12)?,
-                            encryption_key: row.try_get(13)?,
-                        })
+                    let (delete_file, delete_count) = if row.try_get::<Option<i64>, _>(8)?.is_some()
+                    {
+                        (
+                            Some(DuckLakeFileData {
+                                path: row.try_get(9)?,
+                                path_is_relative: row.try_get(10)?,
+                                file_size_bytes: row.try_get(11)?,
+                                footer_size: row.try_get(12)?,
+                                encryption_key: row.try_get(13)?,
+                            }),
+                            row.try_get(14)?,
+                        )
                     } else {
-                        None
+                        (None, None)
                     };
 
                     Ok(DuckLakeTableFile {
@@ -241,6 +245,7 @@ impl MetadataProvider for MySqlMetadataProvider {
                         row_id_start,
                         snapshot_id: Some(snapshot_id),
                         max_row_count: record_count,
+                        delete_count,
                     })
                 })
                 .collect()
@@ -490,6 +495,7 @@ impl MetadataProvider for MySqlMetadataProvider {
                             row_id_start: None,
                             snapshot_id: None,
                             max_row_count: row.try_get(14)?,
+                            delete_count: None,
                         },
                     })
                 })

--- a/src/metadata_provider_postgres.rs
+++ b/src/metadata_provider_postgres.rs
@@ -257,16 +257,20 @@ impl MetadataProvider for PostgresMetadataProvider {
                     let row_id_start: Option<i64> = row.try_get(6)?;
                     let record_count: Option<i64> = row.try_get(7)?;
 
-                    let delete_file = if row.try_get::<Option<i64>, _>(8)?.is_some() {
-                        Some(DuckLakeFileData {
-                            path: row.try_get(9)?,
-                            path_is_relative: row.try_get(10)?,
-                            file_size_bytes: row.try_get(11)?,
-                            footer_size: row.try_get(12)?,
-                            encryption_key: row.try_get(13)?,
-                        })
+                    let (delete_file, delete_count) = if row.try_get::<Option<i64>, _>(8)?.is_some()
+                    {
+                        (
+                            Some(DuckLakeFileData {
+                                path: row.try_get(9)?,
+                                path_is_relative: row.try_get(10)?,
+                                file_size_bytes: row.try_get(11)?,
+                                footer_size: row.try_get(12)?,
+                                encryption_key: row.try_get(13)?,
+                            }),
+                            row.try_get(14)?,
+                        )
                     } else {
-                        None
+                        (None, None)
                     };
 
                     Ok(DuckLakeTableFile {
@@ -275,6 +279,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                         row_id_start,
                         snapshot_id: Some(snapshot_id),
                         max_row_count: record_count,
+                        delete_count,
                     })
                 })
                 .collect()
@@ -523,6 +528,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                             row_id_start: None,
                             snapshot_id: None,
                             max_row_count: row.try_get(14)?,
+                            delete_count: None,
                         },
                     })
                 })

--- a/src/metadata_provider_sqlite.rs
+++ b/src/metadata_provider_sqlite.rs
@@ -224,16 +224,20 @@ impl MetadataProvider for SqliteMetadataProvider {
                     let row_id_start: Option<i64> = row.try_get(6)?;
                     let record_count: Option<i64> = row.try_get(7)?;
 
-                    let delete_file = if row.try_get::<Option<i64>, _>(8)?.is_some() {
-                        Some(DuckLakeFileData {
-                            path: row.try_get(9)?,
-                            path_is_relative: row.try_get(10)?,
-                            file_size_bytes: row.try_get(11)?,
-                            footer_size: row.try_get(12)?,
-                            encryption_key: row.try_get(13)?,
-                        })
+                    let (delete_file, delete_count) = if row.try_get::<Option<i64>, _>(8)?.is_some()
+                    {
+                        (
+                            Some(DuckLakeFileData {
+                                path: row.try_get(9)?,
+                                path_is_relative: row.try_get(10)?,
+                                file_size_bytes: row.try_get(11)?,
+                                footer_size: row.try_get(12)?,
+                                encryption_key: row.try_get(13)?,
+                            }),
+                            row.try_get(14)?,
+                        )
                     } else {
-                        None
+                        (None, None)
                     };
 
                     Ok(DuckLakeTableFile {
@@ -242,6 +246,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                         row_id_start,
                         snapshot_id: Some(snapshot_id),
                         max_row_count: record_count,
+                        delete_count,
                     })
                 })
                 .collect()
@@ -489,6 +494,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                             row_id_start: None,
                             snapshot_id: None,
                             max_row_count: row.try_get(14)?,
+                            delete_count: None,
                         },
                     })
                 })

--- a/src/multicatalog_provider.rs
+++ b/src/multicatalog_provider.rs
@@ -286,16 +286,20 @@ impl MetadataProvider for MulticatalogProvider {
                     let row_id_start: Option<i64> = row.try_get(6)?;
                     let record_count: Option<i64> = row.try_get(7)?;
 
-                    let delete_file = if row.try_get::<Option<i64>, _>(8)?.is_some() {
-                        Some(DuckLakeFileData {
-                            path: row.try_get(9)?,
-                            path_is_relative: row.try_get(10)?,
-                            file_size_bytes: row.try_get(11)?,
-                            footer_size: row.try_get(12)?,
-                            encryption_key: row.try_get(13)?,
-                        })
+                    let (delete_file, delete_count) = if row.try_get::<Option<i64>, _>(8)?.is_some()
+                    {
+                        (
+                            Some(DuckLakeFileData {
+                                path: row.try_get(9)?,
+                                path_is_relative: row.try_get(10)?,
+                                file_size_bytes: row.try_get(11)?,
+                                footer_size: row.try_get(12)?,
+                                encryption_key: row.try_get(13)?,
+                            }),
+                            row.try_get(14)?,
+                        )
                     } else {
-                        None
+                        (None, None)
                     };
 
                     Ok(DuckLakeTableFile {
@@ -304,6 +308,7 @@ impl MetadataProvider for MulticatalogProvider {
                         row_id_start,
                         snapshot_id: Some(snapshot_id),
                         max_row_count: record_count,
+                        delete_count,
                     })
                 })
                 .collect()
@@ -573,6 +578,7 @@ impl MetadataProvider for MulticatalogProvider {
                             row_id_start: None,
                             snapshot_id: None,
                             max_row_count: row.try_get(14)?,
+                            delete_count: None,
                         },
                     })
                 })

--- a/tests/row_count_tests.rs
+++ b/tests/row_count_tests.rs
@@ -1,0 +1,143 @@
+#![cfg(feature = "metadata-duckdb")]
+//! Integration tests for `MetadataProvider::get_table_row_count`.
+//!
+//! The metadata-only row count (`SUM(record_count) - SUM(delete_count)` over
+//! the files visible at a snapshot) is cross-checked against two independent
+//! ground truths for every catalog shape:
+//!
+//! 1. DuckDB/DuckLake's own `SELECT COUNT(*)` (run through a `duckdb`
+//!    connection against the same catalog) — the upstream answer.
+//! 2. DataFusion's `SELECT COUNT(*)` through this crate's delete-filtering scan.
+//!
+//! Shapes covered include merge-on-read updates, a truncate-then-reinsert
+//! sequence (rewritten/superseded data files), and an all-deleted table — the
+//! cases where naively summing physical `record_count` would overcount.
+
+mod common;
+
+use std::path::Path;
+use std::sync::Arc;
+
+use arrow::array::Int64Array;
+use datafusion::error::Result as DataFusionResult;
+use datafusion::prelude::*;
+use datafusion_ducklake::{DuckLakeCatalog, DuckdbMetadataProvider, MetadataProvider};
+use tempfile::TempDir;
+
+fn to_df<E: std::error::Error + Send + Sync + 'static>(e: E) -> datafusion::error::DataFusionError {
+    datafusion::error::DataFusionError::External(Box::new(e))
+}
+
+/// Resolve `(table_id, snapshot)` for `main.<table>` at the catalog head.
+fn resolve_table(provider: &DuckdbMetadataProvider, table: &str) -> DataFusionResult<(i64, i64)> {
+    let snapshot = provider.get_current_snapshot().map_err(to_df)?;
+    let schema = provider
+        .get_schema_by_name("main", snapshot)
+        .map_err(to_df)?
+        .expect("schema 'main' should exist");
+    let table_meta = provider
+        .get_table_by_name(schema.schema_id, table, snapshot)
+        .map_err(to_df)?
+        .unwrap_or_else(|| panic!("table '{table}' should exist"));
+    Ok((table_meta.table_id, snapshot))
+}
+
+/// Upstream ground truth: `SELECT COUNT(*)` via DuckDB's own DuckLake reader.
+fn duckdb_count_star(catalog_path: &Path, table: &str) -> DataFusionResult<i64> {
+    let conn = duckdb::Connection::open_in_memory().map_err(to_df)?;
+    conn.execute("INSTALL ducklake;", []).map_err(to_df)?;
+    conn.execute("LOAD ducklake;", []).map_err(to_df)?;
+    conn.execute(
+        &format!("ATTACH 'ducklake:{}' AS c;", catalog_path.display()),
+        [],
+    )
+    .map_err(to_df)?;
+    conn.query_row(&format!("SELECT COUNT(*) FROM c.main.{table}"), [], |r| {
+        r.get::<_, i64>(0)
+    })
+    .map_err(to_df)
+}
+
+/// `SELECT COUNT(*)` through this crate's DataFusion scan.
+async fn datafusion_count_star(catalog_path: &str, table: &str) -> DataFusionResult<i64> {
+    let provider = DuckdbMetadataProvider::new(catalog_path).map_err(to_df)?;
+    let lake = DuckLakeCatalog::new(provider).map_err(to_df)?;
+    let ctx = SessionContext::new();
+    ctx.register_catalog("c", Arc::new(lake));
+    let batches = ctx
+        .sql(&format!("SELECT COUNT(*) FROM c.main.{table}"))
+        .await?
+        .collect()
+        .await?;
+    Ok(batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .expect("COUNT(*) is Int64")
+        .value(0))
+}
+
+/// For one catalog shape, assert the metadata count equals DuckLake's own
+/// COUNT(*), this crate's COUNT(*), and the expected value.
+async fn assert_counts_agree(
+    create: fn(&Path) -> anyhow::Result<()>,
+    table: &str,
+    expected: u64,
+) -> DataFusionResult<()> {
+    let temp_dir = TempDir::new().map_err(to_df)?;
+    let catalog_path = temp_dir.path().join(format!("{table}.ducklake"));
+    create(&catalog_path).map_err(common::to_datafusion_error)?;
+    let path = catalog_path.to_string_lossy().to_string();
+
+    let provider = DuckdbMetadataProvider::new(&path).map_err(to_df)?;
+    let (table_id, snapshot) = resolve_table(&provider, table)?;
+    let metadata_count = provider
+        .get_table_row_count(table_id, snapshot)
+        .map_err(to_df)?;
+
+    let upstream = duckdb_count_star(&catalog_path, table)?;
+    let datafusion = datafusion_count_star(&path, table).await?;
+
+    assert_eq!(
+        metadata_count, expected,
+        "metadata row count for '{table}' should be {expected}"
+    );
+    assert_eq!(
+        metadata_count as i64, upstream,
+        "metadata count must match DuckLake's own COUNT(*) for '{table}'"
+    );
+    assert_eq!(
+        metadata_count as i64, datafusion,
+        "metadata count must match DataFusion COUNT(*) for '{table}'"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_row_count_no_deletes() -> DataFusionResult<()> {
+    assert_counts_agree(common::create_catalog_no_deletes, "users", 4).await
+}
+
+#[tokio::test]
+async fn test_row_count_with_deletes() -> DataFusionResult<()> {
+    // 5 inserted - 2 deleted = 3 (physical SUM(record_count) would be 5).
+    assert_counts_agree(common::create_catalog_with_deletes, "products", 3).await
+}
+
+#[tokio::test]
+async fn test_row_count_merge_on_read_updates() -> DataFusionResult<()> {
+    // 3 rows, 2 updated: new versions written + old versions delete-marked,
+    // net still 3.
+    assert_counts_agree(common::create_catalog_with_updates, "inventory", 3).await
+}
+
+#[tokio::test]
+async fn test_row_count_truncate_then_reinsert() -> DataFusionResult<()> {
+    // insert(1,2,3) -> delete all -> insert(4,5,6,7) -> delete(5,6): net {4,7}.
+    assert_counts_agree(common::create_catalog_complex_deletions, "items", 2).await
+}
+
+#[tokio::test]
+async fn test_row_count_all_deleted() -> DataFusionResult<()> {
+    assert_counts_agree(common::create_catalog_empty_table, "tbl", 0).await
+}


### PR DESCRIPTION
## Summary

Adds `MetadataProvider::get_table_row_count(table_id, snapshot)`, returning the net live-row count for a table at a snapshot as `SUM(record_count) - SUM(delete_count)` over the files visible at that snapshot.

Previously the only ways to get a row count were to scan the table (`SELECT COUNT(*)`) or to sum `record_count` from the catalog directly. The latter overcounts whenever a snapshot has delete files, since it ignores deleted rows. This computes the correct net count from catalog metadata alone, with no data scan — mirroring DuckLake's own metadata cardinality formula.

## Approach

The default trait implementation derives the count from `get_table_files_for_select`, so it is computed from exactly the file set a scan would read and stays correct across deletes, merge-on-read updates, and rewritten/compacted files.

Every backend's `get_table_files_for_select` query already selected the delete file's `delete_count`, but discarded it. This surfaces it on `DuckLakeTableFile` so the count can subtract it (DuckDB previously bound it to `_delete_count`).

## Tests

`tests/row_count_tests.rs` cross-checks the metadata count against two independent ground truths for each catalog shape:

1. DuckDB/DuckLake's own `SELECT COUNT(*)` (via a `duckdb` connection against the same catalog).
2. DataFusion's `SELECT COUNT(*)` through this crate's delete-filtering scan.

Shapes covered: no deletes, positional deletes, merge-on-read updates, a truncate-then-reinsert sequence (superseded data files), and an all-deleted table — the cases where naively summing physical `record_count` would overcount. All three counts agree in every case.