### PR TITLE
test(write): differential tests for positional deletes

### DIFF
--- a/tests/positional_delete_oracle_postgres_tests.rs
+++ b/tests/positional_delete_oracle_postgres_tests.rs
@@ -1,0 +1,418 @@
+//! Postgres multicatalog counterpart of the positional-delete differential
+//! oracle (the SQLite version lives in `positional_delete_oracle_tests.rs`).
+//!
+//! runtimedb runs on the **multicatalog Postgres** write path, and its
+//! `set_delete_file` / snapshot handling is a *separate implementation* from the
+//! SQLite single-catalog path — the catalog head is per-catalog (not a global
+//! `MAX(snapshot_id)`), and table/file lookups are catalog-scoped. So the same
+//! differential (delete via the real path → read → compare surviving VALUES
+//! against a position-math-free reference) is re-run here against the production
+//! backend, end to end with real parquet.
+//!
+//! The read + `resolve_positions` side is provider-agnostic (`DuckLakeCatalog`
+//! works over any `MetadataProvider`, `MulticatalogProvider` included), and all
+//! catalog-scoped lookups go through the provider API rather than raw SQL, so
+//! nothing here reaches across catalogs.
+//!
+//! Docker-gated (testcontainers Postgres), matching the crate's other Postgres
+//! tests; ignored under `skip-tests-with-docker` on macOS.
+
+#![cfg(feature = "write-postgres")]
+
+use std::sync::Arc;
+
+use arrow::array::{Array, Int32Array, RecordBatch};
+use arrow::datatypes::{DataType, Field, Schema};
+use datafusion::logical_expr::Operator;
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_expr::expressions::{BinaryExpr, col, lit};
+use datafusion::prelude::*;
+use datafusion_ducklake::{
+    DuckLakeCatalog, DuckLakeTable, DuckLakeTableWriter, MetadataProvider, MetadataWriter,
+    MulticatalogManager, MulticatalogProvider, PostgresMetadataWriter,
+};
+use object_store::local::LocalFileSystem;
+use sqlx::postgres::{PgPool, PgPoolOptions};
+use tempfile::TempDir;
+use testcontainers::ContainerAsync;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+type ObjStore = Arc<dyn object_store::ObjectStore>;
+
+async fn spin_up_postgres() -> anyhow::Result<(PgPool, ContainerAsync<Postgres>)> {
+    let container = Postgres::default().start().await?;
+    let port = container.get_host_port_ipv4(5432).await?;
+    let conn_str = format!("postgresql://postgres:postgres@127.0.0.1:{}/postgres", port);
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&conn_str)
+        .await?;
+    datafusion_ducklake::initialize_multicatalog_schema(&pool).await?;
+    Ok((pool, container))
+}
+
+fn object_store() -> ObjStore {
+    Arc::new(LocalFileSystem::new())
+}
+
+/// The ORACLE: which ids survive deleting `del`, with zero position math.
+fn survivors(ids: &[i32], del: &[i32]) -> Vec<i32> {
+    let mut s: Vec<i32> = ids.iter().copied().filter(|x| !del.contains(x)).collect();
+    s.sort_unstable();
+    s
+}
+
+async fn create_catalog(pool: &PgPool, name: &str) -> i64 {
+    MulticatalogManager::new(pool.clone())
+        .create_catalog(name)
+        .await
+        .unwrap()
+}
+
+async fn writer_for(
+    pool: &PgPool,
+    cat: i64,
+    data_path: &std::path::Path,
+) -> Arc<PostgresMetadataWriter> {
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path(data_path.to_str().unwrap()).unwrap();
+    Arc::new(w)
+}
+
+async fn write_ids(
+    pool: &PgPool,
+    cat: i64,
+    os: ObjStore,
+    data_path: &std::path::Path,
+    ids: &[i32],
+    rg: usize,
+) {
+    let w = writer_for(pool, cat, data_path).await;
+    let batch = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)])),
+        vec![Arc::new(Int32Array::from(ids.to_vec()))],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(w, os)
+        .unwrap()
+        .with_max_row_group_rows(rg)
+        .write_table("public", "t", &[batch])
+        .await
+        .unwrap();
+}
+
+async fn append_ids(
+    pool: &PgPool,
+    cat: i64,
+    os: ObjStore,
+    data_path: &std::path::Path,
+    ids: &[i32],
+) {
+    let w = writer_for(pool, cat, data_path).await;
+    let batch = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)])),
+        vec![Arc::new(Int32Array::from(ids.to_vec()))],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(w, os)
+        .unwrap()
+        .append_table("public", "t", &[batch])
+        .await
+        .unwrap();
+}
+
+/// Positional delete for `del` across every live data file in the catalog,
+/// cumulative-aware — all lookups catalog-scoped via the provider API.
+async fn apply_delete(
+    pool: &PgPool,
+    cat: i64,
+    cat_name: &str,
+    os: ObjStore,
+    data_path: &std::path::Path,
+    del: &[i32],
+) {
+    if del.is_empty() {
+        return;
+    }
+
+    // Catalog-scoped metadata: head, schema, table, live files (with their
+    // data_file_id and any live delete file = the cumulative prev).
+    let meta = MulticatalogProvider::with_pool(pool.clone(), cat_name)
+        .await
+        .unwrap();
+    let head = meta.get_current_snapshot().unwrap();
+    let schema = meta.get_schema_by_name("public", head).unwrap().unwrap();
+    let table_meta = meta
+        .get_table_by_name(schema.schema_id, "t", head)
+        .unwrap()
+        .unwrap();
+    let files = meta
+        .get_table_files_for_select(table_meta.table_id, head)
+        .unwrap();
+
+    // A DuckLakeTable (over the same catalog) to resolve key -> physical positions.
+    let read = MulticatalogProvider::with_pool(pool.clone(), cat_name)
+        .await
+        .unwrap();
+    let catalog = DuckLakeCatalog::new(read).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog(cat_name, Arc::new(catalog));
+    let table_provider = ctx
+        .catalog(cat_name)
+        .unwrap()
+        .schema("public")
+        .unwrap()
+        .table("t")
+        .await
+        .unwrap()
+        .unwrap();
+    let table = (table_provider.as_ref() as &dyn std::any::Any)
+        .downcast_ref::<DuckLakeTable>()
+        .expect("provider is a DuckLakeTable");
+    let state = ctx.state();
+
+    let data_schema = Schema::new(vec![Field::new("id", DataType::Int32, false)]);
+    let id = col("id", &data_schema).unwrap();
+    let predicate = del
+        .iter()
+        .map(|d| -> Arc<dyn PhysicalExpr> {
+            Arc::new(BinaryExpr::new(id.clone(), Operator::Eq, lit(*d)))
+        })
+        .reduce(|acc, e| Arc::new(BinaryExpr::new(acc, Operator::Or, e)))
+        .expect("del is non-empty");
+
+    let writer = writer_for(pool, cat, data_path).await;
+
+    for tf in &files {
+        let positions: Vec<i64> = table
+            .resolve_positions(&state, &tf.file, predicate.clone())
+            .await
+            .unwrap()
+            .into_iter()
+            .collect();
+        if positions.is_empty() {
+            continue;
+        }
+        let del_info = DuckLakeTableWriter::new(writer.clone(), os.clone())
+            .unwrap()
+            .write_delete_file("public", "t", &tf.file.path, &positions)
+            .await
+            .unwrap();
+        writer
+            .set_delete_file(
+                table_meta.table_id,
+                "public",
+                "t",
+                head,
+                tf.data_file_id,
+                tf.delete_file_id, // cumulative prev (None on first generation)
+                head,
+                &del_info,
+            )
+            .unwrap();
+    }
+}
+
+async fn read_ids(pool: &PgPool, cat_name: &str) -> Vec<i32> {
+    let provider = MulticatalogProvider::with_pool(pool.clone(), cat_name)
+        .await
+        .unwrap();
+    let catalog = DuckLakeCatalog::new(provider).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog(cat_name, Arc::new(catalog));
+    let batches = ctx
+        .sql(&format!("SELECT id FROM {cat_name}.public.t ORDER BY id"))
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let mut ids = Vec::new();
+    for b in &batches {
+        let c = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        for i in 0..b.num_rows() {
+            ids.push(c.value(i));
+        }
+    }
+    ids
+}
+
+async fn read_id_extra(pool: &PgPool, cat_name: &str) -> Vec<(i32, Option<i32>)> {
+    let provider = MulticatalogProvider::with_pool(pool.clone(), cat_name)
+        .await
+        .unwrap();
+    let catalog = DuckLakeCatalog::new(provider).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog(cat_name, Arc::new(catalog));
+    let batches = ctx
+        .sql(&format!(
+            "SELECT id, extra FROM {cat_name}.public.t ORDER BY id"
+        ))
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let mut rows = Vec::new();
+    for b in &batches {
+        let ids = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        let extra = b.column(1).as_any().downcast_ref::<Int32Array>().unwrap();
+        for i in 0..b.num_rows() {
+            let e = if extra.is_null(i) {
+                None
+            } else {
+                Some(extra.value(i))
+            };
+            rows.push((ids.value(i), e));
+        }
+    }
+    rows
+}
+
+/// Curated id-only shapes on multicatalog Postgres: multi-row-group deletes,
+/// deletes across appended files, update (delete + re-insert), and cumulative
+/// multi-generation deletes — each in its own catalog, one container.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn positional_delete_oracle_postgres() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let tmp = TempDir::new().unwrap();
+    let data = tmp.path().join("data");
+    std::fs::create_dir_all(&data).unwrap();
+    let os = object_store();
+
+    // --- Curated single-file, multi-row-group shapes. ---
+    let shapes: Vec<(&str, Vec<i32>, usize, Vec<i32>)> = vec![
+        ("mrg_diff_groups", (1..=6).collect(), 2, vec![3, 5]),
+        ("mrg_whole_group", (1..=6).collect(), 2, vec![1, 2]),
+        ("mrg_boundary", (1..=6).collect(), 4, vec![4, 5]),
+        ("ragged_last", (1..=5).collect(), 2, vec![5]),
+        ("delete_all", vec![1, 2, 3], 2, vec![1, 2, 3]),
+        ("no_match", (1..=4).collect(), 2, vec![99]),
+    ];
+    for (name, ids, rg, del) in shapes {
+        let cat = create_catalog(&pool, name).await;
+        write_ids(&pool, cat, os.clone(), &data, &ids, rg).await;
+        assert_eq!(
+            read_ids(&pool, name).await,
+            survivors(&ids, &[]),
+            "baseline [{name}]"
+        );
+        apply_delete(&pool, cat, name, os.clone(), &data, &del).await;
+        assert_eq!(
+            read_ids(&pool, name).await,
+            survivors(&ids, &del),
+            "survivors [{name}]"
+        );
+    }
+
+    // --- Deletes across appended files. ---
+    {
+        let name = "appended";
+        let cat = create_catalog(&pool, name).await;
+        write_ids(&pool, cat, os.clone(), &data, &[1, 2, 3, 4], 2).await;
+        append_ids(&pool, cat, os.clone(), &data, &[5, 6, 7, 8]).await;
+        let del = vec![2, 3, 6, 8];
+        apply_delete(&pool, cat, name, os.clone(), &data, &del).await;
+        assert_eq!(
+            read_ids(&pool, name).await,
+            survivors(&[1, 2, 3, 4, 5, 6, 7, 8], &del),
+            "survivors across two files"
+        );
+    }
+
+    // --- Update = delete old + re-insert (re-inserted deleted key survives). ---
+    {
+        let name = "update";
+        let cat = create_catalog(&pool, name).await;
+        let orig = vec![1, 2, 3, 4, 5, 6];
+        write_ids(&pool, cat, os.clone(), &data, &orig, 2).await;
+        let del = vec![2, 4];
+        apply_delete(&pool, cat, name, os.clone(), &data, &del).await;
+        append_ids(&pool, cat, os.clone(), &data, &[2, 7]).await;
+        let mut want = survivors(&orig, &del);
+        want.extend_from_slice(&[2, 7]);
+        want.sort_unstable();
+        assert_eq!(
+            read_ids(&pool, name).await,
+            want,
+            "update: delete old + insert new"
+        );
+    }
+
+    // --- Cumulative multi-generation deletes. ---
+    {
+        let name = "cumulative";
+        let cat = create_catalog(&pool, name).await;
+        let ids: Vec<i32> = (1..=8).collect();
+        write_ids(&pool, cat, os.clone(), &data, &ids, 3).await;
+        apply_delete(&pool, cat, name, os.clone(), &data, &[2, 4]).await;
+        assert_eq!(
+            read_ids(&pool, name).await,
+            survivors(&ids, &[2, 4]),
+            "after gen 1"
+        );
+        apply_delete(&pool, cat, name, os.clone(), &data, &[2, 4, 6, 8]).await;
+        assert_eq!(
+            read_ids(&pool, name).await,
+            survivors(&ids, &[2, 4, 6, 8]),
+            "after gen 2"
+        );
+    }
+}
+
+/// Schema-evolved table on multicatalog Postgres: an appended wider file adds a
+/// nullable column; the pre-evolution file null-fills it, and a delete across
+/// both files keeps the correct `(id, extra)` rows.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn positional_delete_oracle_postgres_schema_evolution() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let tmp = TempDir::new().unwrap();
+    let data = tmp.path().join("data");
+    std::fs::create_dir_all(&data).unwrap();
+    let os = object_store();
+
+    let name = "schema_evo";
+    let cat = create_catalog(&pool, name).await;
+
+    // File 1: {id}.
+    write_ids(&pool, cat, os.clone(), &data, &[1, 2, 3], 2).await;
+
+    // File 2: append under a wider schema — adds nullable `extra` (DDL).
+    let w = writer_for(&pool, cat, &data).await;
+    let wider = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("extra", DataType::Int32, true),
+    ]));
+    let b2 = RecordBatch::try_new(
+        wider,
+        vec![
+            Arc::new(Int32Array::from(vec![4, 5])),
+            Arc::new(Int32Array::from(vec![Some(40), Some(50)])),
+        ],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(w, os.clone())
+        .unwrap()
+        .append_table("public", "t", &[b2])
+        .await
+        .unwrap();
+
+    assert_eq!(
+        read_id_extra(&pool, name).await,
+        vec![(1, None), (2, None), (3, None), (4, Some(40)), (5, Some(50))],
+        "baseline: pre-evolution rows null-fill extra"
+    );
+
+    apply_delete(&pool, cat, name, os.clone(), &data, &[2, 5]).await;
+
+    assert_eq!(
+        read_id_extra(&pool, name).await,
+        vec![(1, None), (3, None), (4, Some(40))],
+        "survivors keep correct (id, extra) across the schema boundary"
+    );
+}

--- a/tests/positional_delete_oracle_tests.rs
+++ b/tests/positional_delete_oracle_tests.rs
@@ -1,0 +1,555 @@
+//! Replace-on-survivors oracle + differential harness for positional deletes.
+//!
+//! The example tests in `positional_delete_tests.rs` hardcode the expected
+//! survivors on a single 4-row, single-row-group file. This harness
+//! instead *computes* the reference survivors independently of the position math
+//! and drives many shapes through the real positional path
+//! (`resolve_positions -> write_delete_file -> set_delete_file`), asserting the
+//! surviving VALUES match — a positional bug silently deletes the wrong rows.
+//!
+//! Why this catches what the example tests can't: the oracle never computes a
+//! physical position. Survivors are derived by *predicate* (which rows are not
+//! deleted), so if the SUT's `row_group_start (prefix-sum) + within-group
+//! offset` math is wrong, the two disagree. The generators deliberately exercise
+//! the regions the single-file example tests never touch: **multi-row-group**
+//! files, **multiple data files** (append), **schema-evolved** files, **update**
+//! (delete + re-insert), and **multi-generation** (cumulative) deletes.
+//!
+//! Deterministic on purpose: fixed shapes + a bounded exhaustive sweep, no
+//! randomness — reproducible and parallel-safe on CI (each case gets its own
+//! temp dir + SQLite catalog). Split into several `#[test]` fns so `cargo test`
+//! parallelizes across them.
+
+#![cfg(all(feature = "write-sqlite", feature = "metadata-sqlite"))]
+
+use std::sync::Arc;
+
+use arrow::array::{Array, Int32Array, RecordBatch};
+use arrow::datatypes::{DataType, Field, Schema};
+use datafusion::logical_expr::Operator;
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_expr::expressions::{BinaryExpr, col, lit};
+use datafusion::prelude::*;
+use datafusion_ducklake::{
+    DuckLakeCatalog, DuckLakeFileData, DuckLakeTable, DuckLakeTableWriter, MetadataWriter,
+    SqliteMetadataProvider, SqliteMetadataWriter,
+};
+use object_store::local::LocalFileSystem;
+use sqlx::Row;
+use sqlx::sqlite::SqlitePool;
+use tempfile::TempDir;
+
+type ObjStore = Arc<dyn object_store::ObjectStore>;
+
+fn object_store() -> ObjStore {
+    Arc::new(LocalFileSystem::new())
+}
+
+/// A writable SQLite-backed catalog + a data dir, in a temp dir.
+async fn create_writer(temp_dir: &TempDir) -> Arc<SqliteMetadataWriter> {
+    let db_path = temp_dir.path().join("test.db");
+    let data_path = temp_dir.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+    let conn_str = format!("sqlite:{}?mode=rwc", db_path.display());
+    let writer = SqliteMetadataWriter::new_with_init(&conn_str)
+        .await
+        .unwrap();
+    writer.set_data_path(data_path.to_str().unwrap()).unwrap();
+    Arc::new(writer)
+}
+
+async fn pool_for(temp_dir: &TempDir) -> SqlitePool {
+    let db_path = temp_dir.path().join("test.db");
+    SqlitePool::connect(&format!("sqlite:{}", db_path.display()))
+        .await
+        .unwrap()
+}
+
+fn int32_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]))
+}
+
+/// Read `id`s from `test.main.t`, ascending, through the full read path (which
+/// applies any live delete files).
+async fn read_ids(temp_dir: &TempDir) -> Vec<i32> {
+    let conn_str = format!("sqlite:{}", temp_dir.path().join("test.db").display());
+    let provider = SqliteMetadataProvider::new(&conn_str).await.unwrap();
+    let catalog = DuckLakeCatalog::new(provider).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog("test", Arc::new(catalog));
+    let batches = ctx
+        .sql("SELECT id FROM test.main.t ORDER BY id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let mut ids = Vec::new();
+    for b in &batches {
+        let c = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        for i in 0..b.num_rows() {
+            ids.push(c.value(i));
+        }
+    }
+    ids
+}
+
+/// Read `(id, extra)` rows, ascending by id — for the schema-evolution case
+/// where rows from the pre-evolution file must null-fill `extra`.
+async fn read_id_extra(temp_dir: &TempDir) -> Vec<(i32, Option<i32>)> {
+    let conn_str = format!("sqlite:{}", temp_dir.path().join("test.db").display());
+    let provider = SqliteMetadataProvider::new(&conn_str).await.unwrap();
+    let catalog = DuckLakeCatalog::new(provider).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog("test", Arc::new(catalog));
+    let batches = ctx
+        .sql("SELECT id, extra FROM test.main.t ORDER BY id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let mut rows = Vec::new();
+    for b in &batches {
+        let ids = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        let extra = b.column(1).as_any().downcast_ref::<Int32Array>().unwrap();
+        for i in 0..b.num_rows() {
+            let e = if extra.is_null(i) {
+                None
+            } else {
+                Some(extra.value(i))
+            };
+            rows.push((ids.value(i), e));
+        }
+    }
+    rows
+}
+
+/// The ORACLE, single column: which ids survive deleting `del`, with zero
+/// position math — delete-by-key removes *every* matching row. Sorted to match
+/// the `ORDER BY id` read. (Replace-on-survivors in spirit: exactly the set a
+/// full rewrite-keeping-survivors retains.)
+fn survivors(ids: &[i32], del: &[i32]) -> Vec<i32> {
+    let mut s: Vec<i32> = ids.iter().copied().filter(|x| !del.contains(x)).collect();
+    s.sort_unstable();
+    s
+}
+
+/// Write `ids` as one data file with `max_row_group_rows = rg` (so `rg < ids.len()`
+/// yields a genuinely multi-row-group file).
+async fn write_initial(writer: Arc<SqliteMetadataWriter>, os: ObjStore, ids: &[i32], rg: usize) {
+    let batch = RecordBatch::try_new(
+        int32_schema(),
+        vec![Arc::new(Int32Array::from(ids.to_vec()))],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(writer, os)
+        .unwrap()
+        .with_max_row_group_rows(rg)
+        .write_table("main", "t", &[batch])
+        .await
+        .unwrap();
+}
+
+/// Append `ids` as an additional same-schema data file.
+async fn append_ids(writer: Arc<SqliteMetadataWriter>, os: ObjStore, ids: &[i32]) {
+    let batch = RecordBatch::try_new(
+        int32_schema(),
+        vec![Arc::new(Int32Array::from(ids.to_vec()))],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(writer, os)
+        .unwrap()
+        .append_table("main", "t", &[batch])
+        .await
+        .unwrap();
+}
+
+/// The real positional-delete path for the key set `del` (an `id IN (del)`
+/// predicate), applied across **every** live data file and cumulative-aware:
+/// resolve matching physical positions per file, author a `(file_path, pos)`
+/// delete file, and register it superseding any prior live delete file for that
+/// data file (the ≤1-live CAS). Pass the *full accumulated* key set to build a
+/// cumulative generation. No-op for files with no match.
+async fn apply_delete(
+    temp_dir: &TempDir,
+    writer: Arc<SqliteMetadataWriter>,
+    os: ObjStore,
+    del: &[i32],
+) {
+    if del.is_empty() {
+        return;
+    }
+    let conn_str = format!("sqlite:{}", temp_dir.path().join("test.db").display());
+    let pool = pool_for(temp_dir).await;
+
+    let table_id: i64 =
+        sqlx::query_scalar("SELECT table_id FROM ducklake_table WHERE end_snapshot IS NULL")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    let files = sqlx::query(
+        "SELECT data_file_id, path, path_is_relative, file_size_bytes
+         FROM ducklake_data_file WHERE table_id = ? AND end_snapshot IS NULL ORDER BY data_file_id",
+    )
+    .bind(table_id)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+
+    // `id = d0 OR id = d1 OR ...`, index-based on the table's logical column 0.
+    let data_schema = Schema::new(vec![Field::new("id", DataType::Int32, false)]);
+    let id = col("id", &data_schema).unwrap();
+    let predicate = del
+        .iter()
+        .map(|d| -> Arc<dyn PhysicalExpr> {
+            Arc::new(BinaryExpr::new(id.clone(), Operator::Eq, lit(*d)))
+        })
+        .reduce(|acc, e| Arc::new(BinaryExpr::new(acc, Operator::Or, e)))
+        .expect("del is non-empty");
+
+    let provider = SqliteMetadataProvider::new(&conn_str).await.unwrap();
+    let catalog = DuckLakeCatalog::new(provider).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog("test", Arc::new(catalog));
+    let table_provider = ctx
+        .catalog("test")
+        .unwrap()
+        .schema("main")
+        .unwrap()
+        .table("t")
+        .await
+        .unwrap()
+        .unwrap();
+    let table = (table_provider.as_ref() as &dyn std::any::Any)
+        .downcast_ref::<DuckLakeTable>()
+        .expect("provider is a DuckLakeTable");
+    let state = ctx.state();
+
+    for f in &files {
+        let data_file_id: i64 = f.try_get(0).unwrap();
+        let path: String = f.try_get(1).unwrap();
+        let path_is_relative: bool = f.try_get::<i64, _>(2).unwrap() != 0;
+        let size: i64 = f.try_get(3).unwrap();
+        let data_file = DuckLakeFileData::new(path.clone(), path_is_relative, size);
+
+        let positions: Vec<i64> = table
+            .resolve_positions(&state, &data_file, predicate.clone())
+            .await
+            .unwrap()
+            .into_iter()
+            .collect();
+        if positions.is_empty() {
+            continue;
+        }
+
+        let prev: Option<i64> = sqlx::query_scalar(
+            "SELECT delete_file_id FROM ducklake_delete_file
+             WHERE data_file_id = ? AND end_snapshot IS NULL",
+        )
+        .bind(data_file_id)
+        .fetch_optional(&pool)
+        .await
+        .unwrap();
+
+        let del_info = DuckLakeTableWriter::new(writer.clone(), os.clone())
+            .unwrap()
+            .write_delete_file("main", "t", &path, &positions)
+            .await
+            .unwrap();
+        let base: i64 = sqlx::query_scalar("SELECT MAX(snapshot_id) FROM ducklake_snapshot")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        writer
+            .set_delete_file(
+                table_id,
+                "main",
+                "t",
+                base,
+                data_file_id,
+                prev,
+                base,
+                &del_info,
+            )
+            .unwrap();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Curated multi-row-group shapes.
+// ---------------------------------------------------------------------------
+
+struct Shape {
+    ids: Vec<i32>,
+    rg: usize,
+    del: Vec<i32>,
+    note: &'static str,
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn curated_multi_row_group_shapes() {
+    let shapes = vec![
+        Shape {
+            ids: (1..=4).collect(),
+            rg: 100,
+            del: vec![2, 4],
+            note: "single row group (control)",
+        },
+        Shape {
+            ids: (1..=6).collect(),
+            rg: 2,
+            del: vec![3, 5],
+            note: "3 row groups, deletes in different groups",
+        },
+        Shape {
+            ids: (1..=6).collect(),
+            rg: 2,
+            del: vec![1, 2],
+            note: "delete an entire row group",
+        },
+        Shape {
+            ids: (1..=6).collect(),
+            rg: 4,
+            del: vec![4, 5],
+            note: "delete spans the row-group boundary",
+        },
+        Shape {
+            ids: vec![10, 20, 30, 40, 50, 60],
+            rg: 2,
+            del: vec![10, 30, 50],
+            note: "first row of each group",
+        },
+        Shape {
+            ids: (1..=5).collect(),
+            rg: 2,
+            del: vec![5],
+            note: "last row, ragged final group",
+        },
+        Shape {
+            ids: vec![1, 2, 3],
+            rg: 2,
+            del: vec![1, 2, 3],
+            note: "delete every row",
+        },
+        Shape {
+            ids: (1..=4).collect(),
+            rg: 2,
+            del: vec![99],
+            note: "no match — nothing deleted",
+        },
+    ];
+
+    for shape in shapes {
+        let temp_dir = TempDir::new().unwrap();
+        let writer = create_writer(&temp_dir).await;
+        let os = object_store();
+
+        write_initial(writer.clone(), os.clone(), &shape.ids, shape.rg).await;
+        assert_eq!(
+            read_ids(&temp_dir).await,
+            survivors(&shape.ids, &[]),
+            "baseline [{}]",
+            shape.note
+        );
+
+        apply_delete(&temp_dir, writer.clone(), os.clone(), &shape.del).await;
+
+        assert_eq!(
+            read_ids(&temp_dir).await,
+            survivors(&shape.ids, &shape.del),
+            "survivors mismatch [{}] rg={} del={:?}",
+            shape.note,
+            shape.rg,
+            shape.del
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Bounded exhaustive sweep — every delete subset × row-group size, for a
+//    few small file sizes. This is the position-math safety net: it is complete
+//    over the small region where boundary bugs live, and fully deterministic.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn exhaustive_small_files_all_delete_subsets() {
+    for n in [4usize, 5, 6] {
+        let ids: Vec<i32> = (1..=n as i32).collect();
+        for rg in [1usize, 2, 3] {
+            for mask in 0u32..(1u32 << n) {
+                let del: Vec<i32> = (0..n)
+                    .filter(|i| mask & (1 << i) != 0)
+                    .map(|i| ids[i])
+                    .collect();
+
+                let temp_dir = TempDir::new().unwrap();
+                let writer = create_writer(&temp_dir).await;
+                let os = object_store();
+
+                write_initial(writer.clone(), os.clone(), &ids, rg).await;
+                apply_delete(&temp_dir, writer.clone(), os.clone(), &del).await;
+
+                assert_eq!(
+                    read_ids(&temp_dir).await,
+                    survivors(&ids, &del),
+                    "n={n} rg={rg} del={del:?}"
+                );
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 3. Deletes across multiple data files (append), each with its own positions.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn deletes_across_appended_files() {
+    let temp_dir = TempDir::new().unwrap();
+    let writer = create_writer(&temp_dir).await;
+    let os = object_store();
+
+    // Two data files, each multi-row-group.
+    write_initial(writer.clone(), os.clone(), &[1, 2, 3, 4], 2).await;
+    append_ids(writer.clone(), os.clone(), &[5, 6, 7, 8]).await;
+    assert_eq!(
+        read_ids(&temp_dir).await,
+        vec![1, 2, 3, 4, 5, 6, 7, 8],
+        "baseline"
+    );
+
+    // Delete keys living in *both* files: 2,3 (file A) and 6,8 (file B).
+    let del = vec![2, 3, 6, 8];
+    apply_delete(&temp_dir, writer.clone(), os.clone(), &del).await;
+
+    assert_eq!(
+        read_ids(&temp_dir).await,
+        survivors(&[1, 2, 3, 4, 5, 6, 7, 8], &del),
+        "survivors across two files"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. Deletes across a schema-evolved table (old file lacks the added column).
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn deletes_across_schema_evolution() {
+    let temp_dir = TempDir::new().unwrap();
+    let writer = create_writer(&temp_dir).await;
+    let os = object_store();
+
+    // File 1: schema {id}.
+    write_initial(writer.clone(), os.clone(), &[1, 2, 3], 2).await;
+
+    // File 2: append under a WIDER schema — adds nullable `extra` (DDL). Old
+    // file's rows must null-fill `extra` on read.
+    let wider = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("extra", DataType::Int32, true),
+    ]));
+    let b2 = RecordBatch::try_new(
+        wider,
+        vec![
+            Arc::new(Int32Array::from(vec![4, 5])),
+            Arc::new(Int32Array::from(vec![Some(40), Some(50)])),
+        ],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(writer.clone(), os.clone())
+        .unwrap()
+        .append_table("main", "t", &[b2])
+        .await
+        .unwrap();
+
+    assert_eq!(
+        read_id_extra(&temp_dir).await,
+        vec![(1, None), (2, None), (3, None), (4, Some(40)), (5, Some(50))],
+        "baseline: pre-evolution rows null-fill extra"
+    );
+
+    // Delete one row from each file: 2 (old-schema file) and 5 (new-schema file).
+    apply_delete(&temp_dir, writer.clone(), os.clone(), &[2, 5]).await;
+
+    assert_eq!(
+        read_id_extra(&temp_dir).await,
+        vec![(1, None), (3, None), (4, Some(40))],
+        "survivors keep correct (id, extra) across the schema boundary"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. Update = positional delete of old versions + append of new versions
+//    (models the update flow at the crate primitive level). A re-inserted deleted key
+//    survives (it lands in a new file the delete doesn't cover).
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_as_delete_then_insert() {
+    let temp_dir = TempDir::new().unwrap();
+    let writer = create_writer(&temp_dir).await;
+    let os = object_store();
+
+    let orig = vec![1, 2, 3, 4, 5, 6];
+    write_initial(writer.clone(), os.clone(), &orig, 2).await;
+
+    // Delete 2 and 4 from the original file, then append new rows [2, 7] — id 2
+    // is re-inserted (must survive), id 7 is new.
+    let del = vec![2, 4];
+    apply_delete(&temp_dir, writer.clone(), os.clone(), &del).await;
+    append_ids(writer.clone(), os.clone(), &[2, 7]).await;
+
+    let mut want = survivors(&orig, &del); // [1,3,5,6]
+    want.extend_from_slice(&[2, 7]);
+    want.sort_unstable(); // [1,2,3,5,6,7]
+
+    assert_eq!(
+        read_ids(&temp_dir).await,
+        want,
+        "update: delete old + insert new"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 6. Multi-generation (cumulative) deletes: a second delete supersedes the
+//    first with the accumulated positions; ≤1 live delete file remains.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cumulative_deletes_across_generations() {
+    let temp_dir = TempDir::new().unwrap();
+    let writer = create_writer(&temp_dir).await;
+    let os = object_store();
+
+    let ids: Vec<i32> = (1..=8).collect();
+    write_initial(writer.clone(), os.clone(), &ids, 3).await;
+
+    // Generation 1: delete {2,4}.
+    apply_delete(&temp_dir, writer.clone(), os.clone(), &[2, 4]).await;
+    assert_eq!(
+        read_ids(&temp_dir).await,
+        survivors(&ids, &[2, 4]),
+        "after gen 1"
+    );
+
+    // Generation 2: the accumulated set {2,4,6,8} — supersedes gen 1.
+    apply_delete(&temp_dir, writer.clone(), os.clone(), &[2, 4, 6, 8]).await;
+    assert_eq!(
+        read_ids(&temp_dir).await,
+        survivors(&ids, &[2, 4, 6, 8]),
+        "after gen 2 (cumulative)"
+    );
+
+    // Invariant: exactly one live delete file remains for the single data file.
+    let pool = pool_for(&temp_dir).await;
+    let live: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM ducklake_delete_file WHERE end_snapshot IS NULL")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        live, 1,
+        "≤1 live delete file per data file after superseding"
+    );
+}


### PR DESCRIPTION
Adds a **Replace-on-survivors oracle** and a **differential harness** for the positional-delete write path, on **both** backends.

It drives the real path (`resolve_positions → write_delete_file → set_delete_file`) and asserts the surviving **values** against a reference computed purely by predicate — no position math — so a wrong `row_group_start` prefix-sum or within-group offset makes the two disagree.

### Coverage (the regions the existing example tests skip)

- **Multi-row-group files** — curated boundary shapes (cross-group deletes, whole-group, ragged final group, no-match) plus a **bounded exhaustive sweep** over small files × row-group sizes × every delete subset. Complete over the small region where boundary bugs live.
- **Multiple data files** (append) — per-file resolve + multi-file read.
- **Schema-evolved files** — a pre-evolution file null-fills the added column; verified across a delete.
- **Update** as delete + re-insert — a re-inserted deleted key survives (lands in a new slot the delete doesn't cover).
- **Multi-generation cumulative deletes** — a later delete supersedes the prior with the accumulated positions; ≤1 live delete file remains.

### Both backends

- **SQLite single-catalog** (`positional_delete_oracle_tests.rs`) — runs everywhere, no Docker; carries the exhaustive sweep.
- **Multicatalog Postgres** (`positional_delete_oracle_postgres_tests.rs`) — the same differential end-to-end with real parquet, since `set_delete_file` and per-catalog snapshot handling are a **separate implementation** (catalog head is per-catalog, not a global `MAX(snapshot_id)`; table/file lookups are catalog-scoped, done via the provider API). Docker-gated (testcontainers), ignored under `skip-tests-with-docker` on macOS.

The read + `resolve_positions` side is provider-agnostic (`DuckLakeCatalog` works over any `MetadataProvider`), so the harness logic is shared across backends.

### Properties

- **Deterministic** — fixed shapes + a deterministic sweep, no randomness; reproducible on CI.
- **Isolated** — a fresh catalog per case (temp dir + SQLite file, or a fresh Postgres catalog).
- Split into several `#[test]` fns so `cargo test` parallelizes across them; SQLite ~5s, Postgres ~a few seconds per container. Runs under the existing `write-sqlite` and Postgres test jobs — no new infra.
