### PR TITLE
Expose unsupported type-change errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,48 @@
 //! Error types for the DuckLake DataFusion extension
 
+use std::fmt;
+
 use thiserror::Error;
+
+/// The data-write mode that attempted an unsupported column type change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TypeChangeWriteMode {
+    /// Drop existing data and replace with new data.
+    Replace,
+    /// Keep existing data and append new records.
+    Append,
+}
+
+impl fmt::Display for TypeChangeWriteMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TypeChangeWriteMode::Replace => write!(f, "Replace"),
+            TypeChangeWriteMode::Append => write!(f, "Append"),
+        }
+    }
+}
+
+/// The operation that attempted an unsupported column type change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TypeChangeOperation {
+    /// Explicit metadata-only schema evolution through `promote_column_type`.
+    PromoteColumnType,
+    /// A data write tried to change the type of an existing same-name column.
+    DataWrite {
+        mode: TypeChangeWriteMode,
+    },
+}
+
+impl fmt::Display for TypeChangeOperation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TypeChangeOperation::PromoteColumnType => write!(f, "promote_column_type"),
+            TypeChangeOperation::DataWrite {
+                mode,
+            } => write!(f, "{mode} data write"),
+        }
+    }
+}
 
 /// Error type for DuckLake operations
 #[derive(Error, Debug)]
@@ -46,6 +88,18 @@ pub enum DuckLakeError {
     /// Invalid catalog configuration
     #[error("Invalid configuration: {0}")]
     InvalidConfig(String),
+
+    /// A write or promotion tried to change an existing column to a type that
+    /// DuckLake cannot adopt through metadata-only schema evolution.
+    #[error(
+        "Unsupported type change during {operation}: column '{column}' from '{from}' to '{to}'"
+    )]
+    UnsupportedTypeChange {
+        operation: TypeChangeOperation,
+        column: String,
+        from: String,
+        to: String,
+    },
 
     /// Unsupported DuckLake type
     #[error("Unsupported DuckLake type: {0}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ pub type Result<T> = std::result::Result<T, DuckLakeError>;
 
 // Re-export main types for convenience
 pub use catalog::DuckLakeCatalog;
-pub use error::DuckLakeError;
+pub use error::{DuckLakeError, TypeChangeOperation, TypeChangeWriteMode};
 pub use metadata_provider::MetadataProvider;
 pub use schema::DuckLakeSchema;
 pub use table::DuckLakeTable;

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -10,6 +10,7 @@
 //! with unchanged columns).
 
 use crate::Result;
+use crate::error::{TypeChangeOperation, TypeChangeWriteMode};
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
     ColumnDef, CommitIds, DataFileInfo, MetadataWriter, WriteMode, WriteSetupResult,
@@ -882,9 +883,12 @@ impl MetadataWriter for PostgresMetadataWriter {
                 )));
             }
             if !crate::types::is_promotable(&cur_type, new_ducklake_type) {
-                return Err(crate::DuckLakeError::InvalidConfig(format!(
-                    "promote_column_type: '{cur_type}' -> '{new_ducklake_type}' is not an allowed lossless widening for column '{column_name}'"
-                )));
+                return Err(crate::DuckLakeError::UnsupportedTypeChange {
+                    operation: TypeChangeOperation::PromoteColumnType,
+                    column: column_name.to_string(),
+                    from: cur_type,
+                    to: new_ducklake_type.to_string(),
+                });
             }
 
             // New snapshot + advance this catalog's head.
@@ -1490,11 +1494,17 @@ impl MetadataWriter for PostgresMetadataWriter {
                             existing_type,
                             &new_col.ducklake_type,
                         ) {
-                            return Err(crate::error::DuckLakeError::InvalidConfig(format!(
-                                "Column '{}' type change ('{}' -> '{}') is not allowed on a {:?} data write; \
-                                 use promote_column_type for a widening, then write data under the new type.",
-                                new_col.name, existing_type, new_col.ducklake_type, mode
-                            )));
+                            return Err(crate::error::DuckLakeError::UnsupportedTypeChange {
+                                operation: TypeChangeOperation::DataWrite {
+                                    mode: match mode {
+                                        WriteMode::Replace => TypeChangeWriteMode::Replace,
+                                        WriteMode::Append => TypeChangeWriteMode::Append,
+                                    },
+                                },
+                                column: new_col.name.clone(),
+                                from: (*existing_type).to_string(),
+                                to: new_col.ducklake_type.clone(),
+                            });
                         }
                     } else if mode == WriteMode::Append && !new_col.is_nullable {
                         return Err(crate::error::DuckLakeError::InvalidConfig(format!(

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -3,6 +3,7 @@
 //! Requires multi-threaded Tokio runtime (`#[tokio::test(flavor = "multi_thread")]`).
 
 use crate::Result;
+use crate::error::{TypeChangeOperation, TypeChangeWriteMode};
 use crate::maintenance::{
     CleanupCriteria, ExpireCriteria, ExpiredSnapshot, ScheduledFile, format_sql_timestamp,
 };
@@ -1193,9 +1194,12 @@ impl MetadataWriter for SqliteMetadataWriter {
                 )));
             }
             if !crate::types::is_promotable(&cur_type, new_ducklake_type) {
-                return Err(crate::DuckLakeError::InvalidConfig(format!(
-                    "promote_column_type: '{cur_type}' -> '{new_ducklake_type}' is not an allowed lossless widening for column '{column_name}'"
-                )));
+                return Err(crate::DuckLakeError::UnsupportedTypeChange {
+                    operation: TypeChangeOperation::PromoteColumnType,
+                    column: column_name.to_string(),
+                    from: cur_type,
+                    to: new_ducklake_type.to_string(),
+                });
             }
 
             // A promote IS schema evolution → DDL: bump schema_version on the
@@ -1681,11 +1685,17 @@ impl MetadataWriter for SqliteMetadataWriter {
                             existing_type,
                             &new_col.ducklake_type,
                         ) {
-                            return Err(crate::error::DuckLakeError::InvalidConfig(format!(
-                                "Column '{}' type change ('{}' -> '{}') is not allowed on a {:?} data write; \
-                                 use promote_column_type for a widening, then write data under the new type.",
-                                new_col.name, existing_type, new_col.ducklake_type, mode
-                            )));
+                            return Err(crate::error::DuckLakeError::UnsupportedTypeChange {
+                                operation: TypeChangeOperation::DataWrite {
+                                    mode: match mode {
+                                        WriteMode::Replace => TypeChangeWriteMode::Replace,
+                                        WriteMode::Append => TypeChangeWriteMode::Append,
+                                    },
+                                },
+                                column: new_col.name.clone(),
+                                from: (*existing_type).to_string(),
+                                to: new_col.ducklake_type.clone(),
+                            });
                         }
                         // Nullable changes remain allowed (strict -> nullable is safe for reads).
                     } else if mode == WriteMode::Append && !new_col.is_nullable {

--- a/tests/multicatalog_postgres_tests.rs
+++ b/tests/multicatalog_postgres_tests.rs
@@ -11,8 +11,8 @@
 
 use datafusion_ducklake::metadata_writer::{ColumnDef, MetadataWriter, WriteMode};
 use datafusion_ducklake::{
-    DuckLakeTableWriter, MulticatalogManager, PostgresMetadataWriter,
-    initialize_multicatalog_schema,
+    DuckLakeError, DuckLakeTableWriter, MulticatalogManager, PostgresMetadataWriter,
+    TypeChangeOperation, TypeChangeWriteMode, initialize_multicatalog_schema,
 };
 use sqlx::Row;
 use sqlx::postgres::{PgPool, PgPoolOptions};
@@ -37,6 +37,44 @@ fn cols() -> Vec<ColumnDef> {
         ColumnDef::new("id", "int64", false).unwrap(),
         ColumnDef::new("name", "varchar", true).unwrap(),
     ]
+}
+
+fn assert_unsupported_type_change<T>(
+    res: datafusion_ducklake::Result<T>,
+    expected_operation: TypeChangeOperation,
+    expected_column: &str,
+    expected_from: &str,
+    expected_to: &str,
+    context: &str,
+) {
+    match res {
+        Err(DuckLakeError::UnsupportedTypeChange {
+            operation,
+            column,
+            from,
+            to,
+        }) => {
+            assert_eq!(operation, expected_operation, "{context}: operation");
+            assert_eq!(column, expected_column, "{context}: column");
+            assert_eq!(from, expected_from, "{context}: from");
+            assert_eq!(to, expected_to, "{context}: to");
+        },
+        Err(other) => panic!("{context}: expected UnsupportedTypeChange, got {other:?}"),
+        Ok(_) => panic!("{context}: expected UnsupportedTypeChange, got Ok"),
+    }
+}
+
+fn assert_invalid_config<T>(res: datafusion_ducklake::Result<T>, context: &str) {
+    match res {
+        Err(DuckLakeError::InvalidConfig(_)) => {},
+        Err(DuckLakeError::UnsupportedTypeChange {
+            ..
+        }) => {
+            panic!("{context}: expected InvalidConfig, got UnsupportedTypeChange")
+        },
+        Err(other) => panic!("{context}: expected InvalidConfig, got {other:?}"),
+        Ok(_) => panic!("{context}: expected InvalidConfig, got Ok"),
+    }
 }
 
 /// Current catalog head = MAX(snapshot_id) over the catalog's mapping rows
@@ -3653,6 +3691,15 @@ async fn multicatalog_promote_widens_column_and_old_values_read_back() {
         .await
         .unwrap();
 
+    assert_invalid_config(
+        writer.promote_column_type(res.table_id, "id", "integer"),
+        "no-op (same canonical type) promote must be rejected without UnsupportedTypeChange",
+    );
+    assert_invalid_config(
+        writer.promote_column_type(res.table_id, "missing", "int64"),
+        "missing-column promote must be rejected without UnsupportedTypeChange",
+    );
+
     // Promote id int32 -> int64 (schema evolution; no data rewritten).
     writer
         .promote_column_type(res.table_id, "id", "int64")
@@ -3910,9 +3957,15 @@ async fn multicatalog_replace_and_append_reject_type_change() {
         .await
         .write_table("public", "t", &[b64a])
         .await;
-    assert!(
-        replace_res.is_err(),
-        "Replace with a type change must be rejected on Postgres"
+    assert_unsupported_type_change(
+        replace_res,
+        TypeChangeOperation::DataWrite {
+            mode: TypeChangeWriteMode::Replace,
+        },
+        "id",
+        "int32",
+        "int64",
+        "Replace with a type change must be rejected on Postgres",
     );
 
     // Append with id int64 → rejected.
@@ -3921,9 +3974,15 @@ async fn multicatalog_replace_and_append_reject_type_change() {
         .await
         .append_table("public", "t", &[b64b])
         .await;
-    assert!(
-        append_res.is_err(),
-        "Append with a type change must be rejected on Postgres"
+    assert_unsupported_type_change(
+        append_res,
+        TypeChangeOperation::DataWrite {
+            mode: TypeChangeWriteMode::Append,
+        },
+        "id",
+        "int32",
+        "int64",
+        "Append with a type change must be rejected on Postgres",
     );
 }
 

--- a/tests/type_promotion_tests.rs
+++ b/tests/type_promotion_tests.rs
@@ -19,8 +19,8 @@ use object_store::local::LocalFileSystem;
 use tempfile::TempDir;
 
 use datafusion_ducklake::{
-    DuckLakeCatalog, DuckLakeTableWriter, MetadataWriter, SqliteMetadataProvider,
-    SqliteMetadataWriter, WriteMode,
+    DuckLakeCatalog, DuckLakeError, DuckLakeTableWriter, MetadataWriter, SqliteMetadataProvider,
+    SqliteMetadataWriter, TypeChangeOperation, TypeChangeWriteMode, WriteMode,
 };
 use sqlx::Row;
 use sqlx::sqlite::SqlitePool;
@@ -59,6 +59,44 @@ async fn create_test_env() -> (SqliteMetadataWriter, TempDir) {
     writer.set_data_path(data_path.to_str().unwrap()).unwrap();
 
     (writer, temp_dir)
+}
+
+fn assert_unsupported_type_change<T>(
+    res: datafusion_ducklake::Result<T>,
+    expected_operation: TypeChangeOperation,
+    expected_column: &str,
+    expected_from: &str,
+    expected_to: &str,
+    context: &str,
+) {
+    match res {
+        Err(DuckLakeError::UnsupportedTypeChange {
+            operation,
+            column,
+            from,
+            to,
+        }) => {
+            assert_eq!(operation, expected_operation, "{context}: operation");
+            assert_eq!(column, expected_column, "{context}: column");
+            assert_eq!(from, expected_from, "{context}: from");
+            assert_eq!(to, expected_to, "{context}: to");
+        },
+        Err(other) => panic!("{context}: expected UnsupportedTypeChange, got {other:?}"),
+        Ok(_) => panic!("{context}: expected UnsupportedTypeChange, got Ok"),
+    }
+}
+
+fn assert_invalid_config<T>(res: datafusion_ducklake::Result<T>, context: &str) {
+    match res {
+        Err(DuckLakeError::InvalidConfig(_)) => {},
+        Err(DuckLakeError::UnsupportedTypeChange {
+            ..
+        }) => {
+            panic!("{context}: expected InvalidConfig, got UnsupportedTypeChange")
+        },
+        Err(other) => panic!("{context}: expected InvalidConfig, got {other:?}"),
+        Ok(_) => panic!("{context}: expected InvalidConfig, got Ok"),
+    }
 }
 
 /// A read-only `SessionContext` over the same catalog (registered as `test`).
@@ -148,9 +186,15 @@ async fn replace_with_type_change_is_rejected() {
         .write_table("main", "t", &[b64])
         .await;
 
-    assert!(
-        res.is_err(),
-        "Replace with a column type change must be rejected (got Ok — the silent type-drop bug C)"
+    assert_unsupported_type_change(
+        res,
+        TypeChangeOperation::DataWrite {
+            mode: TypeChangeWriteMode::Replace,
+        },
+        "id",
+        "int32",
+        "int64",
+        "Replace with a column type change must be rejected",
     );
 }
 
@@ -180,9 +224,15 @@ async fn append_with_type_change_is_rejected() {
         .append_table("main", "t", &[b64])
         .await;
 
-    assert!(
-        res.is_err(),
-        "Append with a column type change (even a widening) must be rejected (got Ok — silent acceptance)"
+    assert_unsupported_type_change(
+        res,
+        TypeChangeOperation::DataWrite {
+            mode: TypeChangeWriteMode::Append,
+        },
+        "id",
+        "int32",
+        "int64",
+        "Append with a column type change must be rejected",
     );
 }
 
@@ -284,13 +334,26 @@ async fn promote_rejects_non_widening() {
 
     // int64 -> int32 is a narrowing; must be rejected.
     let narrow = writer.promote_column_type(res.table_id, "id", "int32");
-    assert!(narrow.is_err(), "narrowing promote must be rejected");
+    assert_unsupported_type_change(
+        narrow,
+        TypeChangeOperation::PromoteColumnType,
+        "id",
+        "int64",
+        "int32",
+        "narrowing promote must be rejected",
+    );
 
     // int64 -> int64 is a no-op; reported as an error (no change), not applied.
     let noop = writer.promote_column_type(res.table_id, "id", "bigint");
-    assert!(
-        noop.is_err(),
-        "no-op (same canonical type) promote must be rejected"
+    assert_invalid_config(
+        noop,
+        "no-op (same canonical type) promote must be rejected without UnsupportedTypeChange",
+    );
+
+    let missing = writer.promote_column_type(res.table_id, "missing", "int32");
+    assert_invalid_config(
+        missing,
+        "missing-column promote must be rejected without UnsupportedTypeChange",
     );
 }
 


### PR DESCRIPTION
## Summary
- add `DuckLakeError::UnsupportedTypeChange` for unsupported column type changes
- add typed `TypeChangeOperation` / `TypeChangeWriteMode` payloads instead of a free-form operation string
- return the typed error from SQLite and Postgres data-write rejects and non-promotable `promote_column_type`
- assert typed error fields in SQLite and Postgres tests, including negative coverage that no-op and missing-column promotes remain `InvalidConfig`

## Compatibility
This changes the error variant for unsupported type-change failures from `InvalidConfig(String)` to `UnsupportedTypeChange { operation, column, from, to }`. Normal successful reads/writes/promotions are unchanged. Consumers that only propagate or display errors should not need changes; consumers that exhaustively match `DuckLakeError`, match these failures as `InvalidConfig`, or assert exact error strings will need to handle the new variant.

## Verification
- `cargo fmt --check`
- `cargo check`
- `cargo check --features write-postgres --test multicatalog_postgres_tests`
- `cargo test --features write-sqlite --test type_promotion_tests`
- `cargo test --features write-postgres --test multicatalog_postgres_tests multicatalog_replace_and_append_reject_type_change -- --exact`
- `cargo test --features write-postgres --test multicatalog_postgres_tests multicatalog_promote_widens_column_and_old_values_read_back -- --exact`