### PR TITLE
fix(write): truncate on a zero-row INSERT OVERWRITE / Replace

### DIFF
--- a/src/insert_exec.rs
+++ b/src/insert_exec.rs
@@ -175,7 +175,12 @@ impl ExecutionPlan for DuckLakeInsertExec {
             let input_stream = input.execute(0, Arc::clone(&context))?;
             let batches: Vec<RecordBatch> = input_stream.try_collect().await?;
 
-            if batches.is_empty() {
+            // An empty input is a genuine no-op only for Append. For
+            // Replace/Overwrite we must still run the write session so the prior
+            // generation is retired (truncated): finish() registers a 0-row file
+            // and finalize_snapshot runs the Replace retirement. Returning early
+            // here would leave the old rows live while reporting count=0 success.
+            if batches.is_empty() && write_mode == WriteMode::Append {
                 let count_array: ArrayRef = Arc::new(UInt64Array::from(vec![0u64]));
                 return Ok(RecordBatch::try_new(output_schema, vec![count_array])?);
             }

--- a/tests/sql_write_tests.rs
+++ b/tests/sql_write_tests.rs
@@ -387,6 +387,78 @@ async fn test_insert_overwrite() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_insert_overwrite_empty_truncates() {
+    // Regression (#10): an INSERT OVERWRITE whose source yields ZERO rows must
+    // TRUNCATE the table (Replace retires the prior generation), not silently
+    // leave the old rows live while reporting success.
+    let (_ctx, temp_dir) = create_writable_catalog().await;
+    let object_store = create_object_store();
+    let db_path = temp_dir.path().join("test.db");
+    let conn_str = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("value", DataType::Utf8, true),
+    ]));
+
+    // Populate with 3 rows.
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3])),
+            Arc::new(StringArray::from(vec!["a", "b", "c"])),
+        ],
+    )
+    .unwrap();
+    let writer = SqliteMetadataWriter::new(&conn_str).await.unwrap();
+    datafusion_ducklake::DuckLakeTableWriter::new(Arc::new(writer), object_store)
+        .unwrap()
+        .write_table("main", "ow_empty", &[batch])
+        .await
+        .unwrap();
+
+    // Fresh writable ctx; overwrite from a source filtered to zero rows.
+    let writer = SqliteMetadataWriter::new(&conn_str).await.unwrap();
+    let provider = SqliteMetadataProvider::new(&conn_str).await.unwrap();
+    let catalog = DuckLakeCatalog::with_writer(Arc::new(provider), Arc::new(writer)).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog("ducklake", Arc::new(catalog));
+    let src = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from(vec![10, 20])), Arc::new(StringArray::from(vec!["x", "y"]))],
+    )
+    .unwrap();
+    ctx.register_batch("src", src).unwrap();
+
+    ctx.sql("INSERT OVERWRITE ducklake.main.ow_empty SELECT * FROM src WHERE 1 = 2")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    // After an empty overwrite the table must be EMPTY.
+    let read_ctx = create_read_context(&temp_dir).await;
+    let batches = read_ctx
+        .sql("SELECT COUNT(*) as cnt FROM ducklake.main.ow_empty")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let count = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap()
+        .value(0);
+    assert_eq!(
+        count, 0,
+        "empty INSERT OVERWRITE must truncate the table, not leave stale rows"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_sql_insert_values() {
     let (_ctx, temp_dir) = create_writable_catalog().await;
     let object_store = create_object_store();


### PR DESCRIPTION
DuckLakeInsertExec returned count=0 success for an empty input without opening a write session, so a Replace/Overwrite that produced no rows left the prior generation live: the table kept its old data while the caller believed it had been replaced, with no error.

Short-circuit the empty input only for Append; for Replace fall through so finish() registers a 0-row file and finalize_snapshot retires the prior generation (truncation).

Add test_insert_overwrite_empty_truncates (an empty INSERT OVERWRITE over a populated table; fails before this fix, count stayed 3).