### PR TITLE
fix: correct reads across schema evolution and repeated writes

### DIFF
--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -656,32 +656,78 @@ async fn finalize_snapshot(
     .await?
     .try_get(0)?;
 
-    // Finalize the column generation: end the prior columns and insert the new
-    // set with the reserved column_ids (matching the parquet field_ids).
-    sqlx::query(
-        "UPDATE ducklake_column SET end_snapshot = ?
+    // Update the column generation SURGICALLY so each column keeps a stable
+    // column_id (== parquet field_id) across writes: end only removed columns,
+    // insert only new ones, and leave unchanged columns (and their ids) in place.
+    // Re-minting ids every write would orphan the field_ids baked into
+    // already-written files, making their rows read back as NULL.
+    use std::collections::{HashMap, HashSet};
+    let current = sqlx::query(
+        "SELECT column_name, column_order, nulls_allowed
+         FROM ducklake_column
          WHERE table_id = ? AND end_snapshot IS NULL",
     )
-    .bind(snapshot_id)
     .bind(table_id)
-    .execute(&mut **tx)
+    .fetch_all(&mut **tx)
     .await?;
 
+    let new_names: HashSet<&str> = columns.iter().map(|c| c.name.as_str()).collect();
+    let mut current_by_name: HashMap<String, (i64, bool)> = HashMap::new();
+    for row in &current {
+        let name: String = row.try_get(0)?;
+        let order: i64 = row.try_get(1)?;
+        let nullable: bool = row.try_get::<Option<bool>, _>(2)?.unwrap_or(true);
+        if !new_names.contains(name.as_str()) {
+            // Column dropped in the new schema: end its generation.
+            sqlx::query(
+                "UPDATE ducklake_column SET end_snapshot = ?
+                 WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL",
+            )
+            .bind(snapshot_id)
+            .bind(table_id)
+            .bind(&name)
+            .execute(&mut **tx)
+            .await?;
+        }
+        current_by_name.insert(name, (order, nullable));
+    }
+
     for (order, (col, column_id)) in columns.iter().zip(column_ids.iter()).enumerate() {
-        sqlx::query(
-            "INSERT INTO ducklake_column
-                 (column_id, table_id, column_name, column_type, column_order, nulls_allowed, begin_snapshot)
-             VALUES (?, ?, ?, ?, ?, ?, ?)",
-        )
-        .bind(column_id)
-        .bind(table_id)
-        .bind(&col.name)
-        .bind(&col.ducklake_type)
-        .bind(order as i64)
-        .bind(col.is_nullable)
-        .bind(snapshot_id)
-        .execute(&mut **tx)
-        .await?;
+        match current_by_name.get(&col.name) {
+            // Existing column kept: its id stays stable. Sync order/nullability
+            // only if they changed (type changes are rejected at begin).
+            Some(&(cur_order, cur_nullable)) => {
+                if cur_order != order as i64 || cur_nullable != col.is_nullable {
+                    sqlx::query(
+                        "UPDATE ducklake_column SET column_order = ?, nulls_allowed = ?
+                         WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL",
+                    )
+                    .bind(order as i64)
+                    .bind(col.is_nullable)
+                    .bind(table_id)
+                    .bind(&col.name)
+                    .execute(&mut **tx)
+                    .await?;
+                }
+            },
+            // Newly added column: insert it with its reserved id.
+            None => {
+                sqlx::query(
+                    "INSERT INTO ducklake_column
+                         (column_id, table_id, column_name, column_type, column_order, nulls_allowed, begin_snapshot)
+                     VALUES (?, ?, ?, ?, ?, ?, ?)",
+                )
+                .bind(column_id)
+                .bind(table_id)
+                .bind(&col.name)
+                .bind(&col.ducklake_type)
+                .bind(order as i64)
+                .bind(col.is_nullable)
+                .bind(snapshot_id)
+                .execute(&mut **tx)
+                .await?;
+            },
+        }
     }
 
     if mode == WriteMode::Replace {
@@ -1059,7 +1105,10 @@ impl MetadataWriter for SqliteMetadataWriter {
             // begins. These ids match the staged parquet field ids.
             let n = columns.len() as i64;
             let last_column_id = reserve_ids(&mut tx, "next_column_id", n).await?;
-            let column_ids: Vec<i64> = ((last_column_id - n + 1)..=last_column_id).collect();
+            // Freshly reserved ids. Only a genuinely-new column actually consumes
+            // one below; an existing column keeps its current id, so some of these
+            // may go unused (harmless monotonic-counter gaps).
+            let fresh_ids: Vec<i64> = ((last_column_id - n + 1)..=last_column_id).collect();
 
             // Tentative id for WriteSetupResult; the real one is assigned at the
             // commit (finalize_snapshot), so it may differ under concurrency.
@@ -1121,9 +1170,13 @@ impl MetadataWriter for SqliteMetadataWriter {
                 }
             };
 
-            // Get existing columns to check schema compatibility for appends
+            // Get existing columns to (a) check schema compatibility for appends
+            // and (b) REUSE each column's id. column_id == parquet field_id == a
+            // column's stable identity; re-minting it every write would orphan the
+            // field_ids already baked into previously-written files, so an
+            // unchanged column must keep its id.
             let rows = sqlx::query(
-                "SELECT column_name, column_type, nulls_allowed
+                "SELECT column_name, column_type, nulls_allowed, column_id
                  FROM ducklake_column
                  WHERE table_id = ? AND end_snapshot IS NULL
                  ORDER BY column_order",
@@ -1133,10 +1186,14 @@ impl MetadataWriter for SqliteMetadataWriter {
             .await?;
 
             let mut existing_columns: Vec<(String, String, bool)> = Vec::with_capacity(rows.len());
+            let mut existing_ids: std::collections::HashMap<String, i64> =
+                std::collections::HashMap::new();
             for row in rows {
                 let name: String = row.try_get(0)?;
                 let col_type: String = row.try_get(1)?;
                 let nullable: bool = row.try_get::<Option<bool>, _>(2)?.unwrap_or(true);
+                let cid: i64 = row.try_get(3)?;
+                existing_ids.insert(name.clone(), cid);
                 existing_columns.push((name, col_type, nullable));
             }
 
@@ -1179,15 +1236,19 @@ impl MetadataWriter for SqliteMetadataWriter {
                 // Columns in existing but not in new schema are implicitly removed - this is allowed
             }
 
-            // Reserve a contiguous column_id block from the monotonic counter
-            // WITHOUT inserting the column rows. The new column generation is
-            // written at the commit point (`finalize_snapshot`), not here, because
-            // the SQLite read path resolves a table's columns by `end_snapshot IS
-            // NULL` only (not snapshot-scoped) — inserting at begin would leak the
-            // new generation to concurrent reads during the upload window. The
-            // reserved ids are returned so the staged parquet's `field_id`
-            // metadata matches the ids eventually committed, and the counter keeps
-            // concurrent writers' blocks disjoint.
+            // Final per-column ids: reuse the existing id for a column already in
+            // the table, consume a freshly reserved id only for a genuinely new
+            // column. These are baked into the staged parquet's field_id metadata,
+            // so they must equal the ids `finalize_snapshot` commits. Column rows
+            // themselves are written at the commit point (not here): the SQLite
+            // read path resolves columns by `end_snapshot IS NULL` only (not
+            // snapshot-scoped), so inserting at begin would leak the new
+            // generation to concurrent reads during the upload window.
+            let column_ids: Vec<i64> = columns
+                .iter()
+                .zip(fresh_ids.iter())
+                .map(|(col, &fresh)| existing_ids.get(&col.name).copied().unwrap_or(fresh))
+                .collect();
 
             // No snapshot row, no column rows, and no Replace retirement are
             // written here — all are deferred to the atomic commit so the head

--- a/src/types.rs
+++ b/src/types.rs
@@ -466,9 +466,12 @@ pub fn extract_parquet_field_ids(metadata: &ParquetMetaData) -> HashMap<i32, Str
     field_id_map
 }
 
-/// Build a schema for reading Parquet files with renamed columns.
-/// Returns (read_schema, name_mapping) where read_schema uses original Parquet names
-/// and name_mapping maps old->new for columns that were renamed.
+/// Build a schema for reading Parquet files across schema evolution.
+/// Returns (read_schema, name_mapping): read_schema uses each column's physical
+/// name in the file, and name_mapping maps that physical name -> current name for
+/// renamed columns. A current column whose field_id is absent from a file that
+/// otherwise carries field_ids is read as an all-NULL column (the file predates
+/// the column, or it was dropped then re-added under the same name).
 pub fn build_read_schema_with_field_id_mapping(
     current_columns: &[DuckLakeTableColumn],
     parquet_field_ids: &HashMap<i32, String>,
@@ -487,15 +490,26 @@ pub fn build_read_schema_with_field_id_mapping(
                 ))
             })?;
 
-            let (read_name, needs_rename) =
+            // Resolve the physical name this column has in THIS file:
+            //  - field_id present: that physical name (rename if it differs).
+            //  - file has no field_ids: external/legacy parquet, match by name.
+            //  - file has field_ids but not this one's: the column is absent from
+            //    this file (added later, or DROPped + re-ADDed under the same name
+            //    with a fresh field_id) and must read as NULL. Matching by name
+            //    would alias a different same-named column (e.g. the still-present
+            //    dropped column) and leak stale data, so use a name guaranteed
+            //    absent so the scan null-fills it, then rename it back.
+            let (read_name, needs_rename, is_absent) =
                 if let Some(parquet_name) = parquet_field_ids.get(&field_id) {
                     if parquet_name != &col.column_name {
-                        (parquet_name.clone(), true) // Column was renamed
+                        (parquet_name.clone(), true, false) // Column was renamed
                     } else {
-                        (col.column_name.clone(), false)
+                        (col.column_name.clone(), false, false)
                     }
+                } else if parquet_field_ids.is_empty() {
+                    (col.column_name.clone(), false, false) // external/legacy file
                 } else {
-                    (col.column_name.clone(), false) // No field_id, use current name
+                    (format!("__ducklake_absent_field_{}", field_id), true, true)
                 };
 
             // For list/nested columns the Parquet reader reproduces the *file's*
@@ -504,11 +518,14 @@ pub fn build_read_schema_with_field_id_mapping(
             // DataFusion's scan validates each batch against the read schema. The
             // reconstructed name (always "item") may not match, so adopt the
             // file's actual type for these columns when the file schema is known.
-            // Scalars keep the reconstructed type (precise per the catalog).
-            if matches!(
-                data_type,
-                DataType::List(_) | DataType::LargeList(_) | DataType::FixedSizeList(_, _)
-            ) && let Some(fs) = file_schema
+            // Scalars keep the reconstructed type (precise per the catalog). An
+            // absent column has a synthetic name not in the file, so skip it.
+            if !is_absent
+                && matches!(
+                    data_type,
+                    DataType::List(_) | DataType::LargeList(_) | DataType::FixedSizeList(_, _)
+                )
+                && let Some(fs) = file_schema
                 && let Ok(file_field) = fs.field_with_name(&read_name)
             {
                 data_type = file_field.data_type().clone();
@@ -518,7 +535,14 @@ pub fn build_read_schema_with_field_id_mapping(
                 name_mapping.insert(read_name.clone(), col.column_name.clone());
             }
 
-            Ok(Field::new(read_name, data_type, col.is_nullable))
+            // An absent column is materialised as a null array by the scan, so its
+            // read field must be nullable; the catalog nullability is still
+            // enforced on output by ColumnRenameExec.
+            Ok(Field::new(
+                read_name,
+                data_type,
+                col.is_nullable || is_absent,
+            ))
         })
         .collect();
 
@@ -604,6 +628,52 @@ mod tests {
         // Falls back to current column name
         assert_eq!(read_schema.field(0).name(), "id");
         assert!(name_mapping.is_empty());
+    }
+
+    #[test]
+    fn test_build_read_schema_absent_field_id_reads_null() {
+        // `tag` (column_id 2) was DROPped then re-ADDed, so it has a fresh
+        // field_id that is absent from a pre-drop file. The file still physically
+        // carries a column literally named "tag" (the dropped one, different
+        // field_id), which must NOT be aliased.
+        let current_columns = vec![
+            DuckLakeTableColumn {
+                column_id: 1,
+                column_name: "id".to_string(),
+                column_type: "int32".to_string(),
+                is_nullable: true,
+            },
+            DuckLakeTableColumn {
+                column_id: 2,
+                column_name: "tag".to_string(),
+                column_type: "varchar".to_string(),
+                is_nullable: true,
+            },
+        ];
+
+        let mut parquet_field_ids = HashMap::new();
+        parquet_field_ids.insert(1, "id".to_string()); // file has field_ids, but not 2
+
+        let (read_schema, name_mapping) =
+            build_read_schema_with_field_id_mapping(&current_columns, &parquet_field_ids, None)
+                .unwrap();
+
+        // `id` reads by name; `tag` gets a synthetic absent name (so the scan
+        // null-fills it) mapped back to "tag", instead of binding to the
+        // physically-present dropped "tag".
+        assert_eq!(read_schema.field(0).name(), "id");
+        assert_ne!(read_schema.field(1).name(), "tag");
+        assert!(
+            read_schema
+                .field(1)
+                .name()
+                .starts_with("__ducklake_absent_field_")
+        );
+        assert!(read_schema.field(1).is_nullable());
+        assert_eq!(
+            name_mapping.get(read_schema.field(1).name()),
+            Some(&"tag".to_string())
+        );
     }
 
     #[test]

--- a/tests/renamed_columns_tests.rs
+++ b/tests/renamed_columns_tests.rs
@@ -419,11 +419,11 @@ async fn test_rename_with_post_rename_file_reads_all_rows() -> Result<()> {
     Ok(())
 }
 
-// ===== SCRATCH ADVERSARIAL TESTS (to be reverted) =====
+// ===== Schema-evolution regression tests =====
 
 /// SELECT * (projection=None) over rename + post-rename file.
 #[tokio::test]
-async fn scratch_select_star_rename_multifile() -> Result<()> {
+async fn test_select_star_rename_multifile_reads_all_rows() -> Result<()> {
     let temp_dir = TempDir::new()?;
     let catalog_path = temp_dir.path().join("star.ducklake");
     create_catalog_renamed_with_post_rename_file(&catalog_path)?;
@@ -485,7 +485,7 @@ fn create_catalog_rename_then_delete(catalog_path: &Path) -> Result<()> {
 }
 
 #[tokio::test]
-async fn scratch_rename_mixed_with_delete() -> Result<()> {
+async fn test_rename_mixed_with_delete_reads_all_rows() -> Result<()> {
     let temp_dir = TempDir::new()?;
     let catalog_path = temp_dir.path().join("mixdel.ducklake");
     create_catalog_rename_then_delete(&catalog_path)?;
@@ -549,12 +549,17 @@ fn create_catalog_drop_readd(catalog_path: &Path) -> Result<()> {
 }
 
 #[tokio::test]
-async fn scratch_drop_readd_column() -> Result<()> {
+async fn test_drop_readd_column_reads_null_for_pre_drop_rows() -> Result<()> {
     let temp_dir = TempDir::new()?;
     let catalog_path = temp_dir.path().join("dropreadd.ducklake");
     create_catalog_drop_readd(&catalog_path)?;
 
-    // What does duckdb itself say the answer is?
+    // The re-added `tag` must read NULL for rows written before the DROP and 'z'
+    // for the row written after the re-ADD — NOT the dropped column's stale data.
+    let expected: Vec<(i32, Option<String>)> =
+        vec![(1, None), (2, None), (3, Some("z".to_string()))];
+
+    // Pin the expectation to DuckDB's own answer so it stays honest.
     {
         let conn = duckdb::Connection::open_in_memory()?;
         conn.execute("INSTALL ducklake;", [])?;
@@ -563,12 +568,11 @@ async fn scratch_drop_readd_column() -> Result<()> {
         conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
         let mut stmt = conn.prepare("SELECT id, tag FROM test_catalog.test_table ORDER BY id")?;
         let mut rows = stmt.query([])?;
-        println!("DUCKDB GROUND TRUTH:");
+        let mut duck: Vec<(i32, Option<String>)> = Vec::new();
         while let Some(r) = rows.next()? {
-            let id: i32 = r.get(0)?;
-            let tag: Option<String> = r.get(1)?;
-            println!("  id={} tag={:?}", id, tag);
+            duck.push((r.get(0)?, r.get(1)?));
         }
+        assert_eq!(duck, expected, "DuckDB ground truth changed");
     }
 
     let provider = DuckdbMetadataProvider::new(catalog_path.to_str().unwrap())?;
@@ -580,7 +584,7 @@ async fn scratch_drop_readd_column() -> Result<()> {
         .sql("SELECT id, tag FROM ducklake.main.test_table ORDER BY id")
         .await?;
     let batches = df.collect().await?;
-    println!("DATAFUSION-DUCKLAKE:");
+    let mut got: Vec<(i32, Option<String>)> = Vec::new();
     for b in &batches {
         let ids = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
         let tags = b.column(1).as_any().downcast_ref::<StringArray>().unwrap();
@@ -590,8 +594,13 @@ async fn scratch_drop_readd_column() -> Result<()> {
             } else {
                 Some(tags.value(i).to_string())
             };
-            println!("  id={} tag={:?}", ids.value(i), tag);
+            got.push((ids.value(i), tag));
         }
     }
+
+    assert_eq!(
+        got, expected,
+        "re-added column must read NULL for pre-drop rows, not the dropped column's stale data"
+    );
     Ok(())
 }

--- a/tests/write_tests.rs
+++ b/tests/write_tests.rs
@@ -342,6 +342,63 @@ async fn test_append_semantics() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_append_preserves_first_file_values() {
+    // Regression: a second append must not orphan the first file's column ids.
+    // Reading back must return BOTH batches' actual values, not NULLs.
+    let (writer, temp_dir) = create_test_env().await;
+    let object_store = create_object_store();
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, true),
+        Field::new("value", DataType::Int32, true),
+    ]));
+    let batch1 = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from(vec![1, 2])), Arc::new(Int32Array::from(vec![100, 200]))],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(Arc::new(writer.clone()), Arc::clone(&object_store))
+        .unwrap()
+        .write_table("main", "t", &[batch1])
+        .await
+        .unwrap();
+
+    let batch2 = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from(vec![3, 4])), Arc::new(Int32Array::from(vec![300, 400]))],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(Arc::new(writer), Arc::clone(&object_store))
+        .unwrap()
+        .append_table("main", "t", &[batch2])
+        .await
+        .unwrap();
+
+    let ctx = create_read_context(&temp_dir).await;
+    let batches = ctx
+        .sql("SELECT id, value FROM test.main.t ORDER BY id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let mut got: Vec<(i32, i32)> = Vec::new();
+    for b in &batches {
+        let ids = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        let vals = b.column(1).as_any().downcast_ref::<Int32Array>().unwrap();
+        for i in 0..b.num_rows() {
+            assert!(
+                !ids.is_null(i) && !vals.is_null(i),
+                "append lost a row's values (read back NULL)"
+            );
+            got.push((ids.value(i), vals.value(i)));
+        }
+    }
+    got.sort();
+    assert_eq!(got, vec![(1, 100), (2, 200), (3, 300), (4, 400)]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_multiple_tables_same_schema() {
     let (writer, temp_dir) = create_test_env().await;
     let object_store = create_object_store();


### PR DESCRIPTION
## What

Two coupled correctness bugs that surface whenever a table's data files don't all share the current schema — i.e. after a column rename / DROP / re-ADD, or simply after more than one write to the same table. Both could silently return wrong data (NULLs or stale values); one could also hard-error an otherwise-readable table. They're interdependent, so they're fixed together (see *Why together*).

## Bug 1 — read path: a column absent from a file was matched by name

`build_read_schema_with_field_id_mapping` fell back to matching a column by **name** whenever its `field_id` was missing from a file's field-id map. For a file that *does* carry field-ids but not this column's — the canonical `DROP COLUMN tag; ADD COLUMN tag …` case, where the re-added column gets a fresh field-id — name-matching aliased the still-physically-present **dropped** column and returned its stale data instead of NULL.

Confirmed against DuckDB on the same catalog: DuckDB returns `tag = NULL, NULL, 'z'`; this engine returned `'x', 'y', 'z'`.

**Fix:** only fall back to by-name when a file has no field-ids at all (external / legacy parquet). Otherwise the column is genuinely absent from that file and is read as NULL — via a synthetic read name the scan null-fills, then renamed back to the catalog name. No same-named column from a different field-id can be aliased.

## Bug 2 — write path: `column_id`s were re-minted on every write

The SQLite writer reserved a fresh `column_id` block for the full column list on every write, and `finalize_snapshot` ended the entire prior column generation and re-inserted every column with brand-new ids. Since each column's `column_id` is baked into its parquet file as the `field_id`, a second `append` left the catalog's current ids out of sync with the field-ids in earlier files — so those files' columns resolved to nothing and read back as **NULL** (or, for a `NOT NULL` column, errored with `Column 'x' is declared as non-nullable but contains null values`).

This was masked by the old by-name fallback (Bug 1) and by the existing append tests only asserting `COUNT(*)`, which survives the null-fill.

**Fix:** reuse each existing column's id in `begin_write_transaction`, and update the column generation **surgically** in `finalize_snapshot` — end only dropped columns, insert only new ones, and leave unchanged columns (and their ids) in place. This also respects the `column_id PRIMARY KEY`, which the previous end-all-then-reinsert-all approach could not honor while reusing an id.

## Why together

With unstable `column_id`s (Bug 2), the read path cannot distinguish a column that is *genuinely absent* from a file from one whose id merely *drifted*. So the Bug 1 null-fill, on its own, would turn every multi-append read into NULLs. Stable ids are the prerequisite that makes the null-fill correct. Landing either alone leaves one path broken.

## Tests

- `renamed_columns_tests.rs`: the DROP + re-ADD case is now an asserting regression test pinned to DuckDB's answer (previously it only printed); two related schema-evolution tests promoted to permanent named tests; a unit test for the absent-field-id resolution.
- `write_tests.rs::test_append_preserves_first_file_values`: writes one batch, appends a second, and asserts the **values** of both — not just `COUNT(*)`, which the prior append tests used and which hid the data loss.

Verified locally: a 20-round write→append→read loop returns correct values 20/20 (was 0/20 with Bug 2 present), and the full single-catalog suite (write, concurrency, maintenance, schema-evolution) is green.
