### PR TITLE
  fix(write): make single-catalog (SQLite) Replace atomic

### DIFF
--- a/examples/maintenance_demo.rs
+++ b/examples/maintenance_demo.rs
@@ -53,6 +53,15 @@ async fn main() -> anyhow::Result<()> {
         &[ColumnDef::new("id", "int64", false)?, ColumnDef::new("name", "varchar", true)?],
         WriteMode::Replace,
     )?;
+    // CREATE TABLE registers no data file; publish the (empty) snapshot so it
+    // becomes the head — begin_write_transaction now only RESERVES the id.
+    writer.publish_snapshot(
+        s1.table_id,
+        s1.snapshot_id,
+        WriteMode::Replace,
+        &cols(),
+        &s1.column_ids,
+    )?;
     print_state(&pool, &data_path, "Step 1 — CREATE TABLE main.t").await?;
 
     // --- snap 2: write data file f1 ("INSERT") ---------------------------------------
@@ -67,6 +76,8 @@ async fn main() -> anyhow::Result<()> {
         s2.snapshot_id,
         &DataFileInfo::new("f1.parquet", 100, 5),
         WriteMode::Replace,
+        &cols(),
+        &s2.column_ids,
     )?;
     touch_file(&data_path, "main", "t", "f1.parquet")?;
     print_state(&pool, &data_path, "Step 2 — write f1 (INSERT)").await?;
@@ -78,6 +89,8 @@ async fn main() -> anyhow::Result<()> {
         s3.snapshot_id,
         &DataFileInfo::new("f2.parquet", 100, 5),
         WriteMode::Replace,
+        &cols(),
+        &s3.column_ids,
     )?;
     touch_file(&data_path, "main", "t", "f2.parquet")?;
     print_state(&pool, &data_path, "Step 3 — Replace: end f1, write f2").await?;

--- a/examples/orphan_cleanup_demo.rs
+++ b/examples/orphan_cleanup_demo.rs
@@ -69,6 +69,8 @@ async fn main() -> anyhow::Result<()> {
         s.snapshot_id,
         &DataFileInfo::new("ref.parquet", 100, 5),
         WriteMode::Replace,
+        &[ColumnDef::new("id", "int64", false)?, ColumnDef::new("name", "varchar", true)?],
+        &s.column_ids,
     )?;
     touch_file(&data_path, "main", "t", "ref.parquet")?;
     print_state(

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -238,21 +238,40 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
     /// Register a new data file and publish its snapshot as the catalog head,
     /// atomically. For `Replace`, retires the prior generation in the same
     /// transaction. Returns the assigned data_file_id.
+    ///
+    /// `columns` / `column_ids` describe the snapshot's column generation (in
+    /// `column_order`, ids matching `WriteSetupResult::column_ids`). Backends
+    /// that finalize columns in `begin_write_transaction` (multicatalog
+    /// Postgres) ignore them; single-catalog backends (SQLite) defer the
+    /// column generation to this commit and use them to insert the column rows.
     fn register_data_file(
         &self,
         table_id: i64,
         snapshot_id: i64,
         file: &DataFileInfo,
         mode: WriteMode,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
     ) -> Result<i64>;
 
     /// Publish a write's snapshot as the catalog head with no data file (CREATE
     /// TABLE, zero-row Replace). For `Replace`, retires the prior generation.
+    /// See [`MetadataWriter::register_data_file`] for `columns` / `column_ids`.
     ///
-    /// Default no-op: single-catalog backends advance the head by inserting the
-    /// snapshot row in `begin_write_transaction`. Multicatalog Postgres
-    /// overrides this to insert the `ducklake_catalog_snapshot_map` head row.
-    fn publish_snapshot(&self, _table_id: i64, _snapshot_id: i64, _mode: WriteMode) -> Result<()> {
+    /// Default no-op. Backends that advance the head in
+    /// `begin_write_transaction` could rely on it, but both shipped backends
+    /// override: multicatalog Postgres inserts the
+    /// `ducklake_catalog_snapshot_map` head row, and SQLite (which defers the
+    /// `ducklake_snapshot` row insert out of `begin_write_transaction`) inserts
+    /// the snapshot row + column generation here.
+    fn publish_snapshot(
+        &self,
+        _table_id: i64,
+        _snapshot_id: i64,
+        _mode: WriteMode,
+        _columns: &[ColumnDef],
+        _column_ids: &[i64],
+    ) -> Result<()> {
         Ok(())
     }
 

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -237,7 +237,9 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
 
     /// Register a new data file and publish its snapshot as the catalog head,
     /// atomically. For `Replace`, retires the prior generation in the same
-    /// transaction. Returns the assigned data_file_id.
+    /// transaction. Returns the committed snapshot id: assigned at this commit
+    /// for SQLite (so it may differ from `WriteSetupResult::snapshot_id` under
+    /// concurrency), reserved at begin for Postgres.
     ///
     /// `columns` / `column_ids` describe the snapshot's column generation (in
     /// `column_order`, ids matching `WriteSetupResult::column_ids`). Backends

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -535,6 +535,12 @@ impl MetadataWriter for PostgresMetadataWriter {
         snapshot_id: i64,
         file: &DataFileInfo,
         mode: WriteMode,
+        // Multicatalog Postgres finalizes the column generation in
+        // `begin_write_transaction` (column visibility is gated by the deferred
+        // `ducklake_catalog_snapshot_map` head row, not `end_snapshot`), so the
+        // commit point does not re-stamp columns.
+        _columns: &[ColumnDef],
+        _column_ids: &[i64],
     ) -> Result<i64> {
         block_on(async {
             // Single atomic commit: retire the prior generation (Replace), insert
@@ -612,7 +618,14 @@ impl MetadataWriter for PostgresMetadataWriter {
         })
     }
 
-    fn publish_snapshot(&self, table_id: i64, snapshot_id: i64, mode: WriteMode) -> Result<()> {
+    fn publish_snapshot(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+        mode: WriteMode,
+        _columns: &[ColumnDef],
+        _column_ids: &[i64],
+    ) -> Result<()> {
         block_on(async {
             let mut tx = self.pool.begin().await?;
             lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -574,11 +574,11 @@ impl MetadataWriter for PostgresMetadataWriter {
                     .await?;
             let row_id_start: i64 = stats_row.try_get(0)?;
 
-            let row = sqlx::query(
+            sqlx::query(
                 "INSERT INTO ducklake_data_file
                      (table_id, path, path_is_relative, file_size_bytes,
                       footer_size, record_count, row_id_start, begin_snapshot)
-                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING data_file_id",
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
             )
             .bind(table_id)
             .bind(&file.path)
@@ -588,9 +588,8 @@ impl MetadataWriter for PostgresMetadataWriter {
             .bind(file.record_count)
             .bind(row_id_start)
             .bind(snapshot_id)
-            .fetch_one(&mut *tx)
+            .execute(&mut *tx)
             .await?;
-            let id: i64 = row.try_get(0)?;
 
             // Advance the counter and accumulate stats. `next_row_id`
             // monotonically increases over the table's lifetime — rowids
@@ -614,7 +613,7 @@ impl MetadataWriter for PostgresMetadataWriter {
             advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
 
             tx.commit().await?;
-            Ok(id)
+            Ok(snapshot_id)
         })
     }
 

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -207,13 +207,14 @@ impl SqliteMetadataWriter {
                 },
             };
 
-            let drop_snapshot = reserve_ids(&mut tx, "next_snapshot_id", 1).await?;
-            sqlx::query(
-                "INSERT INTO ducklake_snapshot (snapshot_id, snapshot_time) VALUES (?, CURRENT_TIMESTAMP)",
+            let drop_snapshot: i64 = sqlx::query(
+                "INSERT INTO ducklake_snapshot (snapshot_id, snapshot_time)
+                 SELECT COALESCE(MAX(snapshot_id), 0) + 1, CURRENT_TIMESTAMP FROM ducklake_snapshot
+                 RETURNING snapshot_id",
             )
-            .bind(drop_snapshot)
-            .execute(&mut *tx)
-            .await?;
+            .fetch_one(&mut *tx)
+            .await?
+            .try_get(0)?;
 
             for child in
                 ["ducklake_table", "ducklake_column", "ducklake_data_file", "ducklake_delete_file"]
@@ -639,19 +640,21 @@ async fn retire_prior_generation(
 async fn finalize_snapshot(
     tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
     table_id: i64,
-    snapshot_id: i64,
     columns: &[ColumnDef],
     column_ids: &[i64],
     mode: WriteMode,
-) -> Result<()> {
-    // Insert the deferred snapshot row with its reserved id — THIS is the head
-    // advance.
-    sqlx::query(
-        "INSERT INTO ducklake_snapshot (snapshot_id, snapshot_time) VALUES (?, CURRENT_TIMESTAMP)",
+) -> Result<i64> {
+    // Assign the snapshot id in commit order: one INSERT ... SELECT MAX+1
+    // RETURNING takes the write lock for the read and insert together, so
+    // concurrent writers can't collide or publish out of order.
+    let snapshot_id: i64 = sqlx::query(
+        "INSERT INTO ducklake_snapshot (snapshot_id, snapshot_time)
+         SELECT COALESCE(MAX(snapshot_id), 0) + 1, CURRENT_TIMESTAMP FROM ducklake_snapshot
+         RETURNING snapshot_id",
     )
-    .bind(snapshot_id)
-    .execute(&mut **tx)
-    .await?;
+    .fetch_one(&mut **tx)
+    .await?
+    .try_get(0)?;
 
     // Finalize the column generation: end the prior columns and insert the new
     // set with the reserved column_ids (matching the parquet field_ids).
@@ -694,20 +697,21 @@ async fn finalize_snapshot(
         .await?;
         retire_prior_generation(tx, table_id, snapshot_id).await?;
     }
-    Ok(())
+    Ok(snapshot_id)
 }
 
 impl MetadataWriter for SqliteMetadataWriter {
     fn create_snapshot(&self) -> Result<i64> {
         block_on(async {
             let mut tx = self.pool.begin().await?;
-            let snapshot_id = reserve_ids(&mut tx, "next_snapshot_id", 1).await?;
-            sqlx::query(
-                "INSERT INTO ducklake_snapshot (snapshot_id, snapshot_time) VALUES (?, CURRENT_TIMESTAMP)",
+            let snapshot_id: i64 = sqlx::query(
+                "INSERT INTO ducklake_snapshot (snapshot_id, snapshot_time)
+                 SELECT COALESCE(MAX(snapshot_id), 0) + 1, CURRENT_TIMESTAMP FROM ducklake_snapshot
+                 RETURNING snapshot_id",
             )
-            .bind(snapshot_id)
-            .execute(&mut *tx)
-            .await?;
+            .fetch_one(&mut *tx)
+            .await?
+            .try_get(0)?;
             tx.commit().await?;
             Ok(snapshot_id)
         })
@@ -844,7 +848,7 @@ impl MetadataWriter for SqliteMetadataWriter {
     fn register_data_file(
         &self,
         table_id: i64,
-        snapshot_id: i64,
+        _snapshot_id: i64,
         file: &DataFileInfo,
         mode: WriteMode,
         columns: &[ColumnDef],
@@ -858,7 +862,8 @@ impl MetadataWriter for SqliteMetadataWriter {
             // only ever resolves to fully-populated data (no empty-read window).
             let mut tx = self.pool.begin().await?;
 
-            finalize_snapshot(&mut tx, table_id, snapshot_id, columns, column_ids, mode).await?;
+            let snapshot_id =
+                finalize_snapshot(&mut tx, table_id, columns, column_ids, mode).await?;
 
             // Seed the stats row for the Append path (Replace already seeded it
             // in finalize_snapshot); INSERT OR IGNORE is a no-op if it exists.
@@ -878,11 +883,11 @@ impl MetadataWriter for SqliteMetadataWriter {
                     .await?;
             let row_id_start: i64 = stats_row.try_get(0)?;
 
-            let data_file_row = sqlx::query(
+            sqlx::query(
                 "INSERT INTO ducklake_data_file
                      (table_id, path, path_is_relative, file_size_bytes,
                       footer_size, record_count, row_id_start, begin_snapshot)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING data_file_id",
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             )
             .bind(table_id)
             .bind(&file.path)
@@ -892,9 +897,8 @@ impl MetadataWriter for SqliteMetadataWriter {
             .bind(file.record_count)
             .bind(row_id_start)
             .bind(snapshot_id)
-            .fetch_one(&mut *tx)
+            .execute(&mut *tx)
             .await?;
-            let data_file_id: i64 = data_file_row.try_get(0)?;
 
             // Advance the counter and accumulate stats. `next_row_id`
             // monotonically increases over the table's lifetime — rowids
@@ -914,14 +918,14 @@ impl MetadataWriter for SqliteMetadataWriter {
             .await?;
 
             tx.commit().await?;
-            Ok(data_file_id)
+            Ok(snapshot_id)
         })
     }
 
     fn publish_snapshot(
         &self,
         table_id: i64,
-        snapshot_id: i64,
+        _snapshot_id: i64,
         mode: WriteMode,
         columns: &[ColumnDef],
         column_ids: &[i64],
@@ -935,7 +939,7 @@ impl MetadataWriter for SqliteMetadataWriter {
         // register_data_file instead.
         block_on(async {
             let mut tx = self.pool.begin().await?;
-            finalize_snapshot(&mut tx, table_id, snapshot_id, columns, column_ids, mode).await?;
+            finalize_snapshot(&mut tx, table_id, columns, column_ids, mode).await?;
             tx.commit().await?;
             Ok(())
         })
@@ -1020,17 +1024,6 @@ impl MetadataWriter for SqliteMetadataWriter {
             // pre-existing catalog continues without reusing ids.
             sqlx::query(
                 "INSERT INTO ducklake_metadata (key, value, scope)
-                 SELECT 'next_snapshot_id',
-                        CAST(COALESCE((SELECT MAX(snapshot_id) FROM ducklake_snapshot), 0) AS TEXT),
-                        NULL
-                 WHERE NOT EXISTS (
-                     SELECT 1 FROM ducklake_metadata WHERE key = 'next_snapshot_id' AND scope IS NULL
-                 )",
-            )
-            .execute(&self.pool)
-            .await?;
-            sqlx::query(
-                "INSERT INTO ducklake_metadata (key, value, scope)
                  SELECT 'next_column_id',
                         CAST(COALESCE((SELECT MAX(column_id) FROM ducklake_column), 0) AS TEXT),
                         NULL
@@ -1061,14 +1054,20 @@ impl MetadataWriter for SqliteMetadataWriter {
         block_on(async {
             let mut tx = self.pool.begin().await?;
 
-            // Reserve the snapshot id from the monotonic counter WITHOUT inserting
-            // the row. The head is COALESCE(MAX(snapshot_id), 0), so inserting here
-            // would advance the head before the data file exists — the
-            // transient-empty-read bug. The row is inserted at the atomic commit
-            // point (`finalize_snapshot`, from register_data_file /
-            // publish_snapshot). The counter serializes under SQLite's write lock,
-            // so concurrent writers get distinct ids and never collide.
-            let snapshot_id = reserve_ids(&mut tx, "next_snapshot_id", 1).await?;
+            // Reserve the column ids first so the counter UPDATE takes the write
+            // lock up front, avoiding a lock-upgrade deadlock between concurrent
+            // begins. These ids match the staged parquet field ids.
+            let n = columns.len() as i64;
+            let last_column_id = reserve_ids(&mut tx, "next_column_id", n).await?;
+            let column_ids: Vec<i64> = ((last_column_id - n + 1)..=last_column_id).collect();
+
+            // Tentative id for WriteSetupResult; the real one is assigned at the
+            // commit (finalize_snapshot), so it may differ under concurrency.
+            let snapshot_id: i64 =
+                sqlx::query("SELECT COALESCE(MAX(snapshot_id), 0) + 1 FROM ducklake_snapshot")
+                    .fetch_one(&mut *tx)
+                    .await?
+                    .try_get(0)?;
 
             let schema_id: i64 = {
                 let existing = sqlx::query(
@@ -1189,9 +1188,6 @@ impl MetadataWriter for SqliteMetadataWriter {
             // reserved ids are returned so the staged parquet's `field_id`
             // metadata matches the ids eventually committed, and the counter keeps
             // concurrent writers' blocks disjoint.
-            let n = columns.len() as i64;
-            let last_column_id = reserve_ids(&mut tx, "next_column_id", n).await?;
-            let column_ids: Vec<i64> = ((last_column_id - n + 1)..=last_column_id).collect();
 
             // No snapshot row, no column rows, and no Replace retirement are
             // written here — all are deferred to the atomic commit so the head
@@ -1316,10 +1312,12 @@ mod tests {
 
         let file = DataFileInfo::new("data.parquet", 1024, 100).with_footer_size(256);
 
-        let file_id = writer
+        // register_data_file returns the committed snapshot id (head); the
+        // first write commits snapshot 1.
+        let committed = writer
             .register_data_file(table_id, snapshot_id, &file, WriteMode::Append, &[], &[])
             .unwrap();
-        assert_eq!(file_id, 1);
+        assert_eq!(committed, 1);
     }
 
     /// Reserve the next snapshot id the way `begin_write_transaction` now does
@@ -1328,24 +1326,20 @@ mod tests {
     /// drive `register_data_file` directly must reserve (not `create_snapshot`)
     /// the snapshot they register, since registration owns the snapshot insert.
     async fn reserve_snapshot(writer: &SqliteMetadataWriter) -> i64 {
-        sqlx::query(
-            "UPDATE ducklake_metadata SET value = CAST(CAST(value AS INTEGER) + 1 AS TEXT)
-             WHERE key = 'next_snapshot_id' AND scope IS NULL
-             RETURNING CAST(value AS INTEGER)",
-        )
-        .fetch_one(&writer.pool)
-        .await
-        .unwrap()
-        .try_get(0)
-        .unwrap()
+        sqlx::query("SELECT COALESCE(MAX(snapshot_id), 0) + 1 FROM ducklake_snapshot")
+            .fetch_one(&writer.pool)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap()
     }
 
     /// Helper for the row-lineage tests: read back what `register_data_file`
     /// wrote into the catalog so we can assert on `row_id_start` and the
     /// stats counter directly.
-    async fn read_row_id_start(writer: &SqliteMetadataWriter, file_id: i64) -> Option<i64> {
-        let row = sqlx::query("SELECT row_id_start FROM ducklake_data_file WHERE data_file_id = ?")
-            .bind(file_id)
+    async fn read_row_id_start(writer: &SqliteMetadataWriter, path: &str) -> Option<i64> {
+        let row = sqlx::query("SELECT row_id_start FROM ducklake_data_file WHERE path = ?")
+            .bind(path)
             .fetch_one(&writer.pool)
             .await
             .unwrap();
@@ -1381,7 +1375,7 @@ mod tests {
             .get_or_create_table(schema_id, "t", None, snap1)
             .unwrap();
 
-        let f1_id = writer
+        writer
             .register_data_file(
                 table_id,
                 snap1,
@@ -1392,7 +1386,7 @@ mod tests {
             )
             .unwrap();
         let snap2 = reserve_snapshot(&writer).await;
-        let f2_id = writer
+        writer
             .register_data_file(
                 table_id,
                 snap2,
@@ -1403,8 +1397,8 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(read_row_id_start(&writer, f1_id).await, Some(0));
-        assert_eq!(read_row_id_start(&writer, f2_id).await, Some(3));
+        assert_eq!(read_row_id_start(&writer, "a.parquet").await, Some(0));
+        assert_eq!(read_row_id_start(&writer, "b.parquet").await, Some(3));
 
         let (records, next, bytes) = read_table_stats(&writer, table_id).await;
         assert_eq!(records, 10, "record_count = 3 + 7");
@@ -1444,7 +1438,7 @@ mod tests {
         assert_eq!(bytes, 0, "file_size_bytes cleared");
 
         let snap3 = reserve_snapshot(&writer).await;
-        let f2_id = writer
+        writer
             .register_data_file(
                 table_id,
                 snap3,
@@ -1455,7 +1449,7 @@ mod tests {
             )
             .unwrap();
         assert_eq!(
-            read_row_id_start(&writer, f2_id).await,
+            read_row_id_start(&writer, "b.parquet").await,
             Some(5),
             "post-replace files must start at the preserved counter, not 0",
         );
@@ -1484,7 +1478,7 @@ mod tests {
             .await
             .unwrap();
 
-        let file_id = writer
+        writer
             .register_data_file(
                 table_id,
                 snapshot_id,
@@ -1494,7 +1488,7 @@ mod tests {
                 &[],
             )
             .unwrap();
-        assert_eq!(read_row_id_start(&writer, file_id).await, Some(0));
+        assert_eq!(read_row_id_start(&writer, "a.parquet").await, Some(0));
         let (records, next, _) = read_table_stats(&writer, table_id).await;
         assert_eq!(records, 4);
         assert_eq!(next, 4);

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -207,12 +207,13 @@ impl SqliteMetadataWriter {
                 },
             };
 
-            let drop_snapshot: i64 = sqlx::query(
-                "INSERT INTO ducklake_snapshot (snapshot_time) VALUES (CURRENT_TIMESTAMP) RETURNING snapshot_id",
+            let drop_snapshot = reserve_ids(&mut tx, "next_snapshot_id", 1).await?;
+            sqlx::query(
+                "INSERT INTO ducklake_snapshot (snapshot_id, snapshot_time) VALUES (?, CURRENT_TIMESTAMP)",
             )
-            .fetch_one(&mut *tx)
-            .await?
-            .try_get(0)?;
+            .bind(drop_snapshot)
+            .execute(&mut *tx)
+            .await?;
 
             for child in
                 ["ducklake_table", "ducklake_column", "ducklake_data_file", "ducklake_delete_file"]
@@ -565,15 +566,150 @@ async fn schedule_files(
     Ok(ids)
 }
 
+/// Atomically reserve `n` consecutive ids from a monotonic counter stored in
+/// `ducklake_metadata` (seeded by `initialize_schema`), returning the LAST id of
+/// the block — the reserved ids are `last - n + 1 ..= last`. The `UPDATE`
+/// serializes under SQLite's single-writer lock, so concurrent writers (even to
+/// different tables) never hand out overlapping ids. Used for `snapshot_id` and
+/// `column_id`, which are reserved in `begin_write_transaction` and inserted at
+/// the commit: rowid autoincrement can't be used there because inserting the
+/// `ducklake_snapshot` row would advance the head (`MAX(snapshot_id)`) before the
+/// data is committed.
+async fn reserve_ids(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    key: &str,
+    n: i64,
+) -> Result<i64> {
+    let last: i64 = sqlx::query(
+        "UPDATE ducklake_metadata
+         SET value = CAST(CAST(value AS INTEGER) + ? AS TEXT)
+         WHERE key = ? AND scope IS NULL
+         RETURNING CAST(value AS INTEGER)",
+    )
+    .bind(n)
+    .bind(key)
+    .fetch_one(&mut **tx)
+    .await?
+    .try_get(0)?;
+    Ok(last)
+}
+
+/// Retire the prior generation's still-visible data files at `snapshot_id` and
+/// zero the visible stat totals. The `begin_snapshot < snapshot_id` guard
+/// spares files registered for *this* snapshot, so a multi-file write does not
+/// retire its own siblings. `next_row_id` is left untouched (rowids stay
+/// monotonic across the table's lifetime). Mirrors the Postgres writer.
+async fn retire_prior_generation(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    table_id: i64,
+    snapshot_id: i64,
+) -> Result<()> {
+    sqlx::query(
+        "UPDATE ducklake_data_file SET end_snapshot = ?
+         WHERE table_id = ? AND end_snapshot IS NULL AND begin_snapshot < ?",
+    )
+    .bind(snapshot_id)
+    .bind(table_id)
+    .bind(snapshot_id)
+    .execute(&mut **tx)
+    .await?;
+
+    sqlx::query(
+        "UPDATE ducklake_table_stats SET record_count = 0, file_size_bytes = 0 WHERE table_id = ?",
+    )
+    .bind(table_id)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+/// The atomic commit point for a single-catalog write. Inserts the deferred
+/// `ducklake_snapshot` row (its reserved id was returned by
+/// `begin_write_transaction` but NOT inserted there), finalizes the column
+/// generation, and — for `Replace` — retires the prior data generation. All
+/// within the caller's transaction, so `COALESCE(MAX(snapshot_id), 0)` only
+/// ever resolves to a fully-populated head (no transient empty read).
+///
+/// The column generation is deferred to here (rather than written in
+/// `begin_write_transaction` like the Postgres backend) because the SQLite read
+/// path resolves a table's columns by `end_snapshot IS NULL` ONLY (not
+/// snapshot-scoped), so inserting the new generation at begin would leak it to
+/// concurrent reads during the upload window. `column_ids` are the ids reserved
+/// at begin and already baked into the staged parquet's `field_id` metadata.
+async fn finalize_snapshot(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    table_id: i64,
+    snapshot_id: i64,
+    columns: &[ColumnDef],
+    column_ids: &[i64],
+    mode: WriteMode,
+) -> Result<()> {
+    // Insert the deferred snapshot row with its reserved id — THIS is the head
+    // advance.
+    sqlx::query(
+        "INSERT INTO ducklake_snapshot (snapshot_id, snapshot_time) VALUES (?, CURRENT_TIMESTAMP)",
+    )
+    .bind(snapshot_id)
+    .execute(&mut **tx)
+    .await?;
+
+    // Finalize the column generation: end the prior columns and insert the new
+    // set with the reserved column_ids (matching the parquet field_ids).
+    sqlx::query(
+        "UPDATE ducklake_column SET end_snapshot = ?
+         WHERE table_id = ? AND end_snapshot IS NULL",
+    )
+    .bind(snapshot_id)
+    .bind(table_id)
+    .execute(&mut **tx)
+    .await?;
+
+    for (order, (col, column_id)) in columns.iter().zip(column_ids.iter()).enumerate() {
+        sqlx::query(
+            "INSERT INTO ducklake_column
+                 (column_id, table_id, column_name, column_type, column_order, nulls_allowed, begin_snapshot)
+             VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(column_id)
+        .bind(table_id)
+        .bind(&col.name)
+        .bind(&col.ducklake_type)
+        .bind(order as i64)
+        .bind(col.is_nullable)
+        .bind(snapshot_id)
+        .execute(&mut **tx)
+        .await?;
+    }
+
+    if mode == WriteMode::Replace {
+        // Seed the stats row (first write to a brand-new table) so retire's
+        // zero-update has a row, then retire the prior data generation.
+        sqlx::query(
+            "INSERT OR IGNORE INTO ducklake_table_stats
+                 (table_id, record_count, next_row_id, file_size_bytes)
+             VALUES (?, 0, 0, 0)",
+        )
+        .bind(table_id)
+        .execute(&mut **tx)
+        .await?;
+        retire_prior_generation(tx, table_id, snapshot_id).await?;
+    }
+    Ok(())
+}
+
 impl MetadataWriter for SqliteMetadataWriter {
     fn create_snapshot(&self) -> Result<i64> {
         block_on(async {
-            let row = sqlx::query(
-                "INSERT INTO ducklake_snapshot (snapshot_time) VALUES (CURRENT_TIMESTAMP) RETURNING snapshot_id",
+            let mut tx = self.pool.begin().await?;
+            let snapshot_id = reserve_ids(&mut tx, "next_snapshot_id", 1).await?;
+            sqlx::query(
+                "INSERT INTO ducklake_snapshot (snapshot_id, snapshot_time) VALUES (?, CURRENT_TIMESTAMP)",
             )
-            .fetch_one(&self.pool)
+            .bind(snapshot_id)
+            .execute(&mut *tx)
             .await?;
-            Ok(row.try_get(0)?)
+            tx.commit().await?;
+            Ok(snapshot_id)
         })
     }
 
@@ -675,21 +811,29 @@ impl MetadataWriter for SqliteMetadataWriter {
             .execute(&mut *tx)
             .await?;
 
+            // Reserve a contiguous column_id block from the monotonic counter and
+            // insert with explicit ids, keeping the allocator authoritative (the
+            // write path's begin/commit reserve column ids from the same counter).
+            let n = columns.len() as i64;
+            let last_column_id = reserve_ids(&mut tx, "next_column_id", n).await?;
+            let first_column_id = last_column_id - n + 1;
             let mut column_ids = Vec::with_capacity(columns.len());
             for (order, col) in columns.iter().enumerate() {
-                let row = sqlx::query(
-                    "INSERT INTO ducklake_column (table_id, column_name, column_type, column_order, nulls_allowed, begin_snapshot)
-                     VALUES (?, ?, ?, ?, ?, ?) RETURNING column_id",
+                let column_id = first_column_id + order as i64;
+                sqlx::query(
+                    "INSERT INTO ducklake_column (column_id, table_id, column_name, column_type, column_order, nulls_allowed, begin_snapshot)
+                     VALUES (?, ?, ?, ?, ?, ?, ?)",
                 )
+                .bind(column_id)
                 .bind(table_id)
                 .bind(&col.name)
                 .bind(&col.ducklake_type)
                 .bind(order as i64)
                 .bind(col.is_nullable)
                 .bind(snapshot_id)
-                .fetch_one(&mut *tx)
+                .execute(&mut *tx)
                 .await?;
-                column_ids.push(row.try_get(0)?);
+                column_ids.push(column_id);
             }
 
             tx.commit().await?;
@@ -702,19 +846,22 @@ impl MetadataWriter for SqliteMetadataWriter {
         table_id: i64,
         snapshot_id: i64,
         file: &DataFileInfo,
-        // Single-catalog SQLite advances the head and retires the prior
-        // generation in `begin_write_transaction`, so registration is
-        // mode-agnostic here.
-        _mode: WriteMode,
+        mode: WriteMode,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
     ) -> Result<i64> {
         block_on(async {
-            // Allocate row_id_start from the table's monotonic counter inside
-            // the same transaction so concurrent writers can't hand out
-            // overlapping ranges. Falls back to inserting a fresh stats row
-            // (next_row_id = 0) for tables created before this writer
-            // started maintaining the table_stats table.
+            // Single atomic commit: insert the deferred snapshot row + finalize
+            // the column generation + retire the prior generation (Replace),
+            // then register this file and advance the monotonic row-lineage
+            // counter — all in one transaction, so the head (MAX(snapshot_id))
+            // only ever resolves to fully-populated data (no empty-read window).
             let mut tx = self.pool.begin().await?;
 
+            finalize_snapshot(&mut tx, table_id, snapshot_id, columns, column_ids, mode).await?;
+
+            // Seed the stats row for the Append path (Replace already seeded it
+            // in finalize_snapshot); INSERT OR IGNORE is a no-op if it exists.
             sqlx::query(
                 "INSERT OR IGNORE INTO ducklake_table_stats
                      (table_id, record_count, next_row_id, file_size_bytes)
@@ -768,6 +915,29 @@ impl MetadataWriter for SqliteMetadataWriter {
 
             tx.commit().await?;
             Ok(data_file_id)
+        })
+    }
+
+    fn publish_snapshot(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+        mode: WriteMode,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+    ) -> Result<()> {
+        // Fileless commit point. Single-catalog SQLite defers the snapshot-row
+        // insert out of begin_write_transaction, so this is no longer a no-op:
+        // it inserts the deferred snapshot row + column generation and, for
+        // Replace, retires the prior generation — making the new head visible
+        // atomically. Used by CREATE TABLE (schema.rs); the crate's own write
+        // path always registers a file (even for zero rows) and so commits via
+        // register_data_file instead.
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            finalize_snapshot(&mut tx, table_id, snapshot_id, columns, column_ids, mode).await?;
+            tx.commit().await?;
+            Ok(())
         })
     }
 
@@ -841,6 +1011,35 @@ impl MetadataWriter for SqliteMetadataWriter {
     fn initialize_schema(&self) -> Result<()> {
         block_on(async {
             sqlx::query(SQL_CREATE_SCHEMA).execute(&self.pool).await?;
+            // Seed the monotonic id allocators. snapshot_id and column_id are
+            // reserved in begin_write_transaction and inserted at the commit, so
+            // they can't use rowid autoincrement (inserting the ducklake_snapshot
+            // row would advance the head before the data is committed). The
+            // counters give collision-free allocation across concurrent writers.
+            // Idempotent on re-open, and seeded from the current MAX so a
+            // pre-existing catalog continues without reusing ids.
+            sqlx::query(
+                "INSERT INTO ducklake_metadata (key, value, scope)
+                 SELECT 'next_snapshot_id',
+                        CAST(COALESCE((SELECT MAX(snapshot_id) FROM ducklake_snapshot), 0) AS TEXT),
+                        NULL
+                 WHERE NOT EXISTS (
+                     SELECT 1 FROM ducklake_metadata WHERE key = 'next_snapshot_id' AND scope IS NULL
+                 )",
+            )
+            .execute(&self.pool)
+            .await?;
+            sqlx::query(
+                "INSERT INTO ducklake_metadata (key, value, scope)
+                 SELECT 'next_column_id',
+                        CAST(COALESCE((SELECT MAX(column_id) FROM ducklake_column), 0) AS TEXT),
+                        NULL
+                 WHERE NOT EXISTS (
+                     SELECT 1 FROM ducklake_metadata WHERE key = 'next_column_id' AND scope IS NULL
+                 )",
+            )
+            .execute(&self.pool)
+            .await?;
             Ok(())
         })
     }
@@ -862,12 +1061,14 @@ impl MetadataWriter for SqliteMetadataWriter {
         block_on(async {
             let mut tx = self.pool.begin().await?;
 
-            let row = sqlx::query(
-                "INSERT INTO ducklake_snapshot (snapshot_time) VALUES (CURRENT_TIMESTAMP) RETURNING snapshot_id",
-            )
-            .fetch_one(&mut *tx)
-            .await?;
-            let snapshot_id: i64 = row.try_get(0)?;
+            // Reserve the snapshot id from the monotonic counter WITHOUT inserting
+            // the row. The head is COALESCE(MAX(snapshot_id), 0), so inserting here
+            // would advance the head before the data file exists — the
+            // transient-empty-read bug. The row is inserted at the atomic commit
+            // point (`finalize_snapshot`, from register_data_file /
+            // publish_snapshot). The counter serializes under SQLite's write lock,
+            // so concurrent writers get distinct ids and never collide.
+            let snapshot_id = reserve_ids(&mut tx, "next_snapshot_id", 1).await?;
 
             let schema_id: i64 = {
                 let existing = sqlx::query(
@@ -979,65 +1180,25 @@ impl MetadataWriter for SqliteMetadataWriter {
                 // Columns in existing but not in new schema are implicitly removed - this is allowed
             }
 
-            sqlx::query(
-                "UPDATE ducklake_column SET end_snapshot = ?
-                 WHERE table_id = ? AND end_snapshot IS NULL",
-            )
-            .bind(snapshot_id)
-            .bind(table_id)
-            .execute(&mut *tx)
-            .await?;
+            // Reserve a contiguous column_id block from the monotonic counter
+            // WITHOUT inserting the column rows. The new column generation is
+            // written at the commit point (`finalize_snapshot`), not here, because
+            // the SQLite read path resolves a table's columns by `end_snapshot IS
+            // NULL` only (not snapshot-scoped) — inserting at begin would leak the
+            // new generation to concurrent reads during the upload window. The
+            // reserved ids are returned so the staged parquet's `field_id`
+            // metadata matches the ids eventually committed, and the counter keeps
+            // concurrent writers' blocks disjoint.
+            let n = columns.len() as i64;
+            let last_column_id = reserve_ids(&mut tx, "next_column_id", n).await?;
+            let column_ids: Vec<i64> = ((last_column_id - n + 1)..=last_column_id).collect();
 
-            let mut column_ids = Vec::with_capacity(columns.len());
-            for (order, col) in columns.iter().enumerate() {
-                let row = sqlx::query(
-                    "INSERT INTO ducklake_column (table_id, column_name, column_type, column_order, nulls_allowed, begin_snapshot)
-                     VALUES (?, ?, ?, ?, ?, ?) RETURNING column_id",
-                )
-                .bind(table_id)
-                .bind(&col.name)
-                .bind(&col.ducklake_type)
-                .bind(order as i64)
-                .bind(col.is_nullable)
-                .bind(snapshot_id)
-                .fetch_one(&mut *tx)
-                .await?;
-                column_ids.push(row.try_get(0)?);
-            }
-
-            if mode == WriteMode::Replace {
-                sqlx::query(
-                    "UPDATE ducklake_data_file SET end_snapshot = ?
-                     WHERE table_id = ? AND end_snapshot IS NULL",
-                )
-                .bind(snapshot_id)
-                .bind(table_id)
-                .execute(&mut *tx)
-                .await?;
-
-                // Mirror end_table_files: drop visible row/byte totals to
-                // zero while keeping next_row_id monotonic. INSERT OR IGNORE
-                // first so we don't fall over if this is the first write
-                // (Replace on a brand-new table).
-                sqlx::query(
-                    "INSERT OR IGNORE INTO ducklake_table_stats
-                         (table_id, record_count, next_row_id, file_size_bytes)
-                     VALUES (?, 0, 0, 0)",
-                )
-                .bind(table_id)
-                .execute(&mut *tx)
-                .await?;
-
-                sqlx::query(
-                    "UPDATE ducklake_table_stats
-                     SET record_count = 0, file_size_bytes = 0
-                     WHERE table_id = ?",
-                )
-                .bind(table_id)
-                .execute(&mut *tx)
-                .await?;
-            }
-
+            // No snapshot row, no column rows, and no Replace retirement are
+            // written here — all are deferred to the atomic commit so the head
+            // never resolves to an incomplete snapshot. TX-A commits only the
+            // idempotent get-or-create schema/table rows; they carry
+            // begin_snapshot = the reserved id and stay invisible until the
+            // snapshot publishes, since schema/table reads ARE snapshot-scoped.
             tx.commit().await?;
 
             Ok(WriteSetupResult {
@@ -1144,7 +1305,8 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_register_data_file() {
         let (writer, _temp) = create_test_writer().await;
-        let snapshot_id = writer.create_snapshot().unwrap();
+        // Reserve (do not create) the snapshot: register_data_file inserts it.
+        let snapshot_id = reserve_snapshot(&writer).await;
         let (schema_id, _) = writer
             .get_or_create_schema("main", None, snapshot_id)
             .unwrap();
@@ -1155,9 +1317,27 @@ mod tests {
         let file = DataFileInfo::new("data.parquet", 1024, 100).with_footer_size(256);
 
         let file_id = writer
-            .register_data_file(table_id, snapshot_id, &file, WriteMode::Append)
+            .register_data_file(table_id, snapshot_id, &file, WriteMode::Append, &[], &[])
             .unwrap();
         assert_eq!(file_id, 1);
+    }
+
+    /// Reserve the next snapshot id the way `begin_write_transaction` now does
+    /// (bump the monotonic counter WITHOUT inserting the row), so a subsequent
+    /// `register_data_file` can insert it atomically at the commit. Tests that
+    /// drive `register_data_file` directly must reserve (not `create_snapshot`)
+    /// the snapshot they register, since registration owns the snapshot insert.
+    async fn reserve_snapshot(writer: &SqliteMetadataWriter) -> i64 {
+        sqlx::query(
+            "UPDATE ducklake_metadata SET value = CAST(CAST(value AS INTEGER) + 1 AS TEXT)
+             WHERE key = 'next_snapshot_id' AND scope IS NULL
+             RETURNING CAST(value AS INTEGER)",
+        )
+        .fetch_one(&writer.pool)
+        .await
+        .unwrap()
+        .try_get(0)
+        .unwrap()
     }
 
     /// Helper for the row-lineage tests: read back what `register_data_file`
@@ -1194,28 +1374,32 @@ mod tests {
         // [row_id_start, row_id_start + record_count) ranges. Counter is
         // initialized lazily on first register_data_file.
         let (writer, _temp) = create_test_writer().await;
-        let snapshot_id = writer.create_snapshot().unwrap();
-        let (schema_id, _) = writer
-            .get_or_create_schema("main", None, snapshot_id)
-            .unwrap();
+        // Two separate writes (each registers its own snapshot atomically).
+        let snap1 = reserve_snapshot(&writer).await;
+        let (schema_id, _) = writer.get_or_create_schema("main", None, snap1).unwrap();
         let (table_id, _) = writer
-            .get_or_create_table(schema_id, "t", None, snapshot_id)
+            .get_or_create_table(schema_id, "t", None, snap1)
             .unwrap();
 
         let f1_id = writer
             .register_data_file(
                 table_id,
-                snapshot_id,
+                snap1,
                 &DataFileInfo::new("a.parquet", 100, 3),
                 WriteMode::Append,
+                &[],
+                &[],
             )
             .unwrap();
+        let snap2 = reserve_snapshot(&writer).await;
         let f2_id = writer
             .register_data_file(
                 table_id,
-                snapshot_id,
+                snap2,
                 &DataFileInfo::new("b.parquet", 250, 7),
                 WriteMode::Append,
+                &[],
+                &[],
             )
             .unwrap();
 
@@ -1234,7 +1418,7 @@ mod tests {
         // currently-visible rows) but keep next_row_id monotonic so the next
         // generation of files gets fresh, non-overlapping rowids.
         let (writer, _temp) = create_test_writer().await;
-        let snap1 = writer.create_snapshot().unwrap();
+        let snap1 = reserve_snapshot(&writer).await;
         let (schema_id, _) = writer.get_or_create_schema("main", None, snap1).unwrap();
         let (table_id, _) = writer
             .get_or_create_table(schema_id, "t", None, snap1)
@@ -1246,6 +1430,8 @@ mod tests {
                 snap1,
                 &DataFileInfo::new("a.parquet", 100, 5),
                 WriteMode::Append,
+                &[],
+                &[],
             )
             .unwrap();
 
@@ -1257,12 +1443,15 @@ mod tests {
         assert_eq!(next, 5, "next_row_id preserved (monotonic across lifetime)");
         assert_eq!(bytes, 0, "file_size_bytes cleared");
 
+        let snap3 = reserve_snapshot(&writer).await;
         let f2_id = writer
             .register_data_file(
                 table_id,
-                snap2,
+                snap3,
                 &DataFileInfo::new("b.parquet", 200, 2),
                 WriteMode::Append,
+                &[],
+                &[],
             )
             .unwrap();
         assert_eq!(
@@ -1278,7 +1467,7 @@ mod tests {
         // maintaining ducklake_table_stats. First register_data_file must
         // self-initialize the stats row rather than fail.
         let (writer, _temp) = create_test_writer().await;
-        let snapshot_id = writer.create_snapshot().unwrap();
+        let snapshot_id = reserve_snapshot(&writer).await;
         let (schema_id, _) = writer
             .get_or_create_schema("main", None, snapshot_id)
             .unwrap();
@@ -1301,6 +1490,8 @@ mod tests {
                 snapshot_id,
                 &DataFileInfo::new("a.parquet", 50, 4),
                 WriteMode::Append,
+                &[],
+                &[],
             )
             .unwrap();
         assert_eq!(read_row_id_start(&writer, file_id).await, Some(0));
@@ -1312,7 +1503,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_end_table_files() {
         let (writer, _temp) = create_test_writer().await;
-        let snapshot1 = writer.create_snapshot().unwrap();
+        let snapshot1 = reserve_snapshot(&writer).await;
         let (schema_id, _) = writer
             .get_or_create_schema("main", None, snapshot1)
             .unwrap();
@@ -1323,7 +1514,7 @@ mod tests {
         // Register a file
         let file = DataFileInfo::new("data1.parquet", 1024, 100);
         writer
-            .register_data_file(table_id, snapshot1, &file, WriteMode::Append)
+            .register_data_file(table_id, snapshot1, &file, WriteMode::Append, &[], &[])
             .unwrap();
 
         // End files at new snapshot

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -219,7 +219,13 @@ impl SchemaProvider for DuckLakeSchema {
         // this the new (empty) table never becomes visible on multicatalog
         // backends that defer the head advance out of begin_write_transaction.
         writer
-            .publish_snapshot(setup.table_id, setup.snapshot_id, WriteMode::Replace)
+            .publish_snapshot(
+                setup.table_id,
+                setup.snapshot_id,
+                WriteMode::Replace,
+                &columns,
+                &setup.column_ids,
+            )
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
         // Resolve table path

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -388,7 +388,9 @@ impl TableWriteSession {
         if !self.path_is_relative {
             file_info = file_info.with_absolute_path();
         }
-        self.metadata.register_data_file(
+        // register_data_file returns the committed snapshot id (assigned at
+        // the commit for SQLite, reserved at begin for Postgres).
+        let committed_snapshot_id = self.metadata.register_data_file(
             self.table_id,
             self.snapshot_id,
             &file_info,
@@ -398,7 +400,7 @@ impl TableWriteSession {
         )?;
 
         Ok(WriteResult {
-            snapshot_id: self.snapshot_id,
+            snapshot_id: committed_snapshot_id,
             table_id: self.table_id,
             schema_id: self.schema_id,
             files_written: 1,

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -194,6 +194,7 @@ impl DuckLakeTableWriter {
             snapshot_id: setup.snapshot_id,
             schema_id: setup.schema_id,
             table_id: setup.table_id,
+            columns,
             column_ids: setup.column_ids,
             schema_with_ids,
             writer: Some(writer),
@@ -265,7 +266,11 @@ pub struct TableWriteSession {
     snapshot_id: i64,
     schema_id: i64,
     table_id: i64,
-    #[allow(dead_code)]
+    /// Column generation for this write (in `column_order`). Threaded to the
+    /// metadata writer at `finish()` so single-catalog backends, which defer the
+    /// column generation out of `begin_write_transaction`, can insert the
+    /// column rows with `column_ids` at the atomic commit.
+    columns: Vec<ColumnDef>,
     column_ids: Vec<i64>,
     schema_with_ids: SchemaRef,
     /// Parquet writer streaming to the local staging file (`temp`). Batches are
@@ -383,8 +388,14 @@ impl TableWriteSession {
         if !self.path_is_relative {
             file_info = file_info.with_absolute_path();
         }
-        self.metadata
-            .register_data_file(self.table_id, self.snapshot_id, &file_info, self.mode)?;
+        self.metadata.register_data_file(
+            self.table_id,
+            self.snapshot_id,
+            &file_info,
+            self.mode,
+            &self.columns,
+            &self.column_ids,
+        )?;
 
         Ok(WriteResult {
             snapshot_id: self.snapshot_id,

--- a/tests/maintenance_sqlite_tests.rs
+++ b/tests/maintenance_sqlite_tests.rs
@@ -92,6 +92,8 @@ async fn drop_table_tombstones_children_and_is_idempotent() {
             s.snapshot_id,
             &DataFileInfo::new("f1.parquet", 100, 5),
             WriteMode::Replace,
+            &cols(),
+            &s.column_ids,
         )
         .unwrap();
 
@@ -166,6 +168,8 @@ fn three_generations(writer: &SqliteMetadataWriter) -> (i64, i64, i64, i64) {
             s1.snapshot_id,
             &DataFileInfo::new("f1.parquet", 100, 5),
             WriteMode::Replace,
+            &cols(),
+            &s1.column_ids,
         )
         .unwrap();
     let s2 = writer
@@ -177,6 +181,8 @@ fn three_generations(writer: &SqliteMetadataWriter) -> (i64, i64, i64, i64) {
             s2.snapshot_id,
             &DataFileInfo::new("f2.parquet", 100, 5),
             WriteMode::Replace,
+            &cols(),
+            &s2.column_ids,
         )
         .unwrap();
     let s3 = writer
@@ -188,6 +194,8 @@ fn three_generations(writer: &SqliteMetadataWriter) -> (i64, i64, i64, i64) {
             s3.snapshot_id,
             &DataFileInfo::new("f3.parquet", 100, 5),
             WriteMode::Replace,
+            &cols(),
+            &s3.column_ids,
         )
         .unwrap();
     (s1.table_id, s1.snapshot_id, s2.snapshot_id, s3.snapshot_id)
@@ -253,6 +261,8 @@ async fn expire_full_after_drop_reclaims_all_table_metadata() {
             s.snapshot_id,
             &DataFileInfo::new("f1.parquet", 100, 5),
             WriteMode::Replace,
+            &cols(),
+            &s.column_ids,
         )
         .unwrap();
     // Drop allocates snapshot 2; the table is now fully tombstoned in [1, 2).
@@ -402,6 +412,8 @@ async fn delete_orphaned_files_removes_unreferenced_keeps_referenced() {
             s.snapshot_id,
             &DataFileInfo::new("referenced.parquet", 100, 5),
             WriteMode::Replace,
+            &cols(),
+            &s.column_ids,
         )
         .unwrap();
     write_physical_file(&h.data_path, "main", "t", "referenced.parquet");
@@ -672,6 +684,8 @@ async fn delete_orphaned_files_recurses_into_nested_directories() {
             s.snapshot_id,
             &DataFileInfo::new("ref.parquet", 100, 5),
             WriteMode::Replace,
+            &cols(),
+            &s.column_ids,
         )
         .unwrap();
     write_physical_file(&h.data_path, "main", "t", "ref.parquet");
@@ -734,6 +748,8 @@ async fn delete_orphaned_files_dry_run_matches_real_run() {
             s.snapshot_id,
             &DataFileInfo::new("ref.parquet", 100, 5),
             WriteMode::Replace,
+            &cols(),
+            &s.column_ids,
         )
         .unwrap();
     write_physical_file(&h.data_path, "main", "t", "ref.parquet");
@@ -814,5 +830,207 @@ async fn delete_orphaned_files_all_on_empty_catalog_wipes_data_path() {
     assert!(
         fresh.exists(),
         "fresh file survives OlderThan sweep on empty catalog"
+    );
+}
+
+// --- spec-aligned atomic Replace: the transient-empty-read regression --------------
+
+/// Rows visible to a reader resolving at `snapshot` (the file-visibility predicate).
+async fn visible_rows(pool: &SqlitePool, table_id: i64, snapshot: i64) -> i64 {
+    scalar_i64(
+        pool,
+        &format!(
+            "SELECT COALESCE(SUM(record_count), 0) FROM ducklake_data_file
+             WHERE table_id = {table_id}
+               AND {snapshot} >= begin_snapshot
+               AND ({snapshot} < end_snapshot OR end_snapshot IS NULL)"
+        ),
+    )
+    .await
+}
+
+async fn head(pool: &SqlitePool) -> i64 {
+    scalar_i64(
+        pool,
+        "SELECT COALESCE(MAX(snapshot_id), 0) FROM ducklake_snapshot",
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn replace_defers_head_and_retirement_until_register() {
+    // A read interleaved between begin_write_transaction and register_data_file
+    // on a Replace must still see the OLD generation (never count = 0), and the
+    // head must not advance to a fileless snapshot. begin only RESERVES the
+    // snapshot id; the snapshot-row insert + prior-generation retirement happen
+    // atomically in register_data_file. Pre-fix this asserts FALSE (begin
+    // committed the snapshot row and retired the old files before the upload).
+    let h = setup().await;
+    let p = pool(&h).await;
+
+    // Generation 1: committed, non-empty.
+    let s1 = h
+        .writer
+        .begin_write_transaction("main", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    h.writer
+        .register_data_file(
+            s1.table_id,
+            s1.snapshot_id,
+            &DataFileInfo::new("gen1.parquet", 100, 5),
+            WriteMode::Replace,
+            &cols(),
+            &s1.column_ids,
+        )
+        .unwrap();
+    assert_eq!(head(&p).await, s1.snapshot_id, "gen 1 is the head");
+    assert_eq!(visible_rows(&p, s1.table_id, s1.snapshot_id).await, 5);
+
+    // Begin generation 2 — the upload window. Reserves only.
+    let s2 = h
+        .writer
+        .begin_write_transaction("main", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    assert_eq!(s2.snapshot_id, s1.snapshot_id + 1, "reserved the next id");
+
+    // DURING THE WINDOW: head unchanged, gen 1 fully visible (no empty read).
+    assert_eq!(
+        head(&p).await,
+        s1.snapshot_id,
+        "head must stay at gen 1 until register commits the snapshot",
+    );
+    assert_eq!(
+        scalar_i64(
+            &p,
+            &format!(
+                "SELECT COUNT(*) FROM ducklake_data_file
+                 WHERE table_id = {} AND end_snapshot IS NULL",
+                s1.table_id
+            ),
+        )
+        .await,
+        1,
+        "gen 1 file must not be retired during the upload window",
+    );
+    assert_eq!(
+        visible_rows(&p, s1.table_id, s1.snapshot_id).await,
+        5,
+        "old generation still serves its complete data",
+    );
+
+    // Commit generation 2 — atomic flip.
+    h.writer
+        .register_data_file(
+            s2.table_id,
+            s2.snapshot_id,
+            &DataFileInfo::new("gen2.parquet", 100, 7),
+            WriteMode::Replace,
+            &cols(),
+            &s2.column_ids,
+        )
+        .unwrap();
+
+    assert_eq!(head(&p).await, s2.snapshot_id, "head advanced to gen 2");
+    assert_eq!(
+        visible_rows(&p, s2.table_id, s2.snapshot_id).await,
+        7,
+        "gen 2 fully visible at the new head",
+    );
+    assert_eq!(
+        scalar_i64(
+            &p,
+            &format!(
+                "SELECT COUNT(*) FROM ducklake_data_file
+                 WHERE table_id = {} AND end_snapshot = {}",
+                s1.table_id, s2.snapshot_id
+            ),
+        )
+        .await,
+        1,
+        "gen 1 file retired exactly at the new snapshot",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn replace_does_not_leak_new_column_generation_until_register() {
+    // The SQLite read path resolves a table's columns by `end_snapshot IS NULL`
+    // only (not snapshot-scoped), so the new column generation of a
+    // schema-evolving Replace must NOT appear until register_data_file commits.
+    let h = setup().await;
+    let p = pool(&h).await;
+
+    let live_cols = |table_id: i64| {
+        format!(
+            "SELECT COUNT(*) FROM ducklake_column \
+             WHERE table_id = {table_id} AND end_snapshot IS NULL"
+        )
+    };
+
+    // Generation 1: two columns.
+    let s1 = h
+        .writer
+        .begin_write_transaction("main", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    h.writer
+        .register_data_file(
+            s1.table_id,
+            s1.snapshot_id,
+            &DataFileInfo::new("g1.parquet", 100, 5),
+            WriteMode::Replace,
+            &cols(),
+            &s1.column_ids,
+        )
+        .unwrap();
+    assert_eq!(scalar_i64(&p, &live_cols(s1.table_id)).await, 2);
+
+    // Begin a schema-evolving Replace (three columns), then pause before commit.
+    let evolved = vec![
+        ColumnDef::new("id", "int64", false).unwrap(),
+        ColumnDef::new("name", "varchar", true).unwrap(),
+        ColumnDef::new("extra", "int64", true).unwrap(),
+    ];
+    let s2 = h
+        .writer
+        .begin_write_transaction("main", "t", &evolved, WriteMode::Replace)
+        .unwrap();
+
+    // DURING THE WINDOW: still the OLD 2-column generation.
+    assert_eq!(
+        scalar_i64(&p, &live_cols(s1.table_id)).await,
+        2,
+        "new column generation must not be visible until register commits",
+    );
+
+    h.writer
+        .register_data_file(
+            s2.table_id,
+            s2.snapshot_id,
+            &DataFileInfo::new("g2.parquet", 100, 7),
+            WriteMode::Replace,
+            &evolved,
+            &s2.column_ids,
+        )
+        .unwrap();
+
+    // After commit: the new 3-column generation, with the reserved ids the
+    // staged parquet's field_id metadata references.
+    assert_eq!(
+        scalar_i64(&p, &live_cols(s2.table_id)).await,
+        3,
+        "new column generation visible after register",
+    );
+    let max_live_col = scalar_i64(
+        &p,
+        &format!(
+            "SELECT COALESCE(MAX(column_id), 0) FROM ducklake_column \
+             WHERE table_id = {} AND end_snapshot IS NULL",
+            s2.table_id
+        ),
+    )
+    .await;
+    assert_eq!(
+        max_live_col,
+        *s2.column_ids.iter().max().unwrap(),
+        "committed column ids match the ids reserved at begin",
     );
 }

--- a/tests/maintenance_sqlite_tests.rs
+++ b/tests/maintenance_sqlite_tests.rs
@@ -1034,3 +1034,85 @@ async fn replace_does_not_leak_new_column_generation_until_register() {
         "committed column ids match the ids reserved at begin",
     );
 }
+
+/// Two concurrent same-table Replace writers that commit out of reservation
+/// order must leave exactly one file and one column generation live at the
+/// head, with no inverted (end_snapshot < begin_snapshot) column lifetimes.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn replace_out_of_order_commit_does_not_corrupt() {
+    let h = setup().await;
+    let p = pool(&h).await;
+
+    // Generation 1: committed, non-empty.
+    let s0 = h
+        .writer
+        .begin_write_transaction("main", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    h.writer
+        .register_data_file(
+            s0.table_id,
+            s0.snapshot_id,
+            &DataFileInfo::new("gen0.parquet", 100, 5),
+            WriteMode::Replace,
+            &cols(),
+            &s0.column_ids,
+        )
+        .unwrap();
+    let tid = s0.table_id;
+
+    // Two Replace writers open their windows...
+    let w1 = h
+        .writer
+        .begin_write_transaction("main", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    let w2 = h
+        .writer
+        .begin_write_transaction("main", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+
+    // ...and commit in the OPPOSITE order (w2 before w1).
+    h.writer
+        .register_data_file(
+            w2.table_id,
+            w2.snapshot_id,
+            &DataFileInfo::new("gen_w2.parquet", 100, 7),
+            WriteMode::Replace,
+            &cols(),
+            &w2.column_ids,
+        )
+        .unwrap();
+    h.writer
+        .register_data_file(
+            w1.table_id,
+            w1.snapshot_id,
+            &DataFileInfo::new("gen_w1.parquet", 100, 3),
+            WriteMode::Replace,
+            &cols(),
+            &w1.column_ids,
+        )
+        .unwrap();
+
+    let live_files = scalar_i64(&p, &format!("SELECT COUNT(*) FROM ducklake_data_file WHERE table_id = {tid} AND end_snapshot IS NULL")).await;
+    let live_cols = scalar_i64(
+        &p,
+        &format!(
+            "SELECT COUNT(*) FROM ducklake_column WHERE table_id = {tid} AND end_snapshot IS NULL"
+        ),
+    )
+    .await;
+    let inverted = scalar_i64(&p, &format!("SELECT COUNT(*) FROM ducklake_column WHERE table_id = {tid} AND end_snapshot IS NOT NULL AND end_snapshot < begin_snapshot")).await;
+
+    assert_eq!(
+        inverted, 0,
+        "no column may end before it begins (published snapshot mutated)"
+    );
+    assert_eq!(
+        live_files, 1,
+        "exactly one file generation may be live at the head after Replace"
+    );
+    assert_eq!(
+        live_cols,
+        cols().len() as i64,
+        "exactly one column generation may be live at the head"
+    );
+}

--- a/tests/multicatalog_hardening_tests.rs
+++ b/tests/multicatalog_hardening_tests.rs
@@ -234,6 +234,8 @@ async fn register_data_file_rejects_cross_catalog_table_id() {
         snap,
         &DataFileInfo::new("evil.parquet", 1024, 1),
         WriteMode::Replace,
+        &[],
+        &[],
     );
     let err = result.expect_err("must reject cross-catalog table_id");
     assert!(

--- a/tests/multicatalog_postgres_tests.rs
+++ b/tests/multicatalog_postgres_tests.rs
@@ -100,6 +100,8 @@ async fn replace_is_atomic_no_empty_read_window() {
         s1.snapshot_id,
         &DataFileInfo::new("g1.parquet", 1024, 10),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
     assert_eq!(current_head(&pool, cat).await, s1.snapshot_id);
@@ -132,6 +134,8 @@ async fn replace_is_atomic_no_empty_read_window() {
         s2.snapshot_id,
         &DataFileInfo::new("g2.parquet", 2048, 7),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
     assert_eq!(current_head(&pool, cat).await, s2.snapshot_id);
@@ -221,7 +225,13 @@ async fn single_catalog_ddl_then_dml_assigns_versions() {
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
         .unwrap();
     writer
-        .publish_snapshot(setup1.table_id, setup1.snapshot_id, WriteMode::Replace)
+        .publish_snapshot(
+            setup1.table_id,
+            setup1.snapshot_id,
+            WriteMode::Replace,
+            &[],
+            &[],
+        )
         .unwrap();
 
     // Second commit: same columns -> DML, carry forward schema_version.
@@ -229,7 +239,13 @@ async fn single_catalog_ddl_then_dml_assigns_versions() {
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
         .unwrap();
     writer
-        .publish_snapshot(setup2.table_id, setup2.snapshot_id, WriteMode::Replace)
+        .publish_snapshot(
+            setup2.table_id,
+            setup2.snapshot_id,
+            WriteMode::Replace,
+            &[],
+            &[],
+        )
         .unwrap();
 
     let v1: i64 =
@@ -272,7 +288,13 @@ async fn single_catalog_ddl_then_dml_assigns_versions() {
         .begin_write_transaction("public", "users", &cols_v2, WriteMode::Replace)
         .unwrap();
     writer
-        .publish_snapshot(setup3.table_id, setup3.snapshot_id, WriteMode::Replace)
+        .publish_snapshot(
+            setup3.table_id,
+            setup3.snapshot_id,
+            WriteMode::Replace,
+            &[],
+            &[],
+        )
         .unwrap();
     let v3: i64 =
         sqlx::query("SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = $1")
@@ -306,13 +328,25 @@ async fn cross_catalog_isolation_same_schema_name() {
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
         .unwrap();
     writer_a
-        .publish_snapshot(setup_a.table_id, setup_a.snapshot_id, WriteMode::Replace)
+        .publish_snapshot(
+            setup_a.table_id,
+            setup_a.snapshot_id,
+            WriteMode::Replace,
+            &[],
+            &[],
+        )
         .unwrap();
     let setup_b = writer_b
         .begin_write_transaction("public", "orders", &cols(), WriteMode::Replace)
         .unwrap();
     writer_b
-        .publish_snapshot(setup_b.table_id, setup_b.snapshot_id, WriteMode::Replace)
+        .publish_snapshot(
+            setup_b.table_id,
+            setup_b.snapshot_id,
+            WriteMode::Replace,
+            &[],
+            &[],
+        )
         .unwrap();
 
     // Schemas: two "public" rows, one per catalog, with different schema_ids.
@@ -380,19 +414,19 @@ async fn schema_version_is_per_catalog_dense_under_interleaving() {
     let a1 = wa
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
         .unwrap();
-    wa.publish_snapshot(a1.table_id, a1.snapshot_id, WriteMode::Replace)
+    wa.publish_snapshot(a1.table_id, a1.snapshot_id, WriteMode::Replace, &[], &[])
         .unwrap();
     // cat_a DML (Replace, same schema)
     let a2 = wa
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
         .unwrap();
-    wa.publish_snapshot(a2.table_id, a2.snapshot_id, WriteMode::Replace)
+    wa.publish_snapshot(a2.table_id, a2.snapshot_id, WriteMode::Replace, &[], &[])
         .unwrap();
     // cat_b DDL (creates orders) — happens in between cat_a's DDLs
     let b1 = wb
         .begin_write_transaction("public", "orders", &cols(), WriteMode::Replace)
         .unwrap();
-    wb.publish_snapshot(b1.table_id, b1.snapshot_id, WriteMode::Replace)
+    wb.publish_snapshot(b1.table_id, b1.snapshot_id, WriteMode::Replace, &[], &[])
         .unwrap();
     // cat_a DDL: adds age column
     let mut cols_v2 = cols();
@@ -400,13 +434,13 @@ async fn schema_version_is_per_catalog_dense_under_interleaving() {
     let a3 = wa
         .begin_write_transaction("public", "users", &cols_v2, WriteMode::Replace)
         .unwrap();
-    wa.publish_snapshot(a3.table_id, a3.snapshot_id, WriteMode::Replace)
+    wa.publish_snapshot(a3.table_id, a3.snapshot_id, WriteMode::Replace, &[], &[])
         .unwrap();
     // cat_b DML
     let b2 = wb
         .begin_write_transaction("public", "orders", &cols(), WriteMode::Replace)
         .unwrap();
-    wb.publish_snapshot(b2.table_id, b2.snapshot_id, WriteMode::Replace)
+    wb.publish_snapshot(b2.table_id, b2.snapshot_id, WriteMode::Replace, &[], &[])
         .unwrap();
 
     let get_v = |snap_id: i64| {
@@ -446,12 +480,12 @@ async fn no_orphan_mapping_rows() {
     let s1 = w
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
         .unwrap();
-    w.publish_snapshot(s1.table_id, s1.snapshot_id, WriteMode::Replace)
+    w.publish_snapshot(s1.table_id, s1.snapshot_id, WriteMode::Replace, &[], &[])
         .unwrap();
     let s2 = w
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
         .unwrap();
-    w.publish_snapshot(s2.table_id, s2.snapshot_id, WriteMode::Replace)
+    w.publish_snapshot(s2.table_id, s2.snapshot_id, WriteMode::Replace, &[], &[])
         .unwrap();
 
     // Every entry in the maps must point at a real row.
@@ -510,7 +544,14 @@ async fn register_data_file_records_against_table() {
 
     let file = DataFileInfo::new("abc.parquet", 4096, 100).with_footer_size(256);
     let file_id = w
-        .register_data_file(setup.table_id, setup.snapshot_id, &file, WriteMode::Replace)
+        .register_data_file(
+            setup.table_id,
+            setup.snapshot_id,
+            &file,
+            WriteMode::Replace,
+            &[],
+            &[],
+        )
         .unwrap();
     assert!(file_id > 0);
 
@@ -591,6 +632,8 @@ async fn drop_catalog_removes_populated_catalog() {
         s1.snapshot_id,
         &DataFileInfo::new("u.parquet", 1024, 10),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
 
@@ -599,8 +642,14 @@ async fn drop_catalog_removes_populated_catalog() {
     let s_ddl = w
         .begin_write_transaction("public", "users", &cols_v2, WriteMode::Replace)
         .unwrap();
-    w.publish_snapshot(s_ddl.table_id, s_ddl.snapshot_id, WriteMode::Replace)
-        .unwrap();
+    w.publish_snapshot(
+        s_ddl.table_id,
+        s_ddl.snapshot_id,
+        WriteMode::Replace,
+        &[],
+        &[],
+    )
+    .unwrap();
 
     let s_orders = w
         .begin_write_transaction("public", "orders", &cols(), WriteMode::Replace)
@@ -610,6 +659,8 @@ async fn drop_catalog_removes_populated_catalog() {
         s_orders.snapshot_id,
         &DataFileInfo::new("o.parquet", 2048, 20),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
 
@@ -682,6 +733,8 @@ async fn drop_catalog_isolates_other_catalogs() {
         sa.snapshot_id,
         &DataFileInfo::new("a.parquet", 1024, 10),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
 
@@ -693,6 +746,8 @@ async fn drop_catalog_isolates_other_catalogs() {
         sb.snapshot_id,
         &DataFileInfo::new("b.parquet", 2048, 20),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
 
@@ -860,6 +915,8 @@ async fn drop_table_in_catalog_tombstones_table_and_children() {
         s.snapshot_id,
         &DataFileInfo::new("u.parquet", 1024, 10),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
 
@@ -972,6 +1029,8 @@ async fn drop_table_in_catalog_hides_table_from_read_path_and_preserves_time_tra
         s.snapshot_id,
         &DataFileInfo::new("u.parquet", 1024, 10),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
 
@@ -1048,6 +1107,8 @@ async fn drop_table_in_catalog_is_idempotent_on_second_call() {
         s.snapshot_id,
         &DataFileInfo::new("u.parquet", 1024, 10),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
 
@@ -1107,6 +1168,8 @@ async fn drop_table_in_catalog_does_not_touch_siblings() {
         s_users.snapshot_id,
         &DataFileInfo::new("u.parquet", 1024, 10),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
 
@@ -1118,6 +1181,8 @@ async fn drop_table_in_catalog_does_not_touch_siblings() {
         s_orders.snapshot_id,
         &DataFileInfo::new("o.parquet", 2048, 20),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
 
@@ -1130,6 +1195,8 @@ async fn drop_table_in_catalog_does_not_touch_siblings() {
         s_other_users.snapshot_id,
         &DataFileInfo::new("au.parquet", 512, 5),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
 
@@ -1228,6 +1295,8 @@ async fn drop_table_in_catalog_allows_recreate_with_fresh_identity() {
         s1.snapshot_id,
         &DataFileInfo::new("v1.parquet", 1024, 10),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
 
@@ -1253,6 +1322,8 @@ async fn drop_table_in_catalog_allows_recreate_with_fresh_identity() {
         s2.snapshot_id,
         &DataFileInfo::new("v2.parquet", 2048, 20),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
 
@@ -1304,6 +1375,8 @@ async fn drop_table_in_catalog_bumps_schema_version_as_ddl() {
         s.snapshot_id,
         &DataFileInfo::new("u.parquet", 1024, 10),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
 
@@ -1372,6 +1445,8 @@ async fn drop_table_in_catalog_isolates_other_catalogs() {
         sa.snapshot_id,
         &DataFileInfo::new("a.parquet", 1024, 10),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
 
@@ -1383,6 +1458,8 @@ async fn drop_table_in_catalog_isolates_other_catalogs() {
         sb.snapshot_id,
         &DataFileInfo::new("b.parquet", 2048, 20),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
 
@@ -1491,6 +1568,8 @@ async fn register_data_file_assigns_non_overlapping_row_id_start() {
             setup.snapshot_id,
             &DataFileInfo::new("f1.parquet", 4096, 100),
             WriteMode::Replace,
+            &[],
+            &[],
         )
         .unwrap();
     let f2 = w
@@ -1499,6 +1578,8 @@ async fn register_data_file_assigns_non_overlapping_row_id_start() {
             setup.snapshot_id,
             &DataFileInfo::new("f2.parquet", 2048, 50),
             WriteMode::Append,
+            &[],
+            &[],
         )
         .unwrap();
     let f3 = w
@@ -1507,6 +1588,8 @@ async fn register_data_file_assigns_non_overlapping_row_id_start() {
             setup.snapshot_id,
             &DataFileInfo::new("f3.parquet", 8192, 200),
             WriteMode::Append,
+            &[],
+            &[],
         )
         .unwrap();
 
@@ -1545,6 +1628,8 @@ async fn replace_preserves_next_row_id_monotonic() {
         s1.snapshot_id,
         &DataFileInfo::new("g1.parquet", 1024, 5),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
     let (rc1, next1, _) = read_table_stats(&pool, s1.table_id).await;
@@ -1557,7 +1642,7 @@ async fn replace_preserves_next_row_id_monotonic() {
     let s2 = w
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
         .unwrap();
-    w.publish_snapshot(s2.table_id, s2.snapshot_id, WriteMode::Replace)
+    w.publish_snapshot(s2.table_id, s2.snapshot_id, WriteMode::Replace, &[], &[])
         .unwrap();
     let (rc2, next2, bytes2) = read_table_stats(&pool, s2.table_id).await;
     assert_eq!(rc2, 0, "record_count must reset on Replace");
@@ -1572,6 +1657,8 @@ async fn replace_preserves_next_row_id_monotonic() {
             s2.snapshot_id,
             &DataFileInfo::new("g2.parquet", 2048, 2),
             WriteMode::Append,
+            &[],
+            &[],
         )
         .unwrap();
     assert_eq!(
@@ -1614,6 +1701,8 @@ async fn register_data_file_self_initialises_stats_for_legacy_tables() {
             setup.snapshot_id,
             &DataFileInfo::new("a.parquet", 50, 4),
             WriteMode::Replace,
+            &[],
+            &[],
         )
         .unwrap();
     assert_eq!(read_row_id_start(&pool, file_id).await, Some(0));
@@ -1643,6 +1732,8 @@ fn three_generations(
             s1.snapshot_id,
             &DataFileInfo::new("f1.parquet", 100, 5),
             WriteMode::Replace,
+            &[],
+            &[],
         )
         .unwrap();
     let s2 = writer
@@ -1654,6 +1745,8 @@ fn three_generations(
             s2.snapshot_id,
             &DataFileInfo::new("f2.parquet", 100, 5),
             WriteMode::Replace,
+            &[],
+            &[],
         )
         .unwrap();
     let s3 = writer
@@ -1665,6 +1758,8 @@ fn three_generations(
             s3.snapshot_id,
             &DataFileInfo::new("f3.parquet", 100, 5),
             WriteMode::Replace,
+            &[],
+            &[],
         )
         .unwrap();
     (s1.table_id, s1.snapshot_id, s2.snapshot_id, s3.snapshot_id)
@@ -1691,6 +1786,8 @@ async fn expire_in_catalog_empty_for_most_recent_and_unknown() {
         s.snapshot_id,
         &DataFileInfo::new("f1.parquet", 100, 5),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
 
@@ -1802,6 +1899,8 @@ async fn expire_in_catalog_full_after_drop_removes_table_metadata() {
         s.snapshot_id,
         &DataFileInfo::new("f1.parquet", 100, 5),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
 
@@ -1875,6 +1974,8 @@ async fn expire_in_catalog_is_scoped_to_catalog() {
         a1.snapshot_id,
         &DataFileInfo::new("f1.parquet", 100, 5),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
     let b1 = wb
@@ -1885,6 +1986,8 @@ async fn expire_in_catalog_is_scoped_to_catalog() {
         b1.snapshot_id,
         &DataFileInfo::new("g1.parquet", 100, 5),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
     let a2 = wa
@@ -1895,6 +1998,8 @@ async fn expire_in_catalog_is_scoped_to_catalog() {
         a2.snapshot_id,
         &DataFileInfo::new("f2.parquet", 100, 5),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
     assert!(
@@ -1991,6 +2096,8 @@ async fn cleanup_old_files_in_catalog_is_scoped_to_catalog() {
         a1.snapshot_id,
         &DataFileInfo::new("f1.parquet", 100, 5),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
     let a2 = wa
@@ -2001,6 +2108,8 @@ async fn cleanup_old_files_in_catalog_is_scoped_to_catalog() {
         a2.snapshot_id,
         &DataFileInfo::new("f2.parquet", 100, 5),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
     let b1 = wb
@@ -2011,6 +2120,8 @@ async fn cleanup_old_files_in_catalog_is_scoped_to_catalog() {
         b1.snapshot_id,
         &DataFileInfo::new("g1.parquet", 100, 5),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
     let b2 = wb
@@ -2021,6 +2132,8 @@ async fn cleanup_old_files_in_catalog_is_scoped_to_catalog() {
         b2.snapshot_id,
         &DataFileInfo::new("g2.parquet", 100, 5),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
 
@@ -2124,6 +2237,8 @@ async fn delete_orphaned_files_reclaims_dropped_catalog_files() {
         s.snapshot_id,
         &DataFileInfo::new("f1.parquet", 100, 5),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
     let dir = data_path.join("public").join("t");
@@ -2182,6 +2297,8 @@ async fn delete_orphaned_files_spares_files_referenced_by_any_catalog() {
         sa.snapshot_id,
         &DataFileInfo::new("a.parquet", 100, 5),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
     let sb = wb
@@ -2192,6 +2309,8 @@ async fn delete_orphaned_files_spares_files_referenced_by_any_catalog() {
         sb.snapshot_id,
         &DataFileInfo::new("b.parquet", 100, 5),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
 
@@ -2310,6 +2429,8 @@ async fn delete_orphaned_files_dry_run_matches_real_run() {
         s.snapshot_id,
         &DataFileInfo::new("ref.parquet", 100, 5),
         WriteMode::Replace,
+        &[],
+        &[],
     )
     .unwrap();
     let dir = data_path.join("public").join("t");

--- a/tests/multicatalog_provider_tests.rs
+++ b/tests/multicatalog_provider_tests.rs
@@ -59,6 +59,8 @@ async fn seed_two_catalogs(pool: &PgPool) -> anyhow::Result<(i64, i64)> {
             setup.snapshot_id,
             &DataFileInfo::new(fname, 1024, 3),
             WriteMode::Replace,
+            &[],
+            &[],
         )
         .unwrap();
     };


### PR DESCRIPTION
  ## Summary

  Single-catalog SQLite `WriteMode::Replace` could expose a **transient empty read**:
  a reader querying a table mid-write saw it as empty (`count = 0`, `MIN/MAX NULL`) —
  a clean zero, not torn data, intermittent under concurrent load during the upload.
  This is the single-catalog analog of the multicatalog-Postgres fix in #135.

  ## The bug

  `Replace` was split across two commits with the parquet upload between them.
  `begin_write_transaction` inserted the head-advancing `ducklake_snapshot` row,
  end-snapshotted the prior generation's files, and zeroed stats — **and committed** —
  before the writer streamed the new parquet and (only in `finish()`) called
  `register_data_file`.

  The single-catalog head is `COALESCE(MAX(snapshot_id), 0)` over `ducklake_snapshot`,
  so the instant `begin` committed: `head = N+1`, every old file retired, no new file
  yet ⇒ **zero visible files** for the whole upload window.
  
  Unlike multicatalog — where #135 deferred a separate `ducklake_catalog_snapshot_map`
  insert — here **the snapshot row _is_ the head**, so the deferred unit must be the
  snapshot-row insert itself. This also keeps the catalog spec-legal: a
  `ducklake_snapshot` row is by definition a committed, resolvable snapshot, never a
  dormant placeholder.

  ## The fix

  Stage the parquet first, then **create the snapshot, finalize columns, retire the
  prior generation, and register the new file in one transaction**, so
  `MAX(snapshot_id)` only ever resolves to a fully-populated head.
  
  - **No schema change and no read-path change.** A non-spec `published` marker column
    was considered and rejected: the DuckLake spec defines the current snapshot as
    `MAX(snapshot_id)`, and external DuckLake/DuckDB readers compute exactly that — they
    would ignore a marker, so it wouldn't fix the bug for real consumers.
  - `begin_write_transaction` now **reserves** the snapshot id (`MAX+1`) and a contiguous
    `column_id` block without inserting either. The column rewrite is deferred too,
    because `get_table_structure` resolves columns by `end_snapshot IS NULL` only (not
    snapshot-scoped) — inserting at `begin` would leak the new generation to concurrent
    reads during the upload.
  - New `finalize_snapshot` helper is the atomic commit point: insert the reserved
    snapshot row, end prior columns + insert the new generation with the reserved ids
    (matching the staged parquet's `field_id` metadata), and for `Replace` retire the
    prior generation (`begin_snapshot < N+1`, multi-file safe) + zero stats.
    `next_row_id` stays monotonic.
  - `register_data_file` now honors `WriteMode` and runs `finalize_snapshot` before
    inserting the file; a SQLite `publish_snapshot` override handles the fileless commit
    (CREATE TABLE).
  
  ## API change

  `MetadataWriter::register_data_file` and `publish_snapshot` gain `columns` +
  `column_ids` parameters so the commit can finalize the deferred column generation.
  The **Postgres impl ignores them** (it still finalizes columns in
  `begin_write_transaction`, where its head is the deferred map row). `table_writer` and
  `schema.rs` thread the values through; both already hold them.
  
  ## Concurrency
  
  Two concurrent same-catalog writers reserve the same id and **collide on the snapshot
  PK at commit** — the loser rolls back and retries. This is acceptable for single-writer
  SQLite and matches the spec's optimistic concurrency model (and is strictly safer than
  silently accumulating both writes).
