### PR TITLE
fix(write): make WriteMode::Replace atomic to close transient empty-row window

### DIFF
--- a/examples/maintenance_demo.rs
+++ b/examples/maintenance_demo.rs
@@ -66,6 +66,7 @@ async fn main() -> anyhow::Result<()> {
         s2.table_id,
         s2.snapshot_id,
         &DataFileInfo::new("f1.parquet", 100, 5),
+        WriteMode::Replace,
     )?;
     touch_file(&data_path, "main", "t", "f1.parquet")?;
     print_state(&pool, &data_path, "Step 2 — write f1 (INSERT)").await?;
@@ -76,6 +77,7 @@ async fn main() -> anyhow::Result<()> {
         s3.table_id,
         s3.snapshot_id,
         &DataFileInfo::new("f2.parquet", 100, 5),
+        WriteMode::Replace,
     )?;
     touch_file(&data_path, "main", "t", "f2.parquet")?;
     print_state(&pool, &data_path, "Step 3 — Replace: end f1, write f2").await?;

--- a/examples/orphan_cleanup_demo.rs
+++ b/examples/orphan_cleanup_demo.rs
@@ -68,6 +68,7 @@ async fn main() -> anyhow::Result<()> {
         s.table_id,
         s.snapshot_id,
         &DataFileInfo::new("ref.parquet", 100, 5),
+        WriteMode::Replace,
     )?;
     touch_file(&data_path, "main", "t", "ref.parquet")?;
     print_state(

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -235,13 +235,26 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
         snapshot_id: i64,
     ) -> Result<Vec<i64>>;
 
-    /// Register a new data file. Returns the assigned data_file_id.
+    /// Register a new data file and publish its snapshot as the catalog head,
+    /// atomically. For `Replace`, retires the prior generation in the same
+    /// transaction. Returns the assigned data_file_id.
     fn register_data_file(
         &self,
         table_id: i64,
         snapshot_id: i64,
         file: &DataFileInfo,
+        mode: WriteMode,
     ) -> Result<i64>;
+
+    /// Publish a write's snapshot as the catalog head with no data file (CREATE
+    /// TABLE, zero-row Replace). For `Replace`, retires the prior generation.
+    ///
+    /// Default no-op: single-catalog backends advance the head by inserting the
+    /// snapshot row in `begin_write_transaction`. Multicatalog Postgres
+    /// overrides this to insert the `ducklake_catalog_snapshot_map` head row.
+    fn publish_snapshot(&self, _table_id: i64, _snapshot_id: i64, _mode: WriteMode) -> Result<()> {
+        Ok(())
+    }
 
     /// End all existing data files for a table. Returns count of files ended.
     fn end_table_files(&self, table_id: i64, snapshot_id: i64) -> Result<u64>;

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -306,6 +306,56 @@ async fn assert_table_in_catalog(
     }
 }
 
+/// Retire the generation preceding `snapshot_id` for a Replace: end-snapshot
+/// every still-live file from an earlier snapshot and zero the visible
+/// record/byte totals. The `begin_snapshot < snapshot_id` guard leaves the
+/// current write's own files untouched (multi-file safety); `next_row_id` stays
+/// monotonic so rowids are never reused.
+async fn retire_prior_generation(
+    table_id: i64,
+    snapshot_id: i64,
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+) -> Result<()> {
+    sqlx::query(
+        "UPDATE ducklake_data_file SET end_snapshot = $1
+         WHERE table_id = $2 AND end_snapshot IS NULL AND begin_snapshot < $1",
+    )
+    .bind(snapshot_id)
+    .bind(table_id)
+    .execute(&mut **tx)
+    .await?;
+
+    sqlx::query(
+        "UPDATE ducklake_table_stats
+         SET record_count = 0, file_size_bytes = 0
+         WHERE table_id = $1",
+    )
+    .bind(table_id)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+/// Publish `snapshot_id` as the catalog head by mapping it to the catalog.
+/// Idempotent (the write path calls it once, but a retried/multi-file commit
+/// must not fail on the PK).
+async fn advance_catalog_head(
+    catalog_id: i64,
+    snapshot_id: i64,
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO ducklake_catalog_snapshot_map (catalog_id, snapshot_id)
+         VALUES ($1, $2)
+         ON CONFLICT (catalog_id, snapshot_id) DO NOTHING",
+    )
+    .bind(catalog_id)
+    .bind(snapshot_id)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
 impl MetadataWriter for PostgresMetadataWriter {
     fn create_snapshot(&self) -> Result<i64> {
         block_on(async {
@@ -484,16 +534,16 @@ impl MetadataWriter for PostgresMetadataWriter {
         table_id: i64,
         snapshot_id: i64,
         file: &DataFileInfo,
+        mode: WriteMode,
     ) -> Result<i64> {
         block_on(async {
-            // Allocate row_id_start from the table's monotonic counter inside
-            // the same transaction so concurrent writers can't hand out
-            // overlapping ranges. The DuckLake row-lineage read path
-            // (RowIdExec) hard-errors on files where row_id_start is NULL and
-            // no embedded `_ducklake_internal_row_id` column is present, so
-            // every file we write must carry a value. Falls back to inserting
-            // a fresh stats row (next_row_id = 0) for tables created before
-            // this writer started maintaining `ducklake_table_stats`.
+            // Single atomic commit: retire the prior generation (Replace), insert
+            // the new file, accumulate stats, and advance the catalog head. The
+            // head is published only here so it never resolves to a snapshot
+            // whose file is still uploading. row_id_start is drawn from the
+            // table's monotonic counter under the catalog lock so concurrent
+            // writers hand out non-overlapping ranges; the stats row is seeded
+            // for tables created before this writer maintained it.
             let mut tx = self.pool.begin().await?;
             lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
             assert_table_in_catalog(self.catalog_id, table_id, &mut tx).await?;
@@ -506,6 +556,10 @@ impl MetadataWriter for PostgresMetadataWriter {
             .bind(table_id)
             .execute(&mut *tx)
             .await?;
+
+            if mode == WriteMode::Replace {
+                retire_prior_generation(table_id, snapshot_id, &mut tx).await?;
+            }
 
             let stats_row =
                 sqlx::query("SELECT next_row_id FROM ducklake_table_stats WHERE table_id = $1")
@@ -534,7 +588,9 @@ impl MetadataWriter for PostgresMetadataWriter {
 
             // Advance the counter and accumulate stats. `next_row_id`
             // monotonically increases over the table's lifetime — rowids
-            // are never reused, even after end-snapshot.
+            // are never reused, even after end-snapshot. For Replace the
+            // record/byte totals were just zeroed, so this leaves them at the
+            // new file's values.
             sqlx::query(
                 "UPDATE ducklake_table_stats
                  SET next_row_id     = next_row_id + $1,
@@ -549,8 +605,35 @@ impl MetadataWriter for PostgresMetadataWriter {
             .execute(&mut *tx)
             .await?;
 
+            advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
+
             tx.commit().await?;
             Ok(id)
+        })
+    }
+
+    fn publish_snapshot(&self, table_id: i64, snapshot_id: i64, mode: WriteMode) -> Result<()> {
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
+            assert_table_in_catalog(self.catalog_id, table_id, &mut tx).await?;
+
+            if mode == WriteMode::Replace {
+                sqlx::query(
+                    "INSERT INTO ducklake_table_stats (table_id, record_count, next_row_id, file_size_bytes)
+                     VALUES ($1, 0, 0, 0)
+                     ON CONFLICT (table_id) DO NOTHING",
+                )
+                .bind(table_id)
+                .execute(&mut *tx)
+                .await?;
+                retire_prior_generation(table_id, snapshot_id, &mut tx).await?;
+            }
+
+            advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
+
+            tx.commit().await?;
+            Ok(())
         })
     }
 
@@ -685,14 +768,10 @@ impl MetadataWriter for PostgresMetadataWriter {
             .await?;
             let snapshot_id: i64 = row.try_get(0)?;
 
-            sqlx::query(
-                "INSERT INTO ducklake_catalog_snapshot_map (catalog_id, snapshot_id)
-                 VALUES ($1, $2)",
-            )
-            .bind(catalog_id)
-            .bind(snapshot_id)
-            .execute(&mut *tx)
-            .await?;
+            // The head advance (ducklake_catalog_snapshot_map insert) and the
+            // Replace retirement are deferred to the commit point
+            // (register_data_file / publish_snapshot) so the head never resolves
+            // to a snapshot whose data file is still uploading.
 
             let schema_id: i64 = {
                 let existing = sqlx::query(
@@ -889,38 +968,8 @@ impl MetadataWriter for PostgresMetadataWriter {
                 .await?;
             }
 
-            if mode == WriteMode::Replace {
-                sqlx::query(
-                    "UPDATE ducklake_data_file SET end_snapshot = $1
-                     WHERE table_id = $2 AND end_snapshot IS NULL",
-                )
-                .bind(snapshot_id)
-                .bind(table_id)
-                .execute(&mut *tx)
-                .await?;
-
-                // Mirror end_table_files: drop visible row/byte totals to
-                // zero while keeping next_row_id monotonic. Seed the row
-                // first in case this is a Replace on a brand-new table.
-                sqlx::query(
-                    "INSERT INTO ducklake_table_stats
-                         (table_id, record_count, next_row_id, file_size_bytes)
-                     VALUES ($1, 0, 0, 0)
-                     ON CONFLICT (table_id) DO NOTHING",
-                )
-                .bind(table_id)
-                .execute(&mut *tx)
-                .await?;
-
-                sqlx::query(
-                    "UPDATE ducklake_table_stats
-                     SET record_count = 0, file_size_bytes = 0
-                     WHERE table_id = $1",
-                )
-                .bind(table_id)
-                .execute(&mut *tx)
-                .await?;
-            }
+            // Replace retirement (end old files + zero stats) is deferred to the
+            // commit point (register_data_file / publish_snapshot).
 
             tx.commit().await?;
 

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -702,6 +702,10 @@ impl MetadataWriter for SqliteMetadataWriter {
         table_id: i64,
         snapshot_id: i64,
         file: &DataFileInfo,
+        // Single-catalog SQLite advances the head and retires the prior
+        // generation in `begin_write_transaction`, so registration is
+        // mode-agnostic here.
+        _mode: WriteMode,
     ) -> Result<i64> {
         block_on(async {
             // Allocate row_id_start from the table's monotonic counter inside
@@ -1151,7 +1155,7 @@ mod tests {
         let file = DataFileInfo::new("data.parquet", 1024, 100).with_footer_size(256);
 
         let file_id = writer
-            .register_data_file(table_id, snapshot_id, &file)
+            .register_data_file(table_id, snapshot_id, &file, WriteMode::Append)
             .unwrap();
         assert_eq!(file_id, 1);
     }
@@ -1203,6 +1207,7 @@ mod tests {
                 table_id,
                 snapshot_id,
                 &DataFileInfo::new("a.parquet", 100, 3),
+                WriteMode::Append,
             )
             .unwrap();
         let f2_id = writer
@@ -1210,6 +1215,7 @@ mod tests {
                 table_id,
                 snapshot_id,
                 &DataFileInfo::new("b.parquet", 250, 7),
+                WriteMode::Append,
             )
             .unwrap();
 
@@ -1235,7 +1241,12 @@ mod tests {
             .unwrap();
 
         writer
-            .register_data_file(table_id, snap1, &DataFileInfo::new("a.parquet", 100, 5))
+            .register_data_file(
+                table_id,
+                snap1,
+                &DataFileInfo::new("a.parquet", 100, 5),
+                WriteMode::Append,
+            )
             .unwrap();
 
         let snap2 = writer.create_snapshot().unwrap();
@@ -1247,7 +1258,12 @@ mod tests {
         assert_eq!(bytes, 0, "file_size_bytes cleared");
 
         let f2_id = writer
-            .register_data_file(table_id, snap2, &DataFileInfo::new("b.parquet", 200, 2))
+            .register_data_file(
+                table_id,
+                snap2,
+                &DataFileInfo::new("b.parquet", 200, 2),
+                WriteMode::Append,
+            )
             .unwrap();
         assert_eq!(
             read_row_id_start(&writer, f2_id).await,
@@ -1284,6 +1300,7 @@ mod tests {
                 table_id,
                 snapshot_id,
                 &DataFileInfo::new("a.parquet", 50, 4),
+                WriteMode::Append,
             )
             .unwrap();
         assert_eq!(read_row_id_start(&writer, file_id).await, Some(0));
@@ -1306,7 +1323,7 @@ mod tests {
         // Register a file
         let file = DataFileInfo::new("data1.parquet", 1024, 100);
         writer
-            .register_data_file(table_id, snapshot1, &file)
+            .register_data_file(table_id, snapshot1, &file, WriteMode::Append)
             .unwrap();
 
         // End files at new snapshot

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -215,6 +215,13 @@ impl SchemaProvider for DuckLakeSchema {
             .begin_write_transaction(&self.schema_name, &name, &columns, WriteMode::Replace)
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
+        // CREATE TABLE registers no data file, so publish the head here; without
+        // this the new (empty) table never becomes visible on multicatalog
+        // backends that defer the head advance out of begin_write_transaction.
+        writer
+            .publish_snapshot(setup.table_id, setup.snapshot_id, WriteMode::Replace)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
         // Resolve table path
         let table_path = resolve_path(&self.schema_path, &name, true)
             .map_err(|e| DataFusionError::External(Box::new(e)))?;

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -200,6 +200,7 @@ impl DuckLakeTableWriter {
             temp: Some(temp),
             catalog_path,
             path_is_relative,
+            mode,
             row_count: 0,
         })
     }
@@ -279,6 +280,9 @@ pub struct TableWriteSession {
     catalog_path: String,
     /// Whether the catalog_path is relative to table path
     path_is_relative: bool,
+    /// Replace vs Append; passed to `register_data_file` so the head advance and
+    /// (for Replace) prior-generation retirement commit atomically with the file.
+    mode: WriteMode,
     row_count: i64,
 }
 
@@ -380,7 +384,7 @@ impl TableWriteSession {
             file_info = file_info.with_absolute_path();
         }
         self.metadata
-            .register_data_file(self.table_id, self.snapshot_id, &file_info)?;
+            .register_data_file(self.table_id, self.snapshot_id, &file_info, self.mode)?;
 
         Ok(WriteResult {
             snapshot_id: self.snapshot_id,

--- a/tests/maintenance_sqlite_tests.rs
+++ b/tests/maintenance_sqlite_tests.rs
@@ -91,6 +91,7 @@ async fn drop_table_tombstones_children_and_is_idempotent() {
             s.table_id,
             s.snapshot_id,
             &DataFileInfo::new("f1.parquet", 100, 5),
+            WriteMode::Replace,
         )
         .unwrap();
 
@@ -164,6 +165,7 @@ fn three_generations(writer: &SqliteMetadataWriter) -> (i64, i64, i64, i64) {
             s1.table_id,
             s1.snapshot_id,
             &DataFileInfo::new("f1.parquet", 100, 5),
+            WriteMode::Replace,
         )
         .unwrap();
     let s2 = writer
@@ -174,6 +176,7 @@ fn three_generations(writer: &SqliteMetadataWriter) -> (i64, i64, i64, i64) {
             s2.table_id,
             s2.snapshot_id,
             &DataFileInfo::new("f2.parquet", 100, 5),
+            WriteMode::Replace,
         )
         .unwrap();
     let s3 = writer
@@ -184,6 +187,7 @@ fn three_generations(writer: &SqliteMetadataWriter) -> (i64, i64, i64, i64) {
             s3.table_id,
             s3.snapshot_id,
             &DataFileInfo::new("f3.parquet", 100, 5),
+            WriteMode::Replace,
         )
         .unwrap();
     (s1.table_id, s1.snapshot_id, s2.snapshot_id, s3.snapshot_id)
@@ -248,6 +252,7 @@ async fn expire_full_after_drop_reclaims_all_table_metadata() {
             s.table_id,
             s.snapshot_id,
             &DataFileInfo::new("f1.parquet", 100, 5),
+            WriteMode::Replace,
         )
         .unwrap();
     // Drop allocates snapshot 2; the table is now fully tombstoned in [1, 2).
@@ -396,6 +401,7 @@ async fn delete_orphaned_files_removes_unreferenced_keeps_referenced() {
             s.table_id,
             s.snapshot_id,
             &DataFileInfo::new("referenced.parquet", 100, 5),
+            WriteMode::Replace,
         )
         .unwrap();
     write_physical_file(&h.data_path, "main", "t", "referenced.parquet");
@@ -665,6 +671,7 @@ async fn delete_orphaned_files_recurses_into_nested_directories() {
             s.table_id,
             s.snapshot_id,
             &DataFileInfo::new("ref.parquet", 100, 5),
+            WriteMode::Replace,
         )
         .unwrap();
     write_physical_file(&h.data_path, "main", "t", "ref.parquet");
@@ -726,6 +733,7 @@ async fn delete_orphaned_files_dry_run_matches_real_run() {
             s.table_id,
             s.snapshot_id,
             &DataFileInfo::new("ref.parquet", 100, 5),
+            WriteMode::Replace,
         )
         .unwrap();
     write_physical_file(&h.data_path, "main", "t", "ref.parquet");

--- a/tests/multicatalog_hardening_tests.rs
+++ b/tests/multicatalog_hardening_tests.rs
@@ -233,6 +233,7 @@ async fn register_data_file_rejects_cross_catalog_table_id() {
         table_b, // ← belongs to cat_b
         snap,
         &DataFileInfo::new("evil.parquet", 1024, 1),
+        WriteMode::Replace,
     );
     let err = result.expect_err("must reject cross-catalog table_id");
     assert!(

--- a/tests/multicatalog_postgres_tests.rs
+++ b/tests/multicatalog_postgres_tests.rs
@@ -39,6 +39,109 @@ fn cols() -> Vec<ColumnDef> {
     ]
 }
 
+/// Current catalog head = MAX(snapshot_id) over the catalog's mapping rows
+/// (mirrors `MulticatalogProvider::get_current_snapshot`).
+async fn current_head(pool: &PgPool, catalog_id: i64) -> i64 {
+    sqlx::query(
+        "SELECT COALESCE(MAX(snapshot_id), 0) FROM ducklake_catalog_snapshot_map
+         WHERE catalog_id = $1",
+    )
+    .bind(catalog_id)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap()
+}
+
+/// Total record_count of the files visible to a reader at the current head —
+/// the same window predicate the read path applies.
+async fn visible_records_at_head(pool: &PgPool, catalog_id: i64, table_id: i64) -> i64 {
+    let head = current_head(pool, catalog_id).await;
+    sqlx::query(
+        "SELECT COALESCE(SUM(record_count), 0) FROM ducklake_data_file
+         WHERE table_id = $1
+           AND $2 >= begin_snapshot
+           AND ($2 < end_snapshot OR end_snapshot IS NULL)",
+    )
+    .bind(table_id)
+    .bind(head)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap()
+}
+
+/// Regression for the transient empty-read bug: a managed-load Replace must
+/// never expose a committed state where the head advanced but the table has
+/// zero live files. The head advance + prior-generation retirement happen only
+/// at the commit point (register_data_file), so a reader interleaved between
+/// begin_write_transaction and register_data_file — i.e. during the data upload
+/// — still sees the fully-complete OLD generation.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn replace_is_atomic_no_empty_read_window() {
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("pg_atomic").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path("/data").unwrap();
+
+    // Generation 1: a committed, non-empty table.
+    let s1 = w
+        .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
+        .unwrap();
+    w.register_data_file(
+        s1.table_id,
+        s1.snapshot_id,
+        &DataFileInfo::new("g1.parquet", 1024, 10),
+        WriteMode::Replace,
+    )
+    .unwrap();
+    assert_eq!(current_head(&pool, cat).await, s1.snapshot_id);
+    assert_eq!(visible_records_at_head(&pool, cat, s1.table_id).await, 10);
+
+    // Begin generation 2 (Replace). The data upload would run here, between
+    // setup and the commit. The new snapshot row exists but is NOT yet the head
+    // and the old file is NOT yet retired.
+    let s2 = w
+        .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
+        .unwrap();
+
+    // A reader interleaved during the upload sees the OLD generation intact:
+    // head unchanged, old data fully visible. (Pre-fix the head had already
+    // advanced to s2 and the old file was already retired ⇒ count == 0.)
+    assert_eq!(
+        current_head(&pool, cat).await,
+        s1.snapshot_id,
+        "head must NOT advance before the new data file is registered"
+    );
+    assert_eq!(
+        visible_records_at_head(&pool, cat, s1.table_id).await,
+        10,
+        "old generation must stay fully visible during the upload window"
+    );
+
+    // Commit generation 2: head advances and generation 1 retires atomically.
+    w.register_data_file(
+        s2.table_id,
+        s2.snapshot_id,
+        &DataFileInfo::new("g2.parquet", 2048, 7),
+        WriteMode::Replace,
+    )
+    .unwrap();
+    assert_eq!(current_head(&pool, cat).await, s2.snapshot_id);
+    assert_eq!(
+        visible_records_at_head(&pool, cat, s2.table_id).await,
+        7,
+        "new generation visible, old generation retired"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
 async fn initialize_multicatalog_schema_is_idempotent() {
@@ -111,14 +214,22 @@ async fn single_catalog_ddl_then_dml_assigns_versions() {
         .unwrap();
     writer.set_data_path("/data").unwrap();
 
-    // First commit: DDL (table doesn't exist).
+    // First commit: DDL (table doesn't exist). publish_snapshot maps the
+    // snapshot as the head — the next commit's schema_version is computed over
+    // mapped predecessors, so without publishing the bump wouldn't advance.
     let setup1 = writer
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
+        .unwrap();
+    writer
+        .publish_snapshot(setup1.table_id, setup1.snapshot_id, WriteMode::Replace)
         .unwrap();
 
     // Second commit: same columns -> DML, carry forward schema_version.
     let setup2 = writer
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
+        .unwrap();
+    writer
+        .publish_snapshot(setup2.table_id, setup2.snapshot_id, WriteMode::Replace)
         .unwrap();
 
     let v1: i64 =
@@ -160,6 +271,9 @@ async fn single_catalog_ddl_then_dml_assigns_versions() {
     let setup3 = writer
         .begin_write_transaction("public", "users", &cols_v2, WriteMode::Replace)
         .unwrap();
+    writer
+        .publish_snapshot(setup3.table_id, setup3.snapshot_id, WriteMode::Replace)
+        .unwrap();
     let v3: i64 =
         sqlx::query("SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = $1")
             .bind(setup3.snapshot_id)
@@ -191,8 +305,14 @@ async fn cross_catalog_isolation_same_schema_name() {
     let setup_a = writer_a
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
         .unwrap();
+    writer_a
+        .publish_snapshot(setup_a.table_id, setup_a.snapshot_id, WriteMode::Replace)
+        .unwrap();
     let setup_b = writer_b
         .begin_write_transaction("public", "orders", &cols(), WriteMode::Replace)
+        .unwrap();
+    writer_b
+        .publish_snapshot(setup_b.table_id, setup_b.snapshot_id, WriteMode::Replace)
         .unwrap();
 
     // Schemas: two "public" rows, one per catalog, with different schema_ids.
@@ -253,17 +373,26 @@ async fn schema_version_is_per_catalog_dense_under_interleaving() {
         .unwrap();
     wa.set_data_path("/data").unwrap();
 
+    // Each write publishes its snapshot as the head; schema_version is computed
+    // over mapped predecessors, so publishing is what lets later DDL bumps see
+    // the prior versions (per-catalog dense).
     // cat_a DDL (creates users)
     let a1 = wa
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
+        .unwrap();
+    wa.publish_snapshot(a1.table_id, a1.snapshot_id, WriteMode::Replace)
         .unwrap();
     // cat_a DML (Replace, same schema)
     let a2 = wa
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
         .unwrap();
+    wa.publish_snapshot(a2.table_id, a2.snapshot_id, WriteMode::Replace)
+        .unwrap();
     // cat_b DDL (creates orders) — happens in between cat_a's DDLs
     let b1 = wb
         .begin_write_transaction("public", "orders", &cols(), WriteMode::Replace)
+        .unwrap();
+    wb.publish_snapshot(b1.table_id, b1.snapshot_id, WriteMode::Replace)
         .unwrap();
     // cat_a DDL: adds age column
     let mut cols_v2 = cols();
@@ -271,9 +400,13 @@ async fn schema_version_is_per_catalog_dense_under_interleaving() {
     let a3 = wa
         .begin_write_transaction("public", "users", &cols_v2, WriteMode::Replace)
         .unwrap();
+    wa.publish_snapshot(a3.table_id, a3.snapshot_id, WriteMode::Replace)
+        .unwrap();
     // cat_b DML
     let b2 = wb
         .begin_write_transaction("public", "orders", &cols(), WriteMode::Replace)
+        .unwrap();
+    wb.publish_snapshot(b2.table_id, b2.snapshot_id, WriteMode::Replace)
         .unwrap();
 
     let get_v = |snap_id: i64| {
@@ -306,11 +439,19 @@ async fn no_orphan_mapping_rows() {
         .await
         .unwrap();
     w.set_data_path("/data").unwrap();
-    let _ = w
+    // Publish each write: a committed write maps its snapshot. (An uncommitted
+    // write deliberately leaves an unmapped snapshot — the head only advances at
+    // the commit point — so the "every snapshot is mapped" check below holds
+    // only once published.)
+    let s1 = w
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
         .unwrap();
-    let _ = w
+    w.publish_snapshot(s1.table_id, s1.snapshot_id, WriteMode::Replace)
+        .unwrap();
+    let s2 = w
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
+        .unwrap();
+    w.publish_snapshot(s2.table_id, s2.snapshot_id, WriteMode::Replace)
         .unwrap();
 
     // Every entry in the maps must point at a real row.
@@ -369,7 +510,7 @@ async fn register_data_file_records_against_table() {
 
     let file = DataFileInfo::new("abc.parquet", 4096, 100).with_footer_size(256);
     let file_id = w
-        .register_data_file(setup.table_id, setup.snapshot_id, &file)
+        .register_data_file(setup.table_id, setup.snapshot_id, &file, WriteMode::Replace)
         .unwrap();
     assert!(file_id > 0);
 
@@ -449,13 +590,16 @@ async fn drop_catalog_removes_populated_catalog() {
         s1.table_id,
         s1.snapshot_id,
         &DataFileInfo::new("u.parquet", 1024, 10),
+        WriteMode::Replace,
     )
     .unwrap();
 
     let mut cols_v2 = cols();
     cols_v2.push(ColumnDef::new("age", "int32", true).unwrap());
-    let _ = w
+    let s_ddl = w
         .begin_write_transaction("public", "users", &cols_v2, WriteMode::Replace)
+        .unwrap();
+    w.publish_snapshot(s_ddl.table_id, s_ddl.snapshot_id, WriteMode::Replace)
         .unwrap();
 
     let s_orders = w
@@ -465,6 +609,7 @@ async fn drop_catalog_removes_populated_catalog() {
         s_orders.table_id,
         s_orders.snapshot_id,
         &DataFileInfo::new("o.parquet", 2048, 20),
+        WriteMode::Replace,
     )
     .unwrap();
 
@@ -536,6 +681,7 @@ async fn drop_catalog_isolates_other_catalogs() {
         sa.table_id,
         sa.snapshot_id,
         &DataFileInfo::new("a.parquet", 1024, 10),
+        WriteMode::Replace,
     )
     .unwrap();
 
@@ -546,6 +692,7 @@ async fn drop_catalog_isolates_other_catalogs() {
         sb.table_id,
         sb.snapshot_id,
         &DataFileInfo::new("b.parquet", 2048, 20),
+        WriteMode::Replace,
     )
     .unwrap();
 
@@ -712,6 +859,7 @@ async fn drop_table_in_catalog_tombstones_table_and_children() {
         s.table_id,
         s.snapshot_id,
         &DataFileInfo::new("u.parquet", 1024, 10),
+        WriteMode::Replace,
     )
     .unwrap();
 
@@ -823,6 +971,7 @@ async fn drop_table_in_catalog_hides_table_from_read_path_and_preserves_time_tra
         s.table_id,
         s.snapshot_id,
         &DataFileInfo::new("u.parquet", 1024, 10),
+        WriteMode::Replace,
     )
     .unwrap();
 
@@ -898,6 +1047,7 @@ async fn drop_table_in_catalog_is_idempotent_on_second_call() {
         s.table_id,
         s.snapshot_id,
         &DataFileInfo::new("u.parquet", 1024, 10),
+        WriteMode::Replace,
     )
     .unwrap();
 
@@ -956,6 +1106,7 @@ async fn drop_table_in_catalog_does_not_touch_siblings() {
         s_users.table_id,
         s_users.snapshot_id,
         &DataFileInfo::new("u.parquet", 1024, 10),
+        WriteMode::Replace,
     )
     .unwrap();
 
@@ -966,6 +1117,7 @@ async fn drop_table_in_catalog_does_not_touch_siblings() {
         s_orders.table_id,
         s_orders.snapshot_id,
         &DataFileInfo::new("o.parquet", 2048, 20),
+        WriteMode::Replace,
     )
     .unwrap();
 
@@ -977,6 +1129,7 @@ async fn drop_table_in_catalog_does_not_touch_siblings() {
         s_other_users.table_id,
         s_other_users.snapshot_id,
         &DataFileInfo::new("au.parquet", 512, 5),
+        WriteMode::Replace,
     )
     .unwrap();
 
@@ -1074,6 +1227,7 @@ async fn drop_table_in_catalog_allows_recreate_with_fresh_identity() {
         s1.table_id,
         s1.snapshot_id,
         &DataFileInfo::new("v1.parquet", 1024, 10),
+        WriteMode::Replace,
     )
     .unwrap();
 
@@ -1098,6 +1252,7 @@ async fn drop_table_in_catalog_allows_recreate_with_fresh_identity() {
         s2.table_id,
         s2.snapshot_id,
         &DataFileInfo::new("v2.parquet", 2048, 20),
+        WriteMode::Replace,
     )
     .unwrap();
 
@@ -1148,6 +1303,7 @@ async fn drop_table_in_catalog_bumps_schema_version_as_ddl() {
         s.table_id,
         s.snapshot_id,
         &DataFileInfo::new("u.parquet", 1024, 10),
+        WriteMode::Replace,
     )
     .unwrap();
 
@@ -1215,6 +1371,7 @@ async fn drop_table_in_catalog_isolates_other_catalogs() {
         sa.table_id,
         sa.snapshot_id,
         &DataFileInfo::new("a.parquet", 1024, 10),
+        WriteMode::Replace,
     )
     .unwrap();
 
@@ -1225,6 +1382,7 @@ async fn drop_table_in_catalog_isolates_other_catalogs() {
         sb.table_id,
         sb.snapshot_id,
         &DataFileInfo::new("b.parquet", 2048, 20),
+        WriteMode::Replace,
     )
     .unwrap();
 
@@ -1332,6 +1490,7 @@ async fn register_data_file_assigns_non_overlapping_row_id_start() {
             setup.table_id,
             setup.snapshot_id,
             &DataFileInfo::new("f1.parquet", 4096, 100),
+            WriteMode::Replace,
         )
         .unwrap();
     let f2 = w
@@ -1339,6 +1498,7 @@ async fn register_data_file_assigns_non_overlapping_row_id_start() {
             setup.table_id,
             setup.snapshot_id,
             &DataFileInfo::new("f2.parquet", 2048, 50),
+            WriteMode::Append,
         )
         .unwrap();
     let f3 = w
@@ -1346,6 +1506,7 @@ async fn register_data_file_assigns_non_overlapping_row_id_start() {
             setup.table_id,
             setup.snapshot_id,
             &DataFileInfo::new("f3.parquet", 8192, 200),
+            WriteMode::Append,
         )
         .unwrap();
 
@@ -1363,10 +1524,10 @@ async fn register_data_file_assigns_non_overlapping_row_id_start() {
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
 async fn replace_preserves_next_row_id_monotonic() {
     // rowids must never be reused, even across WriteMode::Replace cycles.
-    // begin_write_transaction(Replace) end-snapshots the prior generation's
-    // files and clears record_count / file_size_bytes, but next_row_id stays
-    // put — so the first file of the new generation continues where the old
-    // generation left off.
+    // The Replace commit (register_data_file / publish_snapshot) end-snapshots
+    // the prior generation's files and clears record_count / file_size_bytes,
+    // but next_row_id stays put — so the first file of the new generation
+    // continues where the old generation left off.
     use datafusion_ducklake::metadata_writer::DataFileInfo;
     let (pool, _c) = spin_up_postgres().await.unwrap();
     let mgr = MulticatalogManager::new(pool.clone());
@@ -1383,28 +1544,34 @@ async fn replace_preserves_next_row_id_monotonic() {
         s1.table_id,
         s1.snapshot_id,
         &DataFileInfo::new("g1.parquet", 1024, 5),
+        WriteMode::Replace,
     )
     .unwrap();
     let (rc1, next1, _) = read_table_stats(&pool, s1.table_id).await;
     assert_eq!(rc1, 5);
     assert_eq!(next1, 5);
 
-    // Second Replace ends the first generation's files and resets visible
-    // totals to zero while preserving next_row_id.
+    // Second Replace: publish_snapshot retires the first generation's files and
+    // resets visible totals to zero while preserving next_row_id (the retirement
+    // moved here from begin_write_transaction).
     let s2 = w
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
+        .unwrap();
+    w.publish_snapshot(s2.table_id, s2.snapshot_id, WriteMode::Replace)
         .unwrap();
     let (rc2, next2, bytes2) = read_table_stats(&pool, s2.table_id).await;
     assert_eq!(rc2, 0, "record_count must reset on Replace");
     assert_eq!(next2, 5, "next_row_id must NOT reset on Replace");
     assert_eq!(bytes2, 0);
 
-    // The first file of the new generation picks up at 5.
+    // The first file of the new generation picks up at 5. The generation was
+    // already published above, so this registration is additive (Append).
     let f2_id = w
         .register_data_file(
             s2.table_id,
             s2.snapshot_id,
             &DataFileInfo::new("g2.parquet", 2048, 2),
+            WriteMode::Append,
         )
         .unwrap();
     assert_eq!(
@@ -1446,6 +1613,7 @@ async fn register_data_file_self_initialises_stats_for_legacy_tables() {
             setup.table_id,
             setup.snapshot_id,
             &DataFileInfo::new("a.parquet", 50, 4),
+            WriteMode::Replace,
         )
         .unwrap();
     assert_eq!(read_row_id_start(&pool, file_id).await, Some(0));
@@ -1474,6 +1642,7 @@ fn three_generations(
             s1.table_id,
             s1.snapshot_id,
             &DataFileInfo::new("f1.parquet", 100, 5),
+            WriteMode::Replace,
         )
         .unwrap();
     let s2 = writer
@@ -1484,6 +1653,7 @@ fn three_generations(
             s2.table_id,
             s2.snapshot_id,
             &DataFileInfo::new("f2.parquet", 100, 5),
+            WriteMode::Replace,
         )
         .unwrap();
     let s3 = writer
@@ -1494,6 +1664,7 @@ fn three_generations(
             s3.table_id,
             s3.snapshot_id,
             &DataFileInfo::new("f3.parquet", 100, 5),
+            WriteMode::Replace,
         )
         .unwrap();
     (s1.table_id, s1.snapshot_id, s2.snapshot_id, s3.snapshot_id)
@@ -1519,6 +1690,7 @@ async fn expire_in_catalog_empty_for_most_recent_and_unknown() {
         s.table_id,
         s.snapshot_id,
         &DataFileInfo::new("f1.parquet", 100, 5),
+        WriteMode::Replace,
     )
     .unwrap();
 
@@ -1629,6 +1801,7 @@ async fn expire_in_catalog_full_after_drop_removes_table_metadata() {
         s.table_id,
         s.snapshot_id,
         &DataFileInfo::new("f1.parquet", 100, 5),
+        WriteMode::Replace,
     )
     .unwrap();
 
@@ -1701,6 +1874,7 @@ async fn expire_in_catalog_is_scoped_to_catalog() {
         a1.table_id,
         a1.snapshot_id,
         &DataFileInfo::new("f1.parquet", 100, 5),
+        WriteMode::Replace,
     )
     .unwrap();
     let b1 = wb
@@ -1710,6 +1884,7 @@ async fn expire_in_catalog_is_scoped_to_catalog() {
         b1.table_id,
         b1.snapshot_id,
         &DataFileInfo::new("g1.parquet", 100, 5),
+        WriteMode::Replace,
     )
     .unwrap();
     let a2 = wa
@@ -1719,6 +1894,7 @@ async fn expire_in_catalog_is_scoped_to_catalog() {
         a2.table_id,
         a2.snapshot_id,
         &DataFileInfo::new("f2.parquet", 100, 5),
+        WriteMode::Replace,
     )
     .unwrap();
     assert!(
@@ -1814,6 +1990,7 @@ async fn cleanup_old_files_in_catalog_is_scoped_to_catalog() {
         a1.table_id,
         a1.snapshot_id,
         &DataFileInfo::new("f1.parquet", 100, 5),
+        WriteMode::Replace,
     )
     .unwrap();
     let a2 = wa
@@ -1823,6 +2000,7 @@ async fn cleanup_old_files_in_catalog_is_scoped_to_catalog() {
         a2.table_id,
         a2.snapshot_id,
         &DataFileInfo::new("f2.parquet", 100, 5),
+        WriteMode::Replace,
     )
     .unwrap();
     let b1 = wb
@@ -1832,6 +2010,7 @@ async fn cleanup_old_files_in_catalog_is_scoped_to_catalog() {
         b1.table_id,
         b1.snapshot_id,
         &DataFileInfo::new("g1.parquet", 100, 5),
+        WriteMode::Replace,
     )
     .unwrap();
     let b2 = wb
@@ -1841,6 +2020,7 @@ async fn cleanup_old_files_in_catalog_is_scoped_to_catalog() {
         b2.table_id,
         b2.snapshot_id,
         &DataFileInfo::new("g2.parquet", 100, 5),
+        WriteMode::Replace,
     )
     .unwrap();
 
@@ -1943,6 +2123,7 @@ async fn delete_orphaned_files_reclaims_dropped_catalog_files() {
         s.table_id,
         s.snapshot_id,
         &DataFileInfo::new("f1.parquet", 100, 5),
+        WriteMode::Replace,
     )
     .unwrap();
     let dir = data_path.join("public").join("t");
@@ -2000,6 +2181,7 @@ async fn delete_orphaned_files_spares_files_referenced_by_any_catalog() {
         sa.table_id,
         sa.snapshot_id,
         &DataFileInfo::new("a.parquet", 100, 5),
+        WriteMode::Replace,
     )
     .unwrap();
     let sb = wb
@@ -2009,6 +2191,7 @@ async fn delete_orphaned_files_spares_files_referenced_by_any_catalog() {
         sb.table_id,
         sb.snapshot_id,
         &DataFileInfo::new("b.parquet", 100, 5),
+        WriteMode::Replace,
     )
     .unwrap();
 
@@ -2126,6 +2309,7 @@ async fn delete_orphaned_files_dry_run_matches_real_run() {
         s.table_id,
         s.snapshot_id,
         &DataFileInfo::new("ref.parquet", 100, 5),
+        WriteMode::Replace,
     )
     .unwrap();
     let dir = data_path.join("public").join("t");

--- a/tests/multicatalog_provider_tests.rs
+++ b/tests/multicatalog_provider_tests.rs
@@ -58,6 +58,7 @@ async fn seed_two_catalogs(pool: &PgPool) -> anyhow::Result<(i64, i64)> {
             setup.table_id,
             setup.snapshot_id,
             &DataFileInfo::new(fname, 1024, 3),
+            WriteMode::Replace,
         )
         .unwrap();
     };


### PR DESCRIPTION


A managed-load Replace on a multicatalog Postgres DuckLake table could expose a window where readers saw the table as empty (count=0, MIN/MAX NULL) — intermittently, under concurrent load during the data upload, and always as a clean zero rather than torn data.

Root cause: Replace was split across two commits with the upload between them. begin_write_transaction committed (a) the catalog head advance (ducklake_catalog_snapshot_map insert; readers resolve head = MAX over this map) and (b) end-snapshotting the prior generation's files plus zeroing stats — before the writer streamed the new parquet and, only in finish(), called register_data_file to insert the new file. So for the whole upload, the committed state was head = N+1, every old file end_snapshot = N+1 (excluded by the window predicate), and no file yet at begin_snapshot = N+1 -> zero visible files.

Fix: publish the head advance + prior-generation retirement in the SAME transaction that registers the new data file, so N+1 never becomes the resolvable head without its data present.

- begin_write_transaction no longer inserts the snapshot map row, ends old files, or zeroes stats. It still inserts the (now dormant, unmapped) snapshot row, schema/table/columns, and allocates schema_version under the catalog lock as before.
- register_data_file takes a WriteMode and, in its single committed transaction: for Replace, end-snapshots the prior generation (begin_snapshot < N+1, multi-file safe) and zeroes record/byte stats; inserts the new file; accumulates stats; and advances the catalog head (idempotent ON CONFLICT). next_row_id stays monotonic.
- New MetadataWriter::publish_snapshot advances the head (and retires the prior generation for Replace) with no data file, for write paths that register none: CREATE TABLE and zero-row Replace. Default is a no-op; only multicatalog Postgres overrides it. schema.rs CREATE TABLE now calls it so empty tables stay visible.
- Upload stays outside any transaction (unchanged).

Crash safety improves: a crash mid-write now leaves at most an orphan (unmapped) snapshot row and no head change, so readers stay on the fully-complete old generation rather than bricking the table.

SQLite is single-catalog (head = MAX(snapshot_id) over ducklake_snapshot, advanced by the snapshot-row insert in begin_write_transaction), so it is left unchanged; its register_data_file accepts but ignores the mode.

Known trade-off: because the map insert moves out of begin_write_ transaction, a concurrent same-catalog DDL write started during another write's upload won't see the in-flight snapshot when computing schema_version, so dense per-catalog versioning can skew under that narrow race. The common managed-load path (Replace = DML, carry-forward, no schema_versions row) is unaffected and no constraint is violated.

Tests: thread WriteMode through every register_data_file call site; add publish_snapshot between writes in tests that commit without a file; add replace_is_atomic_no_empty_read_window asserting a read interleaved between begin and register sees the old generation and the head does not advance to a fileless snapshot.