### PR TITLE
fix(read): match nested-column field-ids by top-level field, not leaf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Concurrent `WriteMode::Replace` on the experimental PostgreSQL multi-catalog write path could union conflicting generations instead of rejecting one.** Converged the multi-catalog writer onto DuckLake's commit-time model: a snapshot's id is assigned at commit (commit-ordered), and all of its metadata — snapshot, schema/table, columns, data files, and the published head — is written in a single transaction, so committed-but-unpublished rows are never visible to readers or conflict checks. `Replace` now aborts with a `Conflict` error when another writer published a newer generation of the table since the write began. Column field-ids stay stable across a same-schema `Replace`, and an `Append` racing a table creation aborts rather than producing NULL-filled reads. No on-disk format, DuckLake spec, or public API change (#146).
+- **Nested (`List` / struct / map) columns could read back all-NULL.** The read-schema field-id matcher built its `field_id → column` map from Parquet *leaf* columns, but a column's field-id is stamped on its *top-level* field — which for a nested column is the group node, leaving the leaf with no id. The column was therefore treated as absent from the file and null-filled. Field-ids are now read from the top-level fields, so nested columns resolve correctly; scalar columns are unaffected (their top-level field is the leaf). Adds a `List` write→read roundtrip regression test.
 
 ## [0.3.1] - 2026-06-23
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -452,14 +452,21 @@ pub fn extract_parquet_field_ids(metadata: &ParquetMetaData) -> HashMap<i32, Str
     let schema_descr = metadata.file_metadata().schema_descr();
     let mut field_id_map = HashMap::new();
 
-    for i in 0..schema_descr.num_columns() {
-        let column = schema_descr.column(i);
-        let basic_info = column.self_type().get_basic_info();
-
+    // DuckLake assigns one field_id per *top-level* column (`column_id` == the
+    // top-level field's field_id), so read ids off the top-level fields — the
+    // root group's direct children — NOT the Parquet leaf columns.
+    //
+    // For a scalar the top-level field *is* the leaf, so both are equivalent. But
+    // for a nested column (List / struct / map) the field_id lives on the group
+    // node while the leaves carry none — e.g. a `List<Float32>` column `v` is
+    // `v (group, field_id=2) -> list -> element (leaf, no id)`. Walking the leaves
+    // (`num_columns()`) misses `v`'s id entirely, so the matcher treats the column
+    // as absent and null-fills it. Walking top-level fields finds the id where it
+    // actually sits.
+    for field in schema_descr.root_schema().get_fields() {
+        let basic_info = field.get_basic_info();
         if basic_info.has_id() {
-            let field_id = basic_info.id();
-            let column_name = column.name().to_string();
-            field_id_map.insert(field_id, column_name);
+            field_id_map.insert(basic_info.id(), field.name().to_string());
         }
     }
 

--- a/tests/write_tests.rs
+++ b/tests/write_tests.rs
@@ -130,6 +130,79 @@ async fn test_write_and_read_basic_types() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_write_and_read_list_column_roundtrip() {
+    // Nested write->read coverage: a `List` column must round-trip its VALUES, not
+    // get null-filled by the field-id read mapping. The field-id sits on the
+    // top-level node; the List leaf carries none, so a leaf-only field-id lookup
+    // would treat the column as absent. Isolates WRITE (raw parquet) vs READ.
+    use arrow::datatypes::Float32Type;
+
+    let (writer, temp_dir) = create_test_env().await;
+    let object_store = create_object_store();
+
+    let v = arrow::array::ListArray::from_iter_primitive::<Float32Type, _, _>(vec![
+        Some(vec![Some(1.0f32), Some(2.0), Some(3.0)]),
+        Some(vec![Some(4.0f32), Some(5.0), Some(6.0)]),
+        Some(vec![Some(7.0f32), Some(8.0), Some(9.0)]),
+    ]);
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("v", v.data_type().clone(), true),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![Arc::new(Int32Array::from(vec![1, 2, 3])), Arc::new(v)],
+    )
+    .unwrap();
+
+    let table_writer = DuckLakeTableWriter::new(Arc::new(writer), object_store).unwrap();
+    let res = table_writer
+        .write_table("main", "vecs", &[batch])
+        .await
+        .unwrap();
+    assert_eq!(res.records_written, 3);
+
+    // (1) RAW parquet: did the WRITE persist the values, and do leaf columns carry field-ids?
+    let data_dir = temp_dir.path().join("data").join("main").join("vecs");
+    let pq = std::fs::read_dir(&data_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .find(|p| p.extension().map(|x| x == "parquet").unwrap_or(false))
+        .expect("a parquet file was written");
+    {
+        use datafusion::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+        let file = std::fs::File::open(&pq).unwrap();
+        let builder = ParquetRecordBatchReaderBuilder::try_new(file).unwrap();
+        let mut reader = builder.build().unwrap();
+        let raw = reader.next().unwrap().unwrap();
+        let vidx = raw.schema().index_of("v").unwrap();
+        assert_eq!(
+            raw.column(vidx).null_count(),
+            0,
+            "WRITE side: raw parquet must persist v values (no nulls)"
+        );
+    }
+
+    // (2) ducklake READ-BACK: does the read return the values, or null-fill the List?
+    let ctx = create_read_context(&temp_dir).await;
+    let batches = ctx
+        .sql("SELECT v FROM test.main.vecs")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+    let nulls: usize = batches.iter().map(|b| b.column(0).null_count()).sum();
+    assert_eq!(total, 3, "read returns 3 rows");
+    assert_eq!(
+        nulls, 0,
+        "READ side: ducklake must return v VALUES, not null-fill the List column"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_write_temporal_types() {
     let (writer, temp_dir) = create_test_env().await;
     let object_store = create_object_store();
@@ -396,6 +469,73 @@ async fn test_append_preserves_first_file_values() {
     }
     got.sort();
     assert_eq!(got, vec![(1, 100), (2, 200), (3, 300), (4, 400)]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_append_list_columns_multi_file() {
+    // Regression guard for the per-file field-id read mapping on NESTED columns.
+    // A write + an append produce two separate Parquet files; each is matched
+    // independently via extract_parquet_field_ids. A List column's field-id lives
+    // on its top-level node, so a leaf-only walk would null-fill it in EVERY file.
+    // The single-file List roundtrip and the multi-file scalar append tests would
+    // both still pass under that bug, so this multi-file List case is the one that
+    // actually fails if the field-id walk regresses to leaves.
+    use arrow::datatypes::Float32Type;
+
+    let (writer, temp_dir) = create_test_env().await;
+    let object_store = create_object_store();
+
+    let v1 = arrow::array::ListArray::from_iter_primitive::<Float32Type, _, _>(vec![
+        Some(vec![Some(1.0f32), Some(2.0), Some(3.0)]),
+        Some(vec![Some(4.0f32), Some(5.0), Some(6.0)]),
+    ]);
+    let v2 = arrow::array::ListArray::from_iter_primitive::<Float32Type, _, _>(vec![
+        Some(vec![Some(7.0f32), Some(8.0), Some(9.0)]),
+        Some(vec![Some(10.0f32), Some(11.0), Some(12.0)]),
+    ]);
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, true),
+        Field::new("v", v1.data_type().clone(), true),
+    ]));
+
+    let batch1 = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from(vec![1, 2])), Arc::new(v1)],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(Arc::new(writer.clone()), Arc::clone(&object_store))
+        .unwrap()
+        .write_table("main", "vt", &[batch1])
+        .await
+        .unwrap();
+
+    let batch2 = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from(vec![3, 4])), Arc::new(v2)],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(Arc::new(writer), Arc::clone(&object_store))
+        .unwrap()
+        .append_table("main", "vt", &[batch2])
+        .await
+        .unwrap();
+
+    let ctx = create_read_context(&temp_dir).await;
+    let batches = ctx
+        .sql("SELECT id, v FROM test.main.vt ORDER BY id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+    let v_nulls: usize = batches.iter().map(|b| b.column(1).null_count()).sum();
+    assert_eq!(total, 4, "both files' rows must be read");
+    assert_eq!(
+        v_nulls, 0,
+        "List column must survive a multi-file (write + append) read; a leaf-only \
+         field-id walk would null-fill it in each file"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

Nested columns (`List` / struct / map) read back **all-NULL**, even when the Parquet file holds the data. A regression from the field-id–based read mapping added in #140 / #141.

## Cause

`extract_parquet_field_ids` (`src/types.rs`) builds its `field_id → column` map by walking Parquet **leaf** columns (`schema_descr.num_columns()`). But a column's field-id is stamped on its **top-level** field — which for a nested column is the **group** node, leaving the leaf with no id.

For a `List<Float32>` column `v` the file schema is:

```
v          (group, field_id = 2)      ← the id lives here
  └─ list
       └─ element : FLOAT             ← the leaf the matcher inspects — no id
```

The leaf walk never sees `v`'s field-id (2). `build_read_schema_with_field_id_mapping` then finds the file *does* carry field-ids (on the scalar columns) but not this one's, concludes the column is absent from the file, and substitutes a guaranteed-miss name so the scan null-fills it. Scalar columns are unaffected: their top-level field *is* the leaf, so the id and the leaf coincide.

## Fix

Read field-ids from the **top-level fields** (the root group's direct children) instead of the leaves:

```rust
for field in schema_descr.root_schema().get_fields() {
    let info = field.get_basic_info();
    if info.has_id() { field_id_map.insert(info.id(), field.name().to_string()); }
}
```

Scalars are unchanged (top-level == leaf); nested columns now resolve their id where it actually sits. **No on-disk format change and no writer change** — existing files already carry the id on the correct node; the reader was looking one level too deep.

## Testing

Adds `test_write_and_read_list_column_roundtrip` — nested write→read coverage that was previously missing. It writes a `List<Float32>` column and checks both sides: the raw parquet holds the values (0/3 null) and the read returns them (0/3 null — **3/3 before the fix**). The full `--features write-sqlite` suite is green, including `renamed_columns_tests` (the field-id rename path this code also serves).

## Follow-up (not in this PR)

`build_schema_with_field_ids` (the writer) stamps field-ids only on top-level fields, not nested children — a partial implementation of the Iceberg field-id convention. This PR makes the reader consistent with what the writer actually produces; assigning ids to nested children as well would be a separate, larger change.
