### PR TITLE
docs: refresh README, add COMPATIBILITY.md, correct CLAUDE.md

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,6 +3,10 @@ name: Benchmark
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.gitignore'
   workflow_dispatch: # Allow manual trigger
 
 env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ DataFusion-DuckLake is a DataFusion extension that provides read and write acces
 
 The extension integrates DuckLake with Apache DataFusion by implementing DataFusion's catalog and table provider interfaces.
 
-Reads are supported on all four catalog backends. Writes (`INSERT`, `CREATE TABLE AS SELECT`, `DROP TABLE`, and the maintenance API) are feature-gated and currently implemented for SQLite and PostgreSQL (`write-sqlite`, `write-postgres`). See `COMPATIBILITY.md` for the full backend/feature matrix.
+Reads are supported on all four catalog backends. Writes are feature-gated and currently implemented for SQLite (`write-sqlite`) and PostgreSQL (`write-postgres`). SQLite uses the standard single-catalog layout and supports SQL `CREATE TABLE AS SELECT` + `INSERT INTO`; PostgreSQL writes go through the **experimental, library-specific multi-catalog layout** (not part of the DuckLake spec) where tables are created via `DuckLakeTableWriter` and appended to with `INSERT INTO`. See `COMPATIBILITY.md` for the full backend/feature matrix.
 
 ## Commands
 
@@ -57,7 +57,7 @@ The codebase follows a layered architecture with clear separation of concerns:
    - `DuckLakeInsertExec` (`insert_exec.rs`): DataFusion execution plan backing `INSERT INTO` / `CREATE TABLE AS SELECT`. Declares `required_input_distribution() == SinglePartition` so multi-partition inputs are coalesced before writing (guards against silently dropping rows; see `tests/insert_partitioning_tests.rs`)
    - A catalog becomes writable via `DuckLakeCatalog::with_writer(provider, writer)`
    - `maintenance.rs`: expire snapshots, clean up superseded files, reclaim orphaned files (Rust API, not SQL DDL)
-   - Multi-catalog (PostgreSQL): `MulticatalogManager` (`multicatalog.rs`) creates/manages many catalogs in one store; `MulticatalogProvider` (`multicatalog_provider.rs`, feature `multicatalog-postgres`) reads them
+   - Multi-catalog (PostgreSQL, **experimental & library-specific** — not part of the DuckLake spec, not accepted upstream): `MulticatalogManager` (`multicatalog.rs`) creates/manages many catalogs in one store; `MulticatalogProvider` (`multicatalog_provider.rs`, feature `multicatalog-postgres`) reads them. All PostgreSQL writes currently go through this path. SQL CTAS is unsupported here (first write of a table goes through `DuckLakeTableWriter`); `INSERT INTO` works once the table exists.
 
 4. **Additional capabilities**
    - `information_schema.rs`: SQL-queryable catalog metadata (snapshots, schemata, tables, columns, files)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-DataFusion-DuckLake is a DataFusion extension that provides read-only access to DuckLake catalogs. DuckLake is an integrated data lake and catalog format that stores:
+DataFusion-DuckLake is a DataFusion extension that provides read and write access to DuckLake catalogs. DuckLake is an integrated data lake and catalog format that stores:
 - **Metadata**: In SQL databases (DuckDB, SQLite, PostgreSQL, MySQL) as structured catalog tables
 - **Data**: As Apache Parquet files on disk or object storage (S3, MinIO)
 
 The extension integrates DuckLake with Apache DataFusion by implementing DataFusion's catalog and table provider interfaces.
+
+Reads are supported on all four catalog backends. Writes (`INSERT`, `CREATE TABLE AS SELECT`, `DROP TABLE`, and the maintenance API) are feature-gated and currently implemented for SQLite and PostgreSQL (`write-sqlite`, `write-postgres`). See `COMPATIBILITY.md` for the full backend/feature matrix.
 
 ## Commands
 
@@ -33,13 +35,13 @@ cargo run --example basic_query -- <catalog.db> <sql>
 
 The codebase follows a layered architecture with clear separation of concerns:
 
-1. **MetadataProvider Layer** (`src/metadata_provider.rs`, `src/metadata_provider_duckdb.rs`)
+1. **MetadataProvider Layer** (`src/metadata_provider.rs` + per-backend impls)
    - Abstraction for querying DuckLake catalog metadata
    - `MetadataProvider` trait defines interface for listing schemas, tables, columns, and data files
    - Also provides individual lookup methods: `get_schema_by_name()`, `get_table_by_name()`, and `table_exists()`
-   - `DuckdbMetadataProvider` implements the trait using DuckDB as the catalog backend
+   - Four feature-gated implementations: `DuckdbMetadataProvider` (`metadata_provider_duckdb.rs`), `SqliteMetadataProvider` (`metadata_provider_sqlite.rs`), `PostgresMetadataProvider` (`metadata_provider_postgres.rs`), `MySqlMetadataProvider` (`metadata_provider_mysql.rs`)
    - Executes SQL queries against standard DuckLake catalog tables (`ducklake_snapshot`, `ducklake_schema`, `ducklake_table`, `ducklake_column`, `ducklake_data_file`, `ducklake_delete_file`, `ducklake_metadata`)
-   - Thread-safe: Uses a single shared connection protected by Mutex for efficiency
+   - Thread-safe: DuckDB uses a single shared connection protected by Mutex; the sqlx-based backends (sqlite/postgres/mysql) use async connection pools
    - Supports delete files: `get_table_files_for_select()` returns data files with associated delete files
 
 2. **DataFusion Integration Layer** (`src/catalog.rs`, `src/schema.rs`, `src/table.rs`)
@@ -49,21 +51,38 @@ The codebase follows a layered architecture with clear separation of concerns:
    - `DuckLakeTable`: Implements `TableProvider`, caches table structure and file lists at creation time
    - **No HashMaps**: Catalog and schema providers query metadata on-demand rather than caching
 
-3. **Path Resolution** (`src/path_resolver.rs`)
+3. **Write Layer** (feature-gated, `write` / `write-sqlite` / `write-postgres`)
+   - `MetadataWriter` trait (`metadata_writer.rs`) defines catalog mutations; implemented by `SqliteMetadataWriter` (`metadata_writer_sqlite.rs`) and `PostgresMetadataWriter` (`metadata_writer_postgres.rs`)
+   - `DuckLakeTableWriter` / `TableWriteSession` (`table_writer.rs`): write Arrow batches to Parquet with configurable compression and row-group sizing
+   - `DuckLakeInsertExec` (`insert_exec.rs`): DataFusion execution plan backing `INSERT INTO` / `CREATE TABLE AS SELECT`. Declares `required_input_distribution() == SinglePartition` so multi-partition inputs are coalesced before writing (guards against silently dropping rows; see `tests/insert_partitioning_tests.rs`)
+   - A catalog becomes writable via `DuckLakeCatalog::with_writer(provider, writer)`
+   - `maintenance.rs`: expire snapshots, clean up superseded files, reclaim orphaned files (Rust API, not SQL DDL)
+   - Multi-catalog (PostgreSQL): `MulticatalogManager` (`multicatalog.rs`) creates/manages many catalogs in one store; `MulticatalogProvider` (`multicatalog_provider.rs`, feature `multicatalog-postgres`) reads them
+
+4. **Additional capabilities**
+   - `information_schema.rs`: SQL-queryable catalog metadata (snapshots, schemata, tables, columns, files)
+   - `table_functions.rs`: `ducklake_snapshots()`, `ducklake_table_info()`, `ducklake_list_files()`, `ducklake_table_changes()`, `ducklake_table_deletions()`; registered via `register_ducklake_functions()`
+   - `row_id.rs`: DuckLake row lineage (`rowid` virtual column), opt-in via `DuckLakeCatalog::with_row_lineage(true)`
+   - `encryption.rs`: Parquet Modular Encryption (PME) reads (feature `encryption`)
+   - `column_rename.rs`: reads Parquet files whose physical column names predate a rename
+   - `table_changes.rs` / `table_deletions.rs`: change-data-capture between snapshots
+   - `positional_source.rs`: preserves physical row positions (used by rowid and delete filtering)
+
+5. **Path Resolution** (`src/path_resolver.rs`)
    - Centralized utilities for parsing object store URLs and resolving hierarchical paths
    - `parse_object_store_url()`: Parses S3, file://, or local paths into ObjectStoreUrl and path components
    - `resolve_path()`: Resolves relative or absolute paths in the catalog hierarchy
    - `PathResolver`: Maintains base URL and path for hierarchical resolution (catalog -> schema -> table -> file)
    - Handles S3, MinIO, and local filesystem paths uniformly
 
-4. **Delete File Filtering** (`src/delete_filter.rs`)
+6. **Delete File Filtering** (`src/delete_filter.rs`)
    - `DeleteFilterExec`: Custom execution plan that wraps Parquet scans and filters deleted rows
    - Implements MOR (Merge-On-Read) pattern for row-level deletes
    - Delete files contain `(file_path: VARCHAR, pos: INT64)` schema
    - Efficiently filters rows by position during query execution
    - Supports COUNT(*) optimization (zero-column batches)
 
-5. **Type Mapping** (`src/types.rs`)
+7. **Type Mapping** (`src/types.rs`)
    - Converts DuckLake type strings to Arrow DataTypes
    - Handles basic types (integers, floats, strings, dates, timestamps)
    - Supports decimals with precision/scale parsing
@@ -96,7 +115,7 @@ The catalog uses a **pure dynamic lookup** approach with no caching at the catal
 - Simple implementation (no cache invalidation logic)
 
 **Trade-offs**:
-- Small query overhead per metadata lookup (acceptable for read-only DuckDB connections)
+- Small query overhead per metadata lookup (acceptable for typical catalog sizes)
 - Future optimization: Add optional caching layer via wrapper implementation
 
 ### Data Flow
@@ -205,23 +224,29 @@ runtime.register_object_store(&Url::parse("s3://ducklake-data/")?, s3);
 ```
 
 ### Current Limitations
-- Read-only access (no writes to DuckLake catalogs)
-- Complex types (nested lists, structs, maps) return errors (not yet supported)
-- No partition-based file pruning (TODO: add to `MetadataProvider` trait)
-- Single metadata provider implementation (DuckDB only)
+- Writes are supported on SQLite and PostgreSQL only; DuckDB and MySQL are read-only
+- No `UPDATE` / `DELETE` operations yet (delete files are read but not written)
+- No SQL-level time travel (`AS OF`); a catalog binds to one snapshot, selectable programmatically via `DuckLakeCatalog::with_snapshot`
+- Complex types (nested lists, structs, maps) have minimal support (many cases return errors)
+- No partition-based file pruning on read
+- DuckDB-encrypted (non-PME) Parquet files are not supported
+- Data inlining is not read (see `COMPATIBILITY.md` for the `COUNT(*)` undercount caveat)
 - No optional metadata caching layer (all lookups are dynamic)
 
 ### Testing
-The project includes comprehensive tests:
-- **Unit tests**: `src/delete_filter.rs` - Delete file schema and position extraction
-- **Integration tests**:
-  - `tests/delete_filter_tests.rs` - End-to-end delete filtering scenarios
-  - `tests/concurrent_tests.rs` - Thread-safety and concurrent query handling
-  - `tests/object_store_integration_test.rs` - S3/MinIO integration
-- **Test data generation**: All test data is generated in Rust using `tests/common/mod.rs` helpers
-  - No external shell scripts required
-  - Tests use temporary directories for isolation
-  - Each test generates its own DuckLake catalog on-the-fly
+The project includes comprehensive tests (`tests/`, ~27 integration files plus unit
+tests in `src/`). Many are feature-gated — e.g. write tests need `write-sqlite`, and
+the postgres/mysql provider and multicatalog tests require Docker (`testcontainers`).
+Representative groups:
+- **Reads & deletes**: `delete_filter_tests.rs`, `missing_delete_file_tests.rs`, `table_tests.rs`, `row_count_tests.rs`
+- **Writes**: `write_tests.rs`, `sql_write_tests.rs`, `concurrent_write_tests.rs`, `insert_partitioning_tests.rs`
+- **Backends**: `sqlite_metadata_provider_test.rs`, `postgres_metadata_provider_test.rs`, `mysql_metadata_provider_test.rs`, `hybrid_asyncdb.rs`
+- **Multicatalog**: `multicatalog_provider_tests.rs`, `multicatalog_postgres_tests.rs`, `multicatalog_hardening_tests.rs`
+- **Capabilities**: `information_schema_test.rs`, `row_id_tests.rs`, `rowid_physical_position_tests.rs`, `renamed_columns_tests.rs`, `table_changes_tests.rs`, `encryption_tests.rs`, `maintenance_sqlite_tests.rs`
+- **Concurrency & object store**: `concurrent_tests.rs`, `object_store_integration_test.rs`
+- **SQL logic tests**: `sqllogictest_runner.rs` driving `tests/sqllogictests/`
+- **Test data generation**: helpers in `tests/common/mod.rs` — each test builds its own
+  DuckLake catalog in a temp directory on the fly; no external shell scripts required
 
 Run tests with:
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,7 +250,7 @@ Representative groups:
 
 Run tests with:
 ```bash
-cargo test                    # All tests (no setup required)
+cargo test                    # Default features; postgres/mysql/multicatalog tests need Docker
 cargo test delete_filter      # Delete file tests only
 cargo test concurrent         # Concurrency tests only
 cargo test --ignored          # Performance benchmarks

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -12,8 +12,11 @@ backends, object stores, types, capabilities, and current limitations. The
 ## Catalog backends
 
 DuckLake stores catalog metadata in a SQL database. Reads are supported on all four
-backends below; writes (`INSERT`, `CREATE TABLE AS SELECT`, `DROP TABLE`, maintenance)
-are currently implemented for SQLite and PostgreSQL only.
+backends below; writes (`INSERT`, `DROP TABLE`, maintenance) are currently implemented
+for SQLite and PostgreSQL only. SQL `CREATE TABLE`/CTAS works on the SQLite
+single-catalog path; the PostgreSQL path is the experimental multi-catalog layout (see
+below) where tables are created via `DuckLakeTableWriter` and then appended to with
+`INSERT INTO`.
 
 | Backend    | Read | Write | Multi-catalog | Feature flags                                          |
 |------------|:----:|:-----:|:-------------:|--------------------------------------------------------|
@@ -22,10 +25,19 @@ are currently implemented for SQLite and PostgreSQL only.
 | PostgreSQL |  ✅  |  ✅   |      ✅       | `metadata-postgres`, `write-postgres`, `multicatalog-postgres` |
 | MySQL      |  ✅  |  ❌   |      ❌       | `metadata-mysql`                                       |
 
-**Multi-catalog** (PostgreSQL only) lets a single metadata store hold multiple
-independent DuckLake catalogs. Reading multiple catalogs requires
+**Multi-catalog** (PostgreSQL only, **experimental**) lets a single metadata store hold
+multiple independent DuckLake catalogs. Reading multiple catalogs requires
 `multicatalog-postgres` (`MulticatalogProvider`); creating/managing them requires
 `write-postgres` (`MulticatalogManager`).
+
+> ⚠️ The multi-catalog layout is **specific to this library** — it is not part of the
+> DuckLake specification and is not (yet) supported or accepted upstream. Catalogs
+> written this way are only readable through `MulticatalogProvider`, not as standard
+> single-catalog DuckLake stores. PostgreSQL writes currently go through this path, so
+> **all PostgreSQL write support should be treated as experimental** and subject to
+> change. Note also that SQL `CREATE TABLE`/CTAS is not available on this path (the first
+> write of a table goes through `DuckLakeTableWriter`); `INSERT INTO` works once a table
+> exists.
 
 ---
 
@@ -79,8 +91,8 @@ the read backend: `--no-default-features --features metadata-duckdb` (requires
 | Capability                                              | Status |
 |---------------------------------------------------------|:------:|
 | `SELECT` against DuckLake tables                        |   ✅   |
-| `INSERT INTO`                                           |   ✅   |
-| `CREATE TABLE AS SELECT`                                |   ✅   |
+| `INSERT INTO` (table must already exist on the PostgreSQL path) | ✅ |
+| `CREATE TABLE AS SELECT` (SQL DDL; SQLite single-catalog only — not on the PostgreSQL multi-catalog path) | 🟧 |
 | `DROP TABLE` (via `MetadataWriter`)                     |   ✅   |
 | Row-level deletes (Merge-On-Read delete files, read)    |   ✅   |
 | Snapshot-based consistency (bound at catalog creation)  |   ✅   |
@@ -92,7 +104,7 @@ the read backend: `--no-default-features --features metadata-duckdb` (requires
 | Maintenance: expire snapshots, cleanup superseded files, orphan-file reclamation | ✅ |
 | Parquet Modular Encryption (PME) reads (feature `encryption`) | ✅ |
 | Configurable writer output (compression, row-group sizing) | ✅  |
-| Multi-catalog (PostgreSQL)                              |   ✅   |
+| Multi-catalog (PostgreSQL, **experimental** — library-specific, not in the DuckLake spec) | ✅ |
 
 Maintenance and `DROP TABLE` are driven through the Rust API (`maintenance` module and
 `MetadataWriter`), not SQL DDL.

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,119 @@
+# Compatibility & Feature Matrix
+
+This is the authoritative reference for what `datafusion-ducklake` supports: catalog
+backends, object stores, types, capabilities, and current limitations. The
+[README](README.md) covers getting started; this file covers "does it support X?".
+
+> Status: alpha. APIs and supported surface change as DataFusion and the DuckLake
+> spec evolve. See [CHANGELOG.md](CHANGELOG.md) for what shipped when.
+
+---
+
+## Catalog backends
+
+DuckLake stores catalog metadata in a SQL database. Reads are supported on all four
+backends below; writes (`INSERT`, `CREATE TABLE AS SELECT`, `DROP TABLE`, maintenance)
+are currently implemented for SQLite and PostgreSQL only.
+
+| Backend    | Read | Write | Multi-catalog | Feature flags                                          |
+|------------|:----:|:-----:|:-------------:|--------------------------------------------------------|
+| DuckDB     |  ✅  |  ❌   |      ❌       | `metadata-duckdb` (default)                            |
+| SQLite     |  ✅  |  ✅   |      ❌       | `metadata-sqlite`, `write-sqlite`                      |
+| PostgreSQL |  ✅  |  ✅   |      ✅       | `metadata-postgres`, `write-postgres`, `multicatalog-postgres` |
+| MySQL      |  ✅  |  ❌   |      ❌       | `metadata-mysql`                                       |
+
+**Multi-catalog** (PostgreSQL only) lets a single metadata store hold multiple
+independent DuckLake catalogs. Reading multiple catalogs requires
+`multicatalog-postgres` (`MulticatalogProvider`); creating/managing them requires
+`write-postgres` (`MulticatalogManager`).
+
+---
+
+## Object stores
+
+| Store                       | Supported | Notes                                              |
+|-----------------------------|:---------:|----------------------------------------------------|
+| Local filesystem            |    ✅     | Available by default via DataFusion's object store |
+| S3-compatible (S3, MinIO)   |    ✅     | Register with `RuntimeEnv::register_object_store`  |
+| Google Cloud Storage        |    ❌     | Not currently wired up                             |
+| Azure Blob Storage          |    ❌     | Not currently wired up                             |
+
+---
+
+## Feature flags
+
+| Feature                  | Description                                                              | Default |
+|--------------------------|--------------------------------------------------------------------------|:-------:|
+| `metadata-duckdb`        | DuckDB catalog read backend                                              |   ✅    |
+| `duckdb-bundled`         | Statically compile & bundle DuckDB (disable for dynamic linking)         |   ✅    |
+| `metadata-sqlite`        | SQLite catalog read backend                                              |         |
+| `metadata-postgres`      | PostgreSQL catalog read backend                                          |         |
+| `metadata-mysql`         | MySQL catalog read backend                                               |         |
+| `write`                  | Base write support (INSERT, CTAS, maintenance API); needs a write backend|         |
+| `write-sqlite`           | Write to SQLite catalogs (`write` + `metadata-sqlite`)                   |         |
+| `write-postgres`         | Write to PostgreSQL catalogs (`write` + `metadata-postgres` + multi-catalog) |     |
+| `multicatalog-postgres`  | Read multiple catalogs from one PostgreSQL store                         |         |
+| `encryption`             | Parquet Modular Encryption (PME) reads                                   |         |
+| `skip-tests-with-docker` | CI-only: skip tests that require Docker                                  |         |
+
+For dynamic linking against a system `libduckdb`, disable defaults and re-enable just
+the read backend: `--no-default-features --features metadata-duckdb` (requires
+`libduckdb` installed; set `DUCKDB_LIB_DIR` and `DUCKDB_INCLUDE_DIR`).
+
+---
+
+## Type support
+
+| Category                         | Status | Notes                                          |
+|----------------------------------|:------:|------------------------------------------------|
+| Integers / floats / boolean      |   ✅   |                                                |
+| Strings / dates / timestamps     |   ✅   |                                                |
+| Decimal (precision & scale)      |   ✅   |                                                |
+| Geometry                         |   ✅   | Mapped to `Binary` (WKB)                        |
+| Complex / nested (list, struct, map) | 🟧 | Minimal support; many cases return errors      |
+
+---
+
+## Capabilities
+
+| Capability                                              | Status |
+|---------------------------------------------------------|:------:|
+| `SELECT` against DuckLake tables                        |   ✅   |
+| `INSERT INTO`                                           |   ✅   |
+| `CREATE TABLE AS SELECT`                                |   ✅   |
+| `DROP TABLE` (via `MetadataWriter`)                     |   ✅   |
+| Row-level deletes (Merge-On-Read delete files, read)    |   ✅   |
+| Snapshot-based consistency (bound at catalog creation)  |   ✅   |
+| Filter pushdown to Parquet (row-group / page pruning)   |   ✅   |
+| Parquet footer size hints (1 read/file instead of 2)    |   ✅   |
+| Row lineage (`rowid` virtual column, opt-in)            |   ✅   |
+| SQL-queryable `information_schema`                      |   ✅   |
+| Table functions (`ducklake_snapshots()`, `ducklake_table_info()`, `ducklake_list_files()`, `ducklake_table_changes()`, `ducklake_table_deletions()`) | ✅ |
+| Maintenance: expire snapshots, cleanup superseded files, orphan-file reclamation | ✅ |
+| Parquet Modular Encryption (PME) reads (feature `encryption`) | ✅ |
+| Configurable writer output (compression, row-group sizing) | ✅  |
+| Multi-catalog (PostgreSQL)                              |   ✅   |
+
+Maintenance and `DROP TABLE` are driven through the Rust API (`maintenance` module and
+`MetadataWriter`), not SQL DDL.
+
+---
+
+## Limitations
+
+- **Write backends:** DuckDB and MySQL are read-only; writes require SQLite or PostgreSQL.
+- **No SQL-level time travel:** a catalog is bound to a single snapshot. You *can* select
+  the snapshot programmatically — `DuckLakeCatalog::with_snapshot(provider, snapshot_id)`
+  binds to a specific one, and querying another point in time means creating another
+  catalog. What's missing is SQL-level historical querying (`AS OF`) within one handle.
+- **No partition-based file pruning** on read.
+- **Complex / nested types** have minimal support.
+- **DuckDB-encrypted (non-PME) Parquet files** are not supported (only PME).
+- **Data inlining is not read.** DuckDB's ducklake extension inlines small INSERTs
+  (≤ `ducklake_default_data_inlining_row_limit`, default 10 rows) into the catalog
+  rather than Parquet files. This crate only reads `ducklake_data_file` rows, so inlined
+  data is invisible — `SELECT COUNT(*)` will silently undercount. If you write through
+  DuckDB and read through this crate, either disable inlining at write time
+  (`SET ducklake_default_data_inlining_row_limit = 0` on every writer connection) or run
+  `COMPACT` before reading. Catalogs written entirely through this crate's
+  `SqliteMetadataWriter` are unaffected — we never inline.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ datafusion-ducklake = { version = "0.3", features = ["metadata-postgres"] }
 ```
 
 The examples below also use `datafusion`, `object_store`, and `url` directly — add them
-to your `[dependencies]` as well (this crate does not re-export them).
+to your `[dependencies]` as well (this crate does not re-export them). The write example
+additionally uses `sqlx` (with its `postgres` and `runtime-tokio` features) to open the
+connection pool.
 
 Run a query against an existing PostgreSQL catalog with the bundled example:
 
@@ -182,9 +184,10 @@ walkthrough (bootstrap → create catalogs → write → read back).
 
 ## Maintenance
 
-The `maintenance` API (feature `write`) handles lakehouse upkeep from Rust: expiring old
-snapshots, cleaning up superseded files, and reclaiming orphaned files. `DROP TABLE` is
-available through `MetadataWriter`. See
+The `maintenance` API handles lakehouse upkeep from Rust: expiring old snapshots,
+cleaning up superseded files, and reclaiming orphaned files. The concrete entry points
+are backend-gated (`write-sqlite` / `write-postgres`). `DROP TABLE` is available through
+`MetadataWriter`. See
 [`examples/maintenance_demo.rs`](examples/maintenance_demo.rs) and
 [`examples/orphan_cleanup_demo.rs`](examples/orphan_cleanup_demo.rs).
 

--- a/README.md
+++ b/README.md
@@ -1,190 +1,205 @@
 # DataFusion-DuckLake
 
-A [DataFusion](https://datafusion.apache.org/) extension for querying [DuckLake](https://ducklake.select). DuckLake is an integrated data lake and catalog format that stores metadata in SQL databases and data as Parquet files on disk or object storage.
+[![crates.io](https://img.shields.io/crates/v/datafusion-ducklake.svg)](https://crates.io/crates/datafusion-ducklake)
+[![docs.rs](https://img.shields.io/docsrs/datafusion-ducklake)](https://docs.rs/datafusion-ducklake)
+[![CI](https://github.com/hotdata-dev/datafusion-ducklake/actions/workflows/ci.yml/badge.svg)](https://github.com/hotdata-dev/datafusion-ducklake/actions/workflows/ci.yml)
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+[![Discord](https://img.shields.io/badge/Discord-Hotdata-5865F2?logo=discord&logoColor=white)](https://discord.gg/cdHczfxxBc)
 
-The goal of this project is to make DuckLake a first-class, Arrow-native lakehouse format inside DataFusion.
+A [DataFusion](https://datafusion.apache.org/) extension for reading and writing
+[DuckLake](https://ducklake.select) catalogs. DuckLake is an integrated data lake and
+catalog format that stores metadata in a SQL database and data as Parquet files on disk
+or object storage.
 
-If you're interested in joining the development, [join the DataFusion+DuckLake Discord](https://discord.com/channels/885562378132000778/1492192627666321452)
+The goal of this project is to make DuckLake a first-class, Arrow-native lakehouse
+format inside DataFusion.
 
-To meet the [Hotdata](https://www.hotdata.dev) team, [Join the Hotdata Discord](https://discord.gg/cdHczfxxBc)
-
----
-
-## Currently Supported
-
-- Read and write queries against DuckLake catalogs (INSERT INTO support)
-- DuckDB, PostgreSQL, MySQL, and SQLite catalog backends
-- PostgreSQL multi-catalog support: manage and read multiple independent DuckLake catalogs within a single metadata store
-- Maintenance operations: `DROP TABLE`, expire snapshots, clean up superseded files, and delete orphaned files
-- Configurable writer output: Parquet compression and row-group sizing (by row count and byte size)
-- Local filesystem and S3-compatible object stores (MinIO, S3)
-- Snapshot-based consistency
-- Basic and decimal types
-- Hierarchical path resolution (`data_path`, `schema`, `table`, `file`)
-- Delete files for row-level deletion (MOR – Merge-On-Read)
-- Parquet Modular Encryption (PME) for reading encrypted Parquet files
-- Parquet footer size hints for optimized I/O
-- Filter pushdown to Parquet for row group pruning and page-level filtering
-- Dynamic metadata lookup (no upfront catalog caching)
-- SQL-queryable `information_schema` for catalog metadata (snapshots, schemas, tables, columns, files)
-- DuckDB-style table functions: `ducklake_snapshots()`, `ducklake_table_info()`, `ducklake_list_files()`, `ducklake_table_changes()`
-- DuckLake row lineage (`rowid` virtual column), opt-in via `DuckLakeCatalog::with_row_lineage(true)`. Writers always populate the lineage counter, matching DuckDB's default; the flag is read-only. Compatible with files produced by DuckDB's `UPDATE` / compaction (embedded `_ducklake_internal_row_id`).
+- 📦 **crates.io:** <https://crates.io/crates/datafusion-ducklake>
+- 📖 **API docs:** <https://docs.rs/datafusion-ducklake>
+- 🧩 **Feature & backend support:** see [COMPATIBILITY.md](COMPATIBILITY.md)
+- 💬 **Discord:** [DataFusion+DuckLake](https://discord.com/channels/885562378132000778/1492192627666321452) · [Hotdata](https://discord.gg/cdHczfxxBc)
 
 ---
 
-## Known Limitations
+## Quick start
 
-- Complex types (nested lists, structs, maps) have minimal support
-- No partition-based file pruning
-- No time travel support
-- DuckDB-encrypted Parquet files (non-PME) are not supported
-- **Data inlining is not read.** DuckDB's ducklake extension inlines small INSERTs (≤ `ducklake_default_data_inlining_row_limit`, default 10 rows) into the catalog itself rather than parquet files. This crate only reads `ducklake_data_file` rows, so inlined data is invisible — `SELECT COUNT(*)` will silently undercount. If you write through DuckDB and read through this crate, either disable inlining at write time (`SET ducklake_default_data_inlining_row_limit = 0` on every writer connection) or run `COMPACT` before reading. Catalogs written entirely through this crate's `SqliteMetadataWriter` are unaffected — we never inline.
-
----
-
-## Roadmap
-
-This project is under active development. The roadmap below reflects major areas of work currently underway or planned next. For the most up-to-date view, see the open issues and pull requests in this repository.
-
-### Metadata & Catalog Improvements
-
-- ~~Multi-catalog support (PostgreSQL)~~ (Done in v0.3.0)
-- Metadata caching to reduce repeated catalog lookups
-- Clear abstraction boundaries between catalog, metadata provider, and execution
-
-### Query Planning & Performance
-
-- Partition-aware file pruning
-- Improved predicate pushdown
-- Smarter Parquet I/O planning
-- Reduced metadata round-trips during planning
-- Better alignment with DataFusion optimizer rules
-
-### Write Support
-
-- ~~Initial write support for DuckLake tables~~ (Done in v0.0.5)
-- ~~S3/ObjectStore write support~~ (Done in v0.0.6)
-- ~~Row lineage (`rowid` virtual column)~~ (Done in v0.3.0)
-- ~~Maintenance: `DROP TABLE`, expire snapshots, cleanup / orphan-file reclamation~~ (Done in v0.3.0)
-- UPDATE and DELETE operations
-
-### Time Travel & Versioning
-
-- Querying historical snapshots
-- Explicit snapshot selection
-
-### Type System Expansion
-
-- Improved support for complex and nested types
-- Better alignment with DuckDB and DataFusion type semantics
-
-### Stability & Ergonomics
-
-- Expanded test coverage
-- Improved error messages and diagnostics
-- Cleaner APIs for embedding in other DataFusion-based systems
-- Additional documentation and examples
-
----
-
-## Usage
-
-### Feature Flags
-
-| Feature | Description | Default |
-|---------|-------------|---------|
-| `metadata-duckdb` | DuckDB catalog backend | ✅ |
-| `duckdb-bundled` | Statically compile and bundle DuckDB (disable for dynamic linking) | ✅ |
-| `metadata-postgres` | PostgreSQL catalog backend | |
-| `metadata-mysql` | MySQL catalog backend | |
-| `metadata-sqlite` | SQLite catalog backend | |
-| `encryption` | Parquet Modular Encryption (PME) support | |
-| `write` | Write support (INSERT INTO) | |
+Add the crate:
 
 ```bash
-# DuckDB only (default, bundled build)
-cargo build
-
-# DuckDB dynamically linked against a system libduckdb
-# (requires libduckdb installed; set DUCKDB_LIB_DIR and DUCKDB_INCLUDE_DIR)
-cargo build --no-default-features --features metadata-duckdb
-
-# PostgreSQL only
-cargo build --no-default-features --features metadata-postgres
-
-# MySQL only
-cargo build --no-default-features --features metadata-mysql
-
-# SQLite only
-cargo build --no-default-features --features metadata-sqlite
-
-# All backends
-cargo build --features metadata-postgres,metadata-mysql,metadata-sqlite
+cargo add datafusion-ducklake
 ```
 
-### Example
+The default build includes the DuckDB catalog backend, statically bundled. Other
+backends and write support are opt-in via feature flags — see
+[COMPATIBILITY.md](COMPATIBILITY.md) for the full matrix.
+
+```toml
+# Cargo.toml — e.g. read PostgreSQL catalogs and write to SQLite ones
+[dependencies]
+datafusion-ducklake = { version = "0.3", features = ["metadata-postgres", "write-sqlite"] }
+```
+
+The examples below also use `datafusion`, `object_store`, and `url` directly — add them
+to your `[dependencies]` as well (this crate does not re-export them).
+
+Run a query against an existing catalog with the bundled example:
 
 ```bash
 # DuckDB catalog
 cargo run --example basic_query -- catalog.db "SELECT * FROM main.users"
 
-# PostgreSQL catalog
-cargo run --example basic_query --features metadata-postgres -- \
-  "postgresql://user:password@localhost:5432/database" "SELECT * FROM main.users"
-
-# MySQL catalog
-cargo run --example basic_query --features metadata-mysql -- \
-  "mysql://user:password@localhost:3306/database" "SELECT * FROM main.users"
-
-# SQLite catalog
+# SQLite / PostgreSQL / MySQL catalogs (enable the matching backend feature)
 cargo run --example basic_query --features metadata-sqlite -- \
   "sqlite:///path/to/catalog.db" "SELECT * FROM main.users"
 ```
 
-### Integration
-```rust
+---
+
+## Reading a catalog
+
+Register a `DuckLakeCatalog` with a `SessionContext` and query it with normal SQL as
+`catalog.schema.table`:
+
+```rust,ignore
 use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::prelude::*;
 use datafusion_ducklake::{DuckLakeCatalog, DuckdbMetadataProvider};
+use object_store::ObjectStore;
+use object_store::aws::AmazonS3Builder;
 use std::sync::Arc;
+use url::Url;
 
-// Create metadata provider
+// (inside an async fn)
+// Read metadata from a DuckDB catalog
 let provider = DuckdbMetadataProvider::new("catalog.db")?;
 
-// Create runtime (register object stores if using S3/MinIO)
+// Register object stores for any non-local data (S3 / MinIO)
 let runtime = Arc::new(RuntimeEnv::default());
-
-// Example: Register S3/MinIO object store
 let s3: Arc<dyn ObjectStore> = Arc::new(
     AmazonS3Builder::new()
-        .with_endpoint("http://localhost:9000") // Your MinIO endpoint
-        .with_bucket_name("ducklake-data") // Your bucket name
-        .with_access_key_id("minioadmin") // Your credentials
-        .with_secret_access_key("minioadmin") // Your credentials
-        .with_region("us-west-2") // Any region works for MinIO
-        .with_allow_http(true) // Required for http:// endpoints
+        .with_endpoint("http://localhost:9000") // MinIO endpoint
+        .with_bucket_name("ducklake-data")
+        .with_access_key_id("minioadmin")
+        .with_secret_access_key("minioadmin")
+        .with_region("us-west-2") // any region works for MinIO
+        .with_allow_http(true)    // required for http:// endpoints
         .build()?,
-    );
+);
 runtime.register_object_store(&Url::parse("s3://ducklake-data/")?, s3);
 
-// Create DuckLake catalog
 let catalog = DuckLakeCatalog::new(provider)?;
-
-// Create session and register catalog
 let ctx = SessionContext::new_with_config_rt(
     SessionConfig::new().with_default_catalog_and_schema("ducklake", "main"),
-    runtime
+    runtime,
 );
 ctx.register_catalog("ducklake", Arc::new(catalog));
 
-// Query
 let df = ctx.sql("SELECT * FROM ducklake.main.my_table").await?;
 df.show().await?;
-
-
 ```
-### Project Status
 
-This project is evolving alongside DataFusion and DuckLake. APIs may change as core abstractions are refined.
+---
 
-Feedback, issues, and contributions are welcome.
+## Writing a catalog
+
+Writes are supported on **SQLite** and **PostgreSQL** catalogs (enable `write-sqlite`
+or `write-postgres`). Build the catalog with `with_writer`, then use standard SQL —
+`INSERT INTO` and `CREATE TABLE AS SELECT` both work:
+
+```rust,ignore
+use datafusion::prelude::*;
+// `MetadataWriter` is the trait that provides `set_data_path` / `create_snapshot`
+use datafusion_ducklake::{
+    DuckLakeCatalog, MetadataWriter, SqliteMetadataProvider, SqliteMetadataWriter,
+};
+use std::sync::Arc;
+
+let conn = "sqlite:catalog.db?mode=rwc";
+
+// Initialize a writer (creates the DuckLake schema + first snapshot if new)
+let writer = SqliteMetadataWriter::new_with_init(conn).await?;
+writer.set_data_path("data/")?;
+writer.create_snapshot()?;
+
+// A writable catalog pairs a read provider with the writer
+let provider = SqliteMetadataProvider::new(conn).await?;
+let catalog = DuckLakeCatalog::with_writer(Arc::new(provider), Arc::new(writer))?;
+
+let ctx = SessionContext::new();
+ctx.register_catalog("ducklake", Arc::new(catalog));
+
+ctx.sql("CREATE TABLE ducklake.main.events AS SELECT * FROM source").await?.collect().await?;
+ctx.sql("INSERT INTO ducklake.main.events VALUES (1, 'a')").await?.collect().await?;
+```
+
+Writer output is configurable (Parquet compression, row-group sizing by row count and
+byte size). See [`DuckLakeTableWriter`](https://docs.rs/datafusion-ducklake) and the
+examples in [`examples/`](examples/).
+
+---
+
+## Multi-catalog (PostgreSQL)
+
+A single PostgreSQL metadata store can host **multiple independent DuckLake catalogs**.
+This is useful for multi-tenant deployments or keeping many logical lakehouses in one
+database.
+
+- **Read** multiple catalogs with `MulticatalogProvider` (feature `multicatalog-postgres`).
+- **Create and manage** them with `MulticatalogManager` (feature `write-postgres`, which
+  pulls in multi-catalog support).
+
+See [`examples/multicatalog_write.rs`](examples/multicatalog_write.rs) for an end-to-end
+walkthrough.
+
+---
+
+## Maintenance
+
+The `maintenance` API (feature `write`) handles lakehouse upkeep from Rust: expiring old
+snapshots, cleaning up superseded files, and reclaiming orphaned files. `DROP TABLE` is
+available through `MetadataWriter`. See
+[`examples/maintenance_demo.rs`](examples/maintenance_demo.rs) and
+[`examples/orphan_cleanup_demo.rs`](examples/orphan_cleanup_demo.rs).
+
+---
+
+## Compatibility
+
+For the full breakdown of catalog backends, object stores, types, capabilities, and
+current limitations, see **[COMPATIBILITY.md](COMPATIBILITY.md)**.
+
+A few highlights worth knowing up front:
+
+- Reads work on DuckDB, SQLite, PostgreSQL, and MySQL; **writes are SQLite/PostgreSQL only**.
+- Object stores: local filesystem and S3-compatible (S3, MinIO).
+- Snapshots can be selected programmatically (`DuckLakeCatalog::with_snapshot`), but there
+  is no SQL-level time travel (`AS OF`) yet, and no partition-based file pruning.
+- Data inlined by DuckDB's ducklake extension is **not read** — see COMPATIBILITY.md for
+  the `COUNT(*)` undercount caveat and how to avoid it.
+
+---
+
+## Roadmap
+
+This project is under active development. The list below is forward-looking; for what
+has already shipped, see [CHANGELOG.md](CHANGELOG.md).
+
+- **Write:** `UPDATE` and `DELETE` operations
+- **Time travel:** SQL-level historical queries (`AS OF`); programmatic snapshot binding
+  via `DuckLakeCatalog::with_snapshot` already ships
+- **Query planning:** partition-aware file pruning, improved predicate pushdown, fewer
+  metadata round-trips during planning
+- **Metadata:** optional caching layer to reduce repeated catalog lookups
+- **Types:** broader support for complex and nested types
+- **Object stores:** Google Cloud Storage and Azure Blob Storage
+- **Ergonomics:** cleaner APIs for embedding in other DataFusion-based systems, better
+  error messages, more docs and examples
+
+For the most up-to-date view, see the open issues and pull requests.
+
+---
+
+## Project status
+
+This project is in alpha and evolving alongside DataFusion and DuckLake. APIs may change
+as core abstractions are refined. Feedback, issues, and contributions are welcome.

--- a/README.md
+++ b/README.md
@@ -14,10 +14,14 @@ or object storage.
 The goal of this project is to make DuckLake a first-class, Arrow-native lakehouse
 format inside DataFusion.
 
+This project is maintained by [Hotdata](https://www.hotdata.dev) with support from the
+community. Come talk to us on [the Hotdata Discord](https://discord.gg/cdHczfxxBc).
+
 - 📦 **crates.io:** <https://crates.io/crates/datafusion-ducklake>
 - 📖 **API docs:** <https://docs.rs/datafusion-ducklake>
 - 🧩 **Feature & backend support:** see [COMPATIBILITY.md](COMPATIBILITY.md)
-- 💬 **Discord:** [DataFusion+DuckLake](https://discord.com/channels/885562378132000778/1492192627666321452) · [Hotdata](https://discord.gg/cdHczfxxBc)
+- 💬 **Project chat:** [DataFusion+DuckLake Discord](https://discord.com/channels/885562378132000778/1492192627666321452) — development and usage discussion
+- 🧡 **Meet the team:** [Hotdata Discord](https://discord.gg/cdHczfxxBc)
 
 ---
 
@@ -34,24 +38,24 @@ backends and write support are opt-in via feature flags — see
 [COMPATIBILITY.md](COMPATIBILITY.md) for the full matrix.
 
 ```toml
-# Cargo.toml — e.g. read PostgreSQL catalogs and write to SQLite ones
+# Cargo.toml — read PostgreSQL catalogs
+# (for the experimental multi-catalog write path, use features = ["write-postgres"])
 [dependencies]
-datafusion-ducklake = { version = "0.3", features = ["metadata-postgres", "write-sqlite"] }
+datafusion-ducklake = { version = "0.3", features = ["metadata-postgres"] }
 ```
 
 The examples below also use `datafusion`, `object_store`, and `url` directly — add them
 to your `[dependencies]` as well (this crate does not re-export them).
 
-Run a query against an existing catalog with the bundled example:
+Run a query against an existing PostgreSQL catalog with the bundled example:
 
 ```bash
-# DuckDB catalog
-cargo run --example basic_query -- catalog.db "SELECT * FROM main.users"
-
-# SQLite / PostgreSQL / MySQL catalogs (enable the matching backend feature)
-cargo run --example basic_query --features metadata-sqlite -- \
-  "sqlite:///path/to/catalog.db" "SELECT * FROM main.users"
+cargo run --example basic_query --features metadata-postgres -- \
+  "postgresql://user:password@localhost:5432/database" "SELECT * FROM main.users"
 ```
+
+(The example also accepts DuckDB, SQLite, and MySQL connection strings with the matching
+`metadata-*` feature — see [COMPATIBILITY.md](COMPATIBILITY.md).)
 
 ---
 
@@ -63,15 +67,15 @@ Register a `DuckLakeCatalog` with a `SessionContext` and query it with normal SQ
 ```rust,ignore
 use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::prelude::*;
-use datafusion_ducklake::{DuckLakeCatalog, DuckdbMetadataProvider};
+use datafusion_ducklake::{DuckLakeCatalog, PostgresMetadataProvider};
 use object_store::ObjectStore;
 use object_store::aws::AmazonS3Builder;
 use std::sync::Arc;
 use url::Url;
 
 // (inside an async fn)
-// Read metadata from a DuckDB catalog
-let provider = DuckdbMetadataProvider::new("catalog.db")?;
+// Read metadata from a PostgreSQL catalog
+let provider = PostgresMetadataProvider::new("postgresql://user:pass@localhost:5432/db").await?;
 
 // Register object stores for any non-local data (S3 / MinIO)
 let runtime = Arc::new(RuntimeEnv::default());
@@ -100,56 +104,63 @@ df.show().await?;
 
 ---
 
-## Writing a catalog
+## Writing & multi-catalog (PostgreSQL)
 
-Writes are supported on **SQLite** and **PostgreSQL** catalogs (enable `write-sqlite`
-or `write-postgres`). Build the catalog with `with_writer`, then use standard SQL —
-`INSERT INTO` and `CREATE TABLE AS SELECT` both work:
+> **Experimental.** PostgreSQL write support is built on a **multi-catalog** layout that
+> lets a single Postgres metadata store host many independent DuckLake catalogs. This
+> layout is **specific to this library** — it is not part of the DuckLake specification
+> and is not (yet) supported or accepted upstream. Catalogs written this way are read
+> back with this crate's `MulticatalogProvider`; they are not interchangeable with a
+> standard single-catalog DuckLake store. The API and on-disk/in-catalog layout may
+> change. It is useful today for multi-tenant deployments or keeping many logical
+> lakehouses in one database, but treat it as a preview.
+
+Tables are created through the writer API; once a table exists, you can append to it with
+SQL `INSERT INTO`. (SQL `CREATE TABLE` / CTAS is not supported on this path — DataFusion
+cannot create the schema, so the first write goes through `DuckLakeTableWriter`.)
 
 ```rust,ignore
 use datafusion::prelude::*;
-// `MetadataWriter` is the trait that provides `set_data_path` / `create_snapshot`
+use datafusion_ducklake::metadata_writer::MetadataWriter; // set_data_path
 use datafusion_ducklake::{
-    DuckLakeCatalog, MetadataWriter, SqliteMetadataProvider, SqliteMetadataWriter,
+    DuckLakeCatalog, DuckLakeTableWriter, MulticatalogManager, MulticatalogProvider,
+    PostgresMetadataWriter, initialize_multicatalog_schema,
 };
+use sqlx::postgres::PgPoolOptions;
 use std::sync::Arc;
 
-let conn = "sqlite:catalog.db?mode=rwc";
+let pool = PgPoolOptions::new().connect("postgresql://user:pass@localhost:5432/db").await?;
 
-// Initialize a writer (creates the DuckLake schema + first snapshot if new)
-let writer = SqliteMetadataWriter::new_with_init(conn).await?;
-writer.set_data_path("data/")?;
-writer.create_snapshot()?;
+// One-time: bootstrap the multi-catalog tables, then create a named catalog
+initialize_multicatalog_schema(&pool).await?;
+let catalog_id = MulticatalogManager::new(pool.clone()).create_catalog("my_catalog").await?;
 
-// A writable catalog pairs a read provider with the writer
-let provider = SqliteMetadataProvider::new(conn).await?;
-let catalog = DuckLakeCatalog::with_writer(Arc::new(provider), Arc::new(writer))?;
+// Create a table by writing the first batch through the table writer
+let writer = Arc::new(PostgresMetadataWriter::with_pool(pool.clone(), catalog_id).await?);
+writer.set_data_path("/abs/path/to/data")?;
+let object_store: Arc<dyn object_store::ObjectStore> =
+    Arc::new(object_store::local::LocalFileSystem::new());
+let table_writer = DuckLakeTableWriter::new(writer.clone(), object_store)?;
+table_writer.write_table("public", "events", &[batch]).await?;
 
+// Now append with SQL, reading the same catalog back through MulticatalogProvider
+let provider = MulticatalogProvider::with_pool(pool.clone(), "my_catalog").await?;
+let catalog = DuckLakeCatalog::with_writer(Arc::new(provider), writer)?;
 let ctx = SessionContext::new();
 ctx.register_catalog("ducklake", Arc::new(catalog));
-
-ctx.sql("CREATE TABLE ducklake.main.events AS SELECT * FROM source").await?.collect().await?;
-ctx.sql("INSERT INTO ducklake.main.events VALUES (1, 'a')").await?.collect().await?;
+ctx.sql("INSERT INTO ducklake.public.events VALUES (1, 'a')").await?.collect().await?;
+ctx.sql("SELECT count(*) FROM ducklake.public.events").await?.show().await?;
 ```
 
 Writer output is configurable (Parquet compression, row-group sizing by row count and
-byte size). See [`DuckLakeTableWriter`](https://docs.rs/datafusion-ducklake) and the
-examples in [`examples/`](examples/).
+byte size). See [`examples/multicatalog_write.rs`](examples/multicatalog_write.rs) for a
+full end-to-end walkthrough and [`DuckLakeTableWriter`](https://docs.rs/datafusion-ducklake)
+for the writer options.
 
----
-
-## Multi-catalog (PostgreSQL)
-
-A single PostgreSQL metadata store can host **multiple independent DuckLake catalogs**.
-This is useful for multi-tenant deployments or keeping many logical lakehouses in one
-database.
-
-- **Read** multiple catalogs with `MulticatalogProvider` (feature `multicatalog-postgres`).
-- **Create and manage** them with `MulticatalogManager` (feature `write-postgres`, which
-  pulls in multi-catalog support).
-
-See [`examples/multicatalog_write.rs`](examples/multicatalog_write.rs) for an end-to-end
-walkthrough.
+> Writing to a **standard, single-catalog** DuckLake store (the spec-compliant layout) is
+> supported today for **SQLite** via `SqliteMetadataWriter` (feature `write-sqlite`),
+> where SQL `CREATE TABLE AS SELECT` and `INSERT INTO` both work. See
+> [`tests/sql_write_tests.rs`](tests/sql_write_tests.rs).
 
 ---
 
@@ -179,27 +190,8 @@ A few highlights worth knowing up front:
 
 ---
 
-## Roadmap
-
-This project is under active development. The list below is forward-looking; for what
-has already shipped, see [CHANGELOG.md](CHANGELOG.md).
-
-- **Write:** `UPDATE` and `DELETE` operations
-- **Time travel:** SQL-level historical queries (`AS OF`); programmatic snapshot binding
-  via `DuckLakeCatalog::with_snapshot` already ships
-- **Query planning:** partition-aware file pruning, improved predicate pushdown, fewer
-  metadata round-trips during planning
-- **Metadata:** optional caching layer to reduce repeated catalog lookups
-- **Types:** broader support for complex and nested types
-- **Object stores:** Google Cloud Storage and Azure Blob Storage
-- **Ergonomics:** cleaner APIs for embedding in other DataFusion-based systems, better
-  error messages, more docs and examples
-
-For the most up-to-date view, see the open issues and pull requests.
-
----
-
 ## Project status
 
 This project is in alpha and evolving alongside DataFusion and DuckLake. APIs may change
-as core abstractions are refined. Feedback, issues, and contributions are welcome.
+as core abstractions are refined. See [CHANGELOG.md](CHANGELOG.md) for release history.
+Feedback, issues, and contributions are welcome.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![docs.rs](https://img.shields.io/docsrs/datafusion-ducklake)](https://docs.rs/datafusion-ducklake)
 [![CI](https://github.com/hotdata-dev/datafusion-ducklake/actions/workflows/ci.yml/badge.svg)](https://github.com/hotdata-dev/datafusion-ducklake/actions/workflows/ci.yml)
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
-[![Discord](https://img.shields.io/badge/Discord-Hotdata-5865F2?logo=discord&logoColor=white)](https://discord.gg/cdHczfxxBc)
+[![Discord](https://img.shields.io/badge/Discord-DataFusion%2BDuckLake-5865F2?logo=discord&logoColor=white)](https://discord.com/channels/885562378132000778/1492192627666321452)
 
 A [DataFusion](https://datafusion.apache.org/) extension for reading and writing
 [DuckLake](https://ducklake.select) catalogs. DuckLake is an integrated data lake and
@@ -104,19 +104,12 @@ df.show().await?;
 
 ---
 
-## Writing & multi-catalog (PostgreSQL)
+## Writing a catalog
 
-> **Experimental.** PostgreSQL write support is built on a **multi-catalog** layout that
-> lets a single Postgres metadata store host many independent DuckLake catalogs. This
-> layout is **specific to this library** — it is not part of the DuckLake specification
-> and is not (yet) supported or accepted upstream. Catalogs written this way are read
-> back with this crate's `MulticatalogProvider`; they are not interchangeable with a
-> standard single-catalog DuckLake store. The API and on-disk/in-catalog layout may
-> change. It is useful today for multi-tenant deployments or keeping many logical
-> lakehouses in one database, but treat it as a preview.
-
-Tables are created through the writer API; once a table exists, you can append to it with
-SQL `INSERT INTO`. (SQL `CREATE TABLE` / CTAS is not supported on this path — DataFusion
+PostgreSQL writes go through the **experimental multi-catalog layout** described in the
+[next section](#multi-catalog-postgresql-experimental) — treat them as a preview. Tables
+are created through the writer API; once a table exists, you append to it with SQL
+`INSERT INTO`. (SQL `CREATE TABLE` / CTAS is not supported on this path — DataFusion
 cannot create the schema, so the first write goes through `DuckLakeTableWriter`.)
 
 ```rust,ignore
@@ -141,7 +134,7 @@ writer.set_data_path("/abs/path/to/data")?;
 let object_store: Arc<dyn object_store::ObjectStore> =
     Arc::new(object_store::local::LocalFileSystem::new());
 let table_writer = DuckLakeTableWriter::new(writer.clone(), object_store)?;
-table_writer.write_table("public", "events", &[batch]).await?;
+table_writer.write_table("public", "events", &[batch]).await?; // `batch` is your RecordBatch
 
 // Now append with SQL, reading the same catalog back through MulticatalogProvider
 let provider = MulticatalogProvider::with_pool(pool.clone(), "my_catalog").await?;
@@ -153,14 +146,37 @@ ctx.sql("SELECT count(*) FROM ducklake.public.events").await?.show().await?;
 ```
 
 Writer output is configurable (Parquet compression, row-group sizing by row count and
-byte size). See [`examples/multicatalog_write.rs`](examples/multicatalog_write.rs) for a
-full end-to-end walkthrough and [`DuckLakeTableWriter`](https://docs.rs/datafusion-ducklake)
-for the writer options.
+byte size). See [`DuckLakeTableWriter`](https://docs.rs/datafusion-ducklake) for the
+writer options.
 
 > Writing to a **standard, single-catalog** DuckLake store (the spec-compliant layout) is
 > supported today for **SQLite** via `SqliteMetadataWriter` (feature `write-sqlite`),
 > where SQL `CREATE TABLE AS SELECT` and `INSERT INTO` both work. See
 > [`tests/sql_write_tests.rs`](tests/sql_write_tests.rs).
+
+---
+
+## Multi-catalog (PostgreSQL, experimental)
+
+A single PostgreSQL metadata store can host **multiple independent DuckLake catalogs** —
+useful for multi-tenant deployments or keeping many logical lakehouses in one database.
+
+> ⚠️ **Experimental and library-specific.** This multi-catalog layout is **not part of the
+> DuckLake specification** and is not (yet) supported or accepted upstream. Catalogs
+> written this way are read back only through this crate's `MulticatalogProvider` — they
+> are **not** interchangeable with a standard single-catalog DuckLake store. The API and
+> on-disk/in-catalog layout may change. PostgreSQL write support currently depends on this
+> path, so treat it as a preview.
+
+- **Create and manage** catalogs with `MulticatalogManager` (feature `write-postgres`):
+  `initialize_multicatalog_schema` bootstraps the shared tables, then `create_catalog`,
+  and `drop_table_in_catalog` manage their contents.
+- **Read** a specific catalog with `MulticatalogProvider::with_pool(pool, "name")`
+  (feature `multicatalog-postgres`), which plugs into a `DuckLakeCatalog` like any other
+  metadata provider.
+
+See [`examples/multicatalog_write.rs`](examples/multicatalog_write.rs) for an end-to-end
+walkthrough (bootstrap → create catalogs → write → read back).
 
 ---
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,9 @@
 //! - **Catalog Database**: SQL database (DuckDB, SQLite, PostgreSQL, MySQL) storing metadata as SQL tables
 //! - **Data Storage**: Apache Parquet files stored on disk/object storage
 //!
-//! This extension provides read-only access to DuckLake catalogs through DataFusion's
-//! catalog and table provider interfaces.
+//! This extension provides read and write access to DuckLake catalogs through DataFusion's
+//! catalog and table provider interfaces. Writes are feature-gated (`write-sqlite`,
+//! `write-postgres`); see `COMPATIBILITY.md` for the full backend/feature matrix.
 //!
 //! ## Example
 //!


### PR DESCRIPTION
Reorients the README around getting started (badges, Postgres-focused read/write examples, a dedicated experimental multi-catalog section) and moves the authoritative backend/feature/type/limitation matrix into a new COMPATIBILITY.md. Also corrects CLAUDE.md and the lib.rs doc-comment, which wrongly described the crate as read-only / DuckDB-only.