### PR TITLE
chore(release): prepare v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-06-23
+
+### Documentation
+- Refresh the README, add `COMPATIBILITY.md` documenting the backend/feature matrix, and correct `CLAUDE.md` to reflect read **and** write support. Update the crate-level doc comment accordingly (#144).
+
 ## [0.3.0] - 2026-06-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1822,7 +1822,7 @@ checksum = "5c93ad9e37730d2c7196e68616f3f2dd3b04c892e03acd3a8eeca6e177f3c06a"
 
 [[package]]
 name = "datafusion-ducklake"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "arrow 58.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "benchmark"]
 
 [package]
 name = "datafusion-ducklake"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 authors = ["zac@hotdata.dev", "shefeek@hotdata.dev", "anoop@hotdata.dev"]
 description = "DuckLake query engine for rust, built with datafusion."


### PR DESCRIPTION
Patch release to refresh the crates.io page and docs.rs with the docs-only changes from #144 (README, COMPATIBILITY.md, CLAUDE.md, crate doc comment). No code changes since v0.3.0.