### PR TITLE
feat(read): prune row groups by rowid on the lineage scan path

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -1,7 +1,7 @@
 //! DuckLake table provider implementation
 
 use std::any::Any;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 
 use crate::Result;
@@ -31,6 +31,7 @@ use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use datafusion::catalog::{Session, TableProvider};
+use datafusion::common::ScalarValue;
 use datafusion::common::Statistics;
 use datafusion::common::stats::Precision;
 use datafusion::datasource::listing::PartitionedFile;
@@ -41,7 +42,7 @@ use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::execution::object_store::ObjectStoreUrl;
 #[cfg(feature = "write")]
 use datafusion::logical_expr::dml::InsertOp;
-use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
+use datafusion::logical_expr::{Expr, Operator, TableProviderFilterPushDown, TableType};
 use datafusion::physical_plan::ExecutionPlan;
 use futures::StreamExt;
 use object_store::path::Path as ObjectPath;
@@ -129,6 +130,10 @@ struct FileReadConfig {
     /// Number of row groups in the file (`row_group_starts.len()`). Required to
     /// build a `ParquetAccessPlan` of the correct length.
     row_group_count: usize,
+    /// Total physical rows in the file (sum of every row group's `num_rows`).
+    /// Used to bound a synthesized file's rowid range `[row_id_start,
+    /// row_id_start + file_row_count)` when pruning row groups by rowid.
+    file_row_count: i64,
 }
 
 /// DuckLake table provider
@@ -737,6 +742,9 @@ impl DuckLakeTable {
             embedded_rowid_parquet_name,
             row_group_starts,
             row_group_count,
+            // `row_acc` accumulated every row group's `num_rows`, so it is the
+            // file's total physical row count.
+            file_row_count: row_acc,
         });
 
         {
@@ -828,6 +836,61 @@ impl DuckLakeTable {
         Ok((file_groups, partition_starts))
     }
 
+    /// Build positional scan partitions that read **only** the given row groups,
+    /// for a rowid-pruned scan. `selected` must be sorted, unique, non-empty,
+    /// and every index `< read_cfg.row_group_count`.
+    ///
+    /// Each maximal contiguous run of selected row groups becomes one
+    /// [`FileGroup`] (DataFusion partition) carrying a `Scan`/`Skip`
+    /// [`ParquetAccessPlan`], with `partition_starts[i]` set to the physical
+    /// position of that run's first row. Keeping each partition a contiguous run
+    /// (never an internal `Skip`) preserves the `FileRowNumberExec` invariant —
+    /// a partition emits one contiguous, in-order run of physical rows beginning
+    /// at its declared start — so rowid synthesis and positional delete
+    /// filtering remain correct under pruning.
+    fn build_pruned_row_group_partitions(
+        &self,
+        file: &DuckLakeFileData,
+        read_cfg: &FileReadConfig,
+        selected: &[usize],
+    ) -> DataFusionResult<(Vec<FileGroup>, Vec<i64>)> {
+        let resolved_path = self.resolve_file_path(file)?;
+        let file_size = validated_file_size(file.file_size_bytes, &resolved_path)?;
+        let footer_hint = file
+            .footer_size
+            .filter(|&s| s > 0)
+            .and_then(|s| usize::try_from(s).ok());
+        let n = read_cfg.row_group_count;
+
+        let make_pf = |access: ParquetAccessPlan| {
+            let mut pf = PartitionedFile::new(&resolved_path, file_size);
+            if let Some(hint) = footer_hint {
+                pf = pf.with_metadata_size_hint(hint);
+            }
+            pf.with_extensions(Arc::new(access))
+        };
+
+        let mut file_groups = Vec::new();
+        let mut partition_starts = Vec::new();
+        for (run_start, run_end) in contiguous_runs(selected) {
+            let row_groups: Vec<RowGroupAccess> = (0..n)
+                .map(|rg| {
+                    if rg >= run_start && rg <= run_end {
+                        RowGroupAccess::Scan
+                    } else {
+                        RowGroupAccess::Skip
+                    }
+                })
+                .collect();
+            file_groups.push(FileGroup::new(vec![make_pf(ParquetAccessPlan::new(
+                row_groups,
+            ))]));
+            partition_starts.push(read_cfg.row_group_starts[run_start]);
+        }
+
+        Ok((file_groups, partition_starts))
+    }
+
     /// Build a plan for a single file when the synthetic `rowid` column is in
     /// the projection. Always uses per-file scans because each file may have a
     /// different layout (embedded rowid vs. synthesized) and a distinct
@@ -843,6 +906,11 @@ impl DuckLakeTable {
         table_file: &DuckLakeTableFile,
         user_proj: &[usize],
         rowid_idx: usize,
+        // Sorted, de-duplicated rowids from a `rowid IN (…)` / `rowid = …`
+        // predicate on this scan, when present. Used to prune row groups (and
+        // skip whole files) that cannot contain any requested rowid. `None`
+        // means no such predicate — scan the whole file as before.
+        requested_rowids: Option<&[i64]>,
         limit: Option<usize>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         let file_cfg = self.build_file_read_config(state, &table_file.file).await?;
@@ -893,14 +961,49 @@ impl DuckLakeTable {
             physical_proj.clone()
         };
 
+        // Optional rowid-driven row-group pruning. Only synthesized
+        // (non-embedded) files can be pruned positionally — an embedded rowid is
+        // an arbitrary stored value, not derivable from physical position. The
+        // post-scan rowid filter (filters are reported `Inexact`) still
+        // guarantees correctness, so this only avoids reading row groups that
+        // provably contain no requested rowid; over-inclusion would just be
+        // slower, never wrong. Empty selection ⇒ this file holds none of the
+        // requested rowids, so emit nothing for it.
+        let pruned_partitions: Option<(Vec<FileGroup>, Vec<i64>)> =
+            match (requested_rowids, has_embedded, table_file.row_id_start) {
+                (Some(req), false, Some(row_id_start)) => {
+                    let selected = select_row_groups_for_rowids(
+                        req,
+                        row_id_start,
+                        file_cfg.file_row_count,
+                        &file_cfg.row_group_starts,
+                    );
+                    if selected.is_empty() {
+                        use datafusion::physical_plan::empty::EmptyExec;
+                        let output_schema = self.output_schema_for_projection(user_proj, rowid_idx);
+                        return Ok(Arc::new(EmptyExec::new(output_schema)));
+                    }
+                    Some(self.build_pruned_row_group_partitions(
+                        &table_file.file,
+                        &file_cfg,
+                        &selected,
+                    )?)
+                },
+                _ => None,
+            };
+
         let after_deletes: Arc<dyn ExecutionPlan> = if needs_position {
             // Positional path: row-group-aligned partitions + a non-repartition,
             // non-pruning source, so each partition emits a complete, contiguous,
             // in-order run of physical rows. No scan-level limit (it would drop
             // rows before delete filtering); DataFusion enforces LIMIT above.
-            let target_partitions = state.config().target_partitions();
-            let (file_groups, partition_starts) =
-                self.build_row_group_partitions(&table_file.file, &file_cfg, target_partitions)?;
+            let (file_groups, partition_starts) = match pruned_partitions {
+                Some(p) => p,
+                None => {
+                    let target_partitions = state.config().target_partitions();
+                    self.build_row_group_partitions(&table_file.file, &file_cfg, target_partitions)?
+                },
+            };
 
             let source = PositionalFileSource::wrap(Arc::new(
                 self.create_parquet_source(file_cfg.read_schema.clone()),
@@ -1062,8 +1165,10 @@ impl TableProvider for DuckLakeTable {
         // Filters are received here for informational purposes. DataFusion's optimizer
         // automatically pushes them down to the Parquet scanner for row group pruning and
         // page-level filtering since we declared support via supports_filters_pushdown().
-        // We mark them as Inexact, so DataFusion will reapply them after our scan.
-        _filters: &[Expr],
+        // We mark them as Inexact, so DataFusion will reapply them after our scan. We also
+        // mine a `rowid IN (…)` / `rowid = …` predicate from them to prune row groups on
+        // the row-lineage path (see `extract_requested_rowids`).
+        filters: &[Expr],
         limit: Option<usize>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         // Row-lineage detour: when the synthetic `rowid` column is projected,
@@ -1083,10 +1188,20 @@ impl TableProvider for DuckLakeTable {
                 .cloned()
                 .unwrap_or_else(|| (0..self.schema.fields().len()).collect());
 
+            // Mine a rowid predicate once; reused to prune every file's scan.
+            let requested_rowids = extract_requested_rowids(filters);
+
             let mut execs: Vec<Arc<dyn ExecutionPlan>> = Vec::new();
             for tf in &self.table_files {
                 let exec = self
-                    .build_exec_for_file_with_rowid(state, tf, &user_proj, rowid_idx, limit)
+                    .build_exec_for_file_with_rowid(
+                        state,
+                        tf,
+                        &user_proj,
+                        rowid_idx,
+                        requested_rowids.as_deref(),
+                        limit,
+                    )
                     .await?;
                 execs.push(exec);
             }
@@ -1191,6 +1306,117 @@ fn combine_execution_plans(
     }
 }
 
+/// Collapse a sorted, unique list of indices into maximal contiguous
+/// `(start, end)` inclusive runs. `[0,2,3,4,7] → [(0,0),(2,4),(7,7)]`.
+fn contiguous_runs(selected: &[usize]) -> Vec<(usize, usize)> {
+    let mut runs = Vec::new();
+    let mut i = 0;
+    while i < selected.len() {
+        let start = selected[i];
+        let mut end = start;
+        while i + 1 < selected.len() && selected[i + 1] == selected[i] + 1 {
+            end = selected[i + 1];
+            i += 1;
+        }
+        i += 1;
+        runs.push((start, end));
+    }
+    runs
+}
+
+/// Extract the rowids targeted by a `rowid IN (…)` / `rowid = …` predicate
+/// among `filters`, if present, as sorted, de-duplicated values.
+///
+/// Returns `None` when no usable rowid predicate is found — a negated `IN`, a
+/// non-integer literal, or a predicate on another column all yield `None`, in
+/// which case the caller scans without rowid pruning. Correctness never depends
+/// on this: the filters are reported `Inexact`, so DataFusion re-applies the
+/// predicate above the scan regardless. This only enables an I/O optimization.
+fn extract_requested_rowids(filters: &[Expr]) -> Option<Vec<i64>> {
+    for filter in filters {
+        if let Some(mut ids) = rowid_values_from_expr(filter) {
+            ids.sort_unstable();
+            ids.dedup();
+            return Some(ids);
+        }
+    }
+    None
+}
+
+/// Pull rowid literals from a single predicate, or `None` unless it is a
+/// positive equality / `IN` on the `rowid` column with integer literals.
+fn rowid_values_from_expr(expr: &Expr) -> Option<Vec<i64>> {
+    match expr {
+        Expr::InList(in_list) if !in_list.negated && is_rowid_column(&in_list.expr) => {
+            // Every element must be an integer literal; bail otherwise so we
+            // fall back to a full scan rather than mis-prune.
+            in_list.list.iter().map(literal_as_i64).collect()
+        },
+        Expr::BinaryExpr(be) if be.op == Operator::Eq => {
+            let val = if is_rowid_column(&be.left) {
+                literal_as_i64(&be.right)
+            } else if is_rowid_column(&be.right) {
+                literal_as_i64(&be.left)
+            } else {
+                None
+            };
+            val.map(|v| vec![v])
+        },
+        _ => None,
+    }
+}
+
+/// True if `expr` is a bare column reference named [`ROWID_COLUMN_NAME`].
+fn is_rowid_column(expr: &Expr) -> bool {
+    matches!(expr, Expr::Column(col) if col.name == ROWID_COLUMN_NAME)
+}
+
+/// Interpret an expression as an integer literal coerced to `i64`; anything
+/// else (NULL, non-integer, out-of-range u64) yields `None`.
+fn literal_as_i64(expr: &Expr) -> Option<i64> {
+    let Expr::Literal(scalar, ..) = expr else {
+        return None;
+    };
+    let v = match scalar {
+        ScalarValue::Int64(Some(v)) => *v,
+        ScalarValue::Int32(Some(v)) => *v as i64,
+        ScalarValue::Int16(Some(v)) => *v as i64,
+        ScalarValue::Int8(Some(v)) => *v as i64,
+        ScalarValue::UInt8(Some(v)) => *v as i64,
+        ScalarValue::UInt16(Some(v)) => *v as i64,
+        ScalarValue::UInt32(Some(v)) => *v as i64,
+        ScalarValue::UInt64(Some(v)) => i64::try_from(*v).ok()?,
+        _ => return None,
+    };
+    Some(v)
+}
+
+/// Map requested rowids to the sorted, unique set of row-group indices that may
+/// contain them in a synthesized file whose first physical row has rowid
+/// `row_id_start`. A rowid `r` sits at physical position `r - row_id_start`;
+/// its row group is the last one whose start is `<= pos`. Rowids outside this
+/// file's range `[row_id_start, row_id_start + file_row_count)` are ignored, so
+/// an empty result means the file holds none of the requested rowids.
+fn select_row_groups_for_rowids(
+    requested_sorted: &[i64],
+    row_id_start: i64,
+    file_row_count: i64,
+    row_group_starts: &[i64],
+) -> Vec<usize> {
+    let mut set = BTreeSet::new();
+    for &r in requested_sorted {
+        let pos = r - row_id_start;
+        if pos < 0 || pos >= file_row_count {
+            continue;
+        }
+        // `row_group_starts` is sorted and starts at 0, and `pos >= 0`, so
+        // `partition_point` is at least 1; the row group is the entry before it.
+        let idx = row_group_starts.partition_point(|&s| s <= pos) - 1;
+        set.insert(idx);
+    }
+    set.into_iter().collect()
+}
+
 /// Extract deleted row positions from a delete file RecordBatch
 ///
 /// Delete files have schema: (file_path: VARCHAR, pos: INT64)
@@ -1242,6 +1468,117 @@ fn is_object_store_not_found(err: &DataFusionError) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use datafusion::prelude::{col, lit};
+
+    // --- rowid predicate extraction ---
+
+    #[test]
+    fn extract_rowids_from_in_list_sorted_deduped() {
+        let f = col(ROWID_COLUMN_NAME)
+            .in_list(vec![lit(1_000_000i64), lit(100i64), lit(100i64)], false);
+        assert_eq!(extract_requested_rowids(&[f]), Some(vec![100, 1_000_000]));
+    }
+
+    #[test]
+    fn extract_rowids_from_equality_either_side() {
+        assert_eq!(
+            extract_requested_rowids(&[col(ROWID_COLUMN_NAME).eq(lit(42i64))]),
+            Some(vec![42])
+        );
+        // Literal on the left also recognized.
+        assert_eq!(
+            extract_requested_rowids(&[lit(7i64).eq(col(ROWID_COLUMN_NAME))]),
+            Some(vec![7])
+        );
+    }
+
+    #[test]
+    fn extract_rowids_picks_rowid_predicate_among_filters() {
+        let other = col("amount").gt(lit(10i64));
+        let rowid = col(ROWID_COLUMN_NAME).in_list(vec![lit(5i64)], false);
+        assert_eq!(
+            extract_requested_rowids(&[other, rowid]),
+            Some(vec![5]),
+            "should find the rowid predicate even when other filters precede it"
+        );
+    }
+
+    #[test]
+    fn extract_rowids_none_for_unprunable_predicates() {
+        // Negated IN: pruning would drop rows that must be returned.
+        assert_eq!(
+            extract_requested_rowids(&[col(ROWID_COLUMN_NAME).in_list(vec![lit(1i64)], true)]),
+            None
+        );
+        // Predicate on a different column.
+        assert_eq!(
+            extract_requested_rowids(&[col("id").in_list(vec![lit(1i64)], false)]),
+            None
+        );
+        // Non-integer literal in the list.
+        assert_eq!(
+            extract_requested_rowids(&[col(ROWID_COLUMN_NAME).in_list(vec![lit("x")], false)]),
+            None
+        );
+        // No filters at all.
+        assert_eq!(extract_requested_rowids(&[]), None);
+    }
+
+    // --- rowid -> row-group selection ---
+
+    #[test]
+    fn select_row_groups_maps_positions_and_dedupes() {
+        // 4 row groups of 100 rows each; file starts at global rowid 1000.
+        let starts = vec![0, 100, 200, 300];
+        let count = 400;
+        let start = 1000;
+        // pos 0 -> rg0, pos 150 -> rg1, pos 399 -> rg3; the two in rg1 collapse.
+        let req = vec![1000, 1150, 1199, 1399];
+        assert_eq!(
+            select_row_groups_for_rowids(&req, start, count, &starts),
+            vec![0, 1, 3]
+        );
+    }
+
+    #[test]
+    fn select_row_groups_ignores_out_of_range_rowids() {
+        let starts = vec![0, 100];
+        let count = 200;
+        let start = 1000;
+        // 999 is before the file; 1200 is the first rowid past it; 1199 is the last.
+        assert_eq!(
+            select_row_groups_for_rowids(&[999, 1200, 5000], start, count, &starts),
+            Vec::<usize>::new()
+        );
+        assert_eq!(
+            select_row_groups_for_rowids(&[1000, 1199], start, count, &starts),
+            vec![0, 1]
+        );
+    }
+
+    #[test]
+    fn select_row_groups_boundary_lands_in_starting_group() {
+        // A rowid exactly at a row group's start position belongs to that group.
+        let starts = vec![0, 100, 200];
+        let count = 300;
+        assert_eq!(
+            select_row_groups_for_rowids(&[100], 0, count, &starts),
+            vec![1]
+        );
+    }
+
+    // --- contiguous run coalescing ---
+
+    #[test]
+    fn contiguous_runs_coalesces_adjacent_indices() {
+        assert_eq!(contiguous_runs(&[]), Vec::<(usize, usize)>::new());
+        assert_eq!(contiguous_runs(&[5]), vec![(5, 5)]);
+        assert_eq!(
+            contiguous_runs(&[0, 2, 3, 4, 7]),
+            vec![(0, 0), (2, 4), (7, 7)]
+        );
+        assert_eq!(contiguous_runs(&[0, 1, 2]), vec![(0, 2)]);
+    }
 
     #[test]
     fn test_validated_file_size_positive() {

--- a/tests/rowid_physical_position_tests.rs
+++ b/tests/rowid_physical_position_tests.rs
@@ -459,3 +459,113 @@ async fn small_single_row_group_file_unchanged() -> DataFusionResult<()> {
     assert_eq!(pairs, vec![(0, 0), (1, 1), (2, 2), (3, 3), (4, 4)]);
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// 9. rowid IN (...) prunes to the matching row groups and returns EXACTLY the
+//    requested rows (the BM25 point-lookup pattern). Rowids are chosen to span
+//    non-adjacent row groups (DuckDB row-group size 122_880): 5→rg0,
+//    130_000→rg1, 350_000→rg2, 599_999→last; rg3 is skipped, rg1/rg2 coalesce
+//    into one run. Proves pruning keeps rowid synthesis exact and that the
+//    post-scan filter drops the over-scanned rows.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn rowid_in_list_returns_exactly_matching_rows() -> DataFusionResult<()> {
+    let temp = temp()?;
+    let path = temp.path().join("rowid_in.ducklake");
+    {
+        let conn = open(&path).map_err(common::to_datafusion_error)?;
+        conn.execute("CREATE TABLE c.t(i INTEGER);", [])
+            .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+        // Single INSERT => one data file => row_id_start = 0 => rowid == i.
+        conn.execute(
+            &format!("INSERT INTO c.t SELECT i FROM range(0, {BIG}) t(i);"),
+            [],
+        )
+        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    }
+
+    let ctx = split_ctx();
+    ctx.register_catalog("c", catalog(&path.to_string_lossy(), true)?);
+
+    let wanted = [5i64, 130_000, 350_000, 599_999];
+    let batches = ctx
+        .sql("SELECT rowid, i FROM c.main.t WHERE rowid IN (5, 130000, 350000, 599999)")
+        .await?
+        .collect()
+        .await?;
+
+    let mut got: Vec<(i64, i64)> = Vec::new();
+    for b in &batches {
+        let rid = b.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+        let v = b.column(1).as_any().downcast_ref::<Int32Array>().unwrap();
+        for r in 0..b.num_rows() {
+            got.push((rid.value(r), v.value(r) as i64));
+        }
+    }
+    got.sort_unstable();
+    let expected: Vec<(i64, i64)> = wanted.iter().map(|&r| (r, r)).collect();
+    assert_eq!(
+        got, expected,
+        "rowid IN (...) must return exactly the requested rows with rowid == i"
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 10. rowid pruning preserves the positional plan-shape invariant: the scan
+//     remains the direct child of FileRowNumberExec (per-partition seeds
+//     intact). A broken shape would desync positions and fail test 9, but this
+//     asserts the invariant explicitly.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn rowid_in_list_preserves_positional_plan_shape() -> DataFusionResult<()> {
+    let temp = temp()?;
+    let path = temp.path().join("rowid_in_plan.ducklake");
+    {
+        let conn = open(&path).map_err(common::to_datafusion_error)?;
+        conn.execute("CREATE TABLE c.t(i INTEGER);", [])
+            .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+        conn.execute(
+            &format!("INSERT INTO c.t SELECT i FROM range(0, {BIG}) t(i);"),
+            [],
+        )
+        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    }
+
+    let ctx = split_ctx();
+    ctx.register_catalog("c", catalog(&path.to_string_lossy(), true)?);
+
+    let mut plan = String::new();
+    for b in ctx
+        .sql("EXPLAIN SELECT rowid, i FROM c.main.t WHERE rowid IN (5, 130000, 350000, 599999)")
+        .await?
+        .collect()
+        .await?
+    {
+        if let Some(c) = b
+            .column(1)
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+        {
+            for r in 0..b.num_rows() {
+                plan.push_str(c.value(r));
+                plan.push('\n');
+            }
+        }
+    }
+    let lines: Vec<&str> = plan.lines().collect();
+    let frn = lines
+        .iter()
+        .position(|l| l.contains("FileRowNumberExec"))
+        .unwrap_or_else(|| panic!("plan has no FileRowNumberExec:\n{plan}"));
+    assert!(
+        lines
+            .get(frn + 1)
+            .is_some_and(|l| l.contains("DataSourceExec")),
+        "DataSourceExec must remain the direct child of FileRowNumberExec under \
+         rowid pruning:\n{plan}"
+    );
+    Ok(())
+}


### PR DESCRIPTION
The row-lineage scan (when `rowid` is projected) read every row group of every file and applied a `rowid IN (…)` / `rowid = …` predicate only after the scan (filters are reported Inexact). Point lookups — e.g. a BM25 serve query resolving <100 rowids — therefore read whole multi-GB files.

When such a predicate is present, mine the requested rowids in `scan()` and, for each synthesized (non-embedded) file, map them to the row groups that can contain them via `row_id_start + row_group_starts`. Build the positional scan from a pruning ParquetAccessPlan that Scans only those row groups (Skips the rest), coalescing them into maximal contiguous runs so each partition still emits one contiguous, in-order run of physical rows — preserving the FileRowNumberExec position-synthesis invariant. Files holding none of the requested rowids are dropped entirely.

Correctness is unchanged: filters stay Inexact, so DataFusion re-applies the predicate above the scan; pruning only avoids reading row groups that provably contain no requested rowid (over-inclusion is safe, never wrong). Embedded- rowid files and non-rowid predicates fall back to the full scan.

Adds unit tests for predicate extraction, rowid->row-group mapping, and run coalescing, plus end-to-end tests that an 8-way-split 600k-row scan returns exactly the requested rows and keeps the positional plan shape.