### PR TITLE
fix(types): map nanosecond tz timestamps to timestamptz_ns

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -50,6 +50,10 @@ pub fn ducklake_to_arrow_type(ducklake_type: &str) -> Result<DataType> {
             TimeUnit::Microsecond,
             Some("UTC".into()),
         )),
+        "timestamptz_ns" => Ok(DataType::Timestamp(
+            TimeUnit::Nanosecond,
+            Some("UTC".into()),
+        )),
         "timestamp_s" => Ok(DataType::Timestamp(TimeUnit::Second, None)),
         "timestamp_ms" => Ok(DataType::Timestamp(TimeUnit::Millisecond, None)),
         "timestamp_ns" => Ok(DataType::Timestamp(TimeUnit::Nanosecond, None)),
@@ -118,6 +122,13 @@ pub fn arrow_to_ducklake_type(arrow_type: &DataType) -> Result<String> {
         DataType::Timestamp(TimeUnit::Millisecond, None) => Ok("timestamp_ms".to_string()),
         DataType::Timestamp(TimeUnit::Microsecond, None) => Ok("timestamp".to_string()),
         DataType::Timestamp(TimeUnit::Nanosecond, None) => Ok("timestamp_ns".to_string()),
+        // Tz-aware timestamps. DuckLake distinguishes nanosecond precision
+        // (`timestamptz_ns` -> TIMESTAMP_TZ_NS) from microsecond (`timestamptz`
+        // -> TIMESTAMP_TZ); collapsing ns into `timestamptz` truncates the
+        // served value to µs on read while the physical parquet keeps ns. Second
+        // and millisecond tz timestamps have no DuckLake type, so they widen
+        // losslessly to µs `timestamptz`.
+        DataType::Timestamp(TimeUnit::Nanosecond, Some(_)) => Ok("timestamptz_ns".to_string()),
         DataType::Timestamp(_, Some(_)) => Ok("timestamptz".to_string()),
         DataType::Interval(_) => Ok("interval".to_string()),
 
@@ -630,6 +641,15 @@ mod tests {
             ducklake_to_arrow_type("timestamp").unwrap(),
             DataType::Timestamp(TimeUnit::Microsecond, None)
         );
+        assert_eq!(
+            ducklake_to_arrow_type("timestamptz").unwrap(),
+            DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()))
+        );
+        // Nanosecond tz-aware timestamps map to DuckLake's TIMESTAMP_TZ_NS.
+        assert_eq!(
+            ducklake_to_arrow_type("timestamptz_ns").unwrap(),
+            DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into()))
+        );
     }
 
     #[test]
@@ -795,6 +815,37 @@ mod tests {
             .unwrap(),
             "timestamptz"
         );
+        // Nanosecond tz-aware timestamps get their own DuckLake type rather than
+        // collapsing to µs `timestamptz` (which would silently truncate on read).
+        assert_eq!(
+            arrow_to_ducklake_type(&DataType::Timestamp(
+                TimeUnit::Nanosecond,
+                Some("UTC".into())
+            ))
+            .unwrap(),
+            "timestamptz_ns"
+        );
+        // A non-UTC zone label still selects the ns type by unit; the instant is
+        // UTC-normalised and the zone relabels to UTC on read (DuckLake stores an
+        // instant, not the zone name).
+        assert_eq!(
+            arrow_to_ducklake_type(&DataType::Timestamp(
+                TimeUnit::Nanosecond,
+                Some("America/New_York".into())
+            ))
+            .unwrap(),
+            "timestamptz_ns"
+        );
+        // Second/millisecond tz timestamps have no DuckLake type; they widen
+        // losslessly to µs `timestamptz`.
+        assert_eq!(
+            arrow_to_ducklake_type(&DataType::Timestamp(
+                TimeUnit::Millisecond,
+                Some("UTC".into())
+            ))
+            .unwrap(),
+            "timestamptz"
+        );
     }
 
     #[test]
@@ -834,6 +885,9 @@ mod tests {
             DataType::Binary,
             DataType::Date32,
             DataType::Timestamp(TimeUnit::Microsecond, None),
+            DataType::Timestamp(TimeUnit::Nanosecond, None),
+            DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+            DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
             DataType::Decimal128(10, 2),
             DataType::List(Arc::new(Field::new("item", DataType::Int32, true))),
             DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
@@ -844,6 +898,34 @@ mod tests {
             let back = ducklake_to_arrow_type(&ducklake).unwrap();
             assert_eq!(original, back, "Roundtrip failed for {:?}", original);
         }
+    }
+
+    /// Regression: a nanosecond tz-aware timestamp (the pandas/PyArrow default
+    /// for tz-aware datetimes) must not be cataloged as µs `timestamptz`. Doing
+    /// so left the physical parquet at ns while the catalog claimed µs, so the
+    /// read path silently truncated sub-microsecond precision on every scan.
+    #[test]
+    fn test_nanosecond_timestamptz_preserves_precision() {
+        let ns_tz = DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into()));
+
+        // Catalog type must encode nanosecond precision, not collapse to µs.
+        let ducklake = arrow_to_ducklake_type(&ns_tz).unwrap();
+        assert_eq!(ducklake, "timestamptz_ns");
+        assert_ne!(
+            ducklake, "timestamptz",
+            "ns tz-aware timestamp must not collapse to µs timestamptz"
+        );
+
+        // And the catalog type round-trips back to nanosecond precision, so the
+        // served schema matches the physical parquet and no ns->µs cast occurs.
+        let back = ducklake_to_arrow_type(&ducklake).unwrap();
+        assert_eq!(back, ns_tz);
+
+        // The two tz precisions stay distinct (not mutually promotable): changing
+        // a column's precision is not a safe widening.
+        assert!(!is_promotable("timestamptz", "timestamptz_ns"));
+        assert!(!is_promotable("timestamptz_ns", "timestamptz"));
+        assert!(!types_compatible("timestamptz", "timestamptz_ns"));
     }
 
     #[test]

--- a/tests/write_tests.rs
+++ b/tests/write_tests.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use arrow::array::{
     Array, BooleanArray, Date32Array, Float64Array, Int32Array, Int64Array, StringArray,
-    TimestampMicrosecondArray,
+    TimestampMicrosecondArray, TimestampNanosecondArray,
 };
 use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 use arrow::record_batch::RecordBatch;
@@ -990,4 +990,69 @@ async fn test_streaming_write_large_file_uses_multipart() {
         .value(0);
     assert_eq!(n, ROWS);
     assert_eq!(s, ROWS * (ROWS - 1) / 2);
+}
+
+/// End-to-end regression for nanosecond tz-aware timestamps.
+///
+/// A `Timestamp(Nanosecond, Some(tz))` column (the pandas/PyArrow default for
+/// tz-aware datetimes) used to be cataloged as µs `timestamptz`, so the served
+/// schema disagreed with the physical parquet and the read path silently
+/// truncated the sub-microsecond fraction on every scan. This writes ns values
+/// with non-zero sub-µs digits and asserts they survive the full
+/// write -> catalog -> read round-trip at full precision.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_write_and_read_nanosecond_timestamptz() {
+    let (writer, temp_dir) = create_test_env().await;
+    let object_store = create_object_store();
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new(
+            "event_ts",
+            DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
+            true,
+        ),
+    ]));
+
+    // Values with a non-zero sub-microsecond fraction: truncation to µs would
+    // zero the last three digits, so exact equality proves no precision loss.
+    let ns_values = vec![1_000_000_000_123_456_789i64, 1_700_000_000_987_654_321i64];
+    let ts_array = TimestampNanosecondArray::from(ns_values.clone()).with_timezone("UTC");
+
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![Arc::new(Int32Array::from(vec![1, 2])), Arc::new(ts_array)],
+    )
+    .unwrap();
+
+    let table_writer = DuckLakeTableWriter::new(Arc::new(writer), object_store).unwrap();
+    table_writer
+        .write_table("main", "events", &[batch])
+        .await
+        .unwrap();
+
+    let ctx = create_read_context(&temp_dir).await;
+    let df = ctx
+        .sql("SELECT event_ts FROM test.main.events ORDER BY id")
+        .await
+        .unwrap();
+    let batches = df.collect().await.unwrap();
+
+    // Served schema must keep nanosecond precision, not collapse to µs.
+    assert_eq!(
+        batches[0].schema().field(0).data_type(),
+        &DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
+        "served column must round-trip as nanosecond tz-aware"
+    );
+
+    let col = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<TimestampNanosecondArray>()
+        .expect("column reads back as TimestampNanosecondArray");
+    assert_eq!(
+        col.values(),
+        ns_values.as_slice(),
+        "sub-microsecond fraction must survive the round-trip"
+    );
 }


### PR DESCRIPTION
## Problem

A tz-aware `Timestamp(Nanosecond, _)` column — the pandas/PyArrow default for tz-aware datetimes — was mapped to the catalog type `timestamptz`, which reads back as `Timestamp(Microsecond, "UTC")`. But the physical parquet retains nanoseconds, so the **served schema disagreed with the file**, and the read path (`ColumnRenameStream::coerce_column`) silently cast `ns → µs` on every scan — dropping the sub-microsecond fraction with no error.

Symptom: write `…00:00:00.123456789Z`, read back `…00:00:00.123456Z`.

## Fix

DuckLake already distinguishes nanosecond tz timestamps from microsecond:

| catalog type | DuckDB type | precision |
|---|---|---|
| `timestamptz` | `TIMESTAMP_TZ` | microsecond |
| `timestamptz_ns` | `TIMESTAMP_TZ_NS` | nanosecond |

This crate only implemented the first. The change:

- **write** (`arrow_to_ducklake_type`): `Timestamp(Nanosecond, Some(_))` → `timestamptz_ns`; second/millisecond tz timestamps still widen losslessly to µs `timestamptz`.
- **read** (`ducklake_to_arrow_type`): parse `timestamptz_ns` → `Timestamp(Nanosecond, Some("UTC"))`.

Now the catalog type matches the physical file and the read coercion is a no-op. As a bonus, the reader can now handle `timestamptz_ns` columns written by DuckDB itself, which it previously rejected as an unknown type.

The zone name still normalizes to `UTC` on read, matching DuckDB's `TIMESTAMPTZ` semantics (an instant is stored, not the zone string) — the instant is preserved.

## Tests

- Unit (`src/types.rs`): read/write mappings for `timestamptz_ns`, a non-UTC zone, second/ms widening, the round-trip set, and a focused regression asserting ns tz does **not** collapse to µs and that the two tz precisions stay distinct (non-promotable).
- Integration (`tests/write_tests.rs`): `test_write_and_read_nanosecond_timestamptz` writes ns values with non-zero sub-µs digits through the real `DuckLakeTableWriter` → SQLite catalog → parquet → `DuckLakeCatalog` read path and asserts both the served type and the exact values survive. Verified it fails on the pre-fix mapping.

`cargo fmt`, `cargo clippy --lib`, and `cargo test --lib` are clean.