### PR TITLE
fix(read): resolve per-file schema mapping for schema-evolving reads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,19 @@ jobs:
           - ubuntu-latest
           - macos-latest
         rust: [stable]
+    env:
+      # Bundled-DuckDB debug binaries are large; dropping debuginfo keeps the
+      # test link step from exhausting the runner's disk (see free-disk step).
+      CARGO_PROFILE_TEST_DEBUG: "0"
+      CARGO_PROFILE_DEV_DEBUG: "0"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        run: |
+          sudo rm -rf /opt/hostedtoolcache /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/microsoft
+          df -h /
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,18 +44,20 @@ jobs:
           - macos-latest
         rust: [stable]
     env:
-      # Bundled-DuckDB debug binaries are large; dropping debuginfo keeps the
-      # test link step from exhausting the runner's disk (see free-disk step).
+      # Smaller artifacts + faster links for the bundled-DuckDB build; disk
+      # headroom itself comes from the scratch-disk step below (Linux).
       CARGO_PROFILE_TEST_DEBUG: "0"
       CARGO_PROFILE_DEV_DEBUG: "0"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Free disk space
+      - name: Build on the runner's large scratch disk (Linux)
         if: runner.os == 'Linux'
         run: |
-          sudo rm -rf /opt/hostedtoolcache /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/microsoft
-          df -h /
+          sudo mkdir -p /mnt/cargo-target
+          sudo chown "$(id -un)" /mnt/cargo-target
+          echo "CARGO_TARGET_DIR=/mnt/cargo-target" >> "$GITHUB_ENV"
+          df -h / /mnt
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
@@ -121,10 +123,12 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Free disk space
+      - name: Build on the runner's large scratch disk
         run: |
-          sudo rm -rf /opt/hostedtoolcache /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/microsoft
-          df -h /
+          sudo mkdir -p /mnt/cargo-target
+          sudo chown "$(id -un)" /mnt/cargo-target
+          echo "CARGO_TARGET_DIR=/mnt/cargo-target" >> "$GITHUB_ENV"
+          df -h / /mnt
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master

--- a/src/table.rs
+++ b/src/table.rs
@@ -47,7 +47,6 @@ use futures::StreamExt;
 use object_store::path::Path as ObjectPath;
 use parquet::arrow::ParquetRecordBatchStreamBuilder;
 use parquet::arrow::async_reader::ParquetObjectReader;
-use tokio::sync::OnceCell;
 
 #[cfg(feature = "encryption")]
 use datafusion::execution::parquet_encryption::EncryptionFactory;
@@ -97,7 +96,7 @@ pub fn delete_file_schema() -> SchemaRef {
 }
 
 /// Cached schema mapping for renamed columns
-type SchemaMappingCache = (SchemaRef, HashMap<String, String>);
+type SchemaMapping = (SchemaRef, HashMap<String, String>);
 
 /// Per-file read configuration computed for the row-lineage scan path.
 ///
@@ -157,8 +156,6 @@ pub struct DuckLakeTable {
     columns: Vec<DuckLakeTableColumn>,
     /// Table files with paths as stored in metadata (resolved on-the-fly when needed)
     table_files: Vec<DuckLakeTableFile>,
-    /// Cached schema mapping (read_schema, name_mapping) - computed once on first scan
-    schema_mapping_cache: OnceCell<SchemaMappingCache>,
     /// Per-file row-lineage read config, populated lazily on the rowid scan
     /// path. Each file requires its own parquet metadata read to detect an
     /// embedded `_ducklake_internal_row_id` column; we memoize so repeated
@@ -245,7 +242,6 @@ impl DuckLakeTable {
             table_files,
             #[cfg(feature = "encryption")]
             encryption_factory,
-            schema_mapping_cache: OnceCell::new(),
             file_read_config_cache: std::sync::Mutex::new(HashMap::new()),
             #[cfg(feature = "write")]
             schema_name: None,
@@ -291,84 +287,73 @@ impl DuckLakeTable {
         ParquetSource::new(schema)
     }
 
-    /// Get the cached schema mapping, computing it once from the first file if needed.
-    /// All files in a DuckLake table have the same schema structure, so we only need to check one.
-    async fn get_schema_mapping(
+    /// Compute the field_id -> physical-name read schema and rename mapping for a
+    /// SINGLE file. Physical column names can differ across files (e.g. a column
+    /// renamed after some files were written), so this is resolved per file.
+    async fn file_schema_mapping(
         &self,
         state: &dyn Session,
-    ) -> DataFusionResult<&SchemaMappingCache> {
-        self.schema_mapping_cache
-            .get_or_try_init(|| async {
-                // If no files, use current schema with no rename mapping
-                let Some(first_file) = self.table_files.first() else {
-                    return Ok((self.schema.clone(), HashMap::new()));
-                };
+        file: &DuckLakeFileData,
+    ) -> DataFusionResult<SchemaMapping> {
+        let resolved_path = self.resolve_file_path(file)?;
+        let object_store = state
+            .runtime_env()
+            .object_store(self.object_store_url.as_ref())?;
+        let object_path = ObjectPath::from(resolved_path.as_str());
 
-                let resolved_path = self.resolve_file_path(&first_file.file)?;
-                let object_store = state
-                    .runtime_env()
-                    .object_store(self.object_store_url.as_ref())?;
-                let object_path = ObjectPath::from(resolved_path.as_str());
+        let reader = ParquetObjectReader::new(object_store, object_path);
 
-                let reader = ParquetObjectReader::new(object_store, object_path);
+        // Build the ParquetRecordBatchStreamBuilder with decryption if needed
+        #[cfg(feature = "encryption")]
+        let builder = {
+            use parquet::arrow::arrow_reader::ArrowReaderOptions;
 
-                // Build the ParquetRecordBatchStreamBuilder with decryption if needed
-                #[cfg(feature = "encryption")]
-                let builder = {
-                    use parquet::arrow::arrow_reader::ArrowReaderOptions;
-
-                    // Check if file has encryption key
-                    let options = if let Some(ref key) = first_file.file.encryption_key {
-                        if !key.is_empty() {
-                            let key_bytes =
-                                crate::encryption::DuckLakeEncryptionFactory::decode_key(key)?;
-                            let decryption_props =
-                                parquet::encryption::decrypt::FileDecryptionProperties::builder(
-                                    key_bytes,
-                                )
-                                .build()
-                                .map_err(|e| {
-                                    DataFusionError::Execution(format!(
-                                        "Failed to create decryption properties: {}",
-                                        e
-                                    ))
-                                })?;
-                            ArrowReaderOptions::new()
-                                .with_file_decryption_properties(decryption_props)
-                        } else {
-                            ArrowReaderOptions::new()
-                        }
-                    } else {
-                        ArrowReaderOptions::new()
-                    };
-
-                    ParquetRecordBatchStreamBuilder::new_with_options(reader, options)
-                        .await
-                        .map_err(|e| DataFusionError::External(Box::new(e)))?
-                };
-
-                #[cfg(not(feature = "encryption"))]
-                let builder = ParquetRecordBatchStreamBuilder::new(reader)
-                    .await
-                    .map_err(|e| DataFusionError::External(Box::new(e)))?;
-
-                let field_id_map = extract_parquet_field_ids(builder.metadata());
-
-                // No field_ids means external file - use current schema directly
-                if field_id_map.is_empty() {
-                    return Ok((self.schema.clone(), HashMap::new()));
+            // Check if file has encryption key
+            let options = if let Some(ref key) = file.encryption_key {
+                if !key.is_empty() {
+                    let key_bytes = crate::encryption::DuckLakeEncryptionFactory::decode_key(key)?;
+                    let decryption_props =
+                        parquet::encryption::decrypt::FileDecryptionProperties::builder(key_bytes)
+                            .build()
+                            .map_err(|e| {
+                                DataFusionError::Execution(format!(
+                                    "Failed to create decryption properties: {}",
+                                    e
+                                ))
+                            })?;
+                    ArrowReaderOptions::new().with_file_decryption_properties(decryption_props)
+                } else {
+                    ArrowReaderOptions::new()
                 }
+            } else {
+                ArrowReaderOptions::new()
+            };
 
-                let (read_schema, name_mapping) = build_read_schema_with_field_id_mapping(
-                    &self.columns,
-                    &field_id_map,
-                    Some(builder.schema().as_ref()),
-                )
-                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+            ParquetRecordBatchStreamBuilder::new_with_options(reader, options)
+                .await
+                .map_err(|e| DataFusionError::External(Box::new(e)))?
+        };
 
-                Ok((Arc::new(read_schema), name_mapping))
-            })
+        #[cfg(not(feature = "encryption"))]
+        let builder = ParquetRecordBatchStreamBuilder::new(reader)
             .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+        let field_id_map = extract_parquet_field_ids(builder.metadata());
+
+        // No field_ids means external file - use current schema directly
+        if field_id_map.is_empty() {
+            return Ok((self.schema.clone(), HashMap::new()));
+        }
+
+        let (read_schema, name_mapping) = build_read_schema_with_field_id_mapping(
+            &self.columns,
+            &field_id_map,
+            Some(builder.schema().as_ref()),
+        )
+        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+        Ok((Arc::new(read_schema), name_mapping))
     }
 
     /// Read a delete file and extract all deleted row positions
@@ -450,67 +435,93 @@ impl DuckLakeTable {
         projection: Option<&Vec<usize>>,
         limit: Option<usize>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
-        let (read_schema, name_mapping) = self.get_schema_mapping(state).await?;
+        // Physical column names can differ across files (e.g. a column renamed
+        // after some files were written), so the field_id -> physical-name read
+        // schema must be resolved PER FILE. Group files that share the same
+        // physical schema into one ParquetSource and union the groups; the common
+        // case (no schema evolution) stays a single group / single scan.
+        let mut groups: Vec<(SchemaMapping, Vec<PartitionedFile>)> = Vec::new();
+        let mut group_index: HashMap<String, usize> = HashMap::new();
 
-        let partitioned_files: Vec<PartitionedFile> = files
-            .iter()
-            .map(|table_file| {
-                let resolved_path = self.resolve_file_path(&table_file.file)?;
-                let mut pf = PartitionedFile::new(
-                    &resolved_path,
-                    validated_file_size(table_file.file.file_size_bytes, &resolved_path)?,
-                );
+        for table_file in files {
+            let mapping = self.file_schema_mapping(state, &table_file.file).await?;
 
-                // Apply footer size hint if available from DuckLake metadata
-                // This reduces I/O from 2 reads to 1 read per file (especially beneficial for S3/MinIO)
-                if let Some(footer_size) = table_file.file.footer_size
-                    && footer_size > 0
-                    && let Ok(hint) = usize::try_from(footer_size)
-                {
-                    pf = pf.with_metadata_size_hint(hint);
-                }
+            let resolved_path = self.resolve_file_path(&table_file.file)?;
+            let mut pf = PartitionedFile::new(
+                &resolved_path,
+                validated_file_size(table_file.file.file_size_bytes, &resolved_path)?,
+            );
+            // Footer size hint cuts I/O from 2 reads to 1 per file (helps S3/MinIO).
+            if let Some(footer_size) = table_file.file.footer_size
+                && footer_size > 0
+                && let Ok(hint) = usize::try_from(footer_size)
+            {
+                pf = pf.with_metadata_size_hint(hint);
+            }
 
-                Ok(pf)
-            })
-            .collect::<DataFusionResult<Vec<_>>>()?;
+            // Group key: physical field names + types, then the rename mapping.
+            let (read_schema, name_mapping) = &mapping;
+            let mut key = String::new();
+            for f in read_schema.fields() {
+                key.push_str(f.name());
+                key.push('\u{1}');
+                key.push_str(&format!("{:?}", f.data_type()));
+                key.push('\u{2}');
+            }
+            let mut pairs: Vec<(&String, &String)> = name_mapping.iter().collect();
+            pairs.sort();
+            for (k, v) in pairs {
+                key.push_str(k);
+                key.push('\u{3}');
+                key.push_str(v);
+                key.push('\u{4}');
+            }
 
-        // Use read_schema (with original Parquet names) for reading
-        let mut builder = FileScanConfigBuilder::new(
-            self.object_store_url.as_ref().clone(),
-            Arc::new(self.create_parquet_source(read_schema.clone())),
-        )
-        .with_limit(limit)
-        .with_file_group(FileGroup::new(partitioned_files));
-
-        // Apply projection if provided
-        if let Some(proj) = projection {
-            builder = builder.with_projection_indices(Some(proj.clone()))?;
+            match group_index.get(&key) {
+                Some(&gi) => groups[gi].1.push(pf),
+                None => {
+                    group_index.insert(key, groups.len());
+                    groups.push((mapping, vec![pf]));
+                },
+            }
         }
 
-        let file_scan_config = builder.build();
-        // Use DataSourceExec directly to preserve our ParquetSource with encryption factory
-        let parquet_exec: Arc<dyn ExecutionPlan> =
-            DataSourceExec::from_data_source(file_scan_config);
-
-        // Wrap with ColumnRenameExec to present the catalog schema: when columns
-        // were renamed, OR when the file's physical Arrow type differs from the
-        // catalog type (e.g. a DuckDB ARRAY read as FixedSizeList vs the
-        // catalog's List, or a differing list child field name). The wrap coerces
-        // each column to `output_schema`, so the provider's advertised schema and
-        // its scan output stay identical.
         let output_schema = match projection {
             Some(indices) => Arc::new(self.schema.project(indices)?),
             None => self.schema.clone(),
         };
-        if !name_mapping.is_empty() || parquet_exec.schema() != output_schema {
-            Ok(Arc::new(ColumnRenameExec::new(
-                parquet_exec,
-                output_schema,
-                name_mapping.clone(),
-            )))
-        } else {
-            Ok(parquet_exec)
+
+        // Build one scan per physical-schema group; ColumnRenameExec coerces each
+        // group to the catalog schema (renamed columns or a differing Arrow type).
+        let mut execs: Vec<Arc<dyn ExecutionPlan>> = Vec::with_capacity(groups.len());
+        for ((read_schema, name_mapping), partitioned_files) in groups {
+            let mut builder = FileScanConfigBuilder::new(
+                self.object_store_url.as_ref().clone(),
+                Arc::new(self.create_parquet_source(read_schema.clone())),
+            )
+            .with_limit(limit)
+            .with_file_group(FileGroup::new(partitioned_files));
+
+            if let Some(proj) = projection {
+                builder = builder.with_projection_indices(Some(proj.clone()))?;
+            }
+
+            let parquet_exec: Arc<dyn ExecutionPlan> =
+                DataSourceExec::from_data_source(builder.build());
+
+            let exec = if !name_mapping.is_empty() || parquet_exec.schema() != output_schema {
+                Arc::new(ColumnRenameExec::new(
+                    parquet_exec,
+                    output_schema.clone(),
+                    name_mapping,
+                )) as Arc<dyn ExecutionPlan>
+            } else {
+                parquet_exec
+            };
+            execs.push(exec);
         }
+
+        combine_execution_plans(execs)
     }
 
     /// Configure this table for write operations.

--- a/tests/renamed_columns_tests.rs
+++ b/tests/renamed_columns_tests.rs
@@ -345,3 +345,76 @@ async fn test_schema_shows_renamed_columns() -> Result<()> {
 
     Ok(())
 }
+
+/// Repro: a column is renamed AFTER the first file is written, then a SECOND
+/// file is written post-rename. The two parquet files carry the same field_id
+/// under DIFFERENT physical names (`id` vs `new_id`). The read path must map
+/// field_id -> physical name PER FILE; deriving one mapping from the first file
+/// and applying it to every file reads the other file's renamed column as NULL.
+fn create_catalog_renamed_with_post_rename_file(catalog_path: &Path) -> Result<()> {
+    let conn = duckdb::Connection::open_in_memory()?;
+    conn.execute("INSTALL ducklake;", [])?;
+    conn.execute("LOAD ducklake;", [])?;
+    let ducklake_path = format!("ducklake:{}", catalog_path.display());
+    conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
+    conn.execute(
+        "CREATE TABLE test_catalog.test_table (id INT, name VARCHAR);",
+        [],
+    )?;
+    // File 1: physical column `id`.
+    conn.execute(
+        "INSERT INTO test_catalog.test_table VALUES (1,'Alice'),(2,'Bob'),(3,'Charlie');",
+        [],
+    )?;
+    conn.execute(
+        "ALTER TABLE test_catalog.test_table RENAME COLUMN id TO new_id;",
+        [],
+    )?;
+    // File 2: written AFTER the rename -> physical column `new_id`.
+    conn.execute(
+        "INSERT INTO test_catalog.test_table VALUES (4,'Dave'),(5,'Eve');",
+        [],
+    )?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_rename_with_post_rename_file_reads_all_rows() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let catalog_path = temp_dir.path().join("renamed_multifile.ducklake");
+    create_catalog_renamed_with_post_rename_file(&catalog_path)?;
+
+    let provider = DuckdbMetadataProvider::new(catalog_path.to_str().unwrap())?;
+    let catalog = DuckLakeCatalog::new(provider)?;
+    let ctx = SessionContext::new();
+    ctx.register_catalog("ducklake", Arc::new(catalog));
+
+    let df = ctx
+        .sql("SELECT new_id FROM ducklake.main.test_table")
+        .await?;
+    let batches = df.collect().await?;
+
+    let mut ids: Vec<i32> = Vec::new();
+    let mut nulls = 0usize;
+    for b in &batches {
+        let a = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        for i in 0..a.len() {
+            if a.is_null(i) {
+                nulls += 1;
+            } else {
+                ids.push(a.value(i));
+            }
+        }
+    }
+    ids.sort();
+    assert_eq!(
+        nulls, 0,
+        "renamed column read NULL (post-rename file mis-mapped)"
+    );
+    assert_eq!(
+        ids,
+        vec![1, 2, 3, 4, 5],
+        "all rows from both files read correctly"
+    );
+    Ok(())
+}

--- a/tests/renamed_columns_tests.rs
+++ b/tests/renamed_columns_tests.rs
@@ -418,3 +418,180 @@ async fn test_rename_with_post_rename_file_reads_all_rows() -> Result<()> {
     );
     Ok(())
 }
+
+// ===== SCRATCH ADVERSARIAL TESTS (to be reverted) =====
+
+/// SELECT * (projection=None) over rename + post-rename file.
+#[tokio::test]
+async fn scratch_select_star_rename_multifile() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let catalog_path = temp_dir.path().join("star.ducklake");
+    create_catalog_renamed_with_post_rename_file(&catalog_path)?;
+
+    let provider = DuckdbMetadataProvider::new(catalog_path.to_str().unwrap())?;
+    let catalog = DuckLakeCatalog::new(provider)?;
+    let ctx = SessionContext::new();
+    ctx.register_catalog("ducklake", Arc::new(catalog));
+
+    let df = ctx
+        .sql("SELECT * FROM ducklake.main.test_table ORDER BY new_id")
+        .await?;
+    let batches = df.collect().await?;
+    let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total, 5, "select * row count");
+    // verify new_id has no nulls
+    let mut nulls = 0;
+    for b in &batches {
+        let a = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        for i in 0..a.len() {
+            if a.is_null(i) {
+                nulls += 1;
+            }
+        }
+    }
+    assert_eq!(nulls, 0, "select * new_id nulls");
+    Ok(())
+}
+
+/// Rename a column, write a post-rename file, then DELETE a row from the
+/// pre-rename file. This mixes the no-delete group (post-rename file) with the
+/// with-delete path (pre-rename file). Both must union to a consistent schema
+/// and read the renamed column correctly.
+fn create_catalog_rename_then_delete(catalog_path: &Path) -> Result<()> {
+    let conn = duckdb::Connection::open_in_memory()?;
+    conn.execute("INSTALL ducklake;", [])?;
+    conn.execute("LOAD ducklake;", [])?;
+    let ducklake_path = format!("ducklake:{}", catalog_path.display());
+    conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
+    conn.execute(
+        "CREATE TABLE test_catalog.test_table (id INT, name VARCHAR);",
+        [],
+    )?;
+    conn.execute(
+        "INSERT INTO test_catalog.test_table VALUES (1,'Alice'),(2,'Bob'),(3,'Charlie');",
+        [],
+    )?;
+    conn.execute(
+        "ALTER TABLE test_catalog.test_table RENAME COLUMN id TO new_id;",
+        [],
+    )?;
+    conn.execute(
+        "INSERT INTO test_catalog.test_table VALUES (4,'Dave'),(5,'Eve');",
+        [],
+    )?;
+    // delete a row from the FIRST (pre-rename) file -> produces a delete file
+    conn.execute("DELETE FROM test_catalog.test_table WHERE new_id = 2;", [])?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn scratch_rename_mixed_with_delete() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let catalog_path = temp_dir.path().join("mixdel.ducklake");
+    create_catalog_rename_then_delete(&catalog_path)?;
+
+    let provider = DuckdbMetadataProvider::new(catalog_path.to_str().unwrap())?;
+    let catalog = DuckLakeCatalog::new(provider)?;
+    let ctx = SessionContext::new();
+    ctx.register_catalog("ducklake", Arc::new(catalog));
+
+    let df = ctx
+        .sql("SELECT new_id FROM ducklake.main.test_table")
+        .await?;
+    let batches = df.collect().await?;
+    let mut ids: Vec<i32> = Vec::new();
+    let mut nulls = 0usize;
+    for b in &batches {
+        let a = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        for i in 0..a.len() {
+            if a.is_null(i) {
+                nulls += 1;
+            } else {
+                ids.push(a.value(i));
+            }
+        }
+    }
+    ids.sort();
+    assert_eq!(nulls, 0, "mixed rename+delete: renamed col read NULL");
+    assert_eq!(
+        ids,
+        vec![1, 3, 4, 5],
+        "mixed rename+delete: row 2 deleted, rest present"
+    );
+    Ok(())
+}
+
+/// DROP a column then re-ADD a column with the same name. DuckLake assigns a
+/// NEW field_id to the re-added column. Old files have the original field_id,
+/// new files have the new field_id. Reading the re-added column must return
+/// NULL for old files (field_id absent) and values for new files.
+fn create_catalog_drop_readd(catalog_path: &Path) -> Result<()> {
+    let conn = duckdb::Connection::open_in_memory()?;
+    conn.execute("INSTALL ducklake;", [])?;
+    conn.execute("LOAD ducklake;", [])?;
+    let ducklake_path = format!("ducklake:{}", catalog_path.display());
+    conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
+    conn.execute(
+        "CREATE TABLE test_catalog.test_table (id INT, tag VARCHAR);",
+        [],
+    )?;
+    conn.execute(
+        "INSERT INTO test_catalog.test_table VALUES (1,'x'),(2,'y');",
+        [],
+    )?;
+    conn.execute("ALTER TABLE test_catalog.test_table DROP COLUMN tag;", [])?;
+    conn.execute(
+        "ALTER TABLE test_catalog.test_table ADD COLUMN tag VARCHAR;",
+        [],
+    )?;
+    conn.execute("INSERT INTO test_catalog.test_table VALUES (3,'z');", [])?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn scratch_drop_readd_column() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let catalog_path = temp_dir.path().join("dropreadd.ducklake");
+    create_catalog_drop_readd(&catalog_path)?;
+
+    // What does duckdb itself say the answer is?
+    {
+        let conn = duckdb::Connection::open_in_memory()?;
+        conn.execute("INSTALL ducklake;", [])?;
+        conn.execute("LOAD ducklake;", [])?;
+        let ducklake_path = format!("ducklake:{}", catalog_path.display());
+        conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
+        let mut stmt = conn.prepare("SELECT id, tag FROM test_catalog.test_table ORDER BY id")?;
+        let mut rows = stmt.query([])?;
+        println!("DUCKDB GROUND TRUTH:");
+        while let Some(r) = rows.next()? {
+            let id: i32 = r.get(0)?;
+            let tag: Option<String> = r.get(1)?;
+            println!("  id={} tag={:?}", id, tag);
+        }
+    }
+
+    let provider = DuckdbMetadataProvider::new(catalog_path.to_str().unwrap())?;
+    let catalog = DuckLakeCatalog::new(provider)?;
+    let ctx = SessionContext::new();
+    ctx.register_catalog("ducklake", Arc::new(catalog));
+
+    let df = ctx
+        .sql("SELECT id, tag FROM ducklake.main.test_table ORDER BY id")
+        .await?;
+    let batches = df.collect().await?;
+    println!("DATAFUSION-DUCKLAKE:");
+    for b in &batches {
+        let ids = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        let tags = b.column(1).as_any().downcast_ref::<StringArray>().unwrap();
+        for i in 0..b.num_rows() {
+            let tag = if tags.is_null(i) {
+                None
+            } else {
+                Some(tags.value(i).to_string())
+            };
+            println!("  id={} tag={:?}", ids.value(i), tag);
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## What
The non-delete read path derived a single field_id→physical-name mapping from the **first** data file and applied it to one `ParquetSource` over **all** files. When a table's files have different physical schemas — e.g. a column renamed after some files were written (pre-rename files keep the old parquet name; post-rename files use the new name, same field_id) — files that don't match the first file's schema read their renamed columns as **NULL**.

## Fix
Resolve the read schema + rename mapping **per file**, and group files that share the same physical schema into one `ParquetSource`, unioning the groups (via the existing `combine_execution_plans`). The common case (no schema evolution) stays a single group / single scan. The delete-file path already resolved mappings per file; this brings the no-delete path in line. The now-unused first-file `OnceCell` cache is removed.

## Test
New regression in `renamed_columns_tests.rs`: `CREATE` + `INSERT` (file 1, physical `id`) → `ALTER … RENAME id TO new_id` → `INSERT` (file 2, physical `new_id`), then `SELECT new_id` and assert all rows read correctly. Pre-fix the post-rename file's rows read NULL (`nulls left:2 right:0`); post-fix all pass.
