### PR TITLE
fix(write): require single-partition input in DuckLakeInsertExec (#136)

### DIFF
--- a/src/insert_exec.rs
+++ b/src/insert_exec.rs
@@ -119,6 +119,17 @@ impl ExecutionPlan for DuckLakeInsertExec {
         vec![&self.input]
     }
 
+    /// Require all input rows in a single partition.
+    ///
+    /// `execute` only drives `input.execute(0)`, so without this DataFusion
+    /// would feed a multi-partition input (e.g. a parallel scan or aggregation)
+    /// straight through and partitions `1..N` would be silently dropped. Asking
+    /// for `SinglePartition` makes the optimizer insert a `CoalescePartitionsExec`
+    /// that merges every input partition into partition 0 before we read it.
+    fn required_input_distribution(&self) -> Vec<datafusion::physical_expr::Distribution> {
+        vec![datafusion::physical_expr::Distribution::SinglePartition]
+    }
+
     fn with_new_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,

--- a/tests/insert_partitioning_tests.rs
+++ b/tests/insert_partitioning_tests.rs
@@ -1,0 +1,178 @@
+//! Regression tests for `INSERT INTO ... SELECT` with a multi-partition input.
+//!
+//! `DuckLakeInsertExec::execute` only drives `input.execute(0)`. Unless the
+//! operator declares `required_input_distribution() == SinglePartition`,
+//! DataFusion may hand it a multi-partition input (any parallelized scan,
+//! aggregation, join, or `UNION`) and partitions `1..N` would be silently
+//! dropped — losing rows with no error. These tests feed a two-partition
+//! source and assert every row is written.
+
+#![cfg(all(feature = "write-sqlite", feature = "metadata-sqlite"))]
+
+use std::sync::Arc;
+
+use arrow::array::{Int64Array, UInt64Array};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use datafusion::datasource::MemTable;
+use datafusion::physical_plan::ExecutionPlanProperties;
+use datafusion::prelude::*;
+use tempfile::TempDir;
+
+use datafusion_ducklake::{
+    DuckLakeCatalog, DuckLakeTableWriter, MetadataWriter, SqliteMetadataProvider,
+    SqliteMetadataWriter,
+};
+
+fn schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]))
+}
+
+fn batch(ids: Vec<i64>) -> RecordBatch {
+    RecordBatch::try_new(schema(), vec![Arc::new(Int64Array::from(ids))]).unwrap()
+}
+
+/// A `MemTable` source with two partitions: [1..=5] and [6..=10] (10 rows).
+fn two_partition_source() -> Arc<MemTable> {
+    Arc::new(
+        MemTable::try_new(
+            schema(),
+            vec![vec![batch(vec![1, 2, 3, 4, 5])], vec![batch(vec![6, 7, 8, 9, 10])]],
+        )
+        .unwrap(),
+    )
+}
+
+struct Harness {
+    _temp_dir: TempDir,
+    conn_str: String,
+    data_path: String,
+}
+
+impl Harness {
+    async fn new() -> Self {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let data_path = temp_dir.path().join("data");
+        std::fs::create_dir_all(&data_path).unwrap();
+        let conn_str = format!("sqlite:{}?mode=rwc", db_path.display());
+
+        let writer = SqliteMetadataWriter::new_with_init(&conn_str)
+            .await
+            .unwrap();
+        writer.set_data_path(data_path.to_str().unwrap()).unwrap();
+        writer.create_snapshot().unwrap();
+
+        Self {
+            _temp_dir: temp_dir,
+            conn_str,
+            data_path: data_path.to_str().unwrap().to_string(),
+        }
+    }
+
+    /// Create `main.<table>` seeded with the given ids via the direct writer.
+    async fn seed_table(&self, table: &str, ids: Vec<i64>) {
+        let writer = SqliteMetadataWriter::new(&self.conn_str).await.unwrap();
+        let store: Arc<dyn object_store::ObjectStore> =
+            Arc::new(object_store::local::LocalFileSystem::new());
+        DuckLakeTableWriter::new(Arc::new(writer), store)
+            .unwrap()
+            .write_table("main", table, &[batch(ids)])
+            .await
+            .unwrap();
+    }
+
+    async fn writable_ctx(&self) -> SessionContext {
+        let writer = SqliteMetadataWriter::new(&self.conn_str).await.unwrap();
+        writer.set_data_path(&self.data_path).unwrap();
+        let provider = SqliteMetadataProvider::new(&self.conn_str).await.unwrap();
+        let catalog = DuckLakeCatalog::with_writer(Arc::new(provider), Arc::new(writer)).unwrap();
+        let ctx = SessionContext::new();
+        ctx.register_catalog("ducklake", Arc::new(catalog));
+        ctx
+    }
+
+    /// Fresh read context so we observe the post-write snapshot rather than one
+    /// cached at table registration.
+    async fn count(&self, table: &str) -> i64 {
+        let provider = SqliteMetadataProvider::new(&self.conn_str).await.unwrap();
+        let catalog = DuckLakeCatalog::new(provider).unwrap();
+        let ctx = SessionContext::new();
+        ctx.register_catalog("ducklake", Arc::new(catalog));
+        let b = ctx
+            .sql(&format!("SELECT count(*) FROM ducklake.main.{table}"))
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        b[0].column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .value(0)
+    }
+}
+
+async fn run_dml_collect(ctx: &SessionContext, sql: &str) -> u64 {
+    let out = ctx.sql(sql).await.unwrap().collect().await.unwrap();
+    out[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .unwrap()
+        .value(0)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn insert_into_from_multipartition_source_keeps_all_rows() {
+    let h = Harness::new().await;
+    h.seed_table("t", vec![0]).await; // 1 seed row
+
+    let ctx = h.writable_ctx().await;
+    ctx.register_table("src", two_partition_source()).unwrap();
+
+    // Sanity: the source really is multi-partition (otherwise the test is moot).
+    let parts = ctx
+        .sql("SELECT * FROM src")
+        .await
+        .unwrap()
+        .create_physical_plan()
+        .await
+        .unwrap()
+        .output_partitioning()
+        .partition_count();
+    assert!(
+        parts > 1,
+        "source must have >1 partition to exercise the bug, got {parts}"
+    );
+
+    let reported = run_dml_collect(&ctx, "INSERT INTO ducklake.main.t SELECT * FROM src").await;
+    assert_eq!(reported, 10, "INSERT must report all 10 input rows written");
+    assert_eq!(
+        h.count("t").await,
+        11,
+        "table must hold seed + all inserted rows"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn insert_overwrite_from_multipartition_source_keeps_all_rows() {
+    let h = Harness::new().await;
+    h.seed_table("t", vec![0]).await; // seed to be replaced
+
+    let ctx = h.writable_ctx().await;
+    ctx.register_table("src", two_partition_source()).unwrap();
+
+    let reported =
+        run_dml_collect(&ctx, "INSERT OVERWRITE ducklake.main.t SELECT * FROM src").await;
+    assert_eq!(
+        reported, 10,
+        "INSERT OVERWRITE must report all 10 input rows written"
+    );
+    assert_eq!(
+        h.count("t").await,
+        10,
+        "overwrite must replace seed with all 10 rows"
+    );
+}


### PR DESCRIPTION
## What

Fixes silent data loss on `INSERT INTO <ducklake table> SELECT ...` when the
input plan runs with more than one execution partition.

Closes #136.

## Problem

`DuckLakeInsertExec::execute` consumes only the first input partition
(`input.execute(0)`) but did not constrain its input distribution, so it
inherited the default `UnspecifiedDistribution`. DataFusion therefore never
coalesced a multi-partition input, and partitions `1..N` were never executed —
their rows were dropped with no error.

The input is multi-partition whenever the `SELECT` parallelizes (large scan,
`GROUP BY`, join, `UNION`, or any multi-partition source). Small inputs usually
plan to a single partition and appear to work, which is why this hid until now.

Read paths and the direct writer API (`DuckLakeTableWriter::begin_write` /
`write_table`) are unaffected — neither goes through `DuckLakeInsertExec`.

## Fix

Declare `required_input_distribution() -> [Distribution::SinglePartition]`, so
the optimizer inserts a `CoalescePartitionsExec` that merges all input
partitions into partition 0 before the operator reads it.

This mirrors DataFusion's own `DataSinkExec`, which requires `SinglePartition`
for the same reason. No companion overrides are needed: in datafusion 53 the
default `benefits_from_input_partitioning` is derived from
`required_input_distribution`, so requiring `SinglePartition` already yields
`[false]` (i.e. the optimizer won't add a pointless repartition). There is no
throughput regression — the operator already collects all batches and writes a
single file.

## Tests

`tests/insert_partitioning_tests.rs` feeds a two-partition `MemTable` source and
asserts all rows are written, for both:
- `INSERT INTO ... SELECT ...`
- `INSERT OVERWRITE ... SELECT ...`

The append test also asserts the source genuinely has >1 partition, so the test
keeps exercising the multi-partition path (and would fail loudly if it stopped
doing so). Without the fix these fail (only 5 of 10 rows land); with it they
pass.

## Verification

- New tests pass; previously fail without the fix.
- Existing `sql_write_tests` (7) and `write_tests` (18) still pass.
- `cargo fmt --check` clean; `cargo clippy` clean on the library and the new test.
