### PR TITLE
feat(write): positional-delete primitive (resolve_positions, write_delete_file, set_delete_file)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ pub type Result<T> = std::result::Result<T, DuckLakeError>;
 // Re-export main types for convenience
 pub use catalog::DuckLakeCatalog;
 pub use error::{DuckLakeError, TypeChangeOperation, TypeChangeWriteMode};
-pub use metadata_provider::{DuckLakeFileData, MetadataProvider};
+pub use metadata_provider::{DuckLakeFileData, DuckLakeTableFile, MetadataProvider};
 pub use schema::DuckLakeSchema;
 pub use table::DuckLakeTable;
 pub use table_functions::register_ducklake_functions;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,8 @@ pub use metadata_provider_sqlite::SqliteMetadataProvider;
 pub use insert_exec::DuckLakeInsertExec;
 #[cfg(feature = "write")]
 pub use metadata_writer::{
-    ColumnDef, DataFileInfo, MetadataWriter, WriteMode, WriteResult, WriteSetupResult,
+    ColumnDef, CommitIds, DataFileInfo, DeleteFileInfo, MetadataWriter, WriteMode, WriteResult,
+    WriteSetupResult,
 };
 #[cfg(feature = "write-postgres")]
 pub use metadata_writer_postgres::PostgresMetadataWriter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ pub type Result<T> = std::result::Result<T, DuckLakeError>;
 // Re-export main types for convenience
 pub use catalog::DuckLakeCatalog;
 pub use error::{DuckLakeError, TypeChangeOperation, TypeChangeWriteMode};
-pub use metadata_provider::MetadataProvider;
+pub use metadata_provider::{DuckLakeFileData, MetadataProvider};
 pub use schema::DuckLakeSchema;
 pub use table::DuckLakeTable;
 pub use table_functions::register_ducklake_functions;

--- a/src/metadata_provider.rs
+++ b/src/metadata_provider.rs
@@ -484,8 +484,16 @@ impl DuckLakeFileData {
 /// Represents a data file and its associated delete file (if any) for a DuckLake table
 #[derive(Debug, Clone)]
 pub struct DuckLakeTableFile {
+    /// Catalog `data_file_id` — the identity a positional-delete write targets
+    /// (`MetadataWriter::set_delete_file`). Needed by the mutation path; the read
+    /// path ignores it.
+    pub data_file_id: i64,
     /// Metadata for the data file
     pub file: DuckLakeFileData,
+    /// Catalog `delete_file_id` of the currently-live delete file for this data
+    /// file, or `None` if none is live. The compare-and-swap `expected_prev`
+    /// when superseding it with a cumulative delete file.
+    pub delete_file_id: Option<i64>,
     /// Optional associated delete file containing deleted row positions
     pub delete_file: Option<DuckLakeFileData>,
     /// Starting row ID for this file. Combined with each row's position in the
@@ -507,7 +515,12 @@ pub struct DuckLakeTableFile {
 impl DuckLakeTableFile {
     pub fn new(file: DuckLakeFileData) -> Self {
         Self {
+            // A bare file with no catalog context: `data_file_id` is unset (0)
+            // and there is no associated delete file. Not for the mutation path,
+            // which reads files (with real ids) via `get_table_files_for_select`.
+            data_file_id: 0,
             file,
+            delete_file_id: None,
             delete_file: None,
             row_id_start: None,
             snapshot_id: None,

--- a/src/metadata_provider_duckdb.rs
+++ b/src/metadata_provider_duckdb.rs
@@ -185,7 +185,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
                 [table_id, snapshot_id, snapshot_id, table_id, snapshot_id, snapshot_id],
                 |row| {
                     // Parse data file (columns 0-7)
-                    let _data_file_id: i64 = row.get(0)?;
+                    let data_file_id: i64 = row.get(0)?;
                     let data_file = DuckLakeFileData {
                         path: row.get(1)?,
                         path_is_relative: row.get(2)?,
@@ -197,8 +197,8 @@ impl MetadataProvider for DuckdbMetadataProvider {
                     let record_count: Option<i64> = row.get(7)?;
 
                     // Parse delete file (columns 8-14) if exists
-                    let (delete_file, delete_count) =
-                        if let Ok(Some(_)) = row.get::<_, Option<i64>>(8) {
+                    let (delete_file, delete_count, delete_file_id) =
+                        if let Ok(Some(dfid)) = row.get::<_, Option<i64>>(8) {
                             (
                                 Some(DuckLakeFileData {
                                     path: row.get(9)?,
@@ -208,13 +208,16 @@ impl MetadataProvider for DuckdbMetadataProvider {
                                     encryption_key: row.get(13)?,
                                 }),
                                 row.get(14)?,
+                                Some(dfid),
                             )
                         } else {
-                            (None, None)
+                            (None, None, None)
                         };
 
                     Ok(DuckLakeTableFile {
+                        data_file_id,
                         file: data_file,
+                        delete_file_id,
                         delete_file,
                         row_id_start,
                         snapshot_id: Some(snapshot_id),
@@ -377,7 +380,8 @@ impl MetadataProvider for DuckdbMetadataProvider {
                     let schema_name: String = row.get(0)?;
                     let table_name: String = row.get(1)?;
 
-                    // Parse data file (skip column 2: data_file_id, only used for JOIN)
+                    // Column 2 is data_file_id; columns 3-7 are the data file.
+                    let data_file_id: i64 = row.get(2)?;
                     let data_file = DuckLakeFileData {
                         path: row.get(3)?,
                         path_is_relative: row.get(4)?,
@@ -386,18 +390,21 @@ impl MetadataProvider for DuckdbMetadataProvider {
                         encryption_key: row.get(7)?,
                     };
 
-                    // Parse optional delete file (column 8: delete_file_id, check if exists but don't store)
-                    let delete_file =
-                        if let Ok(Some(_delete_file_id)) = row.get::<_, Option<i64>>(8) {
-                            Some(DuckLakeFileData {
-                                path: row.get(9)?,
-                                path_is_relative: row.get(10)?,
-                                file_size_bytes: row.get(11)?,
-                                footer_size: row.get(12)?,
-                                encryption_key: row.get(13)?,
-                            })
+                    // Column 8 is delete_file_id (NULL when no live delete file).
+                    let (delete_file, delete_file_id) =
+                        if let Ok(Some(dfid)) = row.get::<_, Option<i64>>(8) {
+                            (
+                                Some(DuckLakeFileData {
+                                    path: row.get(9)?,
+                                    path_is_relative: row.get(10)?,
+                                    file_size_bytes: row.get(11)?,
+                                    footer_size: row.get(12)?,
+                                    encryption_key: row.get(13)?,
+                                }),
+                                Some(dfid),
+                            )
                         } else {
-                            None
+                            (None, None)
                         };
 
                     let max_row_count = row.get::<_, Option<i64>>(14)?;
@@ -406,7 +413,9 @@ impl MetadataProvider for DuckdbMetadataProvider {
                         schema_name,
                         table_name,
                         file: DuckLakeTableFile {
+                            data_file_id,
                             file: data_file,
+                            delete_file_id,
                             delete_file,
                             row_id_start: None,
                             snapshot_id: None,

--- a/src/metadata_provider_mysql.rs
+++ b/src/metadata_provider_mysql.rs
@@ -248,7 +248,9 @@ impl MetadataProvider for MySqlMetadataProvider {
                     };
 
                     Ok(DuckLakeTableFile {
+                        data_file_id: row.try_get(0)?,
                         file: data_file,
+                        delete_file_id: row.try_get(8)?,
                         delete_file,
                         row_id_start,
                         snapshot_id: Some(snapshot_id),
@@ -502,7 +504,9 @@ impl MetadataProvider for MySqlMetadataProvider {
                         schema_name: row.try_get(0)?,
                         table_name: row.try_get(1)?,
                         file: DuckLakeTableFile {
+                            data_file_id: row.try_get(2)?,
                             file: data_file,
+                            delete_file_id: row.try_get(8)?,
                             delete_file,
                             row_id_start: None,
                             snapshot_id: None,

--- a/src/metadata_provider_postgres.rs
+++ b/src/metadata_provider_postgres.rs
@@ -282,7 +282,9 @@ impl MetadataProvider for PostgresMetadataProvider {
                     };
 
                     Ok(DuckLakeTableFile {
+                        data_file_id: row.try_get(0)?,
                         file: data_file,
+                        delete_file_id: row.try_get(8)?,
                         delete_file,
                         row_id_start,
                         snapshot_id: Some(snapshot_id),
@@ -535,7 +537,9 @@ impl MetadataProvider for PostgresMetadataProvider {
                         schema_name: row.try_get(0)?,
                         table_name: row.try_get(1)?,
                         file: DuckLakeTableFile {
+                            data_file_id: row.try_get(2)?,
                             file: data_file,
+                            delete_file_id: row.try_get(8)?,
                             delete_file,
                             row_id_start: None,
                             snapshot_id: None,

--- a/src/metadata_provider_sqlite.rs
+++ b/src/metadata_provider_sqlite.rs
@@ -249,7 +249,9 @@ impl MetadataProvider for SqliteMetadataProvider {
                     };
 
                     Ok(DuckLakeTableFile {
+                        data_file_id: row.try_get(0)?,
                         file: data_file,
+                        delete_file_id: row.try_get(8)?,
                         delete_file,
                         row_id_start,
                         snapshot_id: Some(snapshot_id),
@@ -501,7 +503,9 @@ impl MetadataProvider for SqliteMetadataProvider {
                         schema_name: row.try_get(0)?,
                         table_name: row.try_get(1)?,
                         file: DuckLakeTableFile {
+                            data_file_id: row.try_get(2)?,
                             file: data_file,
+                            delete_file_id: row.try_get(8)?,
                             delete_file,
                             row_id_start: None,
                             snapshot_id: None,

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -421,10 +421,14 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
     /// Register a positional delete file for a single data file, superseding any
     /// prior live delete file for it (at most one is live per data file).
     ///
-    /// In one transaction: check that `expected_prev_delete_file` (the prior live
-    /// delete file's id, or `None`) and `base_snapshot` still match, else return
-    /// [`crate::DuckLakeError::Conflict`]; then end the prior delete file and
-    /// insert `delete`, which must carry the cumulative position set.
+    /// In one transaction, abort with [`crate::DuckLakeError::Conflict`] if either
+    /// the target `data_file_id` is no longer the live data file (a concurrent
+    /// Replace/compaction retired it since `base_snapshot`, invalidating the
+    /// resolved positions) or the currently-live delete file for it no longer
+    /// matches `expected_prev_delete_file` (a concurrent delete on the same file
+    /// won the race). A concurrent *append* that only adds other files does NOT
+    /// conflict — it never moves this file's rows. Otherwise end the prior delete
+    /// file and insert `delete`, which must carry the cumulative position set.
     ///
     /// Default: unsupported; backends override it.
     #[allow(clippy::too_many_arguments)]

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -13,8 +13,8 @@ use crate::Result;
 use crate::error::{TypeChangeOperation, TypeChangeWriteMode};
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
-    ColumnDef, CommitIds, DataFileInfo, MetadataWriter, WriteMode, WriteSetupResult,
-    columns_differ, validate_name,
+    ColumnDef, CommitIds, DataFileInfo, DeleteFileInfo, MetadataWriter, WriteMode,
+    WriteSetupResult, columns_differ, validate_name,
 };
 use sqlx::Row;
 use sqlx::postgres::{PgPool, PgPoolOptions};
@@ -1207,6 +1207,123 @@ impl MetadataWriter for PostgresMetadataWriter {
             .bind(table_id)
             .execute(&mut *tx)
             .await?;
+
+            // advance_catalog_head MUST be the last write before commit.
+            advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
+
+            tx.commit().await?;
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn set_delete_file(
+        &self,
+        table_id: i64,
+        _schema_name: &str,
+        _table_name: &str,
+        _snapshot_id: i64,
+        data_file_id: i64,
+        expected_prev_delete_file: Option<i64>,
+        base_snapshot: i64,
+        delete: &DeleteFileInfo,
+    ) -> Result<CommitIds> {
+        block_on(async {
+            // Single atomic commit under the catalog lock: fence on
+            // `base_snapshot`, compare-and-swap the currently-live delete file
+            // for this data file, allocate the snapshot, retire the prior delete
+            // file, insert the new cumulative one, and advance the catalog head
+            // LAST — so at most one delete file is ever live per data file and
+            // nothing is visible until the head maps the snapshot.
+            let mut tx = self.pool.begin().await?;
+            lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
+            assert_table_not_in_other_catalog(self.catalog_id, table_id, &mut tx).await?;
+
+            // Fence: a concurrent write that advanced the table's data generation
+            // since `base_snapshot` may have invalidated the resolved positions.
+            detect_replace_conflict(table_id, base_snapshot, &mut tx).await?;
+
+            // Compare-and-swap on the currently-live delete file for this data
+            // file (`end_snapshot IS NULL`); a concurrent delete on the same data
+            // file makes it differ from what the caller saw.
+            let current_prev: Option<i64> = sqlx::query_scalar(
+                "SELECT delete_file_id FROM ducklake_delete_file
+                 WHERE data_file_id = $1 AND end_snapshot IS NULL",
+            )
+            .bind(data_file_id)
+            .fetch_optional(&mut *tx)
+            .await?;
+            if current_prev != expected_prev_delete_file {
+                return Err(crate::DuckLakeError::Conflict(format!(
+                    "delete on data file {data_file_id} conflicts with a concurrent delete \
+                     (expected live delete file {expected_prev_delete_file:?}, found \
+                     {current_prev:?}); retry against the new generation"
+                )));
+            }
+
+            // Allocate the snapshot (commit-ordered IDENTITY). A delete is
+            // non-DDL, so carry the per-catalog `schema_version` forward.
+            let snapshot_id: i64 = sqlx::query(
+                "INSERT INTO ducklake_snapshot (snapshot_time, schema_version)
+                 VALUES (NOW(), 0) RETURNING snapshot_id",
+            )
+            .fetch_one(&mut *tx)
+            .await?
+            .try_get(0)?;
+            let prev_max: i64 = sqlx::query(
+                "SELECT COALESCE(MAX(s.schema_version), 0) FROM ducklake_snapshot s
+                 JOIN ducklake_catalog_snapshot_map m ON m.snapshot_id = s.snapshot_id
+                 WHERE m.catalog_id = $1",
+            )
+            .bind(self.catalog_id)
+            .fetch_one(&mut *tx)
+            .await?
+            .try_get(0)?;
+            sqlx::query("UPDATE ducklake_snapshot SET schema_version = $1 WHERE snapshot_id = $2")
+                .bind(prev_max.max(1))
+                .bind(snapshot_id)
+                .execute(&mut *tx)
+                .await?;
+
+            // Retire the prior delete file (cumulative: the new file carries all
+            // still-deleted positions, so the old one is superseded).
+            if let Some(prev) = expected_prev_delete_file {
+                sqlx::query(
+                    "UPDATE ducklake_delete_file SET end_snapshot = $1
+                     WHERE delete_file_id = $2 AND end_snapshot IS NULL",
+                )
+                .bind(snapshot_id)
+                .bind(prev)
+                .execute(&mut *tx)
+                .await?;
+            }
+
+            sqlx::query(
+                "INSERT INTO ducklake_delete_file
+                     (data_file_id, table_id, path, path_is_relative, file_size_bytes,
+                      footer_size, delete_count, begin_snapshot)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+            )
+            .bind(data_file_id)
+            .bind(table_id)
+            .bind(&delete.path)
+            .bind(delete.path_is_relative)
+            .bind(delete.file_size_bytes)
+            .bind(delete.footer_size)
+            .bind(delete.delete_count)
+            .bind(snapshot_id)
+            .execute(&mut *tx)
+            .await?;
+
+            let schema_id: i64 =
+                sqlx::query_scalar("SELECT schema_id FROM ducklake_table WHERE table_id = $1")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
 
             // advance_catalog_head MUST be the last write before commit.
             advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -1243,9 +1243,27 @@ impl MetadataWriter for PostgresMetadataWriter {
             lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
             assert_table_not_in_other_catalog(self.catalog_id, table_id, &mut tx).await?;
 
-            // Fence: a concurrent write that advanced the table's data generation
-            // since `base_snapshot` may have invalidated the resolved positions.
-            detect_replace_conflict(table_id, base_snapshot, &mut tx).await?;
+            // Target-file fence: the resolved positions are physical row indices
+            // in `data_file_id`, and a parquet data file is immutable — so only a
+            // concurrent write that RETIRED this file (a Replace/compaction) since
+            // `base_snapshot` can invalidate them. An append that adds *other*
+            // files does not move this file's rows, and a concurrent delete on
+            // THIS file is caught by the compare-and-swap below; neither must
+            // block the delete. Abort iff the target is no longer the live file.
+            let target_live: Option<i64> = sqlx::query_scalar(
+                "SELECT 1 FROM ducklake_data_file
+                 WHERE data_file_id = $1 AND end_snapshot IS NULL",
+            )
+            .bind(data_file_id)
+            .fetch_optional(&mut *tx)
+            .await?;
+            if target_live.is_none() {
+                return Err(crate::DuckLakeError::Conflict(format!(
+                    "delete targets data file {data_file_id}, which was retired by a \
+                     concurrent write since snapshot {base_snapshot}; retry against the \
+                     new generation"
+                )));
+            }
 
             // Compare-and-swap on the currently-live delete file for this data
             // file (`end_snapshot IS NULL`); a concurrent delete on the same data

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -1250,8 +1250,10 @@ impl MetadataWriter for PostgresMetadataWriter {
             // files does not move this file's rows, and a concurrent delete on
             // THIS file is caught by the compare-and-swap below; neither must
             // block the delete. Abort iff the target is no longer the live file.
+            // Select the BIGINT `data_file_id` (not a literal `1`, which Postgres
+            // types as INT4 and cannot decode into i64) — we only need existence.
             let target_live: Option<i64> = sqlx::query_scalar(
-                "SELECT 1 FROM ducklake_data_file
+                "SELECT data_file_id FROM ducklake_data_file
                  WHERE data_file_id = $1 AND end_snapshot IS NULL",
             )
             .bind(data_file_id)

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -9,8 +9,8 @@ use crate::maintenance::{
 };
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
-    ColumnDef, CommitIds, DataFileInfo, MetadataWriter, WriteMode, WriteSetupResult,
-    columns_differ, validate_name,
+    ColumnDef, CommitIds, DataFileInfo, DeleteFileInfo, MetadataWriter, WriteMode,
+    WriteSetupResult, columns_differ, validate_name,
 };
 use sqlx::Row;
 use sqlx::sqlite::{SqlitePool, SqlitePoolOptions};
@@ -1389,6 +1389,100 @@ impl MetadataWriter for SqliteMetadataWriter {
                     .fetch_one(&mut *tx)
                     .await?
                     .try_get(0)?;
+
+            tx.commit().await?;
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn set_delete_file(
+        &self,
+        table_id: i64,
+        // SQLite created the schema/table at begin; names unused (trait parity).
+        _schema_name: &str,
+        _table_name: &str,
+        _snapshot_id: i64,
+        data_file_id: i64,
+        expected_prev_delete_file: Option<i64>,
+        base_snapshot: i64,
+        delete: &DeleteFileInfo,
+    ) -> Result<CommitIds> {
+        block_on(async {
+            // Single atomic commit: allocate the snapshot (write-lock-first),
+            // fence against a concurrent generation change, compare-and-swap the
+            // live delete file for this data file, retire the prior one, and
+            // insert the new cumulative delete file — so at most one delete file
+            // is ever live per data file and the head only resolves to a
+            // fully-populated snapshot.
+            let mut tx = self.pool.begin().await?;
+
+            // First write takes the SQLite write lock up front (see
+            // `insert_snapshot`); a delete carries `schema_version` forward.
+            let (snapshot_id, _schema_version) = insert_snapshot(&mut tx).await?;
+
+            // Base-snapshot fence: if a concurrent write advanced the table's
+            // data generation since `base_snapshot`, the positions we resolved
+            // may be stale — abort so the caller retries against the new head.
+            detect_replace_conflict(&mut tx, table_id, base_snapshot).await?;
+
+            // Compare-and-swap on the currently-live delete file for this data
+            // file (`end_snapshot IS NULL`). If it isn't what the caller saw, a
+            // concurrent delete on the same data file won — abort.
+            let current_prev: Option<i64> = sqlx::query_scalar(
+                "SELECT delete_file_id FROM ducklake_delete_file
+                 WHERE data_file_id = ? AND end_snapshot IS NULL",
+            )
+            .bind(data_file_id)
+            .fetch_optional(&mut *tx)
+            .await?;
+            if current_prev != expected_prev_delete_file {
+                return Err(crate::DuckLakeError::Conflict(format!(
+                    "delete on data file {data_file_id} conflicts with a concurrent delete \
+                     (expected live delete file {expected_prev_delete_file:?}, found \
+                     {current_prev:?}); retry against the new generation"
+                )));
+            }
+
+            // Retire the prior delete file (cumulative: the new file carries all
+            // still-deleted positions, so the old one is superseded).
+            if let Some(prev) = expected_prev_delete_file {
+                sqlx::query(
+                    "UPDATE ducklake_delete_file SET end_snapshot = ?
+                     WHERE delete_file_id = ? AND end_snapshot IS NULL",
+                )
+                .bind(snapshot_id)
+                .bind(prev)
+                .execute(&mut *tx)
+                .await?;
+            }
+
+            sqlx::query(
+                "INSERT INTO ducklake_delete_file
+                     (data_file_id, table_id, path, path_is_relative, file_size_bytes,
+                      footer_size, delete_count, begin_snapshot)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            )
+            .bind(data_file_id)
+            .bind(table_id)
+            .bind(&delete.path)
+            .bind(delete.path_is_relative)
+            .bind(delete.file_size_bytes)
+            .bind(delete.footer_size)
+            .bind(delete.delete_count)
+            .bind(snapshot_id)
+            .execute(&mut *tx)
+            .await?;
+
+            let schema_id: i64 =
+                sqlx::query_scalar("SELECT schema_id FROM ducklake_table WHERE table_id = ?")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
 
             tx.commit().await?;
             Ok(CommitIds {

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -1425,10 +1425,27 @@ impl MetadataWriter for SqliteMetadataWriter {
             // `insert_snapshot`); a delete carries `schema_version` forward.
             let (snapshot_id, _schema_version) = insert_snapshot(&mut tx).await?;
 
-            // Base-snapshot fence: if a concurrent write advanced the table's
-            // data generation since `base_snapshot`, the positions we resolved
-            // may be stale — abort so the caller retries against the new head.
-            detect_replace_conflict(&mut tx, table_id, base_snapshot).await?;
+            // Target-file fence: the resolved positions are physical row indices
+            // in `data_file_id`, and a parquet data file is immutable — so only a
+            // concurrent write that RETIRED this file (a Replace/compaction) since
+            // `base_snapshot` can invalidate them. An append that adds *other*
+            // files does not move this file's rows, and a concurrent delete on
+            // THIS file is caught by the compare-and-swap below; neither must
+            // block the delete. Abort iff the target is no longer the live file.
+            let target_live: Option<i64> = sqlx::query_scalar(
+                "SELECT 1 FROM ducklake_data_file
+                 WHERE data_file_id = ? AND end_snapshot IS NULL",
+            )
+            .bind(data_file_id)
+            .fetch_optional(&mut *tx)
+            .await?;
+            if target_live.is_none() {
+                return Err(crate::DuckLakeError::Conflict(format!(
+                    "delete targets data file {data_file_id}, which was retired by a \
+                     concurrent write since snapshot {base_snapshot}; retry against the \
+                     new generation"
+                )));
+            }
 
             // Compare-and-swap on the currently-live delete file for this data
             // file (`end_snapshot IS NULL`). If it isn't what the caller saw, a

--- a/src/multicatalog_provider.rs
+++ b/src/multicatalog_provider.rs
@@ -315,7 +315,9 @@ impl MetadataProvider for MulticatalogProvider {
                     };
 
                     Ok(DuckLakeTableFile {
+                        data_file_id: row.try_get(0)?,
                         file: data_file,
+                        delete_file_id: row.try_get(8)?,
                         delete_file,
                         row_id_start,
                         snapshot_id: Some(snapshot_id),
@@ -585,7 +587,9 @@ impl MetadataProvider for MulticatalogProvider {
                         schema_name: row.try_get(0)?,
                         table_name: row.try_get(1)?,
                         file: DuckLakeTableFile {
+                            data_file_id: row.try_get(2)?,
                             file: data_file,
+                            delete_file_id: row.try_get(8)?,
                             delete_file,
                             row_id_start: None,
                             snapshot_id: None,

--- a/src/table.rs
+++ b/src/table.rs
@@ -12,7 +12,8 @@ use crate::metadata_provider::{
 use crate::path_resolver::resolve_path;
 use crate::positional_source::PositionalFileSource;
 use crate::row_id::{
-    FileRowNumberExec, ROW_ID_PARQUET_FIELD_ID, ROWID_COLUMN_NAME, RowIdExec, rowid_field,
+    FileRowNumberExec, ROW_ID_PARQUET_FIELD_ID, ROW_POS_COLUMN_NAME, ROWID_COLUMN_NAME, RowIdExec,
+    rowid_field,
 };
 use crate::types::{
     build_arrow_schema, build_read_schema_with_field_id_mapping, extract_parquet_field_ids,
@@ -25,7 +26,7 @@ use crate::metadata_writer::{MetadataWriter, WriteMode};
 
 #[cfg(feature = "encryption")]
 use crate::encryption::EncryptionFactoryBuilder;
-use arrow::array::{Array, Int64Array};
+use arrow::array::{Array, BooleanArray, Int64Array};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
@@ -365,11 +366,75 @@ impl DuckLakeTable {
     /// `position = rowid - row_id_start`.
     pub async fn resolve_positions(
         &self,
-        _state: &dyn Session,
-        _data_file: &DuckLakeFileData,
-        _predicate: Arc<dyn datafusion::physical_expr::PhysicalExpr>,
+        state: &dyn Session,
+        data_file: &DuckLakeFileData,
+        predicate: Arc<dyn datafusion::physical_expr::PhysicalExpr>,
     ) -> DataFusionResult<HashSet<i64>> {
-        todo!("resolve_positions is not yet implemented")
+        // Positional scan of the data file: read the physical data columns and
+        // materialize the true physical row position (`ROW_POS_COLUMN_NAME`) via
+        // `FileRowNumberExec`, WITHOUT applying any delete files. Then evaluate
+        // `predicate` per batch and collect the physical positions of matching
+        // rows — exactly the `pos` values a positional delete file records.
+        //
+        // `predicate` is expressed against the table's logical column order
+        // (column index i = the i-th logical/data field); `Column::evaluate` is
+        // index-based, so it resolves against the read batch regardless of any
+        // physical rename. `ROW_POS_COLUMN_NAME` is appended last and is never
+        // referenced by the predicate. Valid for insert-only files, where the
+        // physical position equals `rowid - row_id_start`.
+        let file_cfg = self.build_file_read_config(state, data_file).await?;
+
+        // Row-group-aligned partitions + a non-repartition, non-pruning source so
+        // `FileRowNumberExec` yields true physical positions (mirrors the scan
+        // paths in `build_exec_for_file_with_rowid`).
+        let target_partitions = state.config().target_partitions();
+        let (file_groups, partition_starts) =
+            self.build_row_group_partitions(data_file, &file_cfg, target_partitions)?;
+
+        let source = PositionalFileSource::wrap(Arc::new(
+            self.create_parquet_source(file_cfg.read_schema.clone()),
+        ));
+        // Physical data columns only (logical order); embedded/rowid columns are
+        // not needed to evaluate the predicate or read positions.
+        let physical_proj: Vec<usize> = (0..self.physical_schema.fields().len()).collect();
+        let scan = DataSourceExec::from_data_source(
+            FileScanConfigBuilder::new(self.object_store_url.as_ref().clone(), source)
+                .with_file_groups(file_groups)
+                .with_partitioned_by_file_group(true)
+                .with_projection_indices(Some(physical_proj))?
+                .build(),
+        );
+        let plan: Arc<dyn ExecutionPlan> = Arc::new(FileRowNumberExec::new(scan, partition_starts));
+        let pos_idx = plan.schema().index_of(ROW_POS_COLUMN_NAME)?;
+
+        let batches = datafusion::physical_plan::collect(plan, state.task_ctx()).await?;
+
+        let mut positions = HashSet::new();
+        for batch in &batches {
+            let mask = predicate.evaluate(batch)?.into_array(batch.num_rows())?;
+            let mask = mask
+                .as_any()
+                .downcast_ref::<BooleanArray>()
+                .ok_or_else(|| {
+                    DataFusionError::Execution(
+                        "resolve_positions: predicate did not evaluate to a boolean".to_string(),
+                    )
+                })?;
+            let pos = batch
+                .column(pos_idx)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .ok_or_else(|| {
+                    DataFusionError::Internal(format!("{ROW_POS_COLUMN_NAME} column is not Int64"))
+                })?;
+            for i in 0..batch.num_rows() {
+                // A NULL predicate result is treated as non-match (SQL semantics).
+                if mask.is_valid(i) && mask.value(i) {
+                    positions.insert(pos.value(i));
+                }
+            }
+        }
+        Ok(positions)
     }
 
     /// Read a delete file and extract all deleted row positions

--- a/src/table.rs
+++ b/src/table.rs
@@ -272,6 +272,16 @@ impl DuckLakeTable {
             .then(|| self.physical_schema.fields().len())
     }
 
+    /// The table's live data files (each with its catalog `data_file_id`, any
+    /// live delete file, and that delete file's `delete_file_id`) at the snapshot
+    /// this table was opened at. The positional-delete flow iterates these: for
+    /// each, [`Self::resolve_positions`] finds the rows to delete,
+    /// [`Self::read_delete_file_positions`] reads the already-deleted set, and
+    /// the union is written back via `set_delete_file` (CAS on `delete_file_id`).
+    pub fn files(&self) -> &[DuckLakeTableFile] {
+        &self.table_files
+    }
+
     /// Resolve a file path (data or delete file) to its absolute path
     fn resolve_file_path(&self, file: &DuckLakeFileData) -> DataFusionResult<String> {
         resolve_path(&self.table_path, &file.path, file.path_is_relative)
@@ -437,12 +447,14 @@ impl DuckLakeTable {
         Ok(positions)
     }
 
-    /// Read a delete file and extract all deleted row positions
+    /// Read a delete file and return the set of physical row positions it marks
+    /// deleted (the `pos` column). Callers use this to form the cumulative
+    /// (prior ∪ new) position set when superseding a data file's live delete
+    /// file via [`crate::metadata_writer::MetadataWriter::set_delete_file`].
     ///
-    /// The delete file is already associated with a specific data file via metadata.
-    /// We only need to extract the "pos" column - the "file_path" column is
-    /// metadata/documentation only (for Iceberg compatibility).
-    async fn read_delete_file_positions(
+    /// The delete file is already associated with a specific data file via
+    /// metadata; only `pos` is read (the `file_path` column is documentation).
+    pub async fn read_delete_file_positions(
         &self,
         state: &dyn Session,
         delete_file: &DuckLakeFileData,

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -17,8 +17,11 @@ use tokio::io::AsyncWriteExt;
 use uuid::Uuid;
 
 use crate::Result;
-use crate::metadata_writer::{ColumnDef, DataFileInfo, MetadataWriter, WriteMode, WriteResult};
+use crate::metadata_writer::{
+    ColumnDef, DataFileInfo, DeleteFileInfo, MetadataWriter, WriteMode, WriteResult,
+};
 use crate::path_resolver::join_paths;
+use crate::table::delete_file_schema;
 
 /// High-level writer for DuckLake tables.
 #[derive(Debug)]
@@ -254,6 +257,79 @@ impl DuckLakeTableWriter {
         }
 
         session.finish().await
+    }
+
+    /// Write a positional `(file_path, pos)` delete parquet, upload it, and
+    /// return the [`DeleteFileInfo`] to register via
+    /// [`MetadataWriter::set_delete_file`].
+    ///
+    /// `positions` is the CUMULATIVE set of still-deleted physical row positions
+    /// for `data_file_path`: the engine keeps at most one live delete file per
+    /// data file, so each write carries the full set (the prior file is retired
+    /// on commit). The delete file lands beside the data files it masks — the
+    /// same `cat_{id}/{schema}/{table}/` layout as [`Self::begin_write`] — and is
+    /// registered relative to the table, so the reader resolves it exactly like a
+    /// data file. Readers key deletes off `pos`; `file_path` is recorded for
+    /// provenance.
+    pub async fn write_delete_file(
+        &self,
+        schema_name: &str,
+        table_name: &str,
+        data_file_path: &str,
+        positions: &[i64],
+    ) -> Result<DeleteFileInfo> {
+        use arrow::array::{Int64Array, StringArray};
+
+        let scoped_base = match self.metadata.catalog_id() {
+            Some(id) => join_paths(&self.base_key_path, &format!("cat_{id}"))?,
+            None => self.base_key_path.clone(),
+        };
+        let table_key = join_paths(&join_paths(&scoped_base, schema_name)?, table_name)?;
+        let file_name = format!("{}.parquet", Uuid::new_v4());
+        let object_path_str = join_paths(&table_key, &file_name)?;
+        // Strip leading slash for object_store Path (it expects relative keys).
+        let object_path = ObjectPath::from(object_path_str.trim_start_matches('/'));
+
+        let schema = delete_file_schema();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec![data_file_path; positions.len()])),
+                Arc::new(Int64Array::from(positions.to_vec())),
+            ],
+        )?;
+
+        // Stream to a local staging file, then multipart-upload it — the same
+        // bounded-memory path `finish()` uses for data files.
+        let props = WriterProperties::builder()
+            .set_writer_version(parquet::file::properties::WriterVersion::PARQUET_2_0)
+            .set_compression(self.compression)
+            .build();
+        let temp = NamedTempFile::new()?;
+        let staging = std::io::BufWriter::new(temp.reopen()?);
+        let mut writer = ArrowWriter::try_new(staging, schema, Some(props))?;
+        writer.write(&batch)?;
+        let staged = writer.into_inner()?;
+        let mut file = staged
+            .into_inner()
+            .map_err(|e| crate::error::DuckLakeError::Io(e.into_error()))?;
+        let file_size = file.metadata()?.len() as i64;
+        let footer_size = read_footer_size(&mut file)?;
+
+        let local = tokio::fs::File::open(temp.path()).await?;
+        let mut reader = tokio::io::BufReader::new(local);
+        let mut upload = ObjectBufWriter::new(Arc::clone(&self.object_store), object_path);
+        if let Err(e) = stream_to_upload(&mut reader, &mut upload).await {
+            let _ = upload.abort().await;
+            return Err(e.into());
+        }
+
+        // Registered relative to the table path (like data files); the reader
+        // resolves it against the same table data dir.
+        Ok(
+            DeleteFileInfo::new(file_name, file_size, positions.len() as i64)
+                .with_footer_size(footer_size),
+        )
     }
 }
 

--- a/tests/multicatalog_postgres_tests.rs
+++ b/tests/multicatalog_postgres_tests.rs
@@ -111,6 +111,145 @@ async fn visible_records_at_head(pool: &PgPool, catalog_id: i64, table_id: i64) 
     .unwrap()
 }
 
+/// #864: the postgres `set_delete_file` write — fenced, cumulative,
+/// ≤1-live-delete-file-per-data-file. Asserts the metadata effects directly (the
+/// read-side application via `DeleteFilterExec` is backend-agnostic and covered
+/// by the sqlite round-trip in `positional_delete_tests`).
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn set_delete_file_postgres_cumulative_and_fenced() {
+    use datafusion_ducklake::DeleteFileInfo;
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("pg_delete").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path("/data").unwrap();
+
+    // A committed data file with 4 rows.
+    let s1 = w
+        .begin_write_transaction("public", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    w.register_data_file(
+        s1.table_id,
+        "public",
+        "t",
+        s1.snapshot_id,
+        &DataFileInfo::new("g1.parquet", 1024, 4),
+        WriteMode::Replace,
+        s1.base_snapshot_id,
+        &cols(),
+        &s1.column_ids,
+    )
+    .unwrap();
+    let table_id = s1.table_id;
+    let data_file_id: i64 = sqlx::query(
+        "SELECT data_file_id FROM ducklake_data_file WHERE table_id = $1 AND end_snapshot IS NULL",
+    )
+    .bind(table_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap();
+
+    // First delete: no prior. Records 2 positions.
+    let base1 = current_head(&pool, cat).await;
+    let ids1 = w
+        .set_delete_file(
+            table_id,
+            "public",
+            "t",
+            base1,
+            data_file_id,
+            None,
+            base1,
+            &DeleteFileInfo::new("d1.parquet", 100, 2),
+        )
+        .unwrap();
+    assert!(ids1.snapshot_id > base1, "head advances");
+    assert_eq!(current_head(&pool, cat).await, ids1.snapshot_id);
+    let (live_count, live_id, dcount, begin): (i64, i64, i64, i64) = {
+        let row = sqlx::query(
+            "SELECT COUNT(*), MIN(delete_file_id), MIN(delete_count), MIN(begin_snapshot)
+             FROM ducklake_delete_file WHERE data_file_id = $1 AND end_snapshot IS NULL",
+        )
+        .bind(data_file_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        (
+            row.try_get(0).unwrap(),
+            row.try_get(1).unwrap(),
+            row.try_get(2).unwrap(),
+            row.try_get(3).unwrap(),
+        )
+    };
+    assert_eq!(live_count, 1, "one live delete file");
+    assert_eq!(dcount, 2);
+    assert_eq!(begin, ids1.snapshot_id, "delete file begins at the new snapshot");
+
+    // A stale CAS (still thinks there's no prior) is rejected.
+    let base_stale = current_head(&pool, cat).await;
+    let err = w
+        .set_delete_file(
+            table_id,
+            "public",
+            "t",
+            base_stale,
+            data_file_id,
+            None,
+            base_stale,
+            &DeleteFileInfo::new("d_bad.parquet", 100, 1),
+        )
+        .expect_err("stale expected_prev_delete_file must be rejected");
+    assert!(
+        matches!(err, DuckLakeError::Conflict(_)),
+        "expected Conflict, got {err:?}"
+    );
+
+    // Cumulative second delete: supersede the first (prior retired, one live).
+    let base2 = current_head(&pool, cat).await;
+    let ids2 = w
+        .set_delete_file(
+            table_id,
+            "public",
+            "t",
+            base2,
+            data_file_id,
+            Some(live_id),
+            base2,
+            &DeleteFileInfo::new("d2.parquet", 150, 3),
+        )
+        .unwrap();
+    let live_after: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_delete_file WHERE data_file_id = $1 AND end_snapshot IS NULL",
+    )
+    .bind(data_file_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap();
+    assert_eq!(live_after, 1, "still exactly one live delete file");
+    let prior_end: Option<i64> =
+        sqlx::query("SELECT end_snapshot FROM ducklake_delete_file WHERE delete_file_id = $1")
+            .bind(live_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
+    assert_eq!(
+        prior_end,
+        Some(ids2.snapshot_id),
+        "prior delete file retired at the new snapshot"
+    );
+}
+
 /// Regression for the transient empty-read bug: a managed-load Replace must
 /// never expose a committed state where the head advanced but the table has
 /// zero live files. The head advance + prior-generation retirement happen only

--- a/tests/multicatalog_postgres_tests.rs
+++ b/tests/multicatalog_postgres_tests.rs
@@ -190,7 +190,10 @@ async fn set_delete_file_postgres_cumulative_and_fenced() {
     };
     assert_eq!(live_count, 1, "one live delete file");
     assert_eq!(dcount, 2);
-    assert_eq!(begin, ids1.snapshot_id, "delete file begins at the new snapshot");
+    assert_eq!(
+        begin, ids1.snapshot_id,
+        "delete file begins at the new snapshot"
+    );
 
     // A stale CAS (still thinks there's no prior) is rejected.
     let base_stale = current_head(&pool, cat).await;

--- a/tests/positional_delete_tests.rs
+++ b/tests/positional_delete_tests.rs
@@ -1,0 +1,283 @@
+//! Round-trip tests for the positional-delete write path (#864 / #862):
+//! `MetadataWriter::set_delete_file` registers a positional `(file_path, pos)`
+//! delete file, and a subsequent read applies it via `DeleteFilterExec`. These
+//! validate the fenced, cumulative, ≤1-live-per-data-file write end-to-end
+//! through the SQLite backend (the one the crate's tests can run without a
+//! container), asserting surviving VALUES — a positional bug silently deletes
+//! the wrong rows, so value assertions are the point.
+
+#![cfg(all(feature = "write-sqlite", feature = "metadata-sqlite"))]
+
+use std::sync::Arc;
+
+use arrow::array::{Array, Int32Array, Int64Array, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use datafusion::prelude::*;
+use object_store::local::LocalFileSystem;
+use parquet::arrow::ArrowWriter;
+use tempfile::TempDir;
+
+use datafusion_ducklake::{
+    DeleteFileInfo, DuckLakeCatalog, DuckLakeTableWriter, MetadataWriter, SqliteMetadataProvider,
+    SqliteMetadataWriter,
+};
+use sqlx::Row;
+use sqlx::sqlite::SqlitePool;
+
+/// A writable SQLite-backed catalog + a data dir, in a temp dir.
+async fn create_writer(temp_dir: &TempDir) -> SqliteMetadataWriter {
+    let db_path = temp_dir.path().join("test.db");
+    let data_path = temp_dir.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+    let conn_str = format!("sqlite:{}?mode=rwc", db_path.display());
+    let writer = SqliteMetadataWriter::new_with_init(&conn_str)
+        .await
+        .unwrap();
+    writer.set_data_path(data_path.to_str().unwrap()).unwrap();
+    writer
+}
+
+/// Read `id`s from `test.main.t`, ascending, through the full read path (which
+/// applies any live delete file).
+async fn read_ids(temp_dir: &TempDir) -> Vec<i32> {
+    let db_path = temp_dir.path().join("test.db");
+    let conn_str = format!("sqlite:{}", db_path.display());
+    let provider = SqliteMetadataProvider::new(&conn_str).await.unwrap();
+    let catalog = DuckLakeCatalog::new(provider).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog("test", Arc::new(catalog));
+    let batches = ctx
+        .sql("SELECT id FROM test.main.t ORDER BY id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let mut ids = Vec::new();
+    for b in &batches {
+        let col = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        for i in 0..b.num_rows() {
+            ids.push(col.value(i));
+        }
+    }
+    ids
+}
+
+/// Write a positional delete parquet `(file_path VARCHAR, pos BIGINT)` — the
+/// DuckLake standard delete-file schema — and return its byte size. Only `pos`
+/// is read back; `file_path` is documentation.
+fn write_delete_parquet(path: &std::path::Path, data_file_path: &str, positions: &[i64]) -> i64 {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("file_path", DataType::Utf8, false),
+        Field::new("pos", DataType::Int64, false),
+    ]));
+    let file_paths = StringArray::from(vec![data_file_path; positions.len()]);
+    let pos = Int64Array::from(positions.to_vec());
+    let batch =
+        RecordBatch::try_new(schema.clone(), vec![Arc::new(file_paths), Arc::new(pos)]).unwrap();
+    let file = std::fs::File::create(path).unwrap();
+    let mut w = ArrowWriter::try_new(file, schema, None).unwrap();
+    w.write(&batch).unwrap();
+    w.close().unwrap();
+    std::fs::metadata(path).unwrap().len() as i64
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn set_delete_file_positional_delete_roundtrip() {
+    let temp_dir = TempDir::new().unwrap();
+    let writer = Arc::new(create_writer(&temp_dir).await);
+    let object_store: Arc<dyn object_store::ObjectStore> = Arc::new(LocalFileSystem::new());
+
+    // Write ids [1,2,3,4] as one insert-only data file (physical positions 0..3).
+    let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+    let batch =
+        RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(vec![1, 2, 3, 4]))]).unwrap();
+    DuckLakeTableWriter::new(writer.clone(), object_store.clone())
+        .unwrap()
+        .write_table("main", "t", &[batch])
+        .await
+        .unwrap();
+    assert_eq!(read_ids(&temp_dir).await, vec![1, 2, 3, 4], "baseline");
+
+    // Resolve the catalog ids for the freshly-written data file.
+    let db_path = temp_dir.path().join("test.db");
+    let pool = SqlitePool::connect(&format!("sqlite:{}", db_path.display()))
+        .await
+        .unwrap();
+    let table_id: i64 =
+        sqlx::query_scalar("SELECT table_id FROM ducklake_table WHERE end_snapshot IS NULL")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    let df_row = sqlx::query(
+        "SELECT data_file_id, path FROM ducklake_data_file
+         WHERE table_id = ? AND end_snapshot IS NULL",
+    )
+    .bind(table_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let data_file_id: i64 = df_row.try_get(0).unwrap();
+    let data_file_path: String = df_row.try_get(1).unwrap();
+    let base1: i64 = sqlx::query_scalar("SELECT MAX(snapshot_id) FROM ducklake_snapshot")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    // Delete physical positions {1, 3} → ids 2 and 4. First delete: no prior.
+    let del1 = temp_dir.path().join("delete1.parquet");
+    let size1 = write_delete_parquet(&del1, &data_file_path, &[1, 3]);
+    let info1 =
+        DeleteFileInfo::new(del1.to_string_lossy().to_string(), size1, 2).with_absolute_path();
+    writer
+        .set_delete_file(
+            table_id,
+            "main",
+            "t",
+            base1,
+            data_file_id,
+            None,
+            base1,
+            &info1,
+        )
+        .unwrap();
+    assert_eq!(
+        read_ids(&temp_dir).await,
+        vec![1, 3],
+        "positions 1,3 deleted (ids 2,4)"
+    );
+
+    // Cumulative second delete: supersede the first, deleting {1, 2, 3} → ids
+    // 2, 3, 4. The CAS must see the first delete file as the live prior.
+    let prev: i64 = sqlx::query_scalar(
+        "SELECT delete_file_id FROM ducklake_delete_file
+         WHERE data_file_id = ? AND end_snapshot IS NULL",
+    )
+    .bind(data_file_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let base2: i64 = sqlx::query_scalar("SELECT MAX(snapshot_id) FROM ducklake_snapshot")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let del2 = temp_dir.path().join("delete2.parquet");
+    let size2 = write_delete_parquet(&del2, &data_file_path, &[1, 2, 3]);
+    let info2 =
+        DeleteFileInfo::new(del2.to_string_lossy().to_string(), size2, 3).with_absolute_path();
+    writer
+        .set_delete_file(
+            table_id,
+            "main",
+            "t",
+            base2,
+            data_file_id,
+            Some(prev),
+            base2,
+            &info2,
+        )
+        .unwrap();
+    assert_eq!(
+        read_ids(&temp_dir).await,
+        vec![1],
+        "cumulative delete of positions 1,2,3 (ids 2,3,4)"
+    );
+
+    // Exactly one delete file is live for the data file (the prior was retired).
+    let live: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ducklake_delete_file
+         WHERE data_file_id = ? AND end_snapshot IS NULL",
+    )
+    .bind(data_file_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(live, 1, "at most one live delete file per data file");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn set_delete_file_rejects_stale_prior() {
+    // The compare-and-swap must reject a write whose `expected_prev_delete_file`
+    // doesn't match the live delete file (a concurrent delete won).
+    let temp_dir = TempDir::new().unwrap();
+    let writer = Arc::new(create_writer(&temp_dir).await);
+    let object_store: Arc<dyn object_store::ObjectStore> = Arc::new(LocalFileSystem::new());
+
+    let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+    let batch =
+        RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(vec![1, 2, 3, 4]))]).unwrap();
+    DuckLakeTableWriter::new(writer.clone(), object_store.clone())
+        .unwrap()
+        .write_table("main", "t", &[batch])
+        .await
+        .unwrap();
+
+    let db_path = temp_dir.path().join("test.db");
+    let pool = SqlitePool::connect(&format!("sqlite:{}", db_path.display()))
+        .await
+        .unwrap();
+    let table_id: i64 =
+        sqlx::query_scalar("SELECT table_id FROM ducklake_table WHERE end_snapshot IS NULL")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    let df_row = sqlx::query(
+        "SELECT data_file_id, path FROM ducklake_data_file
+         WHERE table_id = ? AND end_snapshot IS NULL",
+    )
+    .bind(table_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let data_file_id: i64 = df_row.try_get(0).unwrap();
+    let data_file_path: String = df_row.try_get(1).unwrap();
+    let base: i64 = sqlx::query_scalar("SELECT MAX(snapshot_id) FROM ducklake_snapshot")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    // Establish a live delete file (prior = None).
+    let del1 = temp_dir.path().join("delete1.parquet");
+    let size1 = write_delete_parquet(&del1, &data_file_path, &[1]);
+    let info1 =
+        DeleteFileInfo::new(del1.to_string_lossy().to_string(), size1, 1).with_absolute_path();
+    writer
+        .set_delete_file(
+            table_id,
+            "main",
+            "t",
+            base,
+            data_file_id,
+            None,
+            base,
+            &info1,
+        )
+        .unwrap();
+
+    // A write that still thinks there's no prior delete file must be rejected.
+    let del2 = temp_dir.path().join("delete2.parquet");
+    let size2 = write_delete_parquet(&del2, &data_file_path, &[1, 2]);
+    let info2 =
+        DeleteFileInfo::new(del2.to_string_lossy().to_string(), size2, 2).with_absolute_path();
+    let base2: i64 = sqlx::query_scalar("SELECT MAX(snapshot_id) FROM ducklake_snapshot")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let err = writer
+        .set_delete_file(
+            table_id,
+            "main",
+            "t",
+            base2,
+            data_file_id,
+            None,
+            base2,
+            &info2,
+        )
+        .expect_err("stale expected_prev_delete_file must be rejected");
+    assert!(
+        matches!(err, datafusion_ducklake::DuckLakeError::Conflict(_)),
+        "expected a Conflict, got {err:?}"
+    );
+}

--- a/tests/positional_delete_tests.rs
+++ b/tests/positional_delete_tests.rs
@@ -18,9 +18,12 @@ use object_store::local::LocalFileSystem;
 use parquet::arrow::ArrowWriter;
 use tempfile::TempDir;
 
+use datafusion::logical_expr::Operator;
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_expr::expressions::{BinaryExpr, col, lit};
 use datafusion_ducklake::{
-    DeleteFileInfo, DuckLakeCatalog, DuckLakeTableWriter, MetadataWriter, SqliteMetadataProvider,
-    SqliteMetadataWriter,
+    DeleteFileInfo, DuckLakeCatalog, DuckLakeFileData, DuckLakeTable, DuckLakeTableWriter,
+    MetadataWriter, SqliteMetadataProvider, SqliteMetadataWriter,
 };
 use sqlx::Row;
 use sqlx::sqlite::SqlitePool;
@@ -279,5 +282,117 @@ async fn set_delete_file_rejects_stale_prior() {
     assert!(
         matches!(err, datafusion_ducklake::DuckLakeError::Conflict(_)),
         "expected a Conflict, got {err:?}"
+    );
+}
+
+/// The full crate-side delete pipeline, end to end: `resolve_positions` finds
+/// the matching rows' physical positions, `write_delete_file` writes and uploads
+/// the `(file_path, pos)` delete parquet, `set_delete_file` registers it, and the
+/// read path applies it. This is the only test that drives `resolve_positions`
+/// (position discovery) and `write_delete_file` (delete-file authoring); the
+/// other tests hand-build the delete parquet and positions.
+#[tokio::test(flavor = "multi_thread")]
+async fn resolve_write_and_apply_positional_delete() {
+    let temp_dir = TempDir::new().unwrap();
+    let writer = Arc::new(create_writer(&temp_dir).await);
+    let object_store: Arc<dyn object_store::ObjectStore> = Arc::new(LocalFileSystem::new());
+
+    // Write ids [1,2,3,4] as one insert-only data file (physical positions 0..3).
+    let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+    let batch =
+        RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(vec![1, 2, 3, 4]))]).unwrap();
+    DuckLakeTableWriter::new(writer.clone(), object_store.clone())
+        .unwrap()
+        .write_table("main", "t", &[batch])
+        .await
+        .unwrap();
+    assert_eq!(read_ids(&temp_dir).await, vec![1, 2, 3, 4], "baseline");
+
+    // Catalog ids + the data file's stored (path, path_is_relative, size), which
+    // are what `DuckLakeFileData` needs to be scanned.
+    let db_path = temp_dir.path().join("test.db");
+    let conn_str = format!("sqlite:{}", db_path.display());
+    let pool = SqlitePool::connect(&conn_str).await.unwrap();
+    let table_id: i64 =
+        sqlx::query_scalar("SELECT table_id FROM ducklake_table WHERE end_snapshot IS NULL")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    let df_row = sqlx::query(
+        "SELECT data_file_id, path, path_is_relative, file_size_bytes
+         FROM ducklake_data_file WHERE table_id = ? AND end_snapshot IS NULL",
+    )
+    .bind(table_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let data_file_id: i64 = df_row.try_get(0).unwrap();
+    let data_file_path: String = df_row.try_get(1).unwrap();
+    let path_is_relative: bool = df_row.try_get::<i64, _>(2).unwrap() != 0;
+    let file_size_bytes: i64 = df_row.try_get(3).unwrap();
+    let data_file =
+        DuckLakeFileData::new(data_file_path.clone(), path_is_relative, file_size_bytes);
+
+    // Resolve positions for `id = 2 OR id = 4` — ids at physical positions 1 and
+    // 3. The predicate is index-based against the table's logical column order
+    // (`id` is column 0).
+    let provider = SqliteMetadataProvider::new(&conn_str).await.unwrap();
+    let catalog = DuckLakeCatalog::new(provider).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog("test", Arc::new(catalog));
+    let schema_provider = ctx.catalog("test").unwrap().schema("main").unwrap();
+    let table_provider = schema_provider.table("t").await.unwrap().unwrap();
+    // `TableProvider: Any` in DataFusion 54 (no `as_any()` method); upcast to
+    // `dyn Any` to reach the concrete `DuckLakeTable`.
+    let table = (table_provider.as_ref() as &dyn std::any::Any)
+        .downcast_ref::<DuckLakeTable>()
+        .expect("provider is a DuckLakeTable");
+
+    let data_schema = Schema::new(vec![Field::new("id", DataType::Int32, false)]);
+    let id: Arc<dyn PhysicalExpr> = col("id", &data_schema).unwrap();
+    let eq2: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(id.clone(), Operator::Eq, lit(2i32)));
+    let eq4: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(id, Operator::Eq, lit(4i32)));
+    let predicate: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(eq2, Operator::Or, eq4));
+
+    let state = ctx.state();
+    let positions = table
+        .resolve_positions(&state, &data_file, predicate)
+        .await
+        .unwrap();
+    let mut positions: Vec<i64> = positions.into_iter().collect();
+    positions.sort_unstable();
+    assert_eq!(
+        positions,
+        vec![1, 3],
+        "ids 2 and 4 sit at positions 1 and 3"
+    );
+
+    // Author the delete file from those positions and register it (no prior).
+    let del_info = DuckLakeTableWriter::new(writer.clone(), object_store.clone())
+        .unwrap()
+        .write_delete_file("main", "t", &data_file_path, &positions)
+        .await
+        .unwrap();
+    let base: i64 = sqlx::query_scalar("SELECT MAX(snapshot_id) FROM ducklake_snapshot")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    writer
+        .set_delete_file(
+            table_id,
+            "main",
+            "t",
+            base,
+            data_file_id,
+            None,
+            base,
+            &del_info,
+        )
+        .unwrap();
+
+    assert_eq!(
+        read_ids(&temp_dir).await,
+        vec![1, 3],
+        "resolve -> write_delete_file -> set_delete_file deletes ids 2,4"
     );
 }

--- a/tests/positional_delete_tests.rs
+++ b/tests/positional_delete_tests.rs
@@ -396,3 +396,157 @@ async fn resolve_write_and_apply_positional_delete() {
         "resolve -> write_delete_file -> set_delete_file deletes ids 2,4"
     );
 }
+
+/// #864 fence: a concurrent APPEND that adds an unrelated data file must NOT
+/// block a positional delete on a still-live data file. The resolved positions
+/// are physical row indices in the target file, which an append never moves, so
+/// the delete commits even against a pre-append `base_snapshot` and both files
+/// coexist. (The old table-wide fence rejected this; the target-file fence does
+/// not.)
+#[tokio::test(flavor = "multi_thread")]
+async fn set_delete_file_allows_concurrent_append_to_other_file() {
+    let temp_dir = TempDir::new().unwrap();
+    let writer = Arc::new(create_writer(&temp_dir).await);
+    let object_store: Arc<dyn object_store::ObjectStore> = Arc::new(LocalFileSystem::new());
+
+    // Data file D: ids [1,2,3,4] at physical positions 0..3.
+    let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from(vec![1, 2, 3, 4]))],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(writer.clone(), object_store.clone())
+        .unwrap()
+        .write_table("main", "t", &[batch])
+        .await
+        .unwrap();
+
+    let db_path = temp_dir.path().join("test.db");
+    let pool = SqlitePool::connect(&format!("sqlite:{}", db_path.display()))
+        .await
+        .unwrap();
+    let table_id: i64 =
+        sqlx::query_scalar("SELECT table_id FROM ducklake_table WHERE end_snapshot IS NULL")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    let df_row = sqlx::query(
+        "SELECT data_file_id, path FROM ducklake_data_file
+         WHERE table_id = ? AND end_snapshot IS NULL",
+    )
+    .bind(table_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let data_file_id: i64 = df_row.try_get(0).unwrap();
+    let data_file_path: String = df_row.try_get(1).unwrap();
+    // Base snapshot captured BEFORE the concurrent append.
+    let base: i64 = sqlx::query_scalar("SELECT MAX(snapshot_id) FROM ducklake_snapshot")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    // Concurrent append: adds a NEW data file (ids [5,6]) and advances the head,
+    // so the table's data generation moved past `base`.
+    let batch2 = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)])),
+        vec![Arc::new(Int32Array::from(vec![5, 6]))],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(writer.clone(), object_store.clone())
+        .unwrap()
+        .append_table("main", "t", &[batch2])
+        .await
+        .unwrap();
+    assert_eq!(
+        read_ids(&temp_dir).await,
+        vec![1, 2, 3, 4, 5, 6],
+        "after append"
+    );
+
+    // Delete positions {1,3} (ids 2,4) on the ORIGINAL file, committing against
+    // the pre-append `base`. Must succeed despite the intervening append.
+    let del = temp_dir.path().join("delete_append.parquet");
+    let size = write_delete_parquet(&del, &data_file_path, &[1, 3]);
+    let info = DeleteFileInfo::new(del.to_string_lossy().to_string(), size, 2).with_absolute_path();
+    writer
+        .set_delete_file(table_id, "main", "t", base, data_file_id, None, base, &info)
+        .expect("append to an unrelated file must not block the delete");
+
+    assert_eq!(
+        read_ids(&temp_dir).await,
+        vec![1, 3, 5, 6],
+        "positions 1,3 deleted from the original file; appended rows untouched"
+    );
+}
+
+/// #864 fence: a positional delete on a data file that a concurrent Replace has
+/// RETIRED must be rejected — the resolved positions refer to a file that is no
+/// longer live, so committing them would mask the wrong generation.
+#[tokio::test(flavor = "multi_thread")]
+async fn set_delete_file_rejects_delete_on_retired_file() {
+    let temp_dir = TempDir::new().unwrap();
+    let writer = Arc::new(create_writer(&temp_dir).await);
+    let object_store: Arc<dyn object_store::ObjectStore> = Arc::new(LocalFileSystem::new());
+
+    let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from(vec![1, 2, 3, 4]))],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(writer.clone(), object_store.clone())
+        .unwrap()
+        .write_table("main", "t", &[batch])
+        .await
+        .unwrap();
+
+    let db_path = temp_dir.path().join("test.db");
+    let pool = SqlitePool::connect(&format!("sqlite:{}", db_path.display()))
+        .await
+        .unwrap();
+    let table_id: i64 =
+        sqlx::query_scalar("SELECT table_id FROM ducklake_table WHERE end_snapshot IS NULL")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    let df_row = sqlx::query(
+        "SELECT data_file_id, path FROM ducklake_data_file
+         WHERE table_id = ? AND end_snapshot IS NULL",
+    )
+    .bind(table_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let data_file_id: i64 = df_row.try_get(0).unwrap();
+    let data_file_path: String = df_row.try_get(1).unwrap();
+    let base: i64 = sqlx::query_scalar("SELECT MAX(snapshot_id) FROM ducklake_snapshot")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    // Concurrent Replace: retires the original data file and writes a new one.
+    let batch2 = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)])),
+        vec![Arc::new(Int32Array::from(vec![7, 8]))],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(writer.clone(), object_store.clone())
+        .unwrap()
+        .write_table("main", "t", &[batch2])
+        .await
+        .unwrap();
+
+    // Deleting from the now-retired file must Conflict.
+    let del = temp_dir.path().join("delete_retired.parquet");
+    let size = write_delete_parquet(&del, &data_file_path, &[1]);
+    let info = DeleteFileInfo::new(del.to_string_lossy().to_string(), size, 1).with_absolute_path();
+    let err = writer
+        .set_delete_file(table_id, "main", "t", base, data_file_id, None, base, &info)
+        .expect_err("delete on a retired data file must be rejected");
+    assert!(
+        matches!(err, datafusion_ducklake::DuckLakeError::Conflict(_)),
+        "expected a Conflict, got {err:?}"
+    );
+}


### PR DESCRIPTION
Adds write-side support for **row-level deletes** on DuckLake tables (SQLite and PostgreSQL) via **positional delete files**. Reads already apply delete files (merge-on-read); this PR adds the ability to *produce and register* them, so rows can be deleted from a table without rewriting its data files.

The pipeline works end-to-end: take a predicate → find the matching rows in a data file → write a `(file_path, pos)` delete parquet → register it in the catalog → subsequent reads transparently hide those rows.

## What

- **`DuckLakeTable::resolve_positions(predicate)`** — scan a data file and collect the matching rows' **physical positions** (the `pos` values a positional delete file records). Reuses the existing positional-scan machinery (`PositionalFileSource` + `FileRowNumberExec`); evaluates the predicate per batch (index-based, against the table's logical column order); does not apply delete files. Insert-only files; whole-file scan (row-group/bloom pruning is a follow-up).
- **`DuckLakeTableWriter::write_delete_file(positions)`** — write and upload the `(file_path, pos)` delete parquet alongside the data files it masks (same `cat_{id}/{schema}/{table}/` layout as data writes; registered relative to the table, so the reader resolves it exactly like a data file). Takes the **cumulative** set of still-deleted positions (≤1 live delete file per data file). Streams via a staging temp + multipart upload, mirroring the data-file `finish()` path.
- **`set_delete_file`** (sqlite and postgres) — cumulative, ≤1-live-delete-file-per-data-file registration in one atomic commit: allocate the snapshot, **fence on target-file liveness** (abort only if the data file was retired by a concurrent Replace/compaction — a concurrent append to *other* files does not conflict), compare-and-swap the currently-live delete file for the data file, retire the prior, insert the new cumulative file. Postgres uses the multicatalog snapshot/head model (`lock_catalog` … `advance_catalog_head`, non-DDL `schema_version` carry-forward); sqlite uses its write-lock-first model.
- **Provider support for the delete flow** — `DuckLakeTableFile` now surfaces the catalog `data_file_id` and the currently-live `delete_file_id` (populated by all read providers); `DuckLakeTable::files()` iterates them and `read_delete_file_positions()` is public, so a caller can assemble the cumulative *(existing ∪ new)* position set and the CAS `expected_prev`.
- Exports `DeleteFileInfo`, `CommitIds`, `DuckLakeFileData`, and `DuckLakeTableFile` so callers (e.g. runtimedb) can drive the full pipeline.

## Tests

- `tests/positional_delete_tests.rs` (SQLite, no container):
  - **end-to-end** `resolve_positions` → `write_delete_file` → `set_delete_file` → read survivors;
  - a hand-built round-trip **through the read path** asserting surviving values (delete positions {1,3}, then a cumulative {1,2,3}) and the ≤1-live invariant;
  - a CAS-rejection on a stale `expected_prev_delete_file`;
  - fence: a concurrent append to another file does **not** block the delete, and a delete on a Replace-retired file is rejected.
- `tests/multicatalog_postgres_tests.rs` (Postgres testcontainer): the metadata effects of the postgres write — head advances, exactly one live delete file, a cumulative supersede retires the prior, and the CAS rejects a stale prior.

Value assertions are deliberate: a positional bug silently deletes the *wrong* rows.

## Follow-up (not in this PR)

- runtimedb wires this into a `mode=delete` managed-table flow (#864): resolve positions for the caller's predicate, merge with any live delete file into the cumulative set, `write_delete_file`, then `set_delete_file`.
