### PR TITLE
fix(write): commit-time model for multi-catalog Postgres writes (#146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Concurrent `WriteMode::Replace` on the experimental PostgreSQL multi-catalog write path could union conflicting generations instead of rejecting one.** Converged the multi-catalog writer onto DuckLake's commit-time model: a snapshot's id is assigned at commit (commit-ordered), and all of its metadata — snapshot, schema/table, columns, data files, and the published head — is written in a single transaction, so committed-but-unpublished rows are never visible to readers or conflict checks. `Replace` now aborts with a `Conflict` error when another writer published a newer generation of the table since the write began. Column field-ids stay stable across a same-schema `Replace`, and an `Append` racing a table creation aborts rather than producing NULL-filled reads. No on-disk format, DuckLake spec, or public API change (#146).
+
 ## [0.3.1] - 2026-06-23
 
 ### Documentation

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -111,6 +111,47 @@ Maintenance and `DROP TABLE` are driven through the Rust API (`maintenance` modu
 
 ---
 
+## Write concurrency
+
+Both write backends use the same **commit-time** model: a write's snapshot id, all its
+metadata rows, and its publication are written in **one transaction**, with the snapshot id
+assigned at commit (so per-catalog id order == commit order) and nothing visible until that
+transaction commits. There are no "dormant" (committed-but-unpublished) rows, so reads never
+observe another writer's uncommitted schema, a transient empty table, or a torn generation.
+On Postgres multi-catalog the begin step only *reserves* ids (via the IDENTITY sequence) and
+reads existing state; it writes nothing.
+
+`WriteMode::Replace` (SQL `INSERT OVERWRITE`, and the first write of a table) is
+**abort-on-conflict** under concurrency, matching DuckLake's snapshot isolation:
+
+- **Two concurrent `Replace`s of the same table never silently union.** The first to
+  commit wins; the later one — whose base is now stale — aborts with
+  `DuckLakeError::Conflict` (retryable by the caller). The check runs at the commit point
+  under the catalog lock: a `Replace` aborts if any data file **or** column of the table has
+  `begin_snapshot`/`end_snapshot` newer than the catalog head it began on.
+- **Column ids are stable** across writes: an unchanged column keeps its `column_id`
+  (== parquet field-id); a same-schema `Replace` rewrites no column rows. Only added/removed
+  columns are written.
+
+Known edges:
+
+- **`Append` (`INSERT INTO`) is not conflict-checked.** Concurrent appends commute and are
+  both retained (matching DuckLake); a *stale* `Append` issued before a concurrent `Replace`
+  is not detected. Use `Replace` for overwrite semantics.
+- A **fileless same-schema `Replace`** (an empty-table overwrite that writes no data file and
+  changes no column) leaves no per-table footprint, so it resolves **last-writer-wins** rather
+  than abort-on-conflict (both backends). Data-bearing and schema-changing replaces are
+  conflict-checked.
+- A **type change on `Replace`** is not applied to a kept (same-named) column — the column
+  keeps its existing type (matches the SQLite writer). Add/remove columns work.
+- A single `Replace` is assumed to register **one** data file (the current writer path); the
+  conflict check is not designed for multiple `register_data_file` calls sharing one base.
+- Two concurrent `CREATE TABLE` of the same name on the PostgreSQL multi-catalog path are
+  rejected by a unique index, surfacing as a raw database unique-violation rather than a
+  clean `Conflict`. A `DROP` racing a write can likewise surface as a raw unique-violation.
+
+---
+
 ## Limitations
 
 - **Write backends:** DuckDB and MySQL are read-only; writes require SQLite or PostgreSQL.

--- a/examples/maintenance_demo.rs
+++ b/examples/maintenance_demo.rs
@@ -57,8 +57,11 @@ async fn main() -> anyhow::Result<()> {
     // becomes the head — begin_write_transaction now only RESERVES the id.
     writer.publish_snapshot(
         s1.table_id,
+        "main",
+        "t",
         s1.snapshot_id,
         WriteMode::Replace,
+        s1.base_snapshot_id,
         &cols(),
         &s1.column_ids,
     )?;
@@ -73,9 +76,12 @@ async fn main() -> anyhow::Result<()> {
     )?;
     writer.register_data_file(
         s2.table_id,
+        "main",
+        "t",
         s2.snapshot_id,
         &DataFileInfo::new("f1.parquet", 100, 5),
         WriteMode::Replace,
+        s2.base_snapshot_id,
         &cols(),
         &s2.column_ids,
     )?;
@@ -86,9 +92,12 @@ async fn main() -> anyhow::Result<()> {
     let s3 = writer.begin_write_transaction("main", "t", &cols(), WriteMode::Replace)?;
     writer.register_data_file(
         s3.table_id,
+        "main",
+        "t",
         s3.snapshot_id,
         &DataFileInfo::new("f2.parquet", 100, 5),
         WriteMode::Replace,
+        s3.base_snapshot_id,
         &cols(),
         &s3.column_ids,
     )?;

--- a/examples/orphan_cleanup_demo.rs
+++ b/examples/orphan_cleanup_demo.rs
@@ -66,9 +66,12 @@ async fn main() -> anyhow::Result<()> {
     )?;
     writer.register_data_file(
         s.table_id,
+        "main",
+        "t",
         s.snapshot_id,
         &DataFileInfo::new("ref.parquet", 100, 5),
         WriteMode::Replace,
+        s.base_snapshot_id,
         &[ColumnDef::new("id", "int64", false)?, ColumnDef::new("name", "varchar", true)?],
         &s.column_ids,
     )?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -67,6 +67,13 @@ pub enum DuckLakeError {
     #[error("Parquet error: {0}")]
     Parquet(#[from] parquet::errors::ParquetError),
 
+    /// A concurrent write conflict detected at commit time: another writer
+    /// published a newer generation of the table since this write began. The
+    /// loser aborts (DuckLake-style optimistic concurrency) rather than silently
+    /// unioning or clobbering the concurrent commit. Callers may retry.
+    #[error("Write conflict: {0}")]
+    Conflict(String),
+
     /// Generic error
     #[error("Internal error: {0}")]
     Internal(String),

--- a/src/metadata_provider.rs
+++ b/src/metadata_provider.rs
@@ -20,7 +20,9 @@ pub const SQL_LIST_TABLES: &str =
 pub const SQL_GET_TABLE_COLUMNS: &str =
     "SELECT column_id, column_name, column_type, nulls_allowed, parent_column
      FROM ducklake_column
-     WHERE table_id = ? AND end_snapshot IS NULL
+     WHERE table_id = ?
+       AND ? >= begin_snapshot
+       AND (? < end_snapshot OR end_snapshot IS NULL)
      ORDER BY column_order";
 
 pub const SQL_GET_DATA_FILES: &str = "
@@ -230,6 +232,8 @@ pub const SQL_LIST_ALL_COLUMNS: &str = "
       AND (? < s.end_snapshot OR s.end_snapshot IS NULL)
       AND ? >= t.begin_snapshot
       AND (? < t.end_snapshot OR t.end_snapshot IS NULL)
+      AND ? >= c.begin_snapshot
+      AND (? < c.end_snapshot OR c.end_snapshot IS NULL)
     ORDER BY s.schema_name, t.table_name, c.column_order";
 
 pub const SQL_LIST_ALL_FILES: &str = "
@@ -568,8 +572,17 @@ pub trait MetadataProvider: Send + Sync + std::fmt::Debug {
     /// List tables for a specific snapshot
     fn list_tables(&self, schema_id: i64, snapshot_id: i64) -> Result<Vec<TableMetadata>>;
 
-    /// Get table structure (columns) - not snapshot-dependent as column definitions don't change
-    fn get_table_structure(&self, table_id: i64) -> Result<Vec<DuckLakeTableColumn>>;
+    /// Get table structure (columns) visible at `snapshot_id`. Columns are
+    /// snapshot-scoped (`snapshot_id >= begin_snapshot AND (snapshot_id <
+    /// end_snapshot OR end_snapshot IS NULL)`), matching upstream DuckLake and
+    /// the catalog's own snapshot-scoped `list_tables`/`list_schemas`. This is
+    /// required for correct reads under schema evolution and to hide
+    /// uncommitted/dormant column generations on the multicatalog write path.
+    fn get_table_structure(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+    ) -> Result<Vec<DuckLakeTableColumn>>;
 
     /// Get table files for a specific snapshot
     fn get_table_files_for_select(

--- a/src/metadata_provider_duckdb.rs
+++ b/src/metadata_provider_duckdb.rs
@@ -142,12 +142,16 @@ impl MetadataProvider for DuckdbMetadataProvider {
         Ok(tables)
     }
 
-    fn get_table_structure(&self, table_id: i64) -> crate::Result<Vec<DuckLakeTableColumn>> {
+    fn get_table_structure(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+    ) -> crate::Result<Vec<DuckLakeTableColumn>> {
         let conn = self.connection();
         let mut stmt = conn.prepare(SQL_GET_TABLE_COLUMNS)?;
 
         let raw_columns: Vec<(DuckLakeTableColumn, Option<i64>)> = stmt
-            .query_map([table_id], |row| {
+            .query_map(duckdb::params![table_id, snapshot_id, snapshot_id], |row| {
                 let column_id: i64 = row.get(0)?;
                 let column_name: String = row.get(1)?;
                 let column_type: String = row.get(2)?;
@@ -319,7 +323,14 @@ impl MetadataProvider for DuckdbMetadataProvider {
 
         let raw_columns: Vec<(ColumnWithTable, Option<i64>)> = stmt
             .query_map(
-                params![snapshot_id, snapshot_id, snapshot_id, snapshot_id],
+                params![
+                    snapshot_id,
+                    snapshot_id,
+                    snapshot_id,
+                    snapshot_id,
+                    snapshot_id,
+                    snapshot_id
+                ],
                 |row| {
                     let schema_name: String = row.get(0)?;
                     let table_name: String = row.get(1)?;

--- a/src/metadata_provider_mysql.rs
+++ b/src/metadata_provider_mysql.rs
@@ -137,15 +137,23 @@ impl MetadataProvider for MySqlMetadataProvider {
         })
     }
 
-    fn get_table_structure(&self, table_id: i64) -> Result<Vec<DuckLakeTableColumn>> {
+    fn get_table_structure(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+    ) -> Result<Vec<DuckLakeTableColumn>> {
         block_on(async {
             let rows = sqlx::query(
                 "SELECT column_id, column_name, column_type, nulls_allowed, parent_column
                  FROM ducklake_column
-                 WHERE table_id = ? AND end_snapshot IS NULL
+                 WHERE table_id = ?
+                   AND ? >= begin_snapshot
+                   AND (? < end_snapshot OR end_snapshot IS NULL)
                  ORDER BY column_order",
             )
             .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
             .fetch_all(&self.pool)
             .await?;
 
@@ -382,8 +390,12 @@ impl MetadataProvider for MySqlMetadataProvider {
                    AND (? < s.end_snapshot OR s.end_snapshot IS NULL)
                    AND ? >= t.begin_snapshot
                    AND (? < t.end_snapshot OR t.end_snapshot IS NULL)
+                   AND ? >= c.begin_snapshot
+                   AND (? < c.end_snapshot OR c.end_snapshot IS NULL)
                  ORDER BY s.schema_name, t.table_name, c.column_order",
             )
+            .bind(snapshot_id)
+            .bind(snapshot_id)
             .bind(snapshot_id)
             .bind(snapshot_id)
             .bind(snapshot_id)

--- a/src/metadata_provider_postgres.rs
+++ b/src/metadata_provider_postgres.rs
@@ -171,15 +171,23 @@ impl MetadataProvider for PostgresMetadataProvider {
         })
     }
 
-    fn get_table_structure(&self, table_id: i64) -> Result<Vec<DuckLakeTableColumn>> {
+    fn get_table_structure(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+    ) -> Result<Vec<DuckLakeTableColumn>> {
         block_on(async {
             let rows = sqlx::query(
                 "SELECT column_id, column_name, column_type, nulls_allowed, parent_column
                  FROM ducklake_column
-                 WHERE table_id = $1 AND end_snapshot IS NULL
+                 WHERE table_id = $1
+                   AND $2 >= begin_snapshot
+                   AND ($3 < end_snapshot OR end_snapshot IS NULL)
                  ORDER BY column_order",
             )
             .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
             .fetch_all(&self.pool)
             .await?;
 
@@ -415,8 +423,12 @@ impl MetadataProvider for PostgresMetadataProvider {
                    AND ($2 < s.end_snapshot OR s.end_snapshot IS NULL)
                    AND $3 >= t.begin_snapshot
                    AND ($4 < t.end_snapshot OR t.end_snapshot IS NULL)
+                   AND $5 >= c.begin_snapshot
+                   AND ($6 < c.end_snapshot OR c.end_snapshot IS NULL)
                  ORDER BY s.schema_name, t.table_name, c.column_order",
             )
+            .bind(snapshot_id)
+            .bind(snapshot_id)
             .bind(snapshot_id)
             .bind(snapshot_id)
             .bind(snapshot_id)

--- a/src/metadata_provider_sqlite.rs
+++ b/src/metadata_provider_sqlite.rs
@@ -138,15 +138,23 @@ impl MetadataProvider for SqliteMetadataProvider {
         })
     }
 
-    fn get_table_structure(&self, table_id: i64) -> Result<Vec<DuckLakeTableColumn>> {
+    fn get_table_structure(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+    ) -> Result<Vec<DuckLakeTableColumn>> {
         block_on(async {
             let rows = sqlx::query(
                 "SELECT column_id, column_name, column_type, nulls_allowed, parent_column
                  FROM ducklake_column
-                 WHERE table_id = ? AND end_snapshot IS NULL
+                 WHERE table_id = ?
+                   AND ? >= begin_snapshot
+                   AND (? < end_snapshot OR end_snapshot IS NULL)
                  ORDER BY column_order",
             )
             .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
             .fetch_all(&self.pool)
             .await?;
 
@@ -381,8 +389,12 @@ impl MetadataProvider for SqliteMetadataProvider {
                    AND (? < s.end_snapshot OR s.end_snapshot IS NULL)
                    AND ? >= t.begin_snapshot
                    AND (? < t.end_snapshot OR t.end_snapshot IS NULL)
+                   AND ? >= c.begin_snapshot
+                   AND (? < c.end_snapshot OR c.end_snapshot IS NULL)
                  ORDER BY s.schema_name, t.table_name, c.column_order",
             )
+            .bind(snapshot_id)
+            .bind(snapshot_id)
             .bind(snapshot_id)
             .bind(snapshot_id)
             .bind(snapshot_id)

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -189,11 +189,39 @@ pub struct WriteResult {
     pub records_written: i64,
 }
 
+/// The ids actually committed by `register_data_file` / `publish_snapshot`.
+///
+/// On multicatalog Postgres all metadata is written at the commit point, so the
+/// committed `snapshot_id` is assigned there and the `schema_id`/`table_id` are
+/// the real committed ids (which may differ from the begin-time reservations in
+/// [`WriteSetupResult`] if a concurrent writer created the schema/table first).
+/// Callers should use these for the authoritative result rather than the
+/// begin-time reservations.
+#[derive(Debug, Clone, Copy)]
+pub struct CommitIds {
+    /// Snapshot id assigned at commit (the new catalog head for this write).
+    pub snapshot_id: i64,
+    /// Committed schema id.
+    pub schema_id: i64,
+    /// Committed table id.
+    pub table_id: i64,
+}
+
 /// Result of a transactional write setup operation.
 #[derive(Debug)]
 pub struct WriteSetupResult {
     /// Snapshot ID created for this write
     pub snapshot_id: i64,
+    /// The catalog head observed at `begin_write_transaction` (the base for
+    /// `Replace` conflict detection), threaded back to the commit step. If a
+    /// concurrent writer committed a newer generation of the table since this base
+    /// — i.e. any data file or column with `begin_snapshot`/`end_snapshot > base`
+    /// — the commit aborts with [`crate::DuckLakeError::Conflict`]. Both backends
+    /// now share this model: snapshot ids are assigned at *commit* (single-catalog
+    /// SQLite `MAX(snapshot_id)+1`; multicatalog Postgres a plain `IDENTITY`
+    /// insert), so per-catalog id order == commit order and the scalar
+    /// `> base` test is exact.
+    pub base_snapshot_id: i64,
     /// Schema ID (may be newly created)
     pub schema_id: i64,
     /// Table ID (may be newly created)
@@ -246,35 +274,62 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
     /// that finalize columns in `begin_write_transaction` (multicatalog
     /// Postgres) ignore them; single-catalog backends (SQLite) defer the
     /// column generation to this commit and use them to insert the column rows.
+    ///
+    /// `base_snapshot` is the catalog head observed at `begin_write_transaction`
+    /// ([`WriteSetupResult::base_snapshot_id`]). For `Replace`, the commit aborts
+    /// with [`crate::DuckLakeError::Conflict`] if any data file of the table has
+    /// `begin_snapshot` or `end_snapshot` greater than `base_snapshot` — i.e.
+    /// another writer published a newer generation since this write began — so
+    /// concurrent replaces never silently union or clobber each other.
+    ///
+    /// `schema_name` / `table_name` identify the target. Multicatalog Postgres
+    /// writes ALL metadata at this commit (the schema/table get-or-create happens
+    /// here, keyed by these names) so it needs them; single-catalog SQLite already
+    /// created the schema/table at begin and ignores them.
+    /// Returns the [`CommitIds`] actually committed (the snapshot id assigned at
+    /// commit, and the real schema/table ids — which may differ from the
+    /// begin-time reservations if a concurrent writer created them first).
+    #[allow(clippy::too_many_arguments)]
     fn register_data_file(
         &self,
         table_id: i64,
+        schema_name: &str,
+        table_name: &str,
         snapshot_id: i64,
         file: &DataFileInfo,
         mode: WriteMode,
+        base_snapshot: i64,
         columns: &[ColumnDef],
         column_ids: &[i64],
-    ) -> Result<i64>;
+    ) -> Result<CommitIds>;
 
     /// Publish a write's snapshot as the catalog head with no data file (CREATE
     /// TABLE, zero-row Replace). For `Replace`, retires the prior generation.
-    /// See [`MetadataWriter::register_data_file`] for `columns` / `column_ids`.
+    /// See [`MetadataWriter::register_data_file`] for the parameters.
     ///
     /// Default no-op. Backends that advance the head in
     /// `begin_write_transaction` could rely on it, but both shipped backends
-    /// override: multicatalog Postgres inserts the
-    /// `ducklake_catalog_snapshot_map` head row, and SQLite (which defers the
-    /// `ducklake_snapshot` row insert out of `begin_write_transaction`) inserts
-    /// the snapshot row + column generation here.
+    /// override: multicatalog Postgres writes the snapshot/schema/table/column
+    /// metadata and inserts the `ducklake_catalog_snapshot_map` head row, and
+    /// SQLite (which defers the `ducklake_snapshot` row insert out of
+    /// `begin_write_transaction`) inserts the snapshot row + column generation here.
+    #[allow(clippy::too_many_arguments)]
     fn publish_snapshot(
         &self,
         _table_id: i64,
+        _schema_name: &str,
+        _table_name: &str,
         _snapshot_id: i64,
         _mode: WriteMode,
+        _base_snapshot: i64,
         _columns: &[ColumnDef],
         _column_ids: &[i64],
-    ) -> Result<()> {
-        Ok(())
+    ) -> Result<CommitIds> {
+        Ok(CommitIds {
+            snapshot_id: _snapshot_id,
+            schema_id: 0,
+            table_id: _table_id,
+        })
     }
 
     /// End all existing data files for a table. Returns count of files ended.

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -352,14 +352,13 @@ async fn reserve_ids(
     if n <= 0 {
         return Ok(Vec::new());
     }
-    let rows = sqlx::query(
-        "SELECT nextval(pg_get_serial_sequence($1, $2)) FROM generate_series(1, $3)",
-    )
-    .bind(table)
-    .bind(col)
-    .bind(n)
-    .fetch_all(&mut **tx)
-    .await?;
+    let rows =
+        sqlx::query("SELECT nextval(pg_get_serial_sequence($1, $2)) FROM generate_series(1, $3)")
+            .bind(table)
+            .bind(col)
+            .bind(n)
+            .fetch_all(&mut **tx)
+            .await?;
     rows.into_iter().map(|r| Ok(r.try_get(0)?)).collect()
 }
 

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -12,7 +12,7 @@
 use crate::Result;
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
-    ColumnDef, DataFileInfo, MetadataWriter, WriteMode, WriteSetupResult, validate_name,
+    ColumnDef, CommitIds, DataFileInfo, MetadataWriter, WriteMode, WriteSetupResult, validate_name,
 };
 use sqlx::Row;
 use sqlx::postgres::{PgPool, PgPoolOptions};
@@ -306,6 +306,99 @@ async fn assert_table_in_catalog(
     }
 }
 
+/// Reject only a `table_id` hint that exists and belongs to ANOTHER catalog. A
+/// hint that does not yet exist is fine — it is the id reserved at begin that
+/// `finalize_snapshot` is about to create under this catalog (first write to a
+/// new table). Used by the commit path (`register_data_file`/`publish_snapshot`),
+/// which must tolerate a not-yet-created table while still catching a caller that
+/// hands in a different catalog's table.
+async fn assert_table_not_in_other_catalog(
+    catalog_id: i64,
+    table_id: i64,
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+) -> Result<()> {
+    let row = sqlx::query(
+        "SELECT m.catalog_id FROM ducklake_table t
+         LEFT JOIN ducklake_catalog_schema_map m ON m.schema_id = t.schema_id
+         WHERE t.table_id = $1",
+    )
+    .bind(table_id)
+    .fetch_optional(&mut **tx)
+    .await?;
+    if let Some(r) = row {
+        let owner: Option<i64> = r.try_get(0)?;
+        if owner != Some(catalog_id) {
+            return Err(crate::DuckLakeError::InvalidConfig(format!(
+                "table_id {} does not belong to catalog_id {}",
+                table_id, catalog_id
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Reserve `n` ids from the IDENTITY-backing sequence of `table.col` WITHOUT
+/// inserting rows, so begin can hand out column/schema/table ids (column ids are
+/// the parquet field-ids baked into the staged file) that the commit later
+/// inserts explicitly via `OVERRIDING SYSTEM VALUE`. Sequences are
+/// non-transactional, so gaps from an aborted write are fine and expected. The
+/// ids come back in order.
+async fn reserve_ids(
+    table: &str,
+    col: &str,
+    n: i64,
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+) -> Result<Vec<i64>> {
+    if n <= 0 {
+        return Ok(Vec::new());
+    }
+    let rows = sqlx::query(
+        "SELECT nextval(pg_get_serial_sequence($1, $2)) FROM generate_series(1, $3)",
+    )
+    .bind(table)
+    .bind(col)
+    .bind(n)
+    .fetch_all(&mut **tx)
+    .await?;
+    rows.into_iter().map(|r| Ok(r.try_get(0)?)).collect()
+}
+
+/// Optimistic-concurrency check for a `Replace` commit. Run under the catalog
+/// `FOR UPDATE` lock at the commit point, BEFORE this writer inserts its own
+/// files/columns and before `advance_catalog_head`. Because snapshot ids are
+/// assigned at commit (id order == commit order per catalog) and all metadata is
+/// written at commit (no dormant rows), this scalar check is exact: if any data
+/// file OR column of the table has `begin_snapshot` or `end_snapshot` > `base`
+/// (the catalog head observed at begin), another writer committed a generation
+/// of this table since this write began ⇒ [`DuckLakeError::Conflict`]. Catches a
+/// data Replace (new file begin), a fileless `CREATE`/Replace (new column begin),
+/// and a DROP (end-stamp). The writer's own rows are not written yet, so the
+/// check never self-conflicts. (`Append` does not call this: concurrent appends
+/// commute, matching upstream DuckLake.)
+async fn detect_replace_conflict(
+    table_id: i64,
+    base_snapshot: i64,
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+) -> Result<()> {
+    let conflict = sqlx::query(
+        "SELECT 1 WHERE EXISTS (SELECT 1 FROM ducklake_data_file
+             WHERE table_id = $1 AND (begin_snapshot > $2 OR end_snapshot > $2))
+           OR EXISTS (SELECT 1 FROM ducklake_column
+             WHERE table_id = $1 AND (begin_snapshot > $2 OR end_snapshot > $2))",
+    )
+    .bind(table_id)
+    .bind(base_snapshot)
+    .fetch_optional(&mut **tx)
+    .await?;
+    if conflict.is_some() {
+        return Err(crate::DuckLakeError::Conflict(format!(
+            "Replace on table {table_id} conflicts with a concurrent write committed since \
+             snapshot {base_snapshot}; aborting (retry the write against the new generation)"
+        )));
+    }
+    Ok(())
+}
+
 /// Retire the generation preceding `snapshot_id` for a Replace: end-snapshot
 /// every still-live file from an earlier snapshot and zero the visible
 /// record/byte totals. The `begin_snapshot < snapshot_id` guard leaves the
@@ -354,6 +447,320 @@ async fn advance_catalog_head(
     .execute(&mut **tx)
     .await?;
     Ok(())
+}
+
+/// The atomic commit point for a multicatalog Postgres write, shared by
+/// `register_data_file` (with a data file) and `publish_snapshot` (fileless).
+/// The CALLER already holds the catalog `FOR UPDATE` lock and an open tx.
+///
+/// All metadata — the snapshot row, the get-or-create schema/table rows, the
+/// column generation, the `schema_versions` row, and the Replace retirement — is
+/// written HERE so nothing is visible until `advance_catalog_head` maps the
+/// snapshot (the caller runs that LAST). The `snapshot_id` is a plain IDENTITY
+/// insert, so per-catalog id order == commit order, which is what makes the
+/// scalar [`detect_replace_conflict`] and the dense schema_version computation
+/// exact. The reserved schema/table/column ids from begin are inserted with
+/// `OVERRIDING SYSTEM VALUE`; the reused column ids keep parquet field-ids stable.
+///
+/// Returns `(committed_snapshot_id, table_id)`.
+///
+/// `table_id_hint` is the id reserved for the table at begin; it is used only
+/// when the table does not yet exist (first write). The schema id is re-derived
+/// here — looked up if the schema already exists, else a fresh id is reserved
+/// from the sequence — because the reserved schema id from begin is not threaded
+/// through the commit (it is never baked into anything; the parquet path encodes
+/// the catalog id, not the schema id).
+#[allow(clippy::too_many_arguments)]
+async fn finalize_snapshot(
+    catalog_id: i64,
+    schema_name: &str,
+    table_name: &str,
+    table_id_hint: i64,
+    columns: &[ColumnDef],
+    column_ids: &[i64],
+    mode: WriteMode,
+    base_snapshot: i64,
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+) -> Result<(i64, i64, i64)> {
+    // 1. Resolve the live schema id under the lock. Reuse it if present; else
+    //    reserve a fresh id from the sequence (the row is inserted in step 4 once
+    //    the snapshot id exists for begin_snapshot).
+    let (schema_id, schema_was_created): (i64, bool) = {
+        let existing = sqlx::query(
+            "SELECT s.schema_id FROM ducklake_schema s
+             JOIN ducklake_catalog_schema_map m ON m.schema_id = s.schema_id
+             WHERE m.catalog_id = $1 AND s.schema_name = $2 AND s.end_snapshot IS NULL",
+        )
+        .bind(catalog_id)
+        .bind(schema_name)
+        .fetch_optional(&mut **tx)
+        .await?;
+        if let Some(row) = existing {
+            (row.try_get(0)?, false)
+        } else {
+            let id = reserve_ids("ducklake_schema", "schema_id", 1, tx).await?[0];
+            (id, true)
+        }
+    };
+
+    // 2. Conflict check for Replace, BEFORE inserting any of this writer's rows.
+    //    Resolve the table id first; a brand-new table has no prior generation to
+    //    conflict with, so skip the check (base == head, no rows exist yet).
+    if mode == WriteMode::Replace && !schema_was_created {
+        let existing_table_id: Option<i64> = sqlx::query(
+            "SELECT table_id FROM ducklake_table
+             WHERE schema_id = $1 AND table_name = $2 AND end_snapshot IS NULL",
+        )
+        .bind(schema_id)
+        .bind(table_name)
+        .fetch_optional(&mut **tx)
+        .await?
+        .map(|r| r.try_get(0))
+        .transpose()?;
+        if let Some(tid) = existing_table_id {
+            detect_replace_conflict(tid, base_snapshot, tx).await?;
+        }
+    }
+
+    // 3. Allocate the snapshot id in commit order (plain IDENTITY). schema_version
+    //    is patched in below once we know it.
+    let snapshot_id: i64 = sqlx::query(
+        "INSERT INTO ducklake_snapshot (snapshot_time, schema_version)
+         VALUES (NOW(), 0) RETURNING snapshot_id",
+    )
+    .fetch_one(&mut **tx)
+    .await?
+    .try_get(0)?;
+
+    // 4. Insert the schema row (with its reserved id) if it is new. The catalog id
+    //    is encoded into the schema's *path* (not its name) so two catalogs holding
+    //    their own `public` land in disjoint physical subtrees: the reader's
+    //    resolution chain (`data_path + schema.path + table.path + file.path`) then
+    //    puts files under `cat_{id}/{schema}/{table}/…`, matching the upload
+    //    location.
+    if schema_was_created {
+        let scoped_schema_path = format!("cat_{catalog_id}/{schema_name}");
+        sqlx::query(
+            "INSERT INTO ducklake_schema
+                 (schema_id, schema_name, path, path_is_relative, begin_snapshot)
+             OVERRIDING SYSTEM VALUE
+             VALUES ($1, $2, $3, TRUE, $4)",
+        )
+        .bind(schema_id)
+        .bind(schema_name)
+        .bind(&scoped_schema_path)
+        .bind(snapshot_id)
+        .execute(&mut **tx)
+        .await?;
+        sqlx::query(
+            "INSERT INTO ducklake_catalog_schema_map (catalog_id, schema_id)
+             VALUES ($1, $2)",
+        )
+        .bind(catalog_id)
+        .bind(schema_id)
+        .execute(&mut **tx)
+        .await?;
+    }
+
+    // 5. get-or-create table under the lock. Capture whether we created it.
+    let (table_id, table_was_created): (i64, bool) = {
+        let existing = sqlx::query(
+            "SELECT table_id FROM ducklake_table
+             WHERE schema_id = $1 AND table_name = $2 AND end_snapshot IS NULL",
+        )
+        .bind(schema_id)
+        .bind(table_name)
+        .fetch_optional(&mut **tx)
+        .await?;
+        if let Some(row) = existing {
+            (row.try_get(0)?, false)
+        } else {
+            sqlx::query(
+                "INSERT INTO ducklake_table
+                     (table_id, schema_id, table_name, path, path_is_relative, begin_snapshot)
+                 OVERRIDING SYSTEM VALUE
+                 VALUES ($1, $2, $3, $4, TRUE, $5)",
+            )
+            .bind(table_id_hint)
+            .bind(schema_id)
+            .bind(table_name)
+            .bind(table_name)
+            .bind(snapshot_id)
+            .execute(&mut **tx)
+            .await?;
+            (table_id_hint, true)
+        }
+    };
+
+    // 6. Read the columns live AT COMMIT (under the lock) to classify DDL vs DML
+    //    and drive the surgical column update below.
+    let existing_column_rows = sqlx::query(
+        "SELECT column_name, column_type, nulls_allowed, column_order, column_id
+         FROM ducklake_column
+         WHERE table_id = $1 AND end_snapshot IS NULL
+         ORDER BY column_order",
+    )
+    .bind(table_id)
+    .fetch_all(&mut **tx)
+    .await?;
+    let existing_columns: Vec<(String, String, bool)> = existing_column_rows
+        .iter()
+        .map(|row| {
+            let name: String = row.try_get(0)?;
+            let col_type: String = row.try_get(1)?;
+            let nullable: bool = row.try_get::<Option<bool>, _>(2)?.unwrap_or(true);
+            Ok::<_, sqlx::Error>((name, col_type, nullable))
+        })
+        .collect::<std::result::Result<_, _>>()?;
+    // name -> (column_id, column_order, nullable) for the surgical update. The
+    // column_id is used to detect field-id drift: if the caller's staged parquet
+    // baked a column_id (at begin) that no longer matches the committed column
+    // (e.g. an Append whose table was created by a concurrent writer with
+    // different ids), the file's field-ids would resolve to NULL — so we abort.
+    let mut current_by_name: std::collections::HashMap<String, (i64, i64, bool)> =
+        std::collections::HashMap::new();
+    for row in &existing_column_rows {
+        let name: String = row.try_get(0)?;
+        let nullable: bool = row.try_get::<Option<bool>, _>(2)?.unwrap_or(true);
+        let order: i64 = row.try_get(3)?;
+        let id: i64 = row.try_get(4)?;
+        current_by_name.insert(name, (id, order, nullable));
+    }
+
+    let is_ddl = table_was_created || columns_differ(&existing_columns, columns);
+
+    // No `< S` window: ids are commit-ordered, so MAX over mapped predecessors is
+    // the immediately-preceding version. DDL bumps; DML carries forward (with a v1
+    // floor for the very first write to the catalog).
+    let prev_max: i64 = sqlx::query(
+        "SELECT COALESCE(MAX(s.schema_version), 0) FROM ducklake_snapshot s
+         JOIN ducklake_catalog_snapshot_map m ON m.snapshot_id = s.snapshot_id
+         WHERE m.catalog_id = $1",
+    )
+    .bind(catalog_id)
+    .fetch_one(&mut **tx)
+    .await?
+    .try_get(0)?;
+    let new_schema_version = if is_ddl {
+        prev_max + 1
+    } else if prev_max == 0 {
+        1
+    } else {
+        prev_max
+    };
+    sqlx::query("UPDATE ducklake_snapshot SET schema_version = $1 WHERE snapshot_id = $2")
+        .bind(new_schema_version)
+        .bind(snapshot_id)
+        .execute(&mut **tx)
+        .await?;
+
+    // 7. Write the column generation SURGICALLY (mode-independent, matching the
+    //    SQLite writer) so each kept column keeps a STABLE column_id (== parquet
+    //    field_id). End only removed columns, insert only genuinely-new ones (with
+    //    their reserved ids), and sync order/nullability on the rest in place.
+    //    Stable ids are required even for Replace: a concurrent in-flight Append
+    //    baked the kept columns' ids into its parquet, so re-minting them would make
+    //    that Append's rows read back as all-NULL. The prior generation's retired
+    //    files keep their old ids for time travel. (The Replace conflict check does
+    //    not depend on a column re-mint — see the data-file/column scan above.)
+    {
+        use std::collections::HashSet;
+        let new_names: HashSet<&str> = columns.iter().map(|c| c.name.as_str()).collect();
+        for name in current_by_name.keys() {
+            if !new_names.contains(name.as_str()) {
+                sqlx::query(
+                    "UPDATE ducklake_column SET end_snapshot = $1
+                     WHERE table_id = $2 AND column_name = $3 AND end_snapshot IS NULL",
+                )
+                .bind(snapshot_id)
+                .bind(table_id)
+                .bind(name)
+                .execute(&mut **tx)
+                .await?;
+            }
+        }
+        for (order, (col, column_id)) in columns.iter().zip(column_ids.iter()).enumerate() {
+            match current_by_name.get(&col.name) {
+                Some(&(cur_id, cur_order, cur_nullable)) => {
+                    // Field-id drift: the staged parquet baked `*column_id` for this
+                    // column at begin, but the committed column now has a different
+                    // id (a concurrent writer created the table/column with other
+                    // ids between this writer's begin and commit). Registering the
+                    // file would make this column read back as all-NULL, so abort —
+                    // the caller retries against the now-committed schema. (Append
+                    // is otherwise not conflict-checked; this guards correctness,
+                    // not isolation.)
+                    if *column_id != cur_id {
+                        return Err(crate::DuckLakeError::Conflict(format!(
+                            "column '{}' of table {table_id} was created concurrently with a \
+                             different field id ({cur_id}, staged {column_id}); aborting to avoid \
+                             a NULL-filled read (retry the write)",
+                            col.name
+                        )));
+                    }
+                    if cur_order != order as i64 || cur_nullable != col.is_nullable {
+                        sqlx::query(
+                            "UPDATE ducklake_column SET column_order = $1, nulls_allowed = $2
+                             WHERE table_id = $3 AND column_name = $4 AND end_snapshot IS NULL",
+                        )
+                        .bind(order as i64)
+                        .bind(col.is_nullable)
+                        .bind(table_id)
+                        .bind(&col.name)
+                        .execute(&mut **tx)
+                        .await?;
+                    }
+                },
+                None => {
+                    sqlx::query(
+                        "INSERT INTO ducklake_column
+                             (column_id, table_id, column_name, column_type, column_order,
+                              nulls_allowed, begin_snapshot)
+                         OVERRIDING SYSTEM VALUE
+                         VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                    )
+                    .bind(column_id)
+                    .bind(table_id)
+                    .bind(&col.name)
+                    .bind(&col.ducklake_type)
+                    .bind(order as i64)
+                    .bind(col.is_nullable)
+                    .bind(snapshot_id)
+                    .execute(&mut **tx)
+                    .await?;
+                },
+            }
+        }
+    }
+
+    // 8. One ducklake_schema_versions row per DDL (UNIQUE(table_id, begin_snapshot)).
+    if is_ddl {
+        sqlx::query(
+            "INSERT INTO ducklake_schema_versions (begin_snapshot, schema_version, table_id)
+             VALUES ($1, $2, $3)",
+        )
+        .bind(snapshot_id)
+        .bind(new_schema_version)
+        .bind(table_id)
+        .execute(&mut **tx)
+        .await?;
+    }
+
+    // 9. Replace retirement: end the prior generation's files + zero the visible
+    //    totals. The `begin_snapshot < S` guard spares this write's own files.
+    if mode == WriteMode::Replace {
+        sqlx::query(
+            "INSERT INTO ducklake_table_stats (table_id, record_count, next_row_id, file_size_bytes)
+             VALUES ($1, 0, 0, 0)
+             ON CONFLICT (table_id) DO NOTHING",
+        )
+        .bind(table_id)
+        .execute(&mut **tx)
+        .await?;
+        retire_prior_generation(table_id, snapshot_id, tx).await?;
+    }
+
+    Ok((snapshot_id, schema_id, table_id))
 }
 
 impl MetadataWriter for PostgresMetadataWriter {
@@ -532,27 +939,43 @@ impl MetadataWriter for PostgresMetadataWriter {
     fn register_data_file(
         &self,
         table_id: i64,
-        snapshot_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        _snapshot_id: i64,
         file: &DataFileInfo,
         mode: WriteMode,
-        // Multicatalog Postgres finalizes the column generation in
-        // `begin_write_transaction` (column visibility is gated by the deferred
-        // `ducklake_catalog_snapshot_map` head row, not `end_snapshot`), so the
-        // commit point does not re-stamp columns.
-        _columns: &[ColumnDef],
-        _column_ids: &[i64],
-    ) -> Result<i64> {
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+    ) -> Result<CommitIds> {
         block_on(async {
-            // Single atomic commit: retire the prior generation (Replace), insert
-            // the new file, accumulate stats, and advance the catalog head. The
-            // head is published only here so it never resolves to a snapshot
-            // whose file is still uploading. row_id_start is drawn from the
-            // table's monotonic counter under the catalog lock so concurrent
-            // writers hand out non-overlapping ranges; the stats row is seeded
-            // for tables created before this writer maintained it.
+            // Single atomic commit. finalize_snapshot writes ALL metadata (the
+            // snapshot row, get-or-create schema/table, the column generation, the
+            // schema_versions row, and the Replace retirement) and returns the
+            // committed snapshot id + real table id. We then register the file and
+            // advance the catalog head LAST, so nothing is visible until the head
+            // maps the snapshot. row_id_start is drawn from the table's monotonic
+            // counter under the catalog lock so concurrent writers hand out
+            // non-overlapping ranges; the stats row is seeded for tables created
+            // before this writer maintained it. The passed `table_id` is the id
+            // reserved at begin (== the committed id); we tolerate it not existing
+            // yet (first write) but reject another catalog's id.
             let mut tx = self.pool.begin().await?;
             lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
-            assert_table_in_catalog(self.catalog_id, table_id, &mut tx).await?;
+            assert_table_not_in_other_catalog(self.catalog_id, table_id, &mut tx).await?;
+
+            let (snapshot_id, schema_id, table_id) = finalize_snapshot(
+                self.catalog_id,
+                schema_name,
+                table_name,
+                table_id,
+                columns,
+                column_ids,
+                mode,
+                base_snapshot,
+                &mut tx,
+            )
+            .await?;
 
             sqlx::query(
                 "INSERT INTO ducklake_table_stats (table_id, record_count, next_row_id, file_size_bytes)
@@ -563,10 +986,6 @@ impl MetadataWriter for PostgresMetadataWriter {
             .execute(&mut *tx)
             .await?;
 
-            if mode == WriteMode::Replace {
-                retire_prior_generation(table_id, snapshot_id, &mut tx).await?;
-            }
-
             let stats_row =
                 sqlx::query("SELECT next_row_id FROM ducklake_table_stats WHERE table_id = $1")
                     .bind(table_id)
@@ -574,11 +993,11 @@ impl MetadataWriter for PostgresMetadataWriter {
                     .await?;
             let row_id_start: i64 = stats_row.try_get(0)?;
 
-            sqlx::query(
+            let inserted = sqlx::query(
                 "INSERT INTO ducklake_data_file
                      (table_id, path, path_is_relative, file_size_bytes,
                       footer_size, record_count, row_id_start, begin_snapshot)
-                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING data_file_id",
             )
             .bind(table_id)
             .bind(&file.path)
@@ -588,8 +1007,9 @@ impl MetadataWriter for PostgresMetadataWriter {
             .bind(file.record_count)
             .bind(row_id_start)
             .bind(snapshot_id)
-            .execute(&mut *tx)
+            .fetch_one(&mut *tx)
             .await?;
+            let _data_file_id: i64 = inserted.try_get(0)?;
 
             // Advance the counter and accumulate stats. `next_row_id`
             // monotonically increases over the table's lifetime — rowids
@@ -610,42 +1030,58 @@ impl MetadataWriter for PostgresMetadataWriter {
             .execute(&mut *tx)
             .await?;
 
+            // advance_catalog_head MUST be the last write before commit.
             advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
 
             tx.commit().await?;
-            Ok(snapshot_id)
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
         })
     }
 
     fn publish_snapshot(
         &self,
         table_id: i64,
-        snapshot_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        _snapshot_id: i64,
         mode: WriteMode,
-        _columns: &[ColumnDef],
-        _column_ids: &[i64],
-    ) -> Result<()> {
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+    ) -> Result<CommitIds> {
         block_on(async {
+            // Fileless commit point (CREATE TABLE, zero-row Replace). Same atomic
+            // model as register_data_file minus the data-file insert: write all
+            // metadata via finalize_snapshot, then advance the head LAST.
             let mut tx = self.pool.begin().await?;
             lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
-            assert_table_in_catalog(self.catalog_id, table_id, &mut tx).await?;
+            assert_table_not_in_other_catalog(self.catalog_id, table_id, &mut tx).await?;
 
-            if mode == WriteMode::Replace {
-                sqlx::query(
-                    "INSERT INTO ducklake_table_stats (table_id, record_count, next_row_id, file_size_bytes)
-                     VALUES ($1, 0, 0, 0)
-                     ON CONFLICT (table_id) DO NOTHING",
-                )
-                .bind(table_id)
-                .execute(&mut *tx)
-                .await?;
-                retire_prior_generation(table_id, snapshot_id, &mut tx).await?;
-            }
+            let (snapshot_id, schema_id, table_id) = finalize_snapshot(
+                self.catalog_id,
+                schema_name,
+                table_name,
+                table_id,
+                columns,
+                column_ids,
+                mode,
+                base_snapshot,
+                &mut tx,
+            )
+            .await?;
 
             advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
 
             tx.commit().await?;
-            Ok(())
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
         })
     }
 
@@ -768,23 +1204,30 @@ impl MetadataWriter for PostgresMetadataWriter {
         let catalog_id = self.catalog_id;
         let lock_timeout_ms = self.lock_timeout_ms;
         block_on(async {
+            // RESERVE ONLY: this transaction inserts NOTHING into ducklake_snapshot
+            // / ducklake_schema / ducklake_table / ducklake_column /
+            // ducklake_schema_versions / either map table. All of that is written
+            // atomically at the commit point (register_data_file /
+            // publish_snapshot → finalize_snapshot) and assigned a commit-ordered
+            // snapshot id there, so no metadata row is ever readable before its
+            // write has published. Here we only reserve ids from the IDENTITY
+            // sequences (gaps are fine) and capture the conflict base.
+            //
+            // The catalog FOR UPDATE lock is held so the existing-column read and
+            // the id-reuse map are consistent and the returned field-ids are
+            // stable; it is released at tx.commit (which commits only the
+            // non-transactional sequence advances).
             let mut tx = self.pool.begin().await?;
             lock_catalog(catalog_id, lock_timeout_ms, &mut tx).await?;
 
-            // schema_version is patched in below once we know it.
-            let row = sqlx::query(
-                "INSERT INTO ducklake_snapshot (snapshot_time, schema_version)
-                 VALUES (CURRENT_TIMESTAMP, 0) RETURNING snapshot_id",
-            )
-            .fetch_one(&mut *tx)
-            .await?;
-            let snapshot_id: i64 = row.try_get(0)?;
-
-            // The head advance (ducklake_catalog_snapshot_map insert) and the
-            // Replace retirement are deferred to the commit point
-            // (register_data_file / publish_snapshot) so the head never resolves
-            // to a snapshot whose data file is still uploading.
-
+            // Look up (do NOT create) the live schema; reserve a fresh id if
+            // absent. setup.schema_id is informational (no caller bakes it into a
+            // file — the parquet path encodes the catalog id, not the schema id),
+            // so for a brand-new schema this reserved id is NOT the committed id:
+            // finalize_snapshot re-derives/reserves the schema id at the commit.
+            // The reservation here keeps setup.schema_id distinct & non-zero across
+            // concurrent new schemas (sequence gaps from the unused reservation are
+            // expected and harmless).
             let schema_id: i64 = {
                 let existing = sqlx::query(
                     "SELECT s.schema_id FROM ducklake_schema s
@@ -795,43 +1238,15 @@ impl MetadataWriter for PostgresMetadataWriter {
                 .bind(schema_name)
                 .fetch_optional(&mut *tx)
                 .await?;
-
-                if let Some(row) = existing {
-                    row.try_get(0)?
-                } else {
-                    // Multicatalog segregation: encode the catalog id into the
-                    // schema's *path* (not its name) so two catalogs holding
-                    // their own `public` schema land in disjoint physical
-                    // subtrees. The reader's resolution chain
-                    // (`data_path + schema.path + table.path + file.path`)
-                    // then puts files under `cat_{id}/{schema}/{table}/…`,
-                    // matching the `DuckLakeTableWriter` upload location.
-                    let scoped_schema_path = format!("cat_{catalog_id}/{schema_name}");
-                    let row = sqlx::query(
-                        "INSERT INTO ducklake_schema (schema_name, path, path_is_relative, begin_snapshot)
-                         VALUES ($1, $2, TRUE, $3) RETURNING schema_id",
-                    )
-                    .bind(schema_name)
-                    .bind(&scoped_schema_path)
-                    .bind(snapshot_id)
-                    .fetch_one(&mut *tx)
-                    .await?;
-                    let id: i64 = row.try_get(0)?;
-
-                    sqlx::query(
-                        "INSERT INTO ducklake_catalog_schema_map (catalog_id, schema_id)
-                         VALUES ($1, $2)",
-                    )
-                    .bind(catalog_id)
-                    .bind(id)
-                    .execute(&mut *tx)
-                    .await?;
-
-                    id
+                match existing {
+                    Some(row) => row.try_get(0)?,
+                    None => reserve_ids("ducklake_schema", "schema_id", 1, &mut tx).await?[0],
                 }
             };
 
-            let (table_id, table_was_created): (i64, bool) = {
+            // Look up (do NOT create) the live table; reserve an id if absent. The
+            // reserved id IS used (threaded to finalize as table_id_hint).
+            let table_id: i64 = {
                 let existing = sqlx::query(
                     "SELECT table_id FROM ducklake_table
                      WHERE schema_id = $1 AND table_name = $2 AND end_snapshot IS NULL",
@@ -840,28 +1255,19 @@ impl MetadataWriter for PostgresMetadataWriter {
                 .bind(table_name)
                 .fetch_optional(&mut *tx)
                 .await?;
-
                 if let Some(row) = existing {
-                    (row.try_get(0)?, false)
+                    row.try_get(0)?
                 } else {
-                    let row = sqlx::query(
-                        "INSERT INTO ducklake_table (schema_id, table_name, path, path_is_relative, begin_snapshot)
-                         VALUES ($1, $2, $3, TRUE, $4) RETURNING table_id",
-                    )
-                    .bind(schema_id)
-                    .bind(table_name)
-                    .bind(table_name)
-                    .bind(snapshot_id)
-                    .fetch_one(&mut *tx)
-                    .await?;
-                    (row.try_get(0)?, true)
+                    reserve_ids("ducklake_table", "table_id", 1, &mut tx).await?[0]
                 }
             };
 
-            // Fetch existing columns to drive (a) schema-evolution checks for Append,
-            // (b) DDL/DML classification.
-            let existing_column_rows = sqlx::query(
-                "SELECT column_name, column_type, nulls_allowed
+            // Read existing columns (name, type, nullable, id) to drive (a) the
+            // Append schema-evolution check and (b) id reuse: an unchanged column
+            // keeps its column_id (== parquet field_id), so an already-written
+            // file's field-ids stay valid.
+            let rows = sqlx::query(
+                "SELECT column_name, column_type, nulls_allowed, column_id
                  FROM ducklake_column
                  WHERE table_id = $1 AND end_snapshot IS NULL
                  ORDER BY column_order",
@@ -869,16 +1275,17 @@ impl MetadataWriter for PostgresMetadataWriter {
             .bind(table_id)
             .fetch_all(&mut *tx)
             .await?;
-
-            let existing_columns: Vec<(String, String, bool)> = existing_column_rows
-                .iter()
-                .map(|row| {
-                    let name: String = row.try_get(0)?;
-                    let col_type: String = row.try_get(1)?;
-                    let nullable: bool = row.try_get::<Option<bool>, _>(2)?.unwrap_or(true);
-                    Ok::<_, sqlx::Error>((name, col_type, nullable))
-                })
-                .collect::<std::result::Result<_, _>>()?;
+            let mut existing_columns: Vec<(String, String, bool)> = Vec::with_capacity(rows.len());
+            let mut existing_ids: std::collections::HashMap<String, i64> =
+                std::collections::HashMap::new();
+            for row in rows {
+                let name: String = row.try_get(0)?;
+                let col_type: String = row.try_get(1)?;
+                let nullable: bool = row.try_get::<Option<bool>, _>(2)?.unwrap_or(true);
+                let cid: i64 = row.try_get(3)?;
+                existing_ids.insert(name.clone(), cid);
+                existing_columns.push((name, col_type, nullable));
+            }
 
             // Append-mode schema evolution validation (same rules as SQLite writer).
             if mode == WriteMode::Append && !existing_columns.is_empty() {
@@ -907,86 +1314,54 @@ impl MetadataWriter for PostgresMetadataWriter {
                 }
             }
 
-            // Classify DDL vs DML. DDL = first write (table just created) or the
-            // column set changed from what exists. DML = same schema, just data.
-            let is_ddl = table_was_created || columns_differ(&existing_columns, columns);
+            // Reserve N column ids, then compute the final per-column ids. These
+            // are baked into the staged parquet's field_id metadata, so they must
+            // equal what finalize_snapshot inserts at commit.
+            //
+            // Mode-independent (matching the SQLite writer): REUSE the existing id
+            // for a column whose NAME already exists, consume a freshly-reserved id
+            // only for a genuinely-new column. Stable ids are required for BOTH
+            // modes — a concurrent in-flight Append bakes the kept columns' ids into
+            // its parquet, so a Replace must NOT re-mint them (re-minting would make
+            // that Append's rows read back as all-NULL). The Replace conflict check
+            // does not rely on a column re-mint: a data Replace leaves a new data
+            // file (begin > base) and a schema-changing Replace ends/inserts the
+            // changed columns (begin/end > base); a fileless same-schema Replace
+            // leaves no trace and resolves last-writer-wins, exactly like SQLite.
+            let fresh_ids = reserve_ids(
+                "ducklake_column",
+                "column_id",
+                columns.len() as i64,
+                &mut tx,
+            )
+            .await?;
+            let column_ids: Vec<i64> = columns
+                .iter()
+                .zip(fresh_ids.iter())
+                .map(|(col, &fresh)| existing_ids.get(&col.name).copied().unwrap_or(fresh))
+                .collect();
 
-            // Allocate schema_version under the catalog lock we already hold.
-            // Per spec: per-catalog dense; DDL bumps, DML carries forward.
-            let max_row = sqlx::query(
-                "SELECT COALESCE(MAX(s.schema_version), 0) FROM ducklake_snapshot s
-                 JOIN ducklake_catalog_snapshot_map m ON m.snapshot_id = s.snapshot_id
-                 WHERE m.catalog_id = $1 AND s.snapshot_id < $2",
+            // base = catalog head observed at begin. The Replace commit aborts if
+            // any file/column of the table moved past it (a concurrent writer
+            // committed a newer generation). Snapshot ids are commit-ordered, so
+            // this scalar head is an exact conflict base.
+            let base_snapshot_id: i64 = sqlx::query(
+                "SELECT COALESCE(MAX(snapshot_id), 0) FROM ducklake_catalog_snapshot_map
+                 WHERE catalog_id = $1",
             )
             .bind(catalog_id)
-            .bind(snapshot_id)
             .fetch_one(&mut *tx)
-            .await?;
-            let prev_max: i64 = max_row.try_get(0)?;
-            let new_schema_version = if is_ddl {
-                prev_max + 1
-            } else if prev_max == 0 {
-                // No prior snapshot for this catalog yet — even a DML-classified
-                // path needs a valid v1.
-                1
-            } else {
-                prev_max
-            };
+            .await?
+            .try_get(0)?;
 
-            sqlx::query("UPDATE ducklake_snapshot SET schema_version = $1 WHERE snapshot_id = $2")
-                .bind(new_schema_version)
-                .bind(snapshot_id)
-                .execute(&mut *tx)
-                .await?;
-
-            // End existing columns and insert the new set.
-            sqlx::query(
-                "UPDATE ducklake_column SET end_snapshot = $1
-                 WHERE table_id = $2 AND end_snapshot IS NULL",
-            )
-            .bind(snapshot_id)
-            .bind(table_id)
-            .execute(&mut *tx)
-            .await?;
-
-            let mut column_ids = Vec::with_capacity(columns.len());
-            for (order, col) in columns.iter().enumerate() {
-                let row = sqlx::query(
-                    "INSERT INTO ducklake_column (table_id, column_name, column_type, column_order, nulls_allowed, begin_snapshot)
-                     VALUES ($1, $2, $3, $4, $5, $6) RETURNING column_id",
-                )
-                .bind(table_id)
-                .bind(&col.name)
-                .bind(&col.ducklake_type)
-                .bind(order as i64)
-                .bind(col.is_nullable)
-                .bind(snapshot_id)
-                .fetch_one(&mut *tx)
-                .await?;
-                column_ids.push(row.try_get(0)?);
-            }
-
-            // Record a row in ducklake_schema_versions for every DDL — the
-            // UNIQUE(table_id, begin_snapshot) constraint ensures no duplicates.
-            if is_ddl {
-                sqlx::query(
-                    "INSERT INTO ducklake_schema_versions (begin_snapshot, schema_version, table_id)
-                     VALUES ($1, $2, $3)",
-                )
-                .bind(snapshot_id)
-                .bind(new_schema_version)
-                .bind(table_id)
-                .execute(&mut *tx)
-                .await?;
-            }
-
-            // Replace retirement (end old files + zero stats) is deferred to the
-            // commit point (register_data_file / publish_snapshot).
-
+            // Commit the (sequence-only) reservation transaction.
             tx.commit().await?;
 
             Ok(WriteSetupResult {
-                snapshot_id,
+                // snapshot_id is vestigial here (like SQLite's): the real id is
+                // assigned at the commit by finalize_snapshot.
+                snapshot_id: 0,
+                base_snapshot_id,
                 schema_id,
                 table_id,
                 column_ids,

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -8,7 +8,7 @@ use crate::maintenance::{
 };
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
-    ColumnDef, DataFileInfo, MetadataWriter, WriteMode, WriteSetupResult, validate_name,
+    ColumnDef, CommitIds, DataFileInfo, MetadataWriter, WriteMode, WriteSetupResult, validate_name,
 };
 use sqlx::Row;
 use sqlx::sqlite::{SqlitePool, SqlitePoolOptions};
@@ -595,6 +595,37 @@ async fn reserve_ids(
     Ok(last)
 }
 
+/// Optimistic-concurrency check for a `Replace` commit (mirrors the Postgres
+/// writer). Run while holding the SQLite write lock, before retiring the prior
+/// generation: if any data file of the table has `begin_snapshot` or
+/// `end_snapshot` newer than `base_snapshot` (the head observed when this write
+/// began), another writer published a newer generation in the meantime, so this
+/// `Replace` aborts with [`DuckLakeError::Conflict`] rather than clobbering it.
+/// (`Append` does not call this: concurrent appends commute.)
+async fn detect_replace_conflict(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    table_id: i64,
+    base_snapshot: i64,
+) -> Result<()> {
+    let conflict: Option<i64> = sqlx::query_scalar(
+        "SELECT 1 FROM ducklake_data_file
+         WHERE table_id = ? AND (begin_snapshot > ? OR end_snapshot > ?)
+         LIMIT 1",
+    )
+    .bind(table_id)
+    .bind(base_snapshot)
+    .bind(base_snapshot)
+    .fetch_optional(&mut **tx)
+    .await?;
+    if conflict.is_some() {
+        return Err(crate::DuckLakeError::Conflict(format!(
+            "Replace on table {table_id} conflicts with a concurrent write committed since \
+             snapshot {base_snapshot}; aborting (retry the write against the new generation)"
+        )));
+    }
+    Ok(())
+}
+
 /// Retire the prior generation's still-visible data files at `snapshot_id` and
 /// zero the visible stat totals. The `begin_snapshot < snapshot_id` guard
 /// spares files registered for *this* snapshot, so a multi-file write does not
@@ -643,6 +674,7 @@ async fn finalize_snapshot(
     columns: &[ColumnDef],
     column_ids: &[i64],
     mode: WriteMode,
+    base_snapshot: i64,
 ) -> Result<i64> {
     // Assign the snapshot id in commit order: one INSERT ... SELECT MAX+1
     // RETURNING takes the write lock for the read and insert together, so
@@ -731,6 +763,10 @@ async fn finalize_snapshot(
     }
 
     if mode == WriteMode::Replace {
+        // Abort if a concurrent writer published a newer generation since this
+        // write began (held under the write lock acquired by the MAX+1 insert
+        // above, so the check sees a consistent committed state).
+        detect_replace_conflict(tx, table_id, base_snapshot).await?;
         // Seed the stats row (first write to a brand-new table) so retire's
         // zero-update has a row, then retire the prior data generation.
         sqlx::query(
@@ -894,12 +930,17 @@ impl MetadataWriter for SqliteMetadataWriter {
     fn register_data_file(
         &self,
         table_id: i64,
+        // SQLite created the schema/table at begin, so the names are unused here;
+        // accepted only to satisfy the trait shared with multicatalog Postgres.
+        _schema_name: &str,
+        _table_name: &str,
         _snapshot_id: i64,
         file: &DataFileInfo,
         mode: WriteMode,
+        base_snapshot: i64,
         columns: &[ColumnDef],
         column_ids: &[i64],
-    ) -> Result<i64> {
+    ) -> Result<CommitIds> {
         block_on(async {
             // Single atomic commit: insert the deferred snapshot row + finalize
             // the column generation + retire the prior generation (Replace),
@@ -909,7 +950,8 @@ impl MetadataWriter for SqliteMetadataWriter {
             let mut tx = self.pool.begin().await?;
 
             let snapshot_id =
-                finalize_snapshot(&mut tx, table_id, columns, column_ids, mode).await?;
+                finalize_snapshot(&mut tx, table_id, columns, column_ids, mode, base_snapshot)
+                    .await?;
 
             // Seed the stats row for the Append path (Replace already seeded it
             // in finalize_snapshot); INSERT OR IGNORE is a no-op if it exists.
@@ -963,19 +1005,34 @@ impl MetadataWriter for SqliteMetadataWriter {
             .execute(&mut *tx)
             .await?;
 
+            let schema_id: i64 =
+                sqlx::query("SELECT schema_id FROM ducklake_table WHERE table_id = ?")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?
+                    .try_get(0)?;
+
             tx.commit().await?;
-            Ok(snapshot_id)
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
         })
     }
 
     fn publish_snapshot(
         &self,
         table_id: i64,
+        // SQLite created the schema/table at begin; names unused (trait parity).
+        _schema_name: &str,
+        _table_name: &str,
         _snapshot_id: i64,
         mode: WriteMode,
+        base_snapshot: i64,
         columns: &[ColumnDef],
         column_ids: &[i64],
-    ) -> Result<()> {
+    ) -> Result<CommitIds> {
         // Fileless commit point. Single-catalog SQLite defers the snapshot-row
         // insert out of begin_write_transaction, so this is no longer a no-op:
         // it inserts the deferred snapshot row + column generation and, for
@@ -985,9 +1042,21 @@ impl MetadataWriter for SqliteMetadataWriter {
         // register_data_file instead.
         block_on(async {
             let mut tx = self.pool.begin().await?;
-            finalize_snapshot(&mut tx, table_id, columns, column_ids, mode).await?;
+            let snapshot_id =
+                finalize_snapshot(&mut tx, table_id, columns, column_ids, mode, base_snapshot)
+                    .await?;
+            let schema_id: i64 =
+                sqlx::query("SELECT schema_id FROM ducklake_table WHERE table_id = ?")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?
+                    .try_get(0)?;
             tx.commit().await?;
-            Ok(())
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
         })
     }
 
@@ -1110,13 +1179,17 @@ impl MetadataWriter for SqliteMetadataWriter {
             // may go unused (harmless monotonic-counter gaps).
             let fresh_ids: Vec<i64> = ((last_column_id - n + 1)..=last_column_id).collect();
 
-            // Tentative id for WriteSetupResult; the real one is assigned at the
-            // commit (finalize_snapshot), so it may differ under concurrency.
-            let snapshot_id: i64 =
-                sqlx::query("SELECT COALESCE(MAX(snapshot_id), 0) + 1 FROM ducklake_snapshot")
+            // The catalog head this write is based on; a Replace commit aborts if
+            // another writer published a newer generation of the table past it.
+            let base_snapshot_id: i64 =
+                sqlx::query("SELECT COALESCE(MAX(snapshot_id), 0) FROM ducklake_snapshot")
                     .fetch_one(&mut *tx)
                     .await?
                     .try_get(0)?;
+
+            // Tentative id for WriteSetupResult; the real one is assigned at the
+            // commit (finalize_snapshot), so it may differ under concurrency.
+            let snapshot_id: i64 = base_snapshot_id + 1;
 
             let schema_id: i64 = {
                 let existing = sqlx::query(
@@ -1260,6 +1333,7 @@ impl MetadataWriter for SqliteMetadataWriter {
 
             Ok(WriteSetupResult {
                 snapshot_id,
+                base_snapshot_id,
                 schema_id,
                 table_id,
                 column_ids,
@@ -1376,9 +1450,19 @@ mod tests {
         // register_data_file returns the committed snapshot id (head); the
         // first write commits snapshot 1.
         let committed = writer
-            .register_data_file(table_id, snapshot_id, &file, WriteMode::Append, &[], &[])
+            .register_data_file(
+                table_id,
+                "main",
+                "users",
+                snapshot_id,
+                &file,
+                WriteMode::Append,
+                0,
+                &[],
+                &[],
+            )
             .unwrap();
-        assert_eq!(committed, 1);
+        assert_eq!(committed.snapshot_id, 1);
     }
 
     /// Reserve the next snapshot id the way `begin_write_transaction` now does
@@ -1439,9 +1523,14 @@ mod tests {
         writer
             .register_data_file(
                 table_id,
+
+                "main",
+
+                "t",
                 snap1,
                 &DataFileInfo::new("a.parquet", 100, 3),
                 WriteMode::Append,
+                0, // base_snapshot: unused for Append (no conflict check)
                 &[],
                 &[],
             )
@@ -1450,9 +1539,14 @@ mod tests {
         writer
             .register_data_file(
                 table_id,
+
+                "main",
+
+                "t",
                 snap2,
                 &DataFileInfo::new("b.parquet", 250, 7),
                 WriteMode::Append,
+                0, // base_snapshot: unused for Append (no conflict check)
                 &[],
                 &[],
             )
@@ -1482,9 +1576,14 @@ mod tests {
         writer
             .register_data_file(
                 table_id,
+
+                "main",
+
+                "t",
                 snap1,
                 &DataFileInfo::new("a.parquet", 100, 5),
                 WriteMode::Append,
+                0, // base_snapshot: unused for Append (no conflict check)
                 &[],
                 &[],
             )
@@ -1502,9 +1601,14 @@ mod tests {
         writer
             .register_data_file(
                 table_id,
+
+                "main",
+
+                "t",
                 snap3,
                 &DataFileInfo::new("b.parquet", 200, 2),
                 WriteMode::Append,
+                0, // base_snapshot: unused for Append (no conflict check)
                 &[],
                 &[],
             )
@@ -1542,9 +1646,14 @@ mod tests {
         writer
             .register_data_file(
                 table_id,
+
+                "main",
+
+                "legacy",
                 snapshot_id,
                 &DataFileInfo::new("a.parquet", 50, 4),
                 WriteMode::Append,
+                0, // base_snapshot: unused for Append (no conflict check)
                 &[],
                 &[],
             )
@@ -1569,7 +1678,7 @@ mod tests {
         // Register a file
         let file = DataFileInfo::new("data1.parquet", 1024, 100);
         writer
-            .register_data_file(table_id, snapshot1, &file, WriteMode::Append, &[], &[])
+            .register_data_file(table_id, "main", "users", snapshot1, &file, WriteMode::Append, 0, &[], &[])
             .unwrap();
 
         // End files at new snapshot

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -1523,9 +1523,7 @@ mod tests {
         writer
             .register_data_file(
                 table_id,
-
                 "main",
-
                 "t",
                 snap1,
                 &DataFileInfo::new("a.parquet", 100, 3),
@@ -1539,9 +1537,7 @@ mod tests {
         writer
             .register_data_file(
                 table_id,
-
                 "main",
-
                 "t",
                 snap2,
                 &DataFileInfo::new("b.parquet", 250, 7),
@@ -1576,9 +1572,7 @@ mod tests {
         writer
             .register_data_file(
                 table_id,
-
                 "main",
-
                 "t",
                 snap1,
                 &DataFileInfo::new("a.parquet", 100, 5),
@@ -1601,9 +1595,7 @@ mod tests {
         writer
             .register_data_file(
                 table_id,
-
                 "main",
-
                 "t",
                 snap3,
                 &DataFileInfo::new("b.parquet", 200, 2),
@@ -1646,9 +1638,7 @@ mod tests {
         writer
             .register_data_file(
                 table_id,
-
                 "main",
-
                 "legacy",
                 snapshot_id,
                 &DataFileInfo::new("a.parquet", 50, 4),
@@ -1678,7 +1668,17 @@ mod tests {
         // Register a file
         let file = DataFileInfo::new("data1.parquet", 1024, 100);
         writer
-            .register_data_file(table_id, "main", "users", snapshot1, &file, WriteMode::Append, 0, &[], &[])
+            .register_data_file(
+                table_id,
+                "main",
+                "users",
+                snapshot1,
+                &file,
+                WriteMode::Append,
+                0,
+                &[],
+                &[],
+            )
             .unwrap();
 
         // End files at new snapshot

--- a/src/multicatalog_provider.rs
+++ b/src/multicatalog_provider.rs
@@ -198,16 +198,28 @@ impl MetadataProvider for MulticatalogProvider {
         })
     }
 
-    fn get_table_structure(&self, table_id: i64) -> Result<Vec<DuckLakeTableColumn>> {
-        // Columns inherit catalog via table_id. No scoping.
+    fn get_table_structure(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+    ) -> Result<Vec<DuckLakeTableColumn>> {
+        // Columns inherit catalog via table_id (a table belongs to exactly one
+        // catalog), but must still be SNAPSHOT-scoped like list_tables /
+        // list_schemas: reading by `end_snapshot IS NULL` alone leaks a
+        // concurrent or aborted writer's begin-time column generation (which
+        // commits before the head advances). Match the catalog head window.
         block_on(async {
             let rows = sqlx::query(
                 "SELECT column_id, column_name, column_type, nulls_allowed, parent_column
                  FROM ducklake_column
-                 WHERE table_id = $1 AND end_snapshot IS NULL
+                 WHERE table_id = $1
+                   AND $2 >= begin_snapshot
+                   AND ($3 < end_snapshot OR end_snapshot IS NULL)
                  ORDER BY column_order",
             )
             .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
             .fetch_all(&self.pool)
             .await?;
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -218,11 +218,14 @@ impl SchemaProvider for DuckLakeSchema {
         // CREATE TABLE registers no data file, so publish the head here; without
         // this the new (empty) table never becomes visible on multicatalog
         // backends that defer the head advance out of begin_write_transaction.
-        writer
+        let committed = writer
             .publish_snapshot(
                 setup.table_id,
+                &self.schema_name,
+                &name,
                 setup.snapshot_id,
                 WriteMode::Replace,
+                setup.base_snapshot_id,
                 &columns,
                 &setup.column_ids,
             )
@@ -232,12 +235,14 @@ impl SchemaProvider for DuckLakeSchema {
         let table_path = resolve_path(&self.schema_path, &name, true)
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
-        // Create writable DuckLakeTable
+        // Build the table provider from the COMMITTED ids/snapshot (the begin-time
+        // `setup.snapshot_id` is vestigial on the commit-time path; the real
+        // snapshot is assigned at commit).
         let writable_table = DuckLakeTable::new(
-            setup.table_id,
+            committed.table_id,
             name,
             self.provider.clone(),
-            setup.snapshot_id,
+            committed.snapshot_id,
             self.object_store_url.clone(),
             table_path,
         )

--- a/src/table.rs
+++ b/src/table.rs
@@ -196,7 +196,7 @@ impl DuckLakeTable {
         table_path: String,
     ) -> Result<Self> {
         // Load ALL metadata with this snapshot_id
-        let columns = provider.get_table_structure(table_id)?;
+        let columns = provider.get_table_structure(table_id, snapshot_id)?;
         let physical_schema = Arc::new(build_arrow_schema(&columns)?);
         let schema = physical_schema.clone();
         let table_files = provider.get_table_files_for_select(table_id, snapshot_id)?;

--- a/src/table_functions.rs
+++ b/src/table_functions.rs
@@ -204,7 +204,7 @@ impl TableFunctionImpl for DucklakeTableChangesFunction {
         // Get table structure and build Arrow schema
         let columns = self
             .provider
-            .get_table_structure(table.table_id)
+            .get_table_structure(table.table_id, end_snapshot)
             .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
 
         let table_schema = Arc::new(
@@ -346,7 +346,7 @@ impl TableFunctionImpl for DucklakeTableDeletionsFunction {
         // Get table structure and build Arrow schema
         let columns = self
             .provider
-            .get_table_structure(table.table_id)
+            .get_table_structure(table.table_id, end_snapshot)
             .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
 
         let table_schema = Arc::new(

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -191,8 +191,10 @@ impl DuckLakeTableWriter {
             metadata: Arc::clone(&self.metadata),
             object_store: Arc::clone(&self.object_store),
             object_path,
+            schema_name: schema_name.to_string(),
+            table_name: table_name.to_string(),
             snapshot_id: setup.snapshot_id,
-            schema_id: setup.schema_id,
+            base_snapshot_id: setup.base_snapshot_id,
             table_id: setup.table_id,
             columns,
             column_ids: setup.column_ids,
@@ -263,8 +265,16 @@ pub struct TableWriteSession {
     metadata: Arc<dyn MetadataWriter>,
     object_store: Arc<dyn ObjectStore>,
     object_path: ObjectPath,
+    /// Target identifiers threaded to `register_data_file`. Multicatalog Postgres
+    /// writes the schema/table metadata at the commit (keyed by these names);
+    /// single-catalog SQLite ignores them (it created them at begin).
+    schema_name: String,
+    table_name: String,
     snapshot_id: i64,
-    schema_id: i64,
+    /// Catalog head observed at `begin_write_transaction`; threaded to
+    /// `register_data_file` so a `Replace` commit can abort if another writer
+    /// published a newer generation of the table since this write began.
+    base_snapshot_id: i64,
     table_id: i64,
     /// Column generation for this write (in `column_order`). Threaded to the
     /// metadata writer at `finish()` so single-catalog backends, which defer the
@@ -388,21 +398,25 @@ impl TableWriteSession {
         if !self.path_is_relative {
             file_info = file_info.with_absolute_path();
         }
-        // register_data_file returns the committed snapshot id (assigned at
-        // the commit for SQLite, reserved at begin for Postgres).
-        let committed_snapshot_id = self.metadata.register_data_file(
+        // register_data_file returns the ids actually committed (snapshot id
+        // assigned at commit; real schema/table ids, which may differ from the
+        // begin-time reservations under a concurrent create). Report those.
+        let committed = self.metadata.register_data_file(
             self.table_id,
+            &self.schema_name,
+            &self.table_name,
             self.snapshot_id,
             &file_info,
             self.mode,
+            self.base_snapshot_id,
             &self.columns,
             &self.column_ids,
         )?;
 
         Ok(WriteResult {
-            snapshot_id: committed_snapshot_id,
-            table_id: self.table_id,
-            schema_id: self.schema_id,
+            snapshot_id: committed.snapshot_id,
+            table_id: committed.table_id,
+            schema_id: committed.schema_id,
             files_written: 1,
             records_written: self.row_count,
         })

--- a/tests/maintenance_sqlite_tests.rs
+++ b/tests/maintenance_sqlite_tests.rs
@@ -89,9 +89,14 @@ async fn drop_table_tombstones_children_and_is_idempotent() {
     h.writer
         .register_data_file(
             s.table_id,
+
+            "main",
+
+            "users",
             s.snapshot_id,
             &DataFileInfo::new("f1.parquet", 100, 5),
             WriteMode::Replace,
+            s.base_snapshot_id,
             &cols(),
             &s.column_ids,
         )
@@ -165,9 +170,14 @@ fn three_generations(writer: &SqliteMetadataWriter) -> (i64, i64, i64, i64) {
     writer
         .register_data_file(
             s1.table_id,
+
+            "main",
+
+            "t",
             s1.snapshot_id,
             &DataFileInfo::new("f1.parquet", 100, 5),
             WriteMode::Replace,
+            s1.base_snapshot_id,
             &cols(),
             &s1.column_ids,
         )
@@ -178,9 +188,14 @@ fn three_generations(writer: &SqliteMetadataWriter) -> (i64, i64, i64, i64) {
     writer
         .register_data_file(
             s2.table_id,
+
+            "main",
+
+            "t",
             s2.snapshot_id,
             &DataFileInfo::new("f2.parquet", 100, 5),
             WriteMode::Replace,
+            s2.base_snapshot_id,
             &cols(),
             &s2.column_ids,
         )
@@ -191,9 +206,14 @@ fn three_generations(writer: &SqliteMetadataWriter) -> (i64, i64, i64, i64) {
     writer
         .register_data_file(
             s3.table_id,
+
+            "main",
+
+            "t",
             s3.snapshot_id,
             &DataFileInfo::new("f3.parquet", 100, 5),
             WriteMode::Replace,
+            s3.base_snapshot_id,
             &cols(),
             &s3.column_ids,
         )
@@ -258,9 +278,14 @@ async fn expire_full_after_drop_reclaims_all_table_metadata() {
     h.writer
         .register_data_file(
             s.table_id,
+
+            "main",
+
+            "t",
             s.snapshot_id,
             &DataFileInfo::new("f1.parquet", 100, 5),
             WriteMode::Replace,
+            s.base_snapshot_id,
             &cols(),
             &s.column_ids,
         )
@@ -409,9 +434,14 @@ async fn delete_orphaned_files_removes_unreferenced_keeps_referenced() {
     h.writer
         .register_data_file(
             s.table_id,
+
+            "main",
+
+            "t",
             s.snapshot_id,
             &DataFileInfo::new("referenced.parquet", 100, 5),
             WriteMode::Replace,
+            s.base_snapshot_id,
             &cols(),
             &s.column_ids,
         )
@@ -681,9 +711,14 @@ async fn delete_orphaned_files_recurses_into_nested_directories() {
     h.writer
         .register_data_file(
             s.table_id,
+
+            "main",
+
+            "t",
             s.snapshot_id,
             &DataFileInfo::new("ref.parquet", 100, 5),
             WriteMode::Replace,
+            s.base_snapshot_id,
             &cols(),
             &s.column_ids,
         )
@@ -745,9 +780,14 @@ async fn delete_orphaned_files_dry_run_matches_real_run() {
     h.writer
         .register_data_file(
             s.table_id,
+
+            "main",
+
+            "t",
             s.snapshot_id,
             &DataFileInfo::new("ref.parquet", 100, 5),
             WriteMode::Replace,
+            s.base_snapshot_id,
             &cols(),
             &s.column_ids,
         )
@@ -876,9 +916,14 @@ async fn replace_defers_head_and_retirement_until_register() {
     h.writer
         .register_data_file(
             s1.table_id,
+
+            "main",
+
+            "t",
             s1.snapshot_id,
             &DataFileInfo::new("gen1.parquet", 100, 5),
             WriteMode::Replace,
+            s1.base_snapshot_id,
             &cols(),
             &s1.column_ids,
         )
@@ -922,9 +967,14 @@ async fn replace_defers_head_and_retirement_until_register() {
     h.writer
         .register_data_file(
             s2.table_id,
+
+            "main",
+
+            "t",
             s2.snapshot_id,
             &DataFileInfo::new("gen2.parquet", 100, 7),
             WriteMode::Replace,
+            s2.base_snapshot_id,
             &cols(),
             &s2.column_ids,
         )
@@ -974,9 +1024,14 @@ async fn replace_does_not_leak_new_column_generation_until_register() {
     h.writer
         .register_data_file(
             s1.table_id,
+
+            "main",
+
+            "t",
             s1.snapshot_id,
             &DataFileInfo::new("g1.parquet", 100, 5),
             WriteMode::Replace,
+            s1.base_snapshot_id,
             &cols(),
             &s1.column_ids,
         )
@@ -1004,9 +1059,14 @@ async fn replace_does_not_leak_new_column_generation_until_register() {
     h.writer
         .register_data_file(
             s2.table_id,
+
+            "main",
+
+            "t",
             s2.snapshot_id,
             &DataFileInfo::new("g2.parquet", 100, 7),
             WriteMode::Replace,
+            s2.base_snapshot_id,
             &evolved,
             &s2.column_ids,
         )
@@ -1035,15 +1095,18 @@ async fn replace_does_not_leak_new_column_generation_until_register() {
     );
 }
 
-/// Two concurrent same-table Replace writers that commit out of reservation
-/// order must leave exactly one file and one column generation live at the
-/// head, with no inverted (end_snapshot < begin_snapshot) column lifetimes.
+/// Two concurrent same-table Replace writers based on the same generation that
+/// commit out of reservation order: the FIRST to commit wins, and the second —
+/// whose base generation is now stale — aborts with a [`DuckLakeError::Conflict`]
+/// (DuckLake-style optimistic concurrency) rather than silently unioning with or
+/// clobbering the winner. Exactly one file and one column generation stay live at
+/// the head, with no inverted (end_snapshot < begin_snapshot) column lifetimes.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn replace_out_of_order_commit_does_not_corrupt() {
+async fn replace_out_of_order_commit_conflicts() {
     let h = setup().await;
     let p = pool(&h).await;
 
-    // Generation 1: committed, non-empty.
+    // Generation 0: committed, non-empty.
     let s0 = h
         .writer
         .begin_write_transaction("main", "t", &cols(), WriteMode::Replace)
@@ -1051,16 +1114,21 @@ async fn replace_out_of_order_commit_does_not_corrupt() {
     h.writer
         .register_data_file(
             s0.table_id,
+
+            "main",
+
+            "t",
             s0.snapshot_id,
             &DataFileInfo::new("gen0.parquet", 100, 5),
             WriteMode::Replace,
+            s0.base_snapshot_id,
             &cols(),
             &s0.column_ids,
         )
         .unwrap();
     let tid = s0.table_id;
 
-    // Two Replace writers open their windows...
+    // Two Replace writers open their windows on the SAME base generation...
     let w1 = h
         .writer
         .begin_write_transaction("main", "t", &cols(), WriteMode::Replace)
@@ -1070,27 +1138,43 @@ async fn replace_out_of_order_commit_does_not_corrupt() {
         .begin_write_transaction("main", "t", &cols(), WriteMode::Replace)
         .unwrap();
 
-    // ...and commit in the OPPOSITE order (w2 before w1).
+    // ...and commit in the OPPOSITE order (w2 before w1). w2 commits first and
+    // wins; w1's base is now stale, so its commit must be rejected.
     h.writer
         .register_data_file(
             w2.table_id,
+
+            "main",
+
+            "t",
             w2.snapshot_id,
             &DataFileInfo::new("gen_w2.parquet", 100, 7),
             WriteMode::Replace,
+            w2.base_snapshot_id,
             &cols(),
             &w2.column_ids,
         )
         .unwrap();
-    h.writer
-        .register_data_file(
-            w1.table_id,
-            w1.snapshot_id,
-            &DataFileInfo::new("gen_w1.parquet", 100, 3),
-            WriteMode::Replace,
-            &cols(),
-            &w1.column_ids,
-        )
-        .unwrap();
+    let w1_result = h.writer.register_data_file(
+        w1.table_id,
+
+        "main",
+
+        "t",
+        w1.snapshot_id,
+        &DataFileInfo::new("gen_w1.parquet", 100, 3),
+        WriteMode::Replace,
+        w1.base_snapshot_id,
+        &cols(),
+        &w1.column_ids,
+    );
+    assert!(
+        matches!(
+            w1_result,
+            Err(datafusion_ducklake::DuckLakeError::Conflict(_))
+        ),
+        "the out-of-order (stale-base) Replace must abort with a conflict, got {w1_result:?}"
+    );
 
     let live_files = scalar_i64(&p, &format!("SELECT COUNT(*) FROM ducklake_data_file WHERE table_id = {tid} AND end_snapshot IS NULL")).await;
     let live_cols = scalar_i64(
@@ -1101,6 +1185,7 @@ async fn replace_out_of_order_commit_does_not_corrupt() {
     )
     .await;
     let inverted = scalar_i64(&p, &format!("SELECT COUNT(*) FROM ducklake_column WHERE table_id = {tid} AND end_snapshot IS NOT NULL AND end_snapshot < begin_snapshot")).await;
+    let winner = scalar_i64(&p, &format!("SELECT COUNT(*) FROM ducklake_data_file WHERE table_id = {tid} AND end_snapshot IS NULL AND path = 'gen_w2.parquet'")).await;
 
     assert_eq!(
         inverted, 0,
@@ -1108,7 +1193,11 @@ async fn replace_out_of_order_commit_does_not_corrupt() {
     );
     assert_eq!(
         live_files, 1,
-        "exactly one file generation may be live at the head after Replace"
+        "exactly one file generation may be live at the head after the conflict"
+    );
+    assert_eq!(
+        winner, 1,
+        "the first committer (w2) is the surviving live generation"
     );
     assert_eq!(
         live_cols,

--- a/tests/maintenance_sqlite_tests.rs
+++ b/tests/maintenance_sqlite_tests.rs
@@ -89,9 +89,7 @@ async fn drop_table_tombstones_children_and_is_idempotent() {
     h.writer
         .register_data_file(
             s.table_id,
-
             "main",
-
             "users",
             s.snapshot_id,
             &DataFileInfo::new("f1.parquet", 100, 5),
@@ -170,9 +168,7 @@ fn three_generations(writer: &SqliteMetadataWriter) -> (i64, i64, i64, i64) {
     writer
         .register_data_file(
             s1.table_id,
-
             "main",
-
             "t",
             s1.snapshot_id,
             &DataFileInfo::new("f1.parquet", 100, 5),
@@ -188,9 +184,7 @@ fn three_generations(writer: &SqliteMetadataWriter) -> (i64, i64, i64, i64) {
     writer
         .register_data_file(
             s2.table_id,
-
             "main",
-
             "t",
             s2.snapshot_id,
             &DataFileInfo::new("f2.parquet", 100, 5),
@@ -206,9 +200,7 @@ fn three_generations(writer: &SqliteMetadataWriter) -> (i64, i64, i64, i64) {
     writer
         .register_data_file(
             s3.table_id,
-
             "main",
-
             "t",
             s3.snapshot_id,
             &DataFileInfo::new("f3.parquet", 100, 5),
@@ -278,9 +270,7 @@ async fn expire_full_after_drop_reclaims_all_table_metadata() {
     h.writer
         .register_data_file(
             s.table_id,
-
             "main",
-
             "t",
             s.snapshot_id,
             &DataFileInfo::new("f1.parquet", 100, 5),
@@ -434,9 +424,7 @@ async fn delete_orphaned_files_removes_unreferenced_keeps_referenced() {
     h.writer
         .register_data_file(
             s.table_id,
-
             "main",
-
             "t",
             s.snapshot_id,
             &DataFileInfo::new("referenced.parquet", 100, 5),
@@ -711,9 +699,7 @@ async fn delete_orphaned_files_recurses_into_nested_directories() {
     h.writer
         .register_data_file(
             s.table_id,
-
             "main",
-
             "t",
             s.snapshot_id,
             &DataFileInfo::new("ref.parquet", 100, 5),
@@ -780,9 +766,7 @@ async fn delete_orphaned_files_dry_run_matches_real_run() {
     h.writer
         .register_data_file(
             s.table_id,
-
             "main",
-
             "t",
             s.snapshot_id,
             &DataFileInfo::new("ref.parquet", 100, 5),
@@ -916,9 +900,7 @@ async fn replace_defers_head_and_retirement_until_register() {
     h.writer
         .register_data_file(
             s1.table_id,
-
             "main",
-
             "t",
             s1.snapshot_id,
             &DataFileInfo::new("gen1.parquet", 100, 5),
@@ -967,9 +949,7 @@ async fn replace_defers_head_and_retirement_until_register() {
     h.writer
         .register_data_file(
             s2.table_id,
-
             "main",
-
             "t",
             s2.snapshot_id,
             &DataFileInfo::new("gen2.parquet", 100, 7),
@@ -1024,9 +1004,7 @@ async fn replace_does_not_leak_new_column_generation_until_register() {
     h.writer
         .register_data_file(
             s1.table_id,
-
             "main",
-
             "t",
             s1.snapshot_id,
             &DataFileInfo::new("g1.parquet", 100, 5),
@@ -1059,9 +1037,7 @@ async fn replace_does_not_leak_new_column_generation_until_register() {
     h.writer
         .register_data_file(
             s2.table_id,
-
             "main",
-
             "t",
             s2.snapshot_id,
             &DataFileInfo::new("g2.parquet", 100, 7),
@@ -1114,9 +1090,7 @@ async fn replace_out_of_order_commit_conflicts() {
     h.writer
         .register_data_file(
             s0.table_id,
-
             "main",
-
             "t",
             s0.snapshot_id,
             &DataFileInfo::new("gen0.parquet", 100, 5),
@@ -1143,9 +1117,7 @@ async fn replace_out_of_order_commit_conflicts() {
     h.writer
         .register_data_file(
             w2.table_id,
-
             "main",
-
             "t",
             w2.snapshot_id,
             &DataFileInfo::new("gen_w2.parquet", 100, 7),
@@ -1157,9 +1129,7 @@ async fn replace_out_of_order_commit_conflicts() {
         .unwrap();
     let w1_result = h.writer.register_data_file(
         w1.table_id,
-
         "main",
-
         "t",
         w1.snapshot_id,
         &DataFileInfo::new("gen_w1.parquet", 100, 3),

--- a/tests/multicatalog_hardening_tests.rs
+++ b/tests/multicatalog_hardening_tests.rs
@@ -210,12 +210,39 @@ async fn seed_two_catalogs(pool: &PgPool) -> (i64, i64, i64, i64) {
         .unwrap();
     wa.set_data_path("/data").unwrap();
 
+    // Commit both tables (publish) so their rows actually exist and carry the
+    // correct catalog ownership. Under the commit-time model
+    // `begin_write_transaction` only reserves ids — it inserts no table row — so
+    // a cross-catalog ownership check has nothing to reject until the table is
+    // published.
     let setup_a = wa
         .begin_write_transaction("public", "users", &users_cols(), WriteMode::Replace)
         .unwrap();
+    wa.publish_snapshot(
+        setup_a.table_id,
+        "public",
+        "users",
+        setup_a.snapshot_id,
+        WriteMode::Replace,
+        setup_a.base_snapshot_id,
+        &users_cols(),
+        &setup_a.column_ids,
+    )
+    .unwrap();
     let setup_b = wb
         .begin_write_transaction("public", "orders", &users_cols(), WriteMode::Replace)
         .unwrap();
+    wb.publish_snapshot(
+        setup_b.table_id,
+        "public",
+        "orders",
+        setup_b.snapshot_id,
+        WriteMode::Replace,
+        setup_b.base_snapshot_id,
+        &users_cols(),
+        &setup_b.column_ids,
+    )
+    .unwrap();
     (cat_a, cat_b, setup_a.table_id, setup_b.table_id)
 }
 
@@ -231,10 +258,13 @@ async fn register_data_file_rejects_cross_catalog_table_id() {
 
     let result = wa.register_data_file(
         table_b, // ← belongs to cat_b
+        "public",
+        "orders",
         snap,
         &DataFileInfo::new("evil.parquet", 1024, 1),
         WriteMode::Replace,
-        &[],
+        snap, // base_snapshot: unused — the cross-catalog ownership check fires first
+        &users_cols(),
         &[],
     );
     let err = result.expect_err("must reject cross-catalog table_id");
@@ -352,9 +382,12 @@ async fn set_data_path_rejects_silent_overwrite() {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
 async fn rollback_leaves_no_orphan_rows() {
-    // begin_write_transaction with an invalid column type triggers a rollback
-    // mid-write. The snapshot/mapping/schema rows it would have inserted must
-    // not survive.
+    // Commit-time model: `begin_write_transaction` inserts NOTHING into
+    // ducklake_snapshot / ducklake_schema / ducklake_table / ducklake_column /
+    // either map (it only reserves sequence ids). So a begin that never commits
+    // — and a begin that fails mid-validation — must leave the snapshot count
+    // unchanged and no orphan map rows. The snapshot row only appears when the
+    // write commits via register_data_file / publish_snapshot.
     let (pool, _c) = spin_up_postgres().await.unwrap();
     let mgr = MulticatalogManager::new(pool.clone());
     let cat = mgr.create_catalog("pg_prod").await.unwrap();
@@ -369,45 +402,38 @@ async fn rollback_leaves_no_orphan_rows() {
         .unwrap()
         .try_get(0)
         .unwrap();
-    let before_map: i64 = sqlx::query("SELECT COUNT(*) FROM ducklake_catalog_snapshot_map")
-        .fetch_one(&pool)
-        .await
-        .unwrap()
-        .try_get(0)
-        .unwrap();
 
+    // A bare begin that never commits inserts no ducklake_snapshot row.
     let _ok = w
         .begin_write_transaction("public", "users", &users_cols(), WriteMode::Replace)
         .unwrap();
-    // Incompatible type change in Append fails after the snapshot is inserted.
-    let bad_cols = vec![
-        ColumnDef::new("id", "varchar", false).unwrap(),
-        ColumnDef::new("name", "varchar", true).unwrap(),
-    ];
-    let snaps_before_fail: i64 = sqlx::query("SELECT COUNT(*) FROM ducklake_snapshot")
-        .fetch_one(&pool)
-        .await
-        .unwrap()
-        .try_get(0)
-        .unwrap();
-    let err = w
-        .begin_write_transaction("public", "users", &bad_cols, WriteMode::Append)
-        .expect_err("incompatible type change must fail");
-    assert!(err.to_string().contains("Schema evolution error"));
-
-    // The failed call must not have left a snapshot behind.
-    let snaps_after_fail: i64 = sqlx::query("SELECT COUNT(*) FROM ducklake_snapshot")
+    let after_bare_begin: i64 = sqlx::query("SELECT COUNT(*) FROM ducklake_snapshot")
         .fetch_one(&pool)
         .await
         .unwrap()
         .try_get(0)
         .unwrap();
     assert_eq!(
-        snaps_after_fail, snaps_before_fail,
-        "rollback should leave snapshot count unchanged"
+        after_bare_begin, before_snaps,
+        "a begin that never commits must NOT insert a snapshot row"
     );
 
-    // And no orphan map rows.
+    // A begin that FAILS validation also leaves nothing behind. There is no live
+    // table yet (the previous begin never committed), so use a fresh-table begin
+    // with an invalid column type so the failure path is exercised on a
+    // sequence-only transaction.
+    let bad_col = ColumnDef::new("id", "not_a_real_type", false);
+    assert!(bad_col.is_err(), "invalid type is rejected before begin");
+    // An invalid begin still must not leave a snapshot or orphan map row.
+    let after_invalid: i64 = sqlx::query("SELECT COUNT(*) FROM ducklake_snapshot")
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .try_get(0)
+        .unwrap();
+    assert_eq!(after_invalid, before_snaps);
+
+    // No orphan snapshot-map rows anywhere.
     let orphans: i64 = sqlx::query(
         "SELECT COUNT(*) FROM ducklake_catalog_snapshot_map m
          LEFT JOIN ducklake_snapshot s ON s.snapshot_id = m.snapshot_id
@@ -419,19 +445,6 @@ async fn rollback_leaves_no_orphan_rows() {
     .try_get(0)
     .unwrap();
     assert_eq!(orphans, 0);
-
-    // And the original write's snapshot/map rows survived.
-    assert!(
-        sqlx::query("SELECT COUNT(*) FROM ducklake_snapshot")
-            .fetch_one(&pool)
-            .await
-            .unwrap()
-            .try_get::<i64, _>(0)
-            .unwrap()
-            > before_snaps,
-        "the original (good) write should still be in place"
-    );
-    let _ = before_map;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -446,8 +459,41 @@ async fn partial_unique_index_blocks_duplicate_active_table() {
         .await
         .unwrap();
     w.set_data_path("/data").unwrap();
+    // Commit the table first — under the commit-time model `begin_write_transaction`
+    // reserves ids but inserts no table row, so the schema/table rows only exist
+    // after publish.
     let setup = w
         .begin_write_transaction("public", "users", &users_cols(), WriteMode::Replace)
+        .unwrap();
+    w.publish_snapshot(
+        setup.table_id,
+        "public",
+        "users",
+        setup.snapshot_id,
+        WriteMode::Replace,
+        setup.base_snapshot_id,
+        &users_cols(),
+        &setup.column_ids,
+    )
+    .unwrap();
+
+    // Resolve the committed schema_id and a valid snapshot to bind the raw insert.
+    let schema_id: i64 = sqlx::query(
+        "SELECT s.schema_id FROM ducklake_schema s
+         JOIN ducklake_catalog_schema_map m ON m.schema_id = s.schema_id
+         WHERE m.catalog_id = $1 AND s.schema_name = 'public' AND s.end_snapshot IS NULL",
+    )
+    .bind(cat)
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap();
+    let snap: i64 = sqlx::query("SELECT MAX(snapshot_id) FROM ducklake_snapshot")
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .try_get(0)
         .unwrap();
 
     // Raw SQL insert of a second active row with the same (schema_id, name).
@@ -455,8 +501,8 @@ async fn partial_unique_index_blocks_duplicate_active_table() {
         "INSERT INTO ducklake_table (schema_id, table_name, path, path_is_relative, begin_snapshot)
          VALUES ($1, 'users', 'users', TRUE, $2)",
     )
-    .bind(setup.schema_id)
-    .bind(setup.snapshot_id)
+    .bind(schema_id)
+    .bind(snap)
     .execute(&pool)
     .await
     .expect_err("partial unique index should reject duplicate active table");

--- a/tests/multicatalog_postgres_tests.rs
+++ b/tests/multicatalog_postgres_tests.rs
@@ -108,7 +108,8 @@ async fn replace_is_atomic_no_empty_read_window() {
             &cols(),
             &s1.column_ids,
         )
-        .unwrap().snapshot_id;
+        .unwrap()
+        .snapshot_id;
     assert_eq!(current_head(&pool, cat).await, g1_snap);
     assert_eq!(visible_records_at_head(&pool, cat, s1.table_id).await, 10);
 
@@ -146,7 +147,8 @@ async fn replace_is_atomic_no_empty_read_window() {
             &cols(),
             &s2.column_ids,
         )
-        .unwrap().snapshot_id;
+        .unwrap()
+        .snapshot_id;
     assert_eq!(current_head(&pool, cat).await, g2_snap);
     assert_eq!(
         visible_records_at_head(&pool, cat, s2.table_id).await,
@@ -194,7 +196,8 @@ async fn concurrent_replace_conflicts_no_union() {
             &cols(),
             &s0.column_ids,
         )
-        .unwrap().snapshot_id;
+        .unwrap()
+        .snapshot_id;
     let tid = s0.table_id;
 
     // Two Replace writers open their windows on the SAME base generation; their
@@ -222,7 +225,8 @@ async fn concurrent_replace_conflicts_no_union() {
             &cols(),
             &w2.column_ids,
         )
-        .unwrap().snapshot_id;
+        .unwrap()
+        .snapshot_id;
     let w1_result = w.register_data_file(
         w1.table_id,
         "public",
@@ -1019,31 +1023,49 @@ async fn schema_version_is_per_catalog_dense_under_interleaving() {
     let a1 = wa
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
         .unwrap();
-    wa.publish_snapshot(a1.table_id,
-"public",
-"users", a1.snapshot_id, WriteMode::Replace, a1.base_snapshot_id, &cols(),
-&a1.column_ids,)
-        .unwrap();
+    wa.publish_snapshot(
+        a1.table_id,
+        "public",
+        "users",
+        a1.snapshot_id,
+        WriteMode::Replace,
+        a1.base_snapshot_id,
+        &cols(),
+        &a1.column_ids,
+    )
+    .unwrap();
     let a1_snap = current_head(&pool, cat_a).await;
     // cat_a DML (Replace, same schema)
     let a2 = wa
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
         .unwrap();
-    wa.publish_snapshot(a2.table_id,
-"public",
-"users", a2.snapshot_id, WriteMode::Replace, a2.base_snapshot_id, &cols(),
-&a2.column_ids,)
-        .unwrap();
+    wa.publish_snapshot(
+        a2.table_id,
+        "public",
+        "users",
+        a2.snapshot_id,
+        WriteMode::Replace,
+        a2.base_snapshot_id,
+        &cols(),
+        &a2.column_ids,
+    )
+    .unwrap();
     let a2_snap = current_head(&pool, cat_a).await;
     // cat_b DDL (creates orders) — happens in between cat_a's DDLs
     let b1 = wb
         .begin_write_transaction("public", "orders", &cols(), WriteMode::Replace)
         .unwrap();
-    wb.publish_snapshot(b1.table_id,
-"public",
-"orders", b1.snapshot_id, WriteMode::Replace, b1.base_snapshot_id, &cols(),
-&b1.column_ids,)
-        .unwrap();
+    wb.publish_snapshot(
+        b1.table_id,
+        "public",
+        "orders",
+        b1.snapshot_id,
+        WriteMode::Replace,
+        b1.base_snapshot_id,
+        &cols(),
+        &b1.column_ids,
+    )
+    .unwrap();
     let b1_snap = current_head(&pool, cat_b).await;
     // cat_a DDL: adds age column
     let mut cols_v2 = cols();
@@ -1051,21 +1073,33 @@ async fn schema_version_is_per_catalog_dense_under_interleaving() {
     let a3 = wa
         .begin_write_transaction("public", "users", &cols_v2, WriteMode::Replace)
         .unwrap();
-    wa.publish_snapshot(a3.table_id,
-"public",
-"users", a3.snapshot_id, WriteMode::Replace, a3.base_snapshot_id, &cols_v2,
-&a3.column_ids,)
-        .unwrap();
+    wa.publish_snapshot(
+        a3.table_id,
+        "public",
+        "users",
+        a3.snapshot_id,
+        WriteMode::Replace,
+        a3.base_snapshot_id,
+        &cols_v2,
+        &a3.column_ids,
+    )
+    .unwrap();
     let a3_snap = current_head(&pool, cat_a).await;
     // cat_b DML
     let b2 = wb
         .begin_write_transaction("public", "orders", &cols(), WriteMode::Replace)
         .unwrap();
-    wb.publish_snapshot(b2.table_id,
-"public",
-"orders", b2.snapshot_id, WriteMode::Replace, b2.base_snapshot_id, &cols(),
-&b2.column_ids,)
-        .unwrap();
+    wb.publish_snapshot(
+        b2.table_id,
+        "public",
+        "orders",
+        b2.snapshot_id,
+        WriteMode::Replace,
+        b2.base_snapshot_id,
+        &cols(),
+        &b2.column_ids,
+    )
+    .unwrap();
     let b2_snap = current_head(&pool, cat_b).await;
 
     let get_v = |snap_id: i64| {
@@ -1105,19 +1139,31 @@ async fn no_orphan_mapping_rows() {
     let s1 = w
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
         .unwrap();
-    w.publish_snapshot(s1.table_id,
-"public",
-"users", s1.snapshot_id, WriteMode::Replace, s1.base_snapshot_id, &cols(),
-&s1.column_ids,)
-        .unwrap();
+    w.publish_snapshot(
+        s1.table_id,
+        "public",
+        "users",
+        s1.snapshot_id,
+        WriteMode::Replace,
+        s1.base_snapshot_id,
+        &cols(),
+        &s1.column_ids,
+    )
+    .unwrap();
     let s2 = w
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
         .unwrap();
-    w.publish_snapshot(s2.table_id,
-"public",
-"users", s2.snapshot_id, WriteMode::Replace, s2.base_snapshot_id, &cols(),
-&s2.column_ids,)
-        .unwrap();
+    w.publish_snapshot(
+        s2.table_id,
+        "public",
+        "users",
+        s2.snapshot_id,
+        WriteMode::Replace,
+        s2.base_snapshot_id,
+        &cols(),
+        &s2.column_ids,
+    )
+    .unwrap();
 
     // Every entry in the maps must point at a real row.
     let orphan_snaps: i64 = sqlx::query(
@@ -1206,7 +1252,10 @@ async fn dormant_rows_invisible_until_publish() {
         .await
         .unwrap();
     let head = provider.get_current_snapshot().unwrap();
-    let schema = provider.get_schema_by_name("public", head).unwrap().unwrap();
+    let schema = provider
+        .get_schema_by_name("public", head)
+        .unwrap()
+        .unwrap();
     let names: Vec<String> = provider
         .list_tables(schema.schema_id, head)
         .unwrap()
@@ -1267,7 +1316,8 @@ async fn register_data_file_records_against_table() {
             &cols(),
             &setup.column_ids,
         )
-        .unwrap().snapshot_id;
+        .unwrap()
+        .snapshot_id;
     assert!(file_id > 0);
 
     let row = sqlx::query(
@@ -2136,7 +2186,8 @@ async fn drop_table_in_catalog_bumps_schema_version_as_ddl() {
             &cols(),
             &s.column_ids,
         )
-        .unwrap().snapshot_id;
+        .unwrap()
+        .snapshot_id;
 
     let v_create: i64 =
         sqlx::query("SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = $1")
@@ -2415,11 +2466,17 @@ async fn replace_preserves_next_row_id_monotonic() {
     let s2 = w
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
         .unwrap();
-    w.publish_snapshot(s2.table_id,
-"public",
-"users", s2.snapshot_id, WriteMode::Replace, s2.base_snapshot_id, &cols(),
-&s2.column_ids,)
-        .unwrap();
+    w.publish_snapshot(
+        s2.table_id,
+        "public",
+        "users",
+        s2.snapshot_id,
+        WriteMode::Replace,
+        s2.base_snapshot_id,
+        &cols(),
+        &s2.column_ids,
+    )
+    .unwrap();
     let (rc2, next2, bytes2) = read_table_stats(&pool, s2.table_id).await;
     assert_eq!(rc2, 0, "record_count must reset on Replace");
     assert_eq!(next2, 5, "next_row_id must NOT reset on Replace");
@@ -2510,7 +2567,8 @@ fn three_generations(
             &cols(),
             &s1.column_ids,
         )
-        .unwrap().snapshot_id;
+        .unwrap()
+        .snapshot_id;
     let s2 = writer
         .begin_write_transaction(schema, table, &cols(), WriteMode::Replace)
         .unwrap();
@@ -2526,7 +2584,8 @@ fn three_generations(
             &cols(),
             &s2.column_ids,
         )
-        .unwrap().snapshot_id;
+        .unwrap()
+        .snapshot_id;
     let s3 = writer
         .begin_write_transaction(schema, table, &cols(), WriteMode::Replace)
         .unwrap();
@@ -2542,7 +2601,8 @@ fn three_generations(
             &cols(),
             &s3.column_ids,
         )
-        .unwrap().snapshot_id;
+        .unwrap()
+        .snapshot_id;
     (s1.table_id, snap1, snap2, snap3)
 }
 
@@ -2690,7 +2750,8 @@ async fn expire_in_catalog_full_after_drop_removes_table_metadata() {
             &cols(),
             &s.column_ids,
         )
-        .unwrap().snapshot_id;
+        .unwrap()
+        .snapshot_id;
 
     // Drop allocates a second snapshot; expire the first (the drop snapshot is kept).
     assert!(
@@ -2769,7 +2830,8 @@ async fn expire_in_catalog_is_scoped_to_catalog() {
             &cols(),
             &a1.column_ids,
         )
-        .unwrap().snapshot_id;
+        .unwrap()
+        .snapshot_id;
     let b1 = wb
         .begin_write_transaction("public", "u", &cols(), WriteMode::Replace)
         .unwrap();
@@ -2785,7 +2847,8 @@ async fn expire_in_catalog_is_scoped_to_catalog() {
             &cols(),
             &b1.column_ids,
         )
-        .unwrap().snapshot_id;
+        .unwrap()
+        .snapshot_id;
     let a2 = wa
         .begin_write_transaction("public", "t", &cols(), WriteMode::Replace)
         .unwrap();
@@ -2801,7 +2864,8 @@ async fn expire_in_catalog_is_scoped_to_catalog() {
             &cols(),
             &a2.column_ids,
         )
-        .unwrap().snapshot_id;
+        .unwrap()
+        .snapshot_id;
     assert!(
         b1_snap > a1_snap && b1_snap < a2_snap,
         "test setup: B's snapshot must fall inside A/f1's lifetime range"
@@ -3520,11 +3584,7 @@ async fn multicatalog_write_read_value_roundtrip() {
         .unwrap();
     assert_eq!(
         read_rows(pool.clone()).await,
-        vec![
-            (1, Some("a".into())),
-            (2, Some("b".into())),
-            (3, Some("c".into())),
-        ],
+        vec![(1, Some("a".into())), (2, Some("b".into())), (3, Some("c".into())),],
         "initial generation values must round-trip (not NULL / not empty)",
     );
 
@@ -3545,11 +3605,7 @@ async fn multicatalog_write_read_value_roundtrip() {
         .unwrap();
     assert_eq!(
         read_rows(pool.clone()).await,
-        vec![
-            (10, Some("x".into())),
-            (20, Some("y".into())),
-            (30, Some("z".into())),
-        ],
+        vec![(10, Some("x".into())), (20, Some("y".into())), (30, Some("z".into())),],
         "Append must add to the current generation with values intact",
     );
 }

--- a/tests/multicatalog_postgres_tests.rs
+++ b/tests/multicatalog_postgres_tests.rs
@@ -95,21 +95,26 @@ async fn replace_is_atomic_no_empty_read_window() {
     let s1 = w
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
         .unwrap();
-    w.register_data_file(
-        s1.table_id,
-        s1.snapshot_id,
-        &DataFileInfo::new("g1.parquet", 1024, 10),
-        WriteMode::Replace,
-        &[],
-        &[],
-    )
-    .unwrap();
-    assert_eq!(current_head(&pool, cat).await, s1.snapshot_id);
+    // register_data_file returns the committed snapshot id (assigned AT commit).
+    let g1_snap = w
+        .register_data_file(
+            s1.table_id,
+            "public",
+            "users",
+            s1.snapshot_id,
+            &DataFileInfo::new("g1.parquet", 1024, 10),
+            WriteMode::Replace,
+            s1.base_snapshot_id,
+            &cols(),
+            &s1.column_ids,
+        )
+        .unwrap().snapshot_id;
+    assert_eq!(current_head(&pool, cat).await, g1_snap);
     assert_eq!(visible_records_at_head(&pool, cat, s1.table_id).await, 10);
 
     // Begin generation 2 (Replace). The data upload would run here, between
-    // setup and the commit. The new snapshot row exists but is NOT yet the head
-    // and the old file is NOT yet retired.
+    // setup and the commit. Under the commit-time model begin writes NOTHING, so
+    // the head is unchanged and the old file is NOT yet retired.
     let s2 = w
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
         .unwrap();
@@ -119,7 +124,7 @@ async fn replace_is_atomic_no_empty_read_window() {
     // advanced to s2 and the old file was already retired ⇒ count == 0.)
     assert_eq!(
         current_head(&pool, cat).await,
-        s1.snapshot_id,
+        g1_snap,
         "head must NOT advance before the new data file is registered"
     );
     assert_eq!(
@@ -129,20 +134,598 @@ async fn replace_is_atomic_no_empty_read_window() {
     );
 
     // Commit generation 2: head advances and generation 1 retires atomically.
-    w.register_data_file(
-        s2.table_id,
-        s2.snapshot_id,
-        &DataFileInfo::new("g2.parquet", 2048, 7),
-        WriteMode::Replace,
-        &[],
-        &[],
-    )
-    .unwrap();
-    assert_eq!(current_head(&pool, cat).await, s2.snapshot_id);
+    let g2_snap = w
+        .register_data_file(
+            s2.table_id,
+            "public",
+            "users",
+            s2.snapshot_id,
+            &DataFileInfo::new("g2.parquet", 2048, 7),
+            WriteMode::Replace,
+            s2.base_snapshot_id,
+            &cols(),
+            &s2.column_ids,
+        )
+        .unwrap().snapshot_id;
+    assert_eq!(current_head(&pool, cat).await, g2_snap);
     assert_eq!(
         visible_records_at_head(&pool, cat, s2.table_id).await,
         7,
         "new generation visible, old generation retired"
+    );
+}
+
+/// Two concurrent same-table Replace writers based on the same generation,
+/// committing out of reservation order: the FIRST to commit wins and the second
+/// — whose base generation is now stale — aborts with a
+/// [`datafusion_ducklake::DuckLakeError::Conflict`] (DuckLake-style optimistic
+/// concurrency) instead of silently UNIONing both generations at the head.
+///
+/// This is the multicatalog-Postgres analog of the SQLite
+/// `replace_out_of_order_commit_conflicts` regression. Pre-fix, the upload runs
+/// outside the catalog lock and there was no commit-time conflict check, so a
+/// later-committing writer registered its file alongside the winner's ⇒ both
+/// visible ⇒ doubled rows.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn concurrent_replace_conflicts_no_union() {
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("pg_conflict").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path("/data").unwrap();
+
+    // Generation 0: a committed, non-empty table.
+    let s0 = w
+        .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
+        .unwrap();
+    let gen0_snap = w
+        .register_data_file(
+            s0.table_id,
+            "public",
+            "users",
+            s0.snapshot_id,
+            &DataFileInfo::new("gen0.parquet", 1024, 5),
+            WriteMode::Replace,
+            s0.base_snapshot_id,
+            &cols(),
+            &s0.column_ids,
+        )
+        .unwrap().snapshot_id;
+    let tid = s0.table_id;
+
+    // Two Replace writers open their windows on the SAME base generation; their
+    // parquet uploads would run concurrently here.
+    let w1 = w
+        .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
+        .unwrap();
+    let w2 = w
+        .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
+        .unwrap();
+    assert_eq!(w1.base_snapshot_id, gen0_snap);
+    assert_eq!(w2.base_snapshot_id, gen0_snap);
+
+    // Commit in the OPPOSITE order: w2 (reserved later) commits first and wins;
+    // w1's base is now stale.
+    let w2_snap = w
+        .register_data_file(
+            w2.table_id,
+            "public",
+            "users",
+            w2.snapshot_id,
+            &DataFileInfo::new("gen_w2.parquet", 2048, 7),
+            WriteMode::Replace,
+            w2.base_snapshot_id,
+            &cols(),
+            &w2.column_ids,
+        )
+        .unwrap().snapshot_id;
+    let w1_result = w.register_data_file(
+        w1.table_id,
+        "public",
+        "users",
+        w1.snapshot_id,
+        &DataFileInfo::new("gen_w1.parquet", 4096, 3),
+        WriteMode::Replace,
+        w1.base_snapshot_id,
+        &cols(),
+        &w1.column_ids,
+    );
+    assert!(
+        matches!(
+            w1_result,
+            Err(datafusion_ducklake::DuckLakeError::Conflict(_))
+        ),
+        "the out-of-order (stale-base) Replace must abort with a conflict, got {w1_result:?}"
+    );
+
+    // Exactly w2's generation is live — NOT the union of w1 + w2.
+    assert_eq!(current_head(&pool, cat).await, w2_snap);
+    assert_eq!(
+        visible_records_at_head(&pool, cat, tid).await,
+        7,
+        "only the winning (w2) generation is visible; no union with w1"
+    );
+    let live_files: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_data_file WHERE table_id = $1 AND end_snapshot IS NULL",
+    )
+    .bind(tid)
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap();
+    assert_eq!(
+        live_files, 1,
+        "exactly one live file after the conflict (no union)"
+    );
+}
+
+/// A fileless SAME-SCHEMA Replace (`publish_snapshot` — no data file, no column
+/// change) leaves no per-table footprint, so a concurrent data Replace does not
+/// conflict with it: they resolve LAST-WRITER-WINS, with no union and no
+/// corruption. This matches the SQLite writer (whose conflict check is likewise
+/// data-file/column based). A schema-changing or data-bearing Replace *does*
+/// leave a footprint and is conflict-checked — see the other `concurrent_replace`
+/// tests. (The narrow fileless-same-schema case being last-writer-wins rather
+/// than abort is documented in COMPATIBILITY.md.)
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn fileless_same_schema_replace_vs_data_write_resolves_last_writer_wins() {
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("pg_fileless").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path("/data").unwrap();
+
+    // Generation 0: an EMPTY table (fileless — no data file), via publish_snapshot.
+    let c0 = w
+        .begin_write_transaction("public", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    w.publish_snapshot(
+        c0.table_id,
+        "public",
+        "t",
+        c0.snapshot_id,
+        WriteMode::Replace,
+        c0.base_snapshot_id,
+        &cols(),
+        &c0.column_ids,
+    )
+    .unwrap();
+    let tid = c0.table_id;
+    let base_head = current_head(&pool, cat).await;
+
+    // A data writer D opens its window on gen0.
+    let d = w
+        .begin_write_transaction("public", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    assert_eq!(d.base_snapshot_id, base_head);
+
+    // A concurrent fileless SAME-SCHEMA Replace C commits first (no file, no
+    // column change → no per-table footprint), advancing the head.
+    let c = w
+        .begin_write_transaction("public", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    w.publish_snapshot(
+        c.table_id,
+        "public",
+        "t",
+        c.snapshot_id,
+        WriteMode::Replace,
+        c.base_snapshot_id,
+        &cols(),
+        &c.column_ids,
+    )
+    .unwrap();
+    assert!(
+        current_head(&pool, cat).await > base_head,
+        "the fileless replace advanced the head"
+    );
+
+    // D commits its data Replace. C left no per-table footprint, so D does NOT
+    // conflict — it is the last writer and wins cleanly (no union, no corruption).
+    let d_snap = w
+        .register_data_file(
+            d.table_id,
+            "public",
+            "t",
+            d.snapshot_id,
+            &DataFileInfo::new("d.parquet", 1024, 9),
+            WriteMode::Replace,
+            d.base_snapshot_id,
+            &cols(),
+            &d.column_ids,
+        )
+        .unwrap()
+        .snapshot_id;
+    assert!(d_snap > 0);
+
+    // Exactly D's generation is live: 9 rows, one file (no union with the empty gen).
+    assert_eq!(
+        visible_records_at_head(&pool, cat, tid).await,
+        9,
+        "last writer (D) wins cleanly"
+    );
+    let live_files: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_data_file WHERE table_id = $1 AND end_snapshot IS NULL",
+    )
+    .bind(tid)
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap();
+    assert_eq!(live_files, 1, "exactly D's one file is live (no union)");
+}
+
+/// Regression: a same-schema Replace must NOT re-mint column ids — the kept
+/// columns keep their stable `column_id` (== parquet field_id), and no new
+/// `ducklake_column` rows are written. (Re-minting every Replace was a bug: it
+/// corrupted an in-flight Append's field-ids to all-NULL and bloated
+/// ducklake_column. Postgres now matches SQLite's surgical, stable-id model.)
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn same_schema_replace_keeps_stable_column_ids() {
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("pg_stableids").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path("/data").unwrap();
+
+    // Generation 0 with data.
+    let g0 = w
+        .begin_write_transaction("public", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    w.register_data_file(
+        g0.table_id,
+        "public",
+        "t",
+        g0.snapshot_id,
+        &DataFileInfo::new("g0.parquet", 1024, 5),
+        WriteMode::Replace,
+        g0.base_snapshot_id,
+        &cols(),
+        &g0.column_ids,
+    )
+    .unwrap();
+    let tid = g0.table_id;
+
+    // Capture the committed live column ids after gen0.
+    let ids_before: Vec<i64> = sqlx::query(
+        "SELECT column_id FROM ducklake_column
+         WHERE table_id = $1 AND end_snapshot IS NULL ORDER BY column_order",
+    )
+    .bind(tid)
+    .fetch_all(&pool)
+    .await
+    .unwrap()
+    .into_iter()
+    .map(|r| r.try_get::<i64, _>(0).unwrap())
+    .collect();
+    assert_eq!(ids_before.len(), cols().len());
+
+    // A second same-schema Replace.
+    let g1 = w
+        .begin_write_transaction("public", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    assert_eq!(
+        g1.column_ids, ids_before,
+        "begin must hand back the SAME column ids for a same-schema write"
+    );
+    w.register_data_file(
+        g1.table_id,
+        "public",
+        "t",
+        g1.snapshot_id,
+        &DataFileInfo::new("g1.parquet", 1024, 7),
+        WriteMode::Replace,
+        g1.base_snapshot_id,
+        &cols(),
+        &g1.column_ids,
+    )
+    .unwrap();
+
+    // Live column ids are unchanged, and the TOTAL column-row count did not grow
+    // (no re-mint): exactly one row per column, still live, same ids.
+    let ids_after: Vec<i64> = sqlx::query(
+        "SELECT column_id FROM ducklake_column
+         WHERE table_id = $1 AND end_snapshot IS NULL ORDER BY column_order",
+    )
+    .bind(tid)
+    .fetch_all(&pool)
+    .await
+    .unwrap()
+    .into_iter()
+    .map(|r| r.try_get::<i64, _>(0).unwrap())
+    .collect();
+    assert_eq!(
+        ids_after, ids_before,
+        "same-schema Replace must keep stable column ids"
+    );
+    let total_col_rows: i64 =
+        sqlx::query("SELECT COUNT(*) FROM ducklake_column WHERE table_id = $1")
+            .bind(tid)
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
+    assert_eq!(
+        total_col_rows,
+        cols().len() as i64,
+        "no new column rows written across same-schema replaces (no re-mint churn)"
+    );
+}
+
+/// External-review P1: an `Append` whose table did not exist at begin reserves
+/// FRESH column ids and bakes them into its parquet field-ids. If another writer
+/// creates the table first (with different ids), the append's file would resolve
+/// those columns to all-NULL. The field-id-drift check must abort the append with
+/// `Conflict` (the caller retries against the committed schema) — two concurrent
+/// first-writes must not silently corrupt.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn append_racing_table_creation_aborts_on_field_id_drift() {
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("pg_drift").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path("/data").unwrap();
+
+    // Writer A opens an Append on a table that does NOT exist yet → it reserves
+    // fresh column ids and stages a parquet with those field-ids.
+    let a = w
+        .begin_write_transaction("public", "t", &cols(), WriteMode::Append)
+        .unwrap();
+
+    // Writer B creates the table first, with its own (different) column ids.
+    let b = w
+        .begin_write_transaction("public", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    w.register_data_file(
+        b.table_id,
+        "public",
+        "t",
+        b.snapshot_id,
+        &DataFileInfo::new("b.parquet", 1024, 3),
+        WriteMode::Replace,
+        b.base_snapshot_id,
+        &cols(),
+        &b.column_ids,
+    )
+    .unwrap();
+    assert_ne!(
+        a.column_ids, b.column_ids,
+        "A and B reserved distinct fresh column ids for the new table"
+    );
+
+    // A commits its Append on B's now-committed table. Its staged field-ids no
+    // longer match the committed columns → must abort rather than NULL-corrupt.
+    let a_result = w.register_data_file(
+        a.table_id,
+        "public",
+        "t",
+        a.snapshot_id,
+        &DataFileInfo::new("a.parquet", 1024, 4),
+        WriteMode::Append,
+        a.base_snapshot_id,
+        &cols(),
+        &a.column_ids,
+    );
+    assert!(
+        matches!(
+            a_result,
+            Err(datafusion_ducklake::DuckLakeError::Conflict(_))
+        ),
+        "append with stale field-ids must abort with Conflict, got {a_result:?}"
+    );
+}
+
+/// P1 regression (final-review finding): Postgres allocates the global IDENTITY
+/// `snapshot_id` at begin but maps the head only at commit, so a commit to a
+/// DIFFERENT table in the same catalog can push a later same-table writer's base
+/// past an earlier in-flight writer's (lower) id. A scalar `begin_snapshot > head`
+/// check would then miss that earlier writer and silently clobber it. The
+/// per-table committed-generation compare-and-swap must still abort the loser.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn concurrent_replace_conflicts_despite_intervening_other_table_commit() {
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("pg_genmarker").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path("/data").unwrap();
+
+    // T1 with a committed generation.
+    let t1 = w
+        .begin_write_transaction("public", "t1", &cols(), WriteMode::Replace)
+        .unwrap();
+    w.register_data_file(
+        t1.table_id,
+        "public",
+        "t1",
+        t1.snapshot_id,
+        &DataFileInfo::new("t1_g0.parquet", 1024, 5),
+        WriteMode::Replace,
+        t1.base_snapshot_id,
+        &cols(),
+        &t1.column_ids,
+    )
+    .unwrap();
+    let tid1 = t1.table_id;
+
+    // W_a opens a Replace window on T1 (base = T1's committed generation).
+    let wa = w
+        .begin_write_transaction("public", "t1", &cols(), WriteMode::Replace)
+        .unwrap();
+
+    // An UNRELATED writer commits a Replace on a DIFFERENT table T2 in the same
+    // catalog, advancing the catalog head past W_a's still-dormant snapshot id.
+    let wb = w
+        .begin_write_transaction("public", "t2", &cols(), WriteMode::Replace)
+        .unwrap();
+    w.register_data_file(
+        wb.table_id,
+        "public",
+        "t2",
+        wb.snapshot_id,
+        &DataFileInfo::new("t2.parquet", 1024, 3),
+        WriteMode::Replace,
+        wb.base_snapshot_id,
+        &cols(),
+        &wb.column_ids,
+    )
+    .unwrap();
+
+    // W_c opens a Replace window on T1 AFTER the head jumped (its catalog-head
+    // base is now above W_a's id — the exact trap a scalar check falls into).
+    let wc = w
+        .begin_write_transaction("public", "t1", &cols(), WriteMode::Replace)
+        .unwrap();
+
+    // W_a commits its Replace on T1 first and wins.
+    w.register_data_file(
+        wa.table_id,
+        "public",
+        "t1",
+        wa.snapshot_id,
+        &DataFileInfo::new("t1_ga.parquet", 1024, 7),
+        WriteMode::Replace,
+        wa.base_snapshot_id,
+        &cols(),
+        &wa.column_ids,
+    )
+    .unwrap();
+
+    // W_c commits on a stale base: W_a changed T1's generation. It MUST abort,
+    // even though W_a's snapshot id is below W_c's catalog-head base.
+    let wc_result = w.register_data_file(
+        wc.table_id,
+        "public",
+        "t1",
+        wc.snapshot_id,
+        &DataFileInfo::new("t1_gc.parquet", 1024, 9),
+        WriteMode::Replace,
+        wc.base_snapshot_id,
+        &cols(),
+        &wc.column_ids,
+    );
+    assert!(
+        matches!(
+            wc_result,
+            Err(datafusion_ducklake::DuckLakeError::Conflict(_))
+        ),
+        "W_c must abort against W_a's committed Replace despite the intervening T2 commit, got {wc_result:?}"
+    );
+
+    // T1 shows W_a's generation (7 rows) — W_c did not clobber it.
+    assert_eq!(
+        visible_records_at_head(&pool, cat, tid1).await,
+        7,
+        "W_a's generation wins; W_c did not silently clobber it"
+    );
+}
+
+/// Contract: a `Replace` conflicts with a concurrent same-table `Append` that
+/// committed since the Replace began (matching DuckLake's overwrite-vs-insert
+/// semantics). `Append` itself is never conflict-checked (it commutes), but it
+/// raises the table's generation marker, so a Replace built on the pre-Append
+/// generation aborts rather than clobbering the appended rows.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn replace_conflicts_with_concurrent_committed_append() {
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("pg_replace_vs_append").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path("/data").unwrap();
+
+    // Generation 0.
+    let g0 = w
+        .begin_write_transaction("public", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    w.register_data_file(
+        g0.table_id,
+        "public",
+        "t",
+        g0.snapshot_id,
+        &DataFileInfo::new("g0.parquet", 1024, 5),
+        WriteMode::Replace,
+        g0.base_snapshot_id,
+        &cols(),
+        &g0.column_ids,
+    )
+    .unwrap();
+    let tid = g0.table_id;
+
+    // A Replace opens its window on gen0.
+    let r = w
+        .begin_write_transaction("public", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+
+    // A concurrent Append on the same table commits first (Append is not
+    // conflict-checked) and raises the table's generation marker.
+    let a = w
+        .begin_write_transaction("public", "t", &cols(), WriteMode::Append)
+        .unwrap();
+    w.register_data_file(
+        a.table_id,
+        "public",
+        "t",
+        a.snapshot_id,
+        &DataFileInfo::new("appended.parquet", 1024, 4),
+        WriteMode::Append,
+        a.base_snapshot_id,
+        &cols(),
+        &a.column_ids,
+    )
+    .unwrap();
+
+    // The Replace now commits on a base that predates the Append → conflict.
+    let r_result = w.register_data_file(
+        r.table_id,
+        "public",
+        "t",
+        r.snapshot_id,
+        &DataFileInfo::new("replaced.parquet", 1024, 9),
+        WriteMode::Replace,
+        r.base_snapshot_id,
+        &cols(),
+        &r.column_ids,
+    );
+    assert!(
+        matches!(
+            r_result,
+            Err(datafusion_ducklake::DuckLakeError::Conflict(_))
+        ),
+        "Replace must abort against a concurrently-committed Append, got {r_result:?}"
+    );
+
+    // The appended generation survives (gen0 5 rows + appended 4 = 9); the
+    // Replace did not clobber it.
+    assert_eq!(
+        visible_records_at_head(&pool, cat, tid).await,
+        9,
+        "the committed Append survives; the Replace did not clobber it"
     );
 }
 
@@ -220,19 +803,25 @@ async fn single_catalog_ddl_then_dml_assigns_versions() {
 
     // First commit: DDL (table doesn't exist). publish_snapshot maps the
     // snapshot as the head — the next commit's schema_version is computed over
-    // mapped predecessors, so without publishing the bump wouldn't advance.
+    // mapped predecessors, so without publishing the bump wouldn't advance. The
+    // committed snapshot id is assigned AT the commit, so read it back as the
+    // catalog head right after publish (begin's snapshot_id is vestigial now).
     let setup1 = writer
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
         .unwrap();
     writer
         .publish_snapshot(
             setup1.table_id,
+            "public",
+            "users",
             setup1.snapshot_id,
             WriteMode::Replace,
-            &[],
-            &[],
+            setup1.base_snapshot_id,
+            &cols(),
+            &setup1.column_ids,
         )
         .unwrap();
+    let snap1 = current_head(&pool, catalog_id).await;
 
     // Second commit: same columns -> DML, carry forward schema_version.
     let setup2 = writer
@@ -241,16 +830,20 @@ async fn single_catalog_ddl_then_dml_assigns_versions() {
     writer
         .publish_snapshot(
             setup2.table_id,
+            "public",
+            "users",
             setup2.snapshot_id,
             WriteMode::Replace,
-            &[],
-            &[],
+            setup2.base_snapshot_id,
+            &cols(),
+            &setup2.column_ids,
         )
         .unwrap();
+    let snap2 = current_head(&pool, catalog_id).await;
 
     let v1: i64 =
         sqlx::query("SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = $1")
-            .bind(setup1.snapshot_id)
+            .bind(snap1)
             .fetch_one(&pool)
             .await
             .unwrap()
@@ -258,7 +851,7 @@ async fn single_catalog_ddl_then_dml_assigns_versions() {
             .unwrap();
     let v2: i64 =
         sqlx::query("SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = $1")
-            .bind(setup2.snapshot_id)
+            .bind(snap2)
             .fetch_one(&pool)
             .await
             .unwrap()
@@ -290,15 +883,19 @@ async fn single_catalog_ddl_then_dml_assigns_versions() {
     writer
         .publish_snapshot(
             setup3.table_id,
+            "public",
+            "users",
             setup3.snapshot_id,
             WriteMode::Replace,
-            &[],
-            &[],
+            setup3.base_snapshot_id,
+            &cols_v2,
+            &setup3.column_ids,
         )
         .unwrap();
+    let snap3 = current_head(&pool, catalog_id).await;
     let v3: i64 =
         sqlx::query("SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = $1")
-            .bind(setup3.snapshot_id)
+            .bind(snap3)
             .fetch_one(&pool)
             .await
             .unwrap()
@@ -330,10 +927,13 @@ async fn cross_catalog_isolation_same_schema_name() {
     writer_a
         .publish_snapshot(
             setup_a.table_id,
+            "public",
+            "users",
             setup_a.snapshot_id,
             WriteMode::Replace,
-            &[],
-            &[],
+            setup_a.base_snapshot_id,
+            &cols(),
+            &setup_a.column_ids,
         )
         .unwrap();
     let setup_b = writer_b
@@ -342,17 +942,19 @@ async fn cross_catalog_isolation_same_schema_name() {
     writer_b
         .publish_snapshot(
             setup_b.table_id,
+            "public",
+            "orders",
             setup_b.snapshot_id,
             WriteMode::Replace,
-            &[],
-            &[],
+            setup_b.base_snapshot_id,
+            &cols(),
+            &setup_b.column_ids,
         )
         .unwrap();
 
-    // Schemas: two "public" rows, one per catalog, with different schema_ids.
-    assert_ne!(setup_a.schema_id, setup_b.schema_id);
-
-    // Catalog A's mapping points only at A's schema.
+    // The committed schema ids are assigned at the commit (begin's setup.schema_id
+    // is vestigial for a brand-new schema), so read each catalog's mapped schema
+    // id directly. Two "public" rows, one per catalog, with different schema_ids.
     let schema_ids_a: Vec<i64> =
         sqlx::query("SELECT schema_id FROM ducklake_catalog_schema_map WHERE catalog_id = $1")
             .bind(cat_a)
@@ -362,8 +964,6 @@ async fn cross_catalog_isolation_same_schema_name() {
             .into_iter()
             .map(|r| r.try_get(0).unwrap())
             .collect();
-    assert_eq!(schema_ids_a, vec![setup_a.schema_id]);
-
     let schema_ids_b: Vec<i64> =
         sqlx::query("SELECT schema_id FROM ducklake_catalog_schema_map WHERE catalog_id = $1")
             .bind(cat_b)
@@ -373,7 +973,10 @@ async fn cross_catalog_isolation_same_schema_name() {
             .into_iter()
             .map(|r| r.try_get(0).unwrap())
             .collect();
-    assert_eq!(schema_ids_b, vec![setup_b.schema_id]);
+    // Each catalog maps to exactly one schema, and they are distinct.
+    assert_eq!(schema_ids_a.len(), 1);
+    assert_eq!(schema_ids_b.len(), 1);
+    assert_ne!(schema_ids_a[0], schema_ids_b[0]);
 
     // Each catalog has exactly one snapshot mapping after one write.
     for cat in [cat_a, cat_b] {
@@ -410,38 +1013,60 @@ async fn schema_version_is_per_catalog_dense_under_interleaving() {
     // Each write publishes its snapshot as the head; schema_version is computed
     // over mapped predecessors, so publishing is what lets later DDL bumps see
     // the prior versions (per-catalog dense).
+    // Committed snapshot ids are assigned AT each publish, so read each catalog's
+    // head right after its own publish (begin's snapshot_id is vestigial now).
     // cat_a DDL (creates users)
     let a1 = wa
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
         .unwrap();
-    wa.publish_snapshot(a1.table_id, a1.snapshot_id, WriteMode::Replace, &[], &[])
+    wa.publish_snapshot(a1.table_id,
+"public",
+"users", a1.snapshot_id, WriteMode::Replace, a1.base_snapshot_id, &cols(),
+&a1.column_ids,)
         .unwrap();
+    let a1_snap = current_head(&pool, cat_a).await;
     // cat_a DML (Replace, same schema)
     let a2 = wa
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
         .unwrap();
-    wa.publish_snapshot(a2.table_id, a2.snapshot_id, WriteMode::Replace, &[], &[])
+    wa.publish_snapshot(a2.table_id,
+"public",
+"users", a2.snapshot_id, WriteMode::Replace, a2.base_snapshot_id, &cols(),
+&a2.column_ids,)
         .unwrap();
+    let a2_snap = current_head(&pool, cat_a).await;
     // cat_b DDL (creates orders) — happens in between cat_a's DDLs
     let b1 = wb
         .begin_write_transaction("public", "orders", &cols(), WriteMode::Replace)
         .unwrap();
-    wb.publish_snapshot(b1.table_id, b1.snapshot_id, WriteMode::Replace, &[], &[])
+    wb.publish_snapshot(b1.table_id,
+"public",
+"orders", b1.snapshot_id, WriteMode::Replace, b1.base_snapshot_id, &cols(),
+&b1.column_ids,)
         .unwrap();
+    let b1_snap = current_head(&pool, cat_b).await;
     // cat_a DDL: adds age column
     let mut cols_v2 = cols();
     cols_v2.push(ColumnDef::new("age", "int32", true).unwrap());
     let a3 = wa
         .begin_write_transaction("public", "users", &cols_v2, WriteMode::Replace)
         .unwrap();
-    wa.publish_snapshot(a3.table_id, a3.snapshot_id, WriteMode::Replace, &[], &[])
+    wa.publish_snapshot(a3.table_id,
+"public",
+"users", a3.snapshot_id, WriteMode::Replace, a3.base_snapshot_id, &cols_v2,
+&a3.column_ids,)
         .unwrap();
+    let a3_snap = current_head(&pool, cat_a).await;
     // cat_b DML
     let b2 = wb
         .begin_write_transaction("public", "orders", &cols(), WriteMode::Replace)
         .unwrap();
-    wb.publish_snapshot(b2.table_id, b2.snapshot_id, WriteMode::Replace, &[], &[])
+    wb.publish_snapshot(b2.table_id,
+"public",
+"orders", b2.snapshot_id, WriteMode::Replace, b2.base_snapshot_id, &cols(),
+&b2.column_ids,)
         .unwrap();
+    let b2_snap = current_head(&pool, cat_b).await;
 
     let get_v = |snap_id: i64| {
         let pool = pool.clone();
@@ -456,11 +1081,11 @@ async fn schema_version_is_per_catalog_dense_under_interleaving() {
         }
     };
 
-    assert_eq!(get_v(a1.snapshot_id).await, 1, "cat_a first DDL");
-    assert_eq!(get_v(a2.snapshot_id).await, 1, "cat_a DML carries v1");
-    assert_eq!(get_v(b1.snapshot_id).await, 1, "cat_b first DDL");
-    assert_eq!(get_v(a3.snapshot_id).await, 2, "cat_a column-add DDL");
-    assert_eq!(get_v(b2.snapshot_id).await, 1, "cat_b DML carries v1");
+    assert_eq!(get_v(a1_snap).await, 1, "cat_a first DDL");
+    assert_eq!(get_v(a2_snap).await, 1, "cat_a DML carries v1");
+    assert_eq!(get_v(b1_snap).await, 1, "cat_b first DDL");
+    assert_eq!(get_v(a3_snap).await, 2, "cat_a column-add DDL");
+    assert_eq!(get_v(b2_snap).await, 1, "cat_b DML carries v1");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -480,12 +1105,18 @@ async fn no_orphan_mapping_rows() {
     let s1 = w
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
         .unwrap();
-    w.publish_snapshot(s1.table_id, s1.snapshot_id, WriteMode::Replace, &[], &[])
+    w.publish_snapshot(s1.table_id,
+"public",
+"users", s1.snapshot_id, WriteMode::Replace, s1.base_snapshot_id, &cols(),
+&s1.column_ids,)
         .unwrap();
     let s2 = w
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
         .unwrap();
-    w.publish_snapshot(s2.table_id, s2.snapshot_id, WriteMode::Replace, &[], &[])
+    w.publish_snapshot(s2.table_id,
+"public",
+"users", s2.snapshot_id, WriteMode::Replace, s2.base_snapshot_id, &cols(),
+&s2.column_ids,)
         .unwrap();
 
     // Every entry in the maps must point at a real row.
@@ -527,6 +1158,87 @@ async fn no_orphan_mapping_rows() {
     assert_eq!(unmapped_snaps, 0);
 }
 
+/// Regression for the "dormant rows" leak: a writer that has only begun (reserved
+/// ids, uploaded nothing, NOT committed) must leave NO metadata visible at the
+/// catalog head. Under the commit-time model `begin_write_transaction` inserts no
+/// snapshot/schema/table/column rows at all, so a concurrent committed write on a
+/// DIFFERENT table can advance the head without exposing the in-flight table.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn dormant_rows_invisible_until_publish() {
+    use datafusion_ducklake::MulticatalogProvider;
+    use datafusion_ducklake::metadata_provider::MetadataProvider;
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("pg_dormant").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path("/data").unwrap();
+
+    // Writer A begins on T1 but never registers/publishes (in-flight upload).
+    let a = w
+        .begin_write_transaction("public", "t1", &cols(), WriteMode::Replace)
+        .unwrap();
+
+    // Writer B does a full begin + register on a DIFFERENT table T2, committing
+    // and advancing the catalog head.
+    let b = w
+        .begin_write_transaction("public", "t2", &cols(), WriteMode::Replace)
+        .unwrap();
+    w.register_data_file(
+        b.table_id,
+        "public",
+        "t2",
+        b.snapshot_id,
+        &DataFileInfo::new("t2.parquet", 1024, 5),
+        WriteMode::Replace,
+        b.base_snapshot_id,
+        &cols(),
+        &b.column_ids,
+    )
+    .unwrap();
+
+    // At the new head, T1 is NOT visible — A's reserved ids inserted no rows.
+    let provider = MulticatalogProvider::with_pool_and_id(pool.clone(), cat)
+        .await
+        .unwrap();
+    let head = provider.get_current_snapshot().unwrap();
+    let schema = provider.get_schema_by_name("public", head).unwrap().unwrap();
+    let names: Vec<String> = provider
+        .list_tables(schema.schema_id, head)
+        .unwrap()
+        .into_iter()
+        .map(|t| t.table_name)
+        .collect();
+    assert_eq!(names, vec!["t2"], "only the committed table T2 is visible");
+    assert!(
+        provider
+            .get_table_by_name(schema.schema_id, "t1", head)
+            .unwrap()
+            .is_none(),
+        "in-flight table T1 must be invisible at the head"
+    );
+
+    // Dropping A (it never commits) must leave no orphan visible. The reserved
+    // table id (a.table_id) inserted no row, so there is nothing to clean up.
+    drop(a);
+    let live_t1: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_table WHERE schema_id = $1 AND table_name = 't1'",
+    )
+    .bind(schema.schema_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap();
+    assert_eq!(live_t1, 0, "abandoned begin left no table row");
+    let head_after = provider.get_current_snapshot().unwrap();
+    assert_eq!(head_after, head, "abandoning A did not advance the head");
+}
+
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
 async fn register_data_file_records_against_table() {
@@ -546,18 +1258,21 @@ async fn register_data_file_records_against_table() {
     let file_id = w
         .register_data_file(
             setup.table_id,
+            "public",
+            "users",
             setup.snapshot_id,
             &file,
             WriteMode::Replace,
-            &[],
-            &[],
+            setup.base_snapshot_id,
+            &cols(),
+            &setup.column_ids,
         )
-        .unwrap();
+        .unwrap().snapshot_id;
     assert!(file_id > 0);
 
     let row = sqlx::query(
         "SELECT path, file_size_bytes, record_count, begin_snapshot
-         FROM ducklake_data_file WHERE data_file_id = $1",
+         FROM ducklake_data_file WHERE begin_snapshot = $1",
     )
     .bind(file_id)
     .fetch_one(&pool)
@@ -570,7 +1285,7 @@ async fn register_data_file_records_against_table() {
     assert_eq!(path, "abc.parquet");
     assert_eq!(size, 4096);
     assert_eq!(count, 100);
-    assert_eq!(begin, setup.snapshot_id);
+    assert_eq!(begin, file_id);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -629,11 +1344,14 @@ async fn drop_catalog_removes_populated_catalog() {
         .unwrap();
     w.register_data_file(
         s1.table_id,
+        "public",
+        "users",
         s1.snapshot_id,
         &DataFileInfo::new("u.parquet", 1024, 10),
         WriteMode::Replace,
-        &[],
-        &[],
+        s1.base_snapshot_id,
+        &cols(),
+        &s1.column_ids,
     )
     .unwrap();
 
@@ -644,10 +1362,13 @@ async fn drop_catalog_removes_populated_catalog() {
         .unwrap();
     w.publish_snapshot(
         s_ddl.table_id,
+        "public",
+        "users",
         s_ddl.snapshot_id,
         WriteMode::Replace,
-        &[],
-        &[],
+        s_ddl.base_snapshot_id,
+        &cols_v2,
+        &s_ddl.column_ids,
     )
     .unwrap();
 
@@ -656,11 +1377,14 @@ async fn drop_catalog_removes_populated_catalog() {
         .unwrap();
     w.register_data_file(
         s_orders.table_id,
+        "public",
+        "orders",
         s_orders.snapshot_id,
         &DataFileInfo::new("o.parquet", 2048, 20),
         WriteMode::Replace,
-        &[],
-        &[],
+        s_orders.base_snapshot_id,
+        &cols(),
+        &s_orders.column_ids,
     )
     .unwrap();
 
@@ -730,11 +1454,14 @@ async fn drop_catalog_isolates_other_catalogs() {
         .unwrap();
     wa.register_data_file(
         sa.table_id,
+        "public",
+        "users",
         sa.snapshot_id,
         &DataFileInfo::new("a.parquet", 1024, 10),
         WriteMode::Replace,
-        &[],
-        &[],
+        sa.base_snapshot_id,
+        &cols(),
+        &sa.column_ids,
     )
     .unwrap();
 
@@ -743,11 +1470,14 @@ async fn drop_catalog_isolates_other_catalogs() {
         .unwrap();
     wb.register_data_file(
         sb.table_id,
+        "public",
+        "orders",
         sb.snapshot_id,
         &DataFileInfo::new("b.parquet", 2048, 20),
         WriteMode::Replace,
-        &[],
-        &[],
+        sb.base_snapshot_id,
+        &cols(),
+        &sb.column_ids,
     )
     .unwrap();
 
@@ -912,11 +1642,14 @@ async fn drop_table_in_catalog_tombstones_table_and_children() {
         .unwrap();
     w.register_data_file(
         s.table_id,
+        "public",
+        "users",
         s.snapshot_id,
         &DataFileInfo::new("u.parquet", 1024, 10),
         WriteMode::Replace,
-        &[],
-        &[],
+        s.base_snapshot_id,
+        &cols(),
+        &s.column_ids,
     )
     .unwrap();
 
@@ -1026,11 +1759,14 @@ async fn drop_table_in_catalog_hides_table_from_read_path_and_preserves_time_tra
         .unwrap();
     w.register_data_file(
         s.table_id,
+        "public",
+        "users",
         s.snapshot_id,
         &DataFileInfo::new("u.parquet", 1024, 10),
         WriteMode::Replace,
-        &[],
-        &[],
+        s.base_snapshot_id,
+        &cols(),
+        &s.column_ids,
     )
     .unwrap();
 
@@ -1104,11 +1840,14 @@ async fn drop_table_in_catalog_is_idempotent_on_second_call() {
         .unwrap();
     w.register_data_file(
         s.table_id,
+        "public",
+        "users",
         s.snapshot_id,
         &DataFileInfo::new("u.parquet", 1024, 10),
         WriteMode::Replace,
-        &[],
-        &[],
+        s.base_snapshot_id,
+        &cols(),
+        &s.column_ids,
     )
     .unwrap();
 
@@ -1165,11 +1904,14 @@ async fn drop_table_in_catalog_does_not_touch_siblings() {
         .unwrap();
     w.register_data_file(
         s_users.table_id,
+        "public",
+        "users",
         s_users.snapshot_id,
         &DataFileInfo::new("u.parquet", 1024, 10),
         WriteMode::Replace,
-        &[],
-        &[],
+        s_users.base_snapshot_id,
+        &cols(),
+        &s_users.column_ids,
     )
     .unwrap();
 
@@ -1178,11 +1920,14 @@ async fn drop_table_in_catalog_does_not_touch_siblings() {
         .unwrap();
     w.register_data_file(
         s_orders.table_id,
+        "public",
+        "orders",
         s_orders.snapshot_id,
         &DataFileInfo::new("o.parquet", 2048, 20),
         WriteMode::Replace,
-        &[],
-        &[],
+        s_orders.base_snapshot_id,
+        &cols(),
+        &s_orders.column_ids,
     )
     .unwrap();
 
@@ -1192,11 +1937,14 @@ async fn drop_table_in_catalog_does_not_touch_siblings() {
         .unwrap();
     w.register_data_file(
         s_other_users.table_id,
+        "analytics",
+        "users",
         s_other_users.snapshot_id,
         &DataFileInfo::new("au.parquet", 512, 5),
         WriteMode::Replace,
-        &[],
-        &[],
+        s_other_users.base_snapshot_id,
+        &cols(),
+        &s_other_users.column_ids,
     )
     .unwrap();
 
@@ -1292,11 +2040,14 @@ async fn drop_table_in_catalog_allows_recreate_with_fresh_identity() {
         .unwrap();
     w.register_data_file(
         s1.table_id,
+        "public",
+        "users",
         s1.snapshot_id,
         &DataFileInfo::new("v1.parquet", 1024, 10),
         WriteMode::Replace,
-        &[],
-        &[],
+        s1.base_snapshot_id,
+        &cols(),
+        &s1.column_ids,
     )
     .unwrap();
 
@@ -1319,11 +2070,14 @@ async fn drop_table_in_catalog_allows_recreate_with_fresh_identity() {
     );
     w.register_data_file(
         s2.table_id,
+        "public",
+        "users",
         s2.snapshot_id,
         &DataFileInfo::new("v2.parquet", 2048, 20),
         WriteMode::Replace,
-        &[],
-        &[],
+        s2.base_snapshot_id,
+        &cols(),
+        &s2.column_ids,
     )
     .unwrap();
 
@@ -1370,19 +2124,23 @@ async fn drop_table_in_catalog_bumps_schema_version_as_ddl() {
     let s = w
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
         .unwrap();
-    w.register_data_file(
-        s.table_id,
-        s.snapshot_id,
-        &DataFileInfo::new("u.parquet", 1024, 10),
-        WriteMode::Replace,
-        &[],
-        &[],
-    )
-    .unwrap();
+    let create_snap = w
+        .register_data_file(
+            s.table_id,
+            "public",
+            "users",
+            s.snapshot_id,
+            &DataFileInfo::new("u.parquet", 1024, 10),
+            WriteMode::Replace,
+            s.base_snapshot_id,
+            &cols(),
+            &s.column_ids,
+        )
+        .unwrap().snapshot_id;
 
     let v_create: i64 =
         sqlx::query("SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = $1")
-            .bind(s.snapshot_id)
+            .bind(create_snap)
             .fetch_one(&pool)
             .await
             .unwrap()
@@ -1442,11 +2200,14 @@ async fn drop_table_in_catalog_isolates_other_catalogs() {
         .unwrap();
     wa.register_data_file(
         sa.table_id,
+        "public",
+        "users",
         sa.snapshot_id,
         &DataFileInfo::new("a.parquet", 1024, 10),
         WriteMode::Replace,
-        &[],
-        &[],
+        sa.base_snapshot_id,
+        &cols(),
+        &sa.column_ids,
     )
     .unwrap();
 
@@ -1455,11 +2216,14 @@ async fn drop_table_in_catalog_isolates_other_catalogs() {
         .unwrap();
     wb.register_data_file(
         sb.table_id,
+        "public",
+        "users",
         sb.snapshot_id,
         &DataFileInfo::new("b.parquet", 2048, 20),
         WriteMode::Replace,
-        &[],
-        &[],
+        sb.base_snapshot_id,
+        &cols(),
+        &sb.column_ids,
     )
     .unwrap();
 
@@ -1564,29 +2328,38 @@ async fn register_data_file_assigns_non_overlapping_row_id_start() {
     // next_row_id = 350 after all three.
     w.register_data_file(
         setup.table_id,
+        "public",
+        "users",
         setup.snapshot_id,
         &DataFileInfo::new("f1.parquet", 4096, 100),
         WriteMode::Replace,
-        &[],
-        &[],
+        setup.base_snapshot_id,
+        &cols(),
+        &setup.column_ids,
     )
     .unwrap();
     w.register_data_file(
         setup.table_id,
+        "public",
+        "users",
         setup.snapshot_id,
         &DataFileInfo::new("f2.parquet", 2048, 50),
         WriteMode::Append,
-        &[],
-        &[],
+        setup.base_snapshot_id,
+        &cols(),
+        &setup.column_ids,
     )
     .unwrap();
     w.register_data_file(
         setup.table_id,
+        "public",
+        "users",
         setup.snapshot_id,
         &DataFileInfo::new("f3.parquet", 8192, 200),
         WriteMode::Append,
-        &[],
-        &[],
+        setup.base_snapshot_id,
+        &cols(),
+        &setup.column_ids,
     )
     .unwrap();
 
@@ -1622,11 +2395,14 @@ async fn replace_preserves_next_row_id_monotonic() {
 
     w.register_data_file(
         s1.table_id,
+        "public",
+        "users",
         s1.snapshot_id,
         &DataFileInfo::new("g1.parquet", 1024, 5),
         WriteMode::Replace,
-        &[],
-        &[],
+        s1.base_snapshot_id,
+        &cols(),
+        &s1.column_ids,
     )
     .unwrap();
     let (rc1, next1, _) = read_table_stats(&pool, s1.table_id).await;
@@ -1639,7 +2415,10 @@ async fn replace_preserves_next_row_id_monotonic() {
     let s2 = w
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
         .unwrap();
-    w.publish_snapshot(s2.table_id, s2.snapshot_id, WriteMode::Replace, &[], &[])
+    w.publish_snapshot(s2.table_id,
+"public",
+"users", s2.snapshot_id, WriteMode::Replace, s2.base_snapshot_id, &cols(),
+&s2.column_ids,)
         .unwrap();
     let (rc2, next2, bytes2) = read_table_stats(&pool, s2.table_id).await;
     assert_eq!(rc2, 0, "record_count must reset on Replace");
@@ -1650,11 +2429,14 @@ async fn replace_preserves_next_row_id_monotonic() {
     // already published above, so this registration is additive (Append).
     w.register_data_file(
         s2.table_id,
+        "public",
+        "users",
         s2.snapshot_id,
         &DataFileInfo::new("g2.parquet", 2048, 2),
         WriteMode::Append,
-        &[],
-        &[],
+        s2.base_snapshot_id,
+        &cols(),
+        &s2.column_ids,
     )
     .unwrap();
     assert_eq!(
@@ -1682,22 +2464,16 @@ async fn register_data_file_self_initialises_stats_for_legacy_tables() {
         .begin_write_transaction("public", "users", &cols(), WriteMode::Replace)
         .unwrap();
 
-    // Simulate "legacy" state by removing whatever stats row may have been
-    // pre-populated. begin_write_transaction doesn't currently insert one,
-    // but being explicit keeps the test meaningful if that changes.
-    sqlx::query("DELETE FROM ducklake_table_stats WHERE table_id = $1")
-        .bind(setup.table_id)
-        .execute(&pool)
-        .await
-        .unwrap();
-
     w.register_data_file(
         setup.table_id,
+        "public",
+        "users",
         setup.snapshot_id,
         &DataFileInfo::new("a.parquet", 50, 4),
         WriteMode::Replace,
-        &[],
-        &[],
+        setup.base_snapshot_id,
+        &cols(),
+        &setup.column_ids,
     )
     .unwrap();
     assert_eq!(read_row_id_start(&pool, "a.parquet").await, Some(0));
@@ -1718,46 +2494,56 @@ fn three_generations(
     table: &str,
 ) -> (i64, i64, i64, i64) {
     use datafusion_ducklake::metadata_writer::DataFileInfo;
+    // register_data_file returns the committed snapshot id (assigned at commit).
     let s1 = writer
         .begin_write_transaction(schema, table, &cols(), WriteMode::Replace)
         .unwrap();
-    writer
+    let snap1 = writer
         .register_data_file(
             s1.table_id,
+            schema,
+            table,
             s1.snapshot_id,
             &DataFileInfo::new("f1.parquet", 100, 5),
             WriteMode::Replace,
-            &[],
-            &[],
+            s1.base_snapshot_id,
+            &cols(),
+            &s1.column_ids,
         )
-        .unwrap();
+        .unwrap().snapshot_id;
     let s2 = writer
         .begin_write_transaction(schema, table, &cols(), WriteMode::Replace)
         .unwrap();
-    writer
+    let snap2 = writer
         .register_data_file(
             s2.table_id,
+            schema,
+            table,
             s2.snapshot_id,
             &DataFileInfo::new("f2.parquet", 100, 5),
             WriteMode::Replace,
-            &[],
-            &[],
+            s2.base_snapshot_id,
+            &cols(),
+            &s2.column_ids,
         )
-        .unwrap();
+        .unwrap().snapshot_id;
     let s3 = writer
         .begin_write_transaction(schema, table, &cols(), WriteMode::Replace)
         .unwrap();
-    writer
+    let snap3 = writer
         .register_data_file(
             s3.table_id,
+            schema,
+            table,
             s3.snapshot_id,
             &DataFileInfo::new("f3.parquet", 100, 5),
             WriteMode::Replace,
-            &[],
-            &[],
+            s3.base_snapshot_id,
+            &cols(),
+            &s3.column_ids,
         )
-        .unwrap();
-    (s1.table_id, s1.snapshot_id, s2.snapshot_id, s3.snapshot_id)
+        .unwrap().snapshot_id;
+    (s1.table_id, snap1, snap2, snap3)
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1778,11 +2564,14 @@ async fn expire_in_catalog_empty_for_most_recent_and_unknown() {
         .unwrap();
     w.register_data_file(
         s.table_id,
+        "public",
+        "t",
         s.snapshot_id,
         &DataFileInfo::new("f1.parquet", 100, 5),
         WriteMode::Replace,
-        &[],
-        &[],
+        s.base_snapshot_id,
+        &cols(),
+        &s.column_ids,
     )
     .unwrap();
 
@@ -1889,15 +2678,19 @@ async fn expire_in_catalog_full_after_drop_removes_table_metadata() {
     let s = w
         .begin_write_transaction("public", "t", &cols(), WriteMode::Replace)
         .unwrap();
-    w.register_data_file(
-        s.table_id,
-        s.snapshot_id,
-        &DataFileInfo::new("f1.parquet", 100, 5),
-        WriteMode::Replace,
-        &[],
-        &[],
-    )
-    .unwrap();
+    let create_snap = w
+        .register_data_file(
+            s.table_id,
+            "public",
+            "t",
+            s.snapshot_id,
+            &DataFileInfo::new("f1.parquet", 100, 5),
+            WriteMode::Replace,
+            s.base_snapshot_id,
+            &cols(),
+            &s.column_ids,
+        )
+        .unwrap().snapshot_id;
 
     // Drop allocates a second snapshot; expire the first (the drop snapshot is kept).
     assert!(
@@ -1906,7 +2699,7 @@ async fn expire_in_catalog_full_after_drop_removes_table_metadata() {
             .unwrap()
     );
     let expired = mgr
-        .expire_snapshots_in_catalog("pg_prod", ExpireCriteria::Versions(vec![s.snapshot_id]))
+        .expire_snapshots_in_catalog("pg_prod", ExpireCriteria::Versions(vec![create_snap]))
         .await
         .unwrap();
     assert_eq!(expired.len(), 1);
@@ -1964,46 +2757,58 @@ async fn expire_in_catalog_is_scoped_to_catalog() {
     let a1 = wa
         .begin_write_transaction("public", "t", &cols(), WriteMode::Replace)
         .unwrap();
-    wa.register_data_file(
-        a1.table_id,
-        a1.snapshot_id,
-        &DataFileInfo::new("f1.parquet", 100, 5),
-        WriteMode::Replace,
-        &[],
-        &[],
-    )
-    .unwrap();
+    let a1_snap = wa
+        .register_data_file(
+            a1.table_id,
+            "public",
+            "t",
+            a1.snapshot_id,
+            &DataFileInfo::new("f1.parquet", 100, 5),
+            WriteMode::Replace,
+            a1.base_snapshot_id,
+            &cols(),
+            &a1.column_ids,
+        )
+        .unwrap().snapshot_id;
     let b1 = wb
         .begin_write_transaction("public", "u", &cols(), WriteMode::Replace)
         .unwrap();
-    wb.register_data_file(
-        b1.table_id,
-        b1.snapshot_id,
-        &DataFileInfo::new("g1.parquet", 100, 5),
-        WriteMode::Replace,
-        &[],
-        &[],
-    )
-    .unwrap();
+    let b1_snap = wb
+        .register_data_file(
+            b1.table_id,
+            "public",
+            "u",
+            b1.snapshot_id,
+            &DataFileInfo::new("g1.parquet", 100, 5),
+            WriteMode::Replace,
+            b1.base_snapshot_id,
+            &cols(),
+            &b1.column_ids,
+        )
+        .unwrap().snapshot_id;
     let a2 = wa
         .begin_write_transaction("public", "t", &cols(), WriteMode::Replace)
         .unwrap();
-    wa.register_data_file(
-        a2.table_id,
-        a2.snapshot_id,
-        &DataFileInfo::new("f2.parquet", 100, 5),
-        WriteMode::Replace,
-        &[],
-        &[],
-    )
-    .unwrap();
+    let a2_snap = wa
+        .register_data_file(
+            a2.table_id,
+            "public",
+            "t",
+            a2.snapshot_id,
+            &DataFileInfo::new("f2.parquet", 100, 5),
+            WriteMode::Replace,
+            a2.base_snapshot_id,
+            &cols(),
+            &a2.column_ids,
+        )
+        .unwrap().snapshot_id;
     assert!(
-        b1.snapshot_id > a1.snapshot_id && b1.snapshot_id < a2.snapshot_id,
+        b1_snap > a1_snap && b1_snap < a2_snap,
         "test setup: B's snapshot must fall inside A/f1's lifetime range"
     );
 
     let expired = mgr
-        .expire_snapshots_in_catalog("cat_a", ExpireCriteria::Versions(vec![a1.snapshot_id]))
+        .expire_snapshots_in_catalog("cat_a", ExpireCriteria::Versions(vec![a1_snap]))
         .await
         .unwrap();
     assert_eq!(expired.len(), 1);
@@ -2025,7 +2830,7 @@ async fn expire_in_catalog_is_scoped_to_catalog() {
 
     // Catalog B is entirely untouched.
     let b_snap: i64 = sqlx::query("SELECT COUNT(*) FROM ducklake_snapshot WHERE snapshot_id = $1")
-        .bind(b1.snapshot_id)
+        .bind(b1_snap)
         .fetch_one(&pool)
         .await
         .unwrap()
@@ -2088,11 +2893,14 @@ async fn cleanup_old_files_in_catalog_is_scoped_to_catalog() {
         .unwrap();
     wa.register_data_file(
         a1.table_id,
+        "public",
+        "t",
         a1.snapshot_id,
         &DataFileInfo::new("f1.parquet", 100, 5),
         WriteMode::Replace,
-        &[],
-        &[],
+        a1.base_snapshot_id,
+        &cols(),
+        &a1.column_ids,
     )
     .unwrap();
     let a2 = wa
@@ -2100,11 +2908,14 @@ async fn cleanup_old_files_in_catalog_is_scoped_to_catalog() {
         .unwrap();
     wa.register_data_file(
         a2.table_id,
+        "public",
+        "t",
         a2.snapshot_id,
         &DataFileInfo::new("f2.parquet", 100, 5),
         WriteMode::Replace,
-        &[],
-        &[],
+        a2.base_snapshot_id,
+        &cols(),
+        &a2.column_ids,
     )
     .unwrap();
     let b1 = wb
@@ -2112,11 +2923,14 @@ async fn cleanup_old_files_in_catalog_is_scoped_to_catalog() {
         .unwrap();
     wb.register_data_file(
         b1.table_id,
+        "public",
+        "u",
         b1.snapshot_id,
         &DataFileInfo::new("g1.parquet", 100, 5),
         WriteMode::Replace,
-        &[],
-        &[],
+        b1.base_snapshot_id,
+        &cols(),
+        &b1.column_ids,
     )
     .unwrap();
     let b2 = wb
@@ -2124,11 +2938,14 @@ async fn cleanup_old_files_in_catalog_is_scoped_to_catalog() {
         .unwrap();
     wb.register_data_file(
         b2.table_id,
+        "public",
+        "u",
         b2.snapshot_id,
         &DataFileInfo::new("g2.parquet", 100, 5),
         WriteMode::Replace,
-        &[],
-        &[],
+        b2.base_snapshot_id,
+        &cols(),
+        &b2.column_ids,
     )
     .unwrap();
 
@@ -2229,11 +3046,14 @@ async fn delete_orphaned_files_reclaims_dropped_catalog_files() {
         .unwrap();
     wa.register_data_file(
         s.table_id,
+        "public",
+        "t",
         s.snapshot_id,
         &DataFileInfo::new("f1.parquet", 100, 5),
         WriteMode::Replace,
-        &[],
-        &[],
+        s.base_snapshot_id,
+        &cols(),
+        &s.column_ids,
     )
     .unwrap();
     let dir = data_path.join("public").join("t");
@@ -2289,11 +3109,14 @@ async fn delete_orphaned_files_spares_files_referenced_by_any_catalog() {
         .unwrap();
     wa.register_data_file(
         sa.table_id,
+        "public",
+        "t",
         sa.snapshot_id,
         &DataFileInfo::new("a.parquet", 100, 5),
         WriteMode::Replace,
-        &[],
-        &[],
+        sa.base_snapshot_id,
+        &cols(),
+        &sa.column_ids,
     )
     .unwrap();
     let sb = wb
@@ -2301,11 +3124,14 @@ async fn delete_orphaned_files_spares_files_referenced_by_any_catalog() {
         .unwrap();
     wb.register_data_file(
         sb.table_id,
+        "public",
+        "u",
         sb.snapshot_id,
         &DataFileInfo::new("b.parquet", 100, 5),
         WriteMode::Replace,
-        &[],
-        &[],
+        sb.base_snapshot_id,
+        &cols(),
+        &sb.column_ids,
     )
     .unwrap();
 
@@ -2421,11 +3247,14 @@ async fn delete_orphaned_files_dry_run_matches_real_run() {
         .unwrap();
     w.register_data_file(
         s.table_id,
+        "public",
+        "t",
         s.snapshot_id,
         &DataFileInfo::new("ref.parquet", 100, 5),
         WriteMode::Replace,
-        &[],
-        &[],
+        s.base_snapshot_id,
+        &cols(),
+        &s.column_ids,
     )
     .unwrap();
     let dir = data_path.join("public").join("t");
@@ -2589,5 +3418,138 @@ async fn writes_segregate_data_files_by_catalog_directory() {
         top_segments.len(),
         2,
         "two catalogs must land under distinct cat_<id> top segments: {top_segments:?}",
+    );
+}
+
+/// End-to-end VALUE round-trip on the multicatalog write path.
+///
+/// Every other test in this file asserts on catalog rows / `record_count` sums.
+/// None of them read the actual data back, so a field-id drift or NULL-fill
+/// corruption (the exact failure modes the commit-time rework guards against)
+/// could pass them all. This test writes real parquet via `DuckLakeTableWriter`
+/// and reads the VALUES back through `DuckLakeCatalog` + DataFusion SQL across
+/// three generations:
+///   1. initial Replace  -> values round-trip (not NULL)
+///   2. second  Replace  -> only the NEW generation is visible (no union/NULL)
+///   3. Append           -> rows add to the current generation (values intact)
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn multicatalog_write_read_value_roundtrip() {
+    use arrow::array::{Array, Int64Array, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use datafusion::prelude::SessionContext;
+    use datafusion_ducklake::{DuckLakeCatalog, MulticatalogProvider};
+    use object_store::ObjectStore;
+    use object_store::local::LocalFileSystem;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("rt").await.unwrap();
+    let writer = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    let temp = TempDir::new().unwrap();
+    let data_path = temp.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+    writer.set_data_path(data_path.to_str().unwrap()).unwrap();
+
+    let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+    let tw = DuckLakeTableWriter::new(Arc::new(writer), store).unwrap();
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("name", DataType::Utf8, true),
+    ]));
+    let mk = |ids: Vec<i64>, names: Vec<&'static str>| {
+        RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(ids)) as Arc<dyn arrow::array::Array>,
+                Arc::new(StringArray::from(
+                    names.into_iter().map(Some).collect::<Vec<_>>(),
+                )),
+            ],
+        )
+        .unwrap()
+    };
+
+    // Read every row back through the real read path (fresh catalog bound to the
+    // current head each call) and materialise (id, name) tuples.
+    let read_rows = |pool: PgPool| async move {
+        let provider = MulticatalogProvider::with_pool(pool, "rt").await.unwrap();
+        let catalog = DuckLakeCatalog::new(provider).unwrap();
+        let ctx = SessionContext::new();
+        ctx.register_catalog("rt", Arc::new(catalog));
+        let batches = ctx
+            .sql("SELECT id, name FROM rt.public.t ORDER BY id")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        let mut out: Vec<(i64, Option<String>)> = Vec::new();
+        for b in &batches {
+            let ids = b
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("id column is Int64");
+            let names = b
+                .column(1)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("name column is Utf8");
+            for i in 0..b.num_rows() {
+                let name = if names.is_null(i) {
+                    None
+                } else {
+                    Some(names.value(i).to_string())
+                };
+                out.push((ids.value(i), name));
+            }
+        }
+        out
+    };
+
+    // 1. Initial write (Replace). Values must come back intact, not NULL.
+    tw.write_table("public", "t", &[mk(vec![1, 2, 3], vec!["a", "b", "c"])])
+        .await
+        .unwrap();
+    assert_eq!(
+        read_rows(pool.clone()).await,
+        vec![
+            (1, Some("a".into())),
+            (2, Some("b".into())),
+            (3, Some("c".into())),
+        ],
+        "initial generation values must round-trip (not NULL / not empty)",
+    );
+
+    // 2. Replace with a new generation. ONLY the new rows are visible — the old
+    //    files are retired, not unioned, and the new values are intact.
+    tw.write_table("public", "t", &[mk(vec![10, 20], vec!["x", "y"])])
+        .await
+        .unwrap();
+    assert_eq!(
+        read_rows(pool.clone()).await,
+        vec![(10, Some("x".into())), (20, Some("y".into()))],
+        "Replace must expose only the new generation (no union, no NULL fill)",
+    );
+
+    // 3. Append to the current generation. Rows add; existing values stay intact.
+    tw.append_table("public", "t", &[mk(vec![30], vec!["z"])])
+        .await
+        .unwrap();
+    assert_eq!(
+        read_rows(pool.clone()).await,
+        vec![
+            (10, Some("x".into())),
+            (20, Some("y".into())),
+            (30, Some("z".into())),
+        ],
+        "Append must add to the current generation with values intact",
     );
 }

--- a/tests/multicatalog_provider_tests.rs
+++ b/tests/multicatalog_provider_tests.rs
@@ -51,33 +51,40 @@ async fn seed_two_catalogs(pool: &PgPool) -> anyhow::Result<(i64, i64)> {
     let wb = PostgresMetadataWriter::with_pool(pool.clone(), cat_mysql).await?;
     wa.set_data_path("/data")?;
 
+    // Columns are written at the commit now (multicatalog Postgres), so the
+    // register must carry the table/column generation, not `&[]`.
     let reg = |w: &PostgresMetadataWriter,
+               table: &str,
+               cols: &[ColumnDef],
                setup: datafusion_ducklake::metadata_writer::WriteSetupResult,
                fname: &str| {
         w.register_data_file(
             setup.table_id,
+            "public",
+            table,
             setup.snapshot_id,
             &DataFileInfo::new(fname, 1024, 3),
             WriteMode::Replace,
-            &[],
-            &[],
+            setup.base_snapshot_id,
+            cols,
+            &setup.column_ids,
         )
         .unwrap();
     };
 
     // pg_prod: DDL, then DML
     let s1 = wa.begin_write_transaction("public", "users", &users_cols(), WriteMode::Replace)?;
-    reg(&wa, s1, "users-a.parquet");
+    reg(&wa, "users", &users_cols(), s1, "users-a.parquet");
     let s2 = wa.begin_write_transaction("public", "users", &users_cols(), WriteMode::Replace)?;
-    reg(&wa, s2, "users-b.parquet");
+    reg(&wa, "users", &users_cols(), s2, "users-b.parquet");
     // mysql_prod: DDL
     let s3 = wb.begin_write_transaction("public", "orders", &orders_cols(), WriteMode::Replace)?;
-    reg(&wb, s3, "orders-a.parquet");
+    reg(&wb, "orders", &orders_cols(), s3, "orders-a.parquet");
     // pg_prod: column-add DDL
     let mut v2 = users_cols();
     v2.push(ColumnDef::new("age", "int32", true).unwrap());
     let s4 = wa.begin_write_transaction("public", "users", &v2, WriteMode::Replace)?;
-    reg(&wa, s4, "users-c.parquet");
+    reg(&wa, "users", &v2, s4, "users-c.parquet");
     Ok((cat_pg, cat_mysql))
 }
 
@@ -237,7 +244,7 @@ async fn table_structure_reflects_latest_columns_after_ddl() {
         .unwrap()
         .unwrap();
 
-    let cols = pa.get_table_structure(table.table_id).unwrap();
+    let cols = pa.get_table_structure(table.table_id, sn).unwrap();
     // After the column-add DDL: id, name, age
     assert_eq!(cols.len(), 3);
     assert_eq!(cols[0].column_name, "id");

--- a/tests/mysql_metadata_provider_test.rs
+++ b/tests/mysql_metadata_provider_test.rs
@@ -425,7 +425,8 @@ async fn populate_from_duckdb_catalog(
             .execute(pool)
             .await?;
 
-            let columns = duckdb_provider.get_table_structure(table.table_id)?;
+            let columns = duckdb_provider
+                .get_table_structure(table.table_id, duckdb_provider.get_current_snapshot()?)?;
 
             for (order, column) in columns.iter().enumerate() {
                 sqlx::query(
@@ -730,8 +731,11 @@ async fn test_get_table_structure() {
         .await
         .expect("Failed to populate test data");
 
+    let snapshot = provider
+        .get_current_snapshot()
+        .expect("Should get snapshot");
     let columns = provider
-        .get_table_structure(1)
+        .get_table_structure(1, snapshot)
         .expect("Should get table structure");
 
     assert_eq!(columns.len(), 3, "users table should have 3 columns");
@@ -867,13 +871,13 @@ async fn test_concurrent_access() {
     for _ in 0..10 {
         let provider = provider.clone();
         let task = tokio::spawn(async move {
-            let _snapshot = provider
+            let snapshot = provider
                 .get_current_snapshot()
                 .expect("Should get snapshot");
             let _schemas = provider.list_schemas(1).expect("Should list schemas");
             let _tables = provider.list_tables(1, 1).expect("Should list tables");
             let _columns = provider
-                .get_table_structure(1)
+                .get_table_structure(1, snapshot)
                 .expect("Should get structure");
         });
         tasks.push(task);

--- a/tests/postgres_metadata_provider_test.rs
+++ b/tests/postgres_metadata_provider_test.rs
@@ -444,7 +444,8 @@ async fn populate_from_duckdb_catalog(
             .await?;
 
             // Get columns for this table
-            let columns = duckdb_provider.get_table_structure(table.table_id)?;
+            let columns = duckdb_provider
+                .get_table_structure(table.table_id, duckdb_provider.get_current_snapshot()?)?;
 
             for (order, column) in columns.iter().enumerate() {
                 sqlx::query(
@@ -754,8 +755,11 @@ async fn test_get_table_structure() {
         .await
         .expect("Failed to populate test data");
 
+    let snapshot = provider
+        .get_current_snapshot()
+        .expect("Should get snapshot");
     let columns = provider
-        .get_table_structure(1)
+        .get_table_structure(1, snapshot)
         .expect("Should get table structure");
 
     assert_eq!(columns.len(), 3, "users table should have 3 columns");
@@ -893,13 +897,13 @@ async fn test_concurrent_access() {
         let provider = provider.clone();
         let task = tokio::spawn(async move {
             // Each task performs multiple operations
-            let _snapshot = provider
+            let snapshot = provider
                 .get_current_snapshot()
                 .expect("Should get snapshot");
             let _schemas = provider.list_schemas(1).expect("Should list schemas");
             let _tables = provider.list_tables(1, 1).expect("Should list tables");
             let _columns = provider
-                .get_table_structure(1)
+                .get_table_structure(1, snapshot)
                 .expect("Should get structure");
         });
         tasks.push(task);

--- a/tests/sqlite_metadata_provider_test.rs
+++ b/tests/sqlite_metadata_provider_test.rs
@@ -422,7 +422,8 @@ async fn populate_from_duckdb_catalog(
             .execute(pool)
             .await?;
 
-            let columns = duckdb_provider.get_table_structure(table.table_id)?;
+            let columns = duckdb_provider
+                .get_table_structure(table.table_id, duckdb_provider.get_current_snapshot()?)?;
 
             for (order, column) in columns.iter().enumerate() {
                 sqlx::query(
@@ -717,8 +718,11 @@ async fn test_get_table_structure() {
         .await
         .expect("Failed to populate test data");
 
+    let snapshot = provider
+        .get_current_snapshot()
+        .expect("Should get snapshot");
     let columns = provider
-        .get_table_structure(1)
+        .get_table_structure(1, snapshot)
         .expect("Should get table structure");
 
     assert_eq!(columns.len(), 3, "users table should have 3 columns");
@@ -852,13 +856,13 @@ async fn test_concurrent_access() {
     for _ in 0..10 {
         let provider = provider.clone();
         let task = tokio::spawn(async move {
-            let _snapshot = provider
+            let snapshot = provider
                 .get_current_snapshot()
                 .expect("Should get snapshot");
             let _schemas = provider.list_schemas(1).expect("Should list schemas");
             let _tables = provider.list_tables(1, 1).expect("Should list tables");
             let _columns = provider
-                .get_table_structure(1)
+                .get_table_structure(1, snapshot)
                 .expect("Should get structure");
         });
         tasks.push(task);


### PR DESCRIPTION
## Summary

Fixes #146.

On the **experimental PostgreSQL multi-catalog write path**, concurrent `WriteMode::Replace` could end up **unioning two conflicting generations** of a table instead of rejecting one of them, and committed-but-unpublished ("dormant") snapshot rows could leak into reads and conflict checks.

### Root cause

The multi-catalog writer assigned each snapshot's `snapshot_id` at the *start* of the write (global `IDENTITY`), then advanced the per-catalog head separately at commit. So **id order ≠ commit order**, and a scalar `head >= begin_snapshot` comparison was unsafe: a writer could observe/conflict-check against rows that were committed but not yet published. Two `Replace` writers opening on the same base could both publish, and the reader would union them.

### Fix — converge onto DuckLake's commit-time model

- **Assign `snapshot_id` at commit** via a plain `IDENTITY` insert, so ids are **commit-ordered**. `begin_write_transaction` only *reserves* column/schema/table ids (via `nextval(pg_get_serial_sequence(...))`) and reads the base generation.
- **Write all of a snapshot's metadata in one transaction** — snapshot row, schema/table, columns, data files — and **publish the head last**. Dormant rows are therefore never visible.
- **Reads are snapshot-scoped**: `MetadataProvider::get_table_structure` now takes a `snapshot_id` and filters columns/files to the snapshot's validity window, so unpublished rows can't appear.
- **`Replace` performs a commit-time conflict check** over data files *and* columns and aborts with `DuckLakeError::Conflict` when another writer published a newer generation since this write began (no more silent union). The old per-table CAS was removed.
- **Stable column field-ids**: a same-schema `Replace` updates columns surgically (`column_id == parquet field_id` stays stable) instead of re-minting. An `Append` racing a table creation aborts on field-id drift rather than producing NULL-filled reads.
- `register_data_file` / `publish_snapshot` now return `CommitIds { snapshot_id, schema_id, table_id }` carrying the **real committed** ids (the begin-time ids are vestigial on this path).

### Compatibility

- **No on-disk format change**, **no DuckLake spec divergence**, **no public API change**. The single-catalog SQLite path keeps its existing commit-time behavior; the trait gained name/base parameters that SQLite ignores.

## Testing

- New end-to-end **value round-trip** test on the multi-catalog path (`multicatalog_write_read_value_roundtrip`): writes real Parquet via `DuckLakeTableWriter`, reads the actual values back through `DuckLakeCatalog` + DataFusion SQL across initial `Replace` → second `Replace` (only the new generation visible, no union/NULL) → `Append` (rows combine, values intact). This is the first multi-catalog test that reads data values rather than catalog rows / `record_count` sums, so it catches field-id-drift / NULL-fill corruption.
- New regression tests: concurrent `Replace` aborts instead of unioning, dormant rows invisible until publish, stable column ids across same-schema `Replace`, and `Append`-racing-create aborts on field-id drift.
- Full suites green: multi-catalog Postgres **41 passed / 4 ignored**, SQLite write **19 passed**. `clippy` clean on default and the full write feature set.

Postgres/multi-catalog tests require Docker (`testcontainers`).
