### PR TITLE
feat(write): add set_delete_file + resolve_positions (positional-delete scaffolding)

### DIFF
--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -213,6 +213,56 @@ impl DataFileInfo {
     }
 }
 
+/// A positional delete file to register via [`MetadataWriter::set_delete_file`].
+/// Mirrors [`DataFileInfo`]; the parquet has the standard `(file_path, pos)`
+/// schema. Must be cumulative for its data file (all still-deleted positions),
+/// since at most one delete file is live per data file at a time.
+#[derive(Debug, Clone)]
+pub struct DeleteFileInfo {
+    /// Path to the delete file (relative to the table path, or absolute).
+    pub path: String,
+    /// Whether the path is relative to the table's path.
+    pub path_is_relative: bool,
+    /// Size of the delete file in bytes.
+    pub file_size_bytes: i64,
+    /// Size of the Parquet footer in bytes (read optimization hint).
+    pub footer_size: Option<i64>,
+    /// Number of deleted positions in this file.
+    pub delete_count: i64,
+}
+
+impl DeleteFileInfo {
+    /// Create a new delete-file info with a relative path.
+    ///
+    /// # Panics
+    /// Panics if `delete_count` is negative.
+    pub fn new(path: impl Into<String>, file_size_bytes: i64, delete_count: i64) -> Self {
+        assert!(
+            delete_count >= 0,
+            "delete_count must be non-negative, got {delete_count}"
+        );
+        Self {
+            path: path.into(),
+            path_is_relative: true,
+            file_size_bytes,
+            footer_size: None,
+            delete_count,
+        }
+    }
+
+    /// Set the footer size for read optimization.
+    pub fn with_footer_size(mut self, footer_size: i64) -> Self {
+        self.footer_size = Some(footer_size);
+        self
+    }
+
+    /// Mark this delete file as having an absolute path.
+    pub fn with_absolute_path(mut self) -> Self {
+        self.path_is_relative = false;
+        self
+    }
+}
+
 /// Result of a write operation.
 #[derive(Debug)]
 pub struct WriteResult {
@@ -367,6 +417,32 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
         columns: &[ColumnDef],
         column_ids: &[i64],
     ) -> Result<CommitIds>;
+
+    /// Register a positional delete file for a single data file, superseding any
+    /// prior live delete file for it (at most one is live per data file).
+    ///
+    /// In one transaction: check that `expected_prev_delete_file` (the prior live
+    /// delete file's id, or `None`) and `base_snapshot` still match, else return
+    /// [`crate::DuckLakeError::Conflict`]; then end the prior delete file and
+    /// insert `delete`, which must carry the cumulative position set.
+    ///
+    /// Default: unsupported; backends override it.
+    #[allow(clippy::too_many_arguments)]
+    fn set_delete_file(
+        &self,
+        _table_id: i64,
+        _schema_name: &str,
+        _table_name: &str,
+        _snapshot_id: i64,
+        _data_file_id: i64,
+        _expected_prev_delete_file: Option<i64>,
+        _base_snapshot: i64,
+        _delete: &DeleteFileInfo,
+    ) -> Result<CommitIds> {
+        Err(DuckLakeError::InvalidConfig(
+            "set_delete_file is not supported by this metadata writer".to_string(),
+        ))
+    }
 
     /// Publish a write's snapshot as the catalog head with no data file (CREATE
     /// TABLE, zero-row Replace). For `Replace`, retires the prior generation.

--- a/src/table.rs
+++ b/src/table.rs
@@ -355,6 +355,23 @@ impl DuckLakeTable {
         Ok((Arc::new(read_schema), name_mapping))
     }
 
+    /// Scan `data_file` and return the physical positions of rows matching
+    /// `predicate`, without applying delete files. These are the positions used
+    /// by a delete file's `pos` column and
+    /// [`crate::metadata_writer::MetadataWriter::set_delete_file`].
+    ///
+    /// Scans the whole file; pushing `predicate` down for row-group/bloom pruning
+    /// is a possible optimization. Only valid for insert-only files, where
+    /// `position = rowid - row_id_start`.
+    pub async fn resolve_positions(
+        &self,
+        _state: &dyn Session,
+        _data_file: &DuckLakeFileData,
+        _predicate: Arc<dyn datafusion::physical_expr::PhysicalExpr>,
+    ) -> DataFusionResult<HashSet<i64>> {
+        todo!("resolve_positions is not yet implemented")
+    }
+
     /// Read a delete file and extract all deleted row positions
     ///
     /// The delete file is already associated with a specific data file via metadata.


### PR DESCRIPTION
Adds two additive, gated APIs for **positional-delete support** on DuckLake tables. Bodies are unimplemented (a default "unsupported" impl / `todo!()`) so the interface is fixed while the implementation is built. **Existing paths are unchanged**, and it stays within the DuckLake format (positional deletes — `(file_path, pos)` — no new catalog schema or file layout).

### `MetadataWriter::set_delete_file` (+ `DeleteFileInfo`)

Register a positional delete file for a single data file, superseding any prior live delete file for it (merge-on-read keeps at most one live delete file per data file):

- fenced on `expected_prev_delete_file` + `base_snapshot` → `DuckLakeError::Conflict` if either moved;
- end-snapshots the prior live delete file, then inserts the new one;
- `delete: &DeleteFileInfo` (new; mirrors `DataFileInfo`) carries the **cumulative** `(file_path, pos)` positions — a delta-only file would resurrect previously-deleted rows;
- **default impl returns "unsupported"**, so existing backends are unaffected.

### `DuckLakeTable::resolve_positions`

Scan one data file and return the file-physical positions of rows matching a `PhysicalExpr` predicate, with delete files **not** applied (the same position space `set_delete_file` writes) — the read counterpart used to resolve deletes to positions. Full scan for now; pushing the predicate to the reader (row-group statistics + a bloom filter) is a possible optimization.

### Status

`cargo check` green; no behaviour change to existing paths. Implementation + backend wiring follow.
