### PR TITLE
feat(write): atomic append-with-deletes commit (one snapshot)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,8 +107,8 @@ pub use metadata_provider_sqlite::SqliteMetadataProvider;
 pub use insert_exec::DuckLakeInsertExec;
 #[cfg(feature = "write")]
 pub use metadata_writer::{
-    ColumnDef, CommitIds, DataFileInfo, DeleteFileInfo, MetadataWriter, WriteMode, WriteResult,
-    WriteSetupResult,
+    ColumnDef, CommitIds, DataFileInfo, DeleteFileEntry, DeleteFileInfo, MetadataWriter, WriteMode,
+    WriteResult, WriteSetupResult,
 };
 #[cfg(feature = "write-postgres")]
 pub use metadata_writer_postgres::PostgresMetadataWriter;

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -263,6 +263,22 @@ impl DeleteFileInfo {
     }
 }
 
+/// One data file's positional delete, applied as part of a combined
+/// [`MetadataWriter::register_data_file_with_deletes`] commit. Supersedes the
+/// live delete file for `data_file_id` with `delete` (which must be cumulative),
+/// guarded by the same compare-and-swap as
+/// [`MetadataWriter::set_delete_file`].
+#[derive(Debug, Clone)]
+pub struct DeleteFileEntry {
+    /// The existing data file whose rows are being (partly) deleted.
+    pub data_file_id: i64,
+    /// The live delete file the caller resolved against for `data_file_id`
+    /// (compare-and-swap guard), or `None` if none was live.
+    pub expected_prev_delete_file: Option<i64>,
+    /// The new cumulative delete file (all still-deleted positions for the file).
+    pub delete: DeleteFileInfo,
+}
+
 /// Result of a write operation.
 #[derive(Debug)]
 pub struct WriteResult {
@@ -445,6 +461,46 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
     ) -> Result<CommitIds> {
         Err(DuckLakeError::InvalidConfig(
             "set_delete_file is not supported by this metadata writer".to_string(),
+        ))
+    }
+
+    /// Atomically register one new data file AND apply positional deletes to
+    /// existing data files, in a SINGLE snapshot — the primitive behind an
+    /// update/upsert (supersede rows and insert their new versions in one commit).
+    ///
+    /// In one transaction: allocate one snapshot; insert `file` and advance the
+    /// stats/row-lineage counter exactly as
+    /// [`register_data_file`](MetadataWriter::register_data_file); then, for each
+    /// [`DeleteFileEntry`], apply the same target-file fence + compare-and-swap +
+    /// retire-prior + insert-cumulative as
+    /// [`set_delete_file`](MetadataWriter::set_delete_file), all stamped with that
+    /// one snapshot. Advance the catalog head LAST, so the append and every delete
+    /// become visible together — never a half-applied intermediate state. Aborts
+    /// with [`crate::DuckLakeError::Conflict`] on the first entry whose target
+    /// data file was retired since `base_snapshot`, or whose live delete file no
+    /// longer matches `expected_prev_delete_file`.
+    ///
+    /// `deletes` may be empty (equivalent to
+    /// [`register_data_file`](MetadataWriter::register_data_file)); each entry
+    /// must target a distinct `data_file_id`.
+    ///
+    /// Default: unsupported; backends override it.
+    #[allow(clippy::too_many_arguments)]
+    fn register_data_file_with_deletes(
+        &self,
+        _table_id: i64,
+        _schema_name: &str,
+        _table_name: &str,
+        _snapshot_id: i64,
+        _file: &DataFileInfo,
+        _deletes: &[DeleteFileEntry],
+        _mode: WriteMode,
+        _base_snapshot: i64,
+        _columns: &[ColumnDef],
+        _column_ids: &[i64],
+    ) -> Result<CommitIds> {
+        Err(DuckLakeError::InvalidConfig(
+            "register_data_file_with_deletes is not supported by this metadata writer".to_string(),
         ))
     }
 

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -279,6 +279,39 @@ pub struct DeleteFileEntry {
     pub delete: DeleteFileInfo,
 }
 
+/// Validate the `deletes` of a
+/// [`MetadataWriter::register_data_file_with_deletes`] call before any work.
+///
+/// Positional deletes require [`WriteMode::Append`]: a `Replace` retires the
+/// very data files the deletes target, so the fence could never find them and
+/// the commit would abort with a misleading "retired by a concurrent write"
+/// error. Each entry must also target a distinct data file — positions are
+/// cumulative per file, so the caller unions them into one entry per file;
+/// duplicates would otherwise abort on the second entry's compare-and-swap.
+pub(crate) fn validate_delete_entries(mode: WriteMode, deletes: &[DeleteFileEntry]) -> Result<()> {
+    if deletes.is_empty() {
+        return Ok(());
+    }
+    if mode == WriteMode::Replace {
+        return Err(DuckLakeError::InvalidConfig(
+            "register_data_file_with_deletes: positional deletes require WriteMode::Append; \
+             Replace retires the data files the deletes target"
+                .to_string(),
+        ));
+    }
+    let mut seen = std::collections::HashSet::with_capacity(deletes.len());
+    for entry in deletes {
+        if !seen.insert(entry.data_file_id) {
+            return Err(DuckLakeError::InvalidConfig(format!(
+                "register_data_file_with_deletes: duplicate delete entry for data file {}; \
+                 each entry must target a distinct data file",
+                entry.data_file_id
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Result of a write operation.
 #[derive(Debug)]
 pub struct WriteResult {

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -14,7 +14,7 @@ use crate::error::{TypeChangeOperation, TypeChangeWriteMode};
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
     ColumnDef, CommitIds, DataFileInfo, DeleteFileEntry, DeleteFileInfo, MetadataWriter, WriteMode,
-    WriteSetupResult, columns_differ, validate_name,
+    WriteSetupResult, columns_differ, validate_delete_entries, validate_name,
 };
 use sqlx::Row;
 use sqlx::postgres::{PgPool, PgPoolOptions};
@@ -1371,6 +1371,7 @@ impl MetadataWriter for PostgresMetadataWriter {
         columns: &[ColumnDef],
         column_ids: &[i64],
     ) -> Result<CommitIds> {
+        validate_delete_entries(mode, deletes)?;
         block_on(async {
             // One atomic commit for a combined append + positional deletes (an
             // update/upsert). finalize_snapshot writes the snapshot + schema/columns

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -13,7 +13,7 @@ use crate::Result;
 use crate::error::{TypeChangeOperation, TypeChangeWriteMode};
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
-    ColumnDef, CommitIds, DataFileInfo, DeleteFileInfo, MetadataWriter, WriteMode,
+    ColumnDef, CommitIds, DataFileInfo, DeleteFileEntry, DeleteFileInfo, MetadataWriter, WriteMode,
     WriteSetupResult, columns_differ, validate_name,
 };
 use sqlx::Row;
@@ -1344,6 +1344,170 @@ impl MetadataWriter for PostgresMetadataWriter {
                     .bind(table_id)
                     .fetch_one(&mut *tx)
                     .await?;
+
+            // advance_catalog_head MUST be the last write before commit.
+            advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
+
+            tx.commit().await?;
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn register_data_file_with_deletes(
+        &self,
+        table_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        _snapshot_id: i64,
+        file: &DataFileInfo,
+        deletes: &[DeleteFileEntry],
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+    ) -> Result<CommitIds> {
+        block_on(async {
+            // One atomic commit for a combined append + positional deletes (an
+            // update/upsert). finalize_snapshot writes the snapshot + schema/columns
+            // and returns the committed snapshot id; the new data file AND every
+            // delete file are stamped with that one id, and advance_catalog_head runs
+            // LAST — so the whole mutation becomes visible together, never a
+            // half-applied intermediate.
+            let mut tx = self.pool.begin().await?;
+            lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
+            assert_table_not_in_other_catalog(self.catalog_id, table_id, &mut tx).await?;
+
+            let (snapshot_id, schema_id, table_id) = finalize_snapshot(
+                self.catalog_id,
+                schema_name,
+                table_name,
+                table_id,
+                columns,
+                column_ids,
+                mode,
+                base_snapshot,
+                &mut tx,
+            )
+            .await?;
+
+            // Register the new data file (the inserted row versions), exactly as
+            // register_data_file: seed stats, draw the row-id range, insert, and
+            // accumulate. Deletes are accounted at read time (delete_count), so the
+            // stats record_count stays gross — do not adjust it for the deletes.
+            sqlx::query(
+                "INSERT INTO ducklake_table_stats (table_id, record_count, next_row_id, file_size_bytes)
+                 VALUES ($1, 0, 0, 0)
+                 ON CONFLICT (table_id) DO NOTHING",
+            )
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+
+            let stats_row =
+                sqlx::query("SELECT next_row_id FROM ducklake_table_stats WHERE table_id = $1")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
+            let row_id_start: i64 = stats_row.try_get(0)?;
+
+            sqlx::query(
+                "INSERT INTO ducklake_data_file
+                     (table_id, path, path_is_relative, file_size_bytes,
+                      footer_size, record_count, row_id_start, begin_snapshot)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+            )
+            .bind(table_id)
+            .bind(&file.path)
+            .bind(file.path_is_relative)
+            .bind(file.file_size_bytes)
+            .bind(file.footer_size)
+            .bind(file.record_count)
+            .bind(row_id_start)
+            .bind(snapshot_id)
+            .execute(&mut *tx)
+            .await?;
+
+            sqlx::query(
+                "UPDATE ducklake_table_stats
+                 SET next_row_id     = next_row_id + $1,
+                     record_count    = record_count + $2,
+                     file_size_bytes = file_size_bytes + $3
+                 WHERE table_id = $4",
+            )
+            .bind(file.record_count)
+            .bind(file.record_count)
+            .bind(file.file_size_bytes)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+
+            // Apply each positional delete with the same fence + compare-and-swap as
+            // set_delete_file, stamped with this snapshot. Each entry targets a
+            // distinct data file, so there is no intra-transaction CAS contention.
+            for entry in deletes {
+                let target_live: Option<i64> = sqlx::query_scalar(
+                    "SELECT data_file_id FROM ducklake_data_file
+                     WHERE data_file_id = $1 AND end_snapshot IS NULL",
+                )
+                .bind(entry.data_file_id)
+                .fetch_optional(&mut *tx)
+                .await?;
+                if target_live.is_none() {
+                    return Err(crate::DuckLakeError::Conflict(format!(
+                        "delete targets data file {}, which was retired by a concurrent write \
+                         since snapshot {base_snapshot}; retry against the new generation",
+                        entry.data_file_id
+                    )));
+                }
+
+                let current_prev: Option<i64> = sqlx::query_scalar(
+                    "SELECT delete_file_id FROM ducklake_delete_file
+                     WHERE data_file_id = $1 AND end_snapshot IS NULL",
+                )
+                .bind(entry.data_file_id)
+                .fetch_optional(&mut *tx)
+                .await?;
+                if current_prev != entry.expected_prev_delete_file {
+                    return Err(crate::DuckLakeError::Conflict(format!(
+                        "delete on data file {} conflicts with a concurrent delete (expected live \
+                         delete file {:?}, found {current_prev:?}); retry against the new generation",
+                        entry.data_file_id, entry.expected_prev_delete_file
+                    )));
+                }
+
+                if let Some(prev) = entry.expected_prev_delete_file {
+                    sqlx::query(
+                        "UPDATE ducklake_delete_file SET end_snapshot = $1
+                         WHERE delete_file_id = $2 AND end_snapshot IS NULL",
+                    )
+                    .bind(snapshot_id)
+                    .bind(prev)
+                    .execute(&mut *tx)
+                    .await?;
+                }
+
+                sqlx::query(
+                    "INSERT INTO ducklake_delete_file
+                         (data_file_id, table_id, path, path_is_relative, file_size_bytes,
+                          footer_size, delete_count, begin_snapshot)
+                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+                )
+                .bind(entry.data_file_id)
+                .bind(table_id)
+                .bind(&entry.delete.path)
+                .bind(entry.delete.path_is_relative)
+                .bind(entry.delete.file_size_bytes)
+                .bind(entry.delete.footer_size)
+                .bind(entry.delete.delete_count)
+                .bind(snapshot_id)
+                .execute(&mut *tx)
+                .await?;
+            }
 
             // advance_catalog_head MUST be the last write before commit.
             advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -9,7 +9,7 @@ use crate::maintenance::{
 };
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
-    ColumnDef, CommitIds, DataFileInfo, DeleteFileInfo, MetadataWriter, WriteMode,
+    ColumnDef, CommitIds, DataFileInfo, DeleteFileEntry, DeleteFileInfo, MetadataWriter, WriteMode,
     WriteSetupResult, columns_differ, validate_name,
 };
 use sqlx::Row;
@@ -1494,6 +1494,161 @@ impl MetadataWriter for SqliteMetadataWriter {
             .bind(snapshot_id)
             .execute(&mut *tx)
             .await?;
+
+            let schema_id: i64 =
+                sqlx::query_scalar("SELECT schema_id FROM ducklake_table WHERE table_id = ?")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
+
+            tx.commit().await?;
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn register_data_file_with_deletes(
+        &self,
+        table_id: i64,
+        // SQLite created the schema/table at begin; names unused (trait parity).
+        _schema_name: &str,
+        _table_name: &str,
+        _snapshot_id: i64,
+        file: &DataFileInfo,
+        deletes: &[DeleteFileEntry],
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+    ) -> Result<CommitIds> {
+        block_on(async {
+            // One atomic commit for a combined append + positional deletes (an
+            // update/upsert). finalize_snapshot allocates the snapshot + finalizes
+            // the column generation; the new data file AND every delete file are
+            // stamped with that one id and committed together, so the head only
+            // ever resolves to the fully-applied mutation.
+            let mut tx = self.pool.begin().await?;
+
+            let snapshot_id =
+                finalize_snapshot(&mut tx, table_id, columns, column_ids, mode, base_snapshot)
+                    .await?;
+
+            // Register the new data file (inserted row versions), as in
+            // register_data_file. Deletes are accounted at read time
+            // (delete_count), so record_count stays gross — no adjustment for them.
+            sqlx::query(
+                "INSERT OR IGNORE INTO ducklake_table_stats
+                     (table_id, record_count, next_row_id, file_size_bytes)
+                 VALUES (?, 0, 0, 0)",
+            )
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+
+            let stats_row =
+                sqlx::query("SELECT next_row_id FROM ducklake_table_stats WHERE table_id = ?")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
+            let row_id_start: i64 = stats_row.try_get(0)?;
+
+            sqlx::query(
+                "INSERT INTO ducklake_data_file
+                     (table_id, path, path_is_relative, file_size_bytes,
+                      footer_size, record_count, row_id_start, begin_snapshot)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            )
+            .bind(table_id)
+            .bind(&file.path)
+            .bind(file.path_is_relative)
+            .bind(file.file_size_bytes)
+            .bind(file.footer_size)
+            .bind(file.record_count)
+            .bind(row_id_start)
+            .bind(snapshot_id)
+            .execute(&mut *tx)
+            .await?;
+
+            sqlx::query(
+                "UPDATE ducklake_table_stats
+                 SET next_row_id     = next_row_id + ?,
+                     record_count    = record_count + ?,
+                     file_size_bytes = file_size_bytes + ?
+                 WHERE table_id = ?",
+            )
+            .bind(file.record_count)
+            .bind(file.record_count)
+            .bind(file.file_size_bytes)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+
+            // Apply each positional delete with the same fence + compare-and-swap as
+            // set_delete_file, stamped with this snapshot. Each entry targets a
+            // distinct data file, so there is no intra-transaction CAS contention.
+            for entry in deletes {
+                let target_live: Option<i64> = sqlx::query_scalar(
+                    "SELECT 1 FROM ducklake_data_file
+                     WHERE data_file_id = ? AND end_snapshot IS NULL",
+                )
+                .bind(entry.data_file_id)
+                .fetch_optional(&mut *tx)
+                .await?;
+                if target_live.is_none() {
+                    return Err(crate::DuckLakeError::Conflict(format!(
+                        "delete targets data file {}, which was retired by a concurrent write \
+                         since snapshot {base_snapshot}; retry against the new generation",
+                        entry.data_file_id
+                    )));
+                }
+
+                let current_prev: Option<i64> = sqlx::query_scalar(
+                    "SELECT delete_file_id FROM ducklake_delete_file
+                     WHERE data_file_id = ? AND end_snapshot IS NULL",
+                )
+                .bind(entry.data_file_id)
+                .fetch_optional(&mut *tx)
+                .await?;
+                if current_prev != entry.expected_prev_delete_file {
+                    return Err(crate::DuckLakeError::Conflict(format!(
+                        "delete on data file {} conflicts with a concurrent delete (expected live \
+                         delete file {:?}, found {current_prev:?}); retry against the new generation",
+                        entry.data_file_id, entry.expected_prev_delete_file
+                    )));
+                }
+
+                if let Some(prev) = entry.expected_prev_delete_file {
+                    sqlx::query(
+                        "UPDATE ducklake_delete_file SET end_snapshot = ?
+                         WHERE delete_file_id = ? AND end_snapshot IS NULL",
+                    )
+                    .bind(snapshot_id)
+                    .bind(prev)
+                    .execute(&mut *tx)
+                    .await?;
+                }
+
+                sqlx::query(
+                    "INSERT INTO ducklake_delete_file
+                         (data_file_id, table_id, path, path_is_relative, file_size_bytes,
+                          footer_size, delete_count, begin_snapshot)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                )
+                .bind(entry.data_file_id)
+                .bind(table_id)
+                .bind(&entry.delete.path)
+                .bind(entry.delete.path_is_relative)
+                .bind(entry.delete.file_size_bytes)
+                .bind(entry.delete.footer_size)
+                .bind(entry.delete.delete_count)
+                .bind(snapshot_id)
+                .execute(&mut *tx)
+                .await?;
+            }
 
             let schema_id: i64 =
                 sqlx::query_scalar("SELECT schema_id FROM ducklake_table WHERE table_id = ?")

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -10,7 +10,7 @@ use crate::maintenance::{
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
     ColumnDef, CommitIds, DataFileInfo, DeleteFileEntry, DeleteFileInfo, MetadataWriter, WriteMode,
-    WriteSetupResult, columns_differ, validate_name,
+    WriteSetupResult, columns_differ, validate_delete_entries, validate_name,
 };
 use sqlx::Row;
 use sqlx::sqlite::{SqlitePool, SqlitePoolOptions};
@@ -1525,6 +1525,7 @@ impl MetadataWriter for SqliteMetadataWriter {
         columns: &[ColumnDef],
         column_ids: &[i64],
     ) -> Result<CommitIds> {
+        validate_delete_entries(mode, deletes)?;
         block_on(async {
             // One atomic commit for a combined append + positional deletes (an
             // update/upsert). finalize_snapshot allocates the snapshot + finalizes

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -18,7 +18,8 @@ use uuid::Uuid;
 
 use crate::Result;
 use crate::metadata_writer::{
-    ColumnDef, DataFileInfo, DeleteFileInfo, MetadataWriter, WriteMode, WriteResult,
+    ColumnDef, DataFileInfo, DeleteFileEntry, DeleteFileInfo, MetadataWriter, WriteMode,
+    WriteResult,
 };
 use crate::path_resolver::join_paths;
 use crate::table::delete_file_schema;
@@ -438,6 +439,65 @@ impl TableWriteSession {
     }
 
     pub async fn finish(mut self) -> Result<WriteResult> {
+        let file_info = self.upload_staged().await?;
+        // register_data_file returns the ids actually committed (snapshot id
+        // assigned at commit; real schema/table ids, which may differ from the
+        // begin-time reservations under a concurrent create). Report those.
+        let committed = self.metadata.register_data_file(
+            self.table_id,
+            &self.schema_name,
+            &self.table_name,
+            self.snapshot_id,
+            &file_info,
+            self.mode,
+            self.base_snapshot_id,
+            &self.columns,
+            &self.column_ids,
+        )?;
+
+        Ok(WriteResult {
+            snapshot_id: committed.snapshot_id,
+            table_id: committed.table_id,
+            schema_id: committed.schema_id,
+            files_written: 1,
+            records_written: self.row_count,
+        })
+    }
+
+    /// Like [`finish`](Self::finish), but atomically applies positional
+    /// `deletes` to existing data files in the SAME snapshot as this append —
+    /// the commit behind an update/upsert (supersede rows and insert their new
+    /// versions in one snapshot). The caller resolves the positions and writes
+    /// each delete file (see [`DuckLakeTableWriter::write_delete_file`]) before
+    /// calling this; `deletes` may be empty (equivalent to `finish`).
+    pub async fn finish_with_deletes(mut self, deletes: &[DeleteFileEntry]) -> Result<WriteResult> {
+        let file_info = self.upload_staged().await?;
+        let committed = self.metadata.register_data_file_with_deletes(
+            self.table_id,
+            &self.schema_name,
+            &self.table_name,
+            self.snapshot_id,
+            &file_info,
+            deletes,
+            self.mode,
+            self.base_snapshot_id,
+            &self.columns,
+            &self.column_ids,
+        )?;
+
+        Ok(WriteResult {
+            snapshot_id: committed.snapshot_id,
+            table_id: committed.table_id,
+            schema_id: committed.schema_id,
+            files_written: 1,
+            records_written: self.row_count,
+        })
+    }
+
+    /// Finalise + upload the staged parquet and return its [`DataFileInfo`],
+    /// leaving the metadata commit to the caller. Shared by
+    /// [`finish`](Self::finish) and [`finish_with_deletes`](Self::finish_with_deletes).
+    async fn upload_staged(&mut self) -> Result<DataFileInfo> {
         let writer = self.writer.take().ok_or_else(|| {
             crate::error::DuckLakeError::Internal("Writer already closed".to_string())
         })?;
@@ -474,28 +534,7 @@ impl TableWriteSession {
         if !self.path_is_relative {
             file_info = file_info.with_absolute_path();
         }
-        // register_data_file returns the ids actually committed (snapshot id
-        // assigned at commit; real schema/table ids, which may differ from the
-        // begin-time reservations under a concurrent create). Report those.
-        let committed = self.metadata.register_data_file(
-            self.table_id,
-            &self.schema_name,
-            &self.table_name,
-            self.snapshot_id,
-            &file_info,
-            self.mode,
-            self.base_snapshot_id,
-            &self.columns,
-            &self.column_ids,
-        )?;
-
-        Ok(WriteResult {
-            snapshot_id: committed.snapshot_id,
-            table_id: committed.table_id,
-            schema_id: committed.schema_id,
-            files_written: 1,
-            records_written: self.row_count,
-        })
+        Ok(file_info)
     }
 }
 

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -19,7 +19,7 @@ use uuid::Uuid;
 use crate::Result;
 use crate::metadata_writer::{
     ColumnDef, DataFileInfo, DeleteFileEntry, DeleteFileInfo, MetadataWriter, WriteMode,
-    WriteResult,
+    WriteResult, validate_delete_entries,
 };
 use crate::path_resolver::join_paths;
 use crate::table::delete_file_schema;
@@ -471,6 +471,9 @@ impl TableWriteSession {
     /// each delete file (see [`DuckLakeTableWriter::write_delete_file`]) before
     /// calling this; `deletes` may be empty (equivalent to `finish`).
     pub async fn finish_with_deletes(mut self, deletes: &[DeleteFileEntry]) -> Result<WriteResult> {
+        // Reject an unsupported combination before uploading the staged parquet,
+        // so a misuse leaves no orphan object in storage.
+        validate_delete_entries(self.mode, deletes)?;
         let file_info = self.upload_staged().await?;
         let committed = self.metadata.register_data_file_with_deletes(
             self.table_id,

--- a/tests/append_with_deletes_postgres_tests.rs
+++ b/tests/append_with_deletes_postgres_tests.rs
@@ -1,0 +1,235 @@
+//! Postgres multicatalog counterpart of `append_with_deletes_tests.rs`.
+//!
+//! The multicatalog Postgres write path is a *separate implementation* from the
+//! SQLite one (per-catalog head, catalog-scoped lookups), so the atomic
+//! append-with-deletes primitive (`register_data_file_with_deletes`, driven via
+//! `TableWriteSession::finish_with_deletes`) is re-validated here end to end:
+//! an update (delete + insert by key) lands as ONE snapshot, with the resulting
+//! VALUES asserted. Docker-gated (testcontainers Postgres).
+
+#![cfg(feature = "write-postgres")]
+
+use std::sync::Arc;
+
+use arrow::array::{Array, Int32Array, RecordBatch};
+use arrow::datatypes::{DataType, Field, Schema};
+use datafusion::logical_expr::Operator;
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_expr::expressions::{BinaryExpr, col, lit};
+use datafusion::prelude::*;
+use datafusion_ducklake::{
+    DeleteFileEntry, DuckLakeCatalog, DuckLakeTable, DuckLakeTableWriter, MetadataProvider,
+    MetadataWriter, MulticatalogManager, MulticatalogProvider, PostgresMetadataWriter, WriteMode,
+};
+use object_store::local::LocalFileSystem;
+use sqlx::postgres::{PgPool, PgPoolOptions};
+use tempfile::TempDir;
+use testcontainers::ContainerAsync;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+type ObjStore = Arc<dyn object_store::ObjectStore>;
+
+async fn spin_up_postgres() -> anyhow::Result<(PgPool, ContainerAsync<Postgres>)> {
+    let container = Postgres::default().start().await?;
+    let port = container.get_host_port_ipv4(5432).await?;
+    let conn_str = format!("postgresql://postgres:postgres@127.0.0.1:{}/postgres", port);
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&conn_str)
+        .await?;
+    datafusion_ducklake::initialize_multicatalog_schema(&pool).await?;
+    Ok((pool, container))
+}
+
+/// The `(id, val)` table schema used throughout.
+fn schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("val", DataType::Int32, false),
+    ]))
+}
+
+async fn writer_for(
+    pool: &PgPool,
+    cat: i64,
+    data_path: &std::path::Path,
+) -> Arc<PostgresMetadataWriter> {
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path(data_path.to_str().unwrap()).unwrap();
+    Arc::new(w)
+}
+
+async fn read_pairs(pool: &PgPool, cat_name: &str) -> Vec<(i32, i32)> {
+    let provider = MulticatalogProvider::with_pool(pool.clone(), cat_name)
+        .await
+        .unwrap();
+    let catalog = DuckLakeCatalog::new(provider).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog(cat_name, Arc::new(catalog));
+    let batches = ctx
+        .sql(&format!(
+            "SELECT id, val FROM {cat_name}.public.t ORDER BY id"
+        ))
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let mut rows = Vec::new();
+    for b in &batches {
+        let ids = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        let vals = b.column(1).as_any().downcast_ref::<Int32Array>().unwrap();
+        for i in 0..b.num_rows() {
+            rows.push((ids.value(i), vals.value(i)));
+        }
+    }
+    rows
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn update_via_finish_with_deletes_is_one_snapshot_postgres() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let tmp = TempDir::new().unwrap();
+    let data = tmp.path().join("data");
+    std::fs::create_dir_all(&data).unwrap();
+    let os: ObjStore = Arc::new(LocalFileSystem::new());
+    let cat_name = "cat";
+    let cat = MulticatalogManager::new(pool.clone())
+        .create_catalog(cat_name)
+        .await
+        .unwrap();
+    let sch = schema();
+
+    // Seed (id, val): (1,10),(2,20),(3,30),(4,40) as one data file.
+    let seed = RecordBatch::try_new(
+        sch.clone(),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3, 4])),
+            Arc::new(Int32Array::from(vec![10, 20, 30, 40])),
+        ],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(writer_for(&pool, cat, &data).await, os.clone())
+        .unwrap()
+        .write_table("public", "t", &[seed])
+        .await
+        .unwrap();
+    assert_eq!(
+        read_pairs(&pool, cat_name).await,
+        vec![(1, 10), (2, 20), (3, 30), (4, 40)],
+        "baseline"
+    );
+
+    // Catalog-scoped metadata: head, table, the single live data file.
+    let meta = MulticatalogProvider::with_pool(pool.clone(), cat_name)
+        .await
+        .unwrap();
+    let head = meta.get_current_snapshot().unwrap();
+    let schema_meta = meta.get_schema_by_name("public", head).unwrap().unwrap();
+    let table_meta = meta
+        .get_table_by_name(schema_meta.schema_id, "t", head)
+        .unwrap()
+        .unwrap();
+    let files = meta
+        .get_table_files_for_select(table_meta.table_id, head)
+        .unwrap();
+    assert_eq!(files.len(), 1, "one seed data file");
+    let tf = files[0].clone();
+
+    // Resolve positions of ids {2,4} on the seed file (physical positions 1,3).
+    let read = MulticatalogProvider::with_pool(pool.clone(), cat_name)
+        .await
+        .unwrap();
+    let catalog = DuckLakeCatalog::new(read).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog(cat_name, Arc::new(catalog));
+    let table_provider = ctx
+        .catalog(cat_name)
+        .unwrap()
+        .schema("public")
+        .unwrap()
+        .table("t")
+        .await
+        .unwrap()
+        .unwrap();
+    let table = (table_provider.as_ref() as &dyn std::any::Any)
+        .downcast_ref::<DuckLakeTable>()
+        .expect("provider is a DuckLakeTable");
+    let data_schema = schema();
+    let id: Arc<dyn PhysicalExpr> = col("id", data_schema.as_ref()).unwrap();
+    let eq2: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(id.clone(), Operator::Eq, lit(2i32)));
+    let eq4: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(id, Operator::Eq, lit(4i32)));
+    let predicate: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(eq2, Operator::Or, eq4));
+    let state = ctx.state();
+    let mut positions: Vec<i64> = table
+        .resolve_positions(&state, &tf.file, predicate)
+        .await
+        .unwrap()
+        .into_iter()
+        .collect();
+    positions.sort_unstable();
+    assert_eq!(positions, vec![1, 3], "ids 2,4 sit at positions 1,3");
+
+    // Author the delete file, then append the NEW versions and commit them
+    // together with the delete in ONE snapshot.
+    let writer = writer_for(&pool, cat, &data).await;
+    let del_info = DuckLakeTableWriter::new(writer.clone(), os.clone())
+        .unwrap()
+        .write_delete_file("public", "t", &tf.file.path, &positions)
+        .await
+        .unwrap();
+    let new_versions = RecordBatch::try_new(
+        sch.clone(),
+        vec![Arc::new(Int32Array::from(vec![2, 4])), Arc::new(Int32Array::from(vec![200, 400]))],
+    )
+    .unwrap();
+    let mut session = DuckLakeTableWriter::new(writer.clone(), os.clone())
+        .unwrap()
+        .begin_write("public", "t", sch.as_ref(), WriteMode::Append)
+        .unwrap();
+    session.write_batch(&new_versions).unwrap();
+    let entries = vec![DeleteFileEntry {
+        data_file_id: tf.data_file_id,
+        expected_prev_delete_file: tf.delete_file_id,
+        delete: del_info,
+    }];
+    let result = session.finish_with_deletes(&entries).await.unwrap();
+
+    assert_eq!(
+        read_pairs(&pool, cat_name).await,
+        vec![(1, 10), (2, 200), (3, 30), (4, 400)],
+        "rows 2,4 updated in place; 1,3 unchanged"
+    );
+
+    // Atomicity: the delete file and the appended data file carry the SAME
+    // begin_snapshot — the committed head — so they became visible together.
+    let delete_snap: i64 = sqlx::query_scalar(
+        "SELECT begin_snapshot FROM ducklake_delete_file
+         WHERE data_file_id = $1 AND end_snapshot IS NULL",
+    )
+    .bind(tf.data_file_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let appended_snap: i64 = sqlx::query_scalar(
+        "SELECT begin_snapshot FROM ducklake_data_file
+         WHERE table_id = $1 AND data_file_id <> $2 AND end_snapshot IS NULL",
+    )
+    .bind(table_meta.table_id)
+    .bind(tf.data_file_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        delete_snap, appended_snap,
+        "delete file and appended data file share one snapshot"
+    );
+    assert_eq!(
+        delete_snap, result.snapshot_id,
+        "that shared snapshot is the committed head"
+    );
+}

--- a/tests/append_with_deletes_tests.rs
+++ b/tests/append_with_deletes_tests.rs
@@ -1,0 +1,365 @@
+//! Round-trip tests for the combined append-with-deletes write path:
+//! `MetadataWriter::register_data_file_with_deletes` (driven via
+//! `TableWriteSession::finish_with_deletes`) registers a new data file AND
+//! positional delete files for existing data files in ONE snapshot — the commit
+//! primitive behind an update/upsert (supersede rows, insert their new versions,
+//! atomically). These validate the atomic single-snapshot behaviour and the
+//! resulting VALUES end-to-end through the SQLite backend, since a bug here
+//! either half-applies the mutation or updates the wrong rows.
+
+#![cfg(all(feature = "write-sqlite", feature = "metadata-sqlite"))]
+
+use std::sync::Arc;
+
+use arrow::array::{Array, Int32Array};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use datafusion::prelude::*;
+use object_store::local::LocalFileSystem;
+use tempfile::TempDir;
+
+use datafusion::logical_expr::Operator;
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_expr::expressions::{BinaryExpr, col, lit};
+use datafusion_ducklake::{
+    DeleteFileEntry, DuckLakeCatalog, DuckLakeFileData, DuckLakeTable, DuckLakeTableWriter,
+    MetadataWriter, SqliteMetadataProvider, SqliteMetadataWriter, WriteMode,
+};
+use sqlx::Row;
+use sqlx::sqlite::SqlitePool;
+
+/// A writable SQLite-backed catalog + a data dir, in a temp dir.
+async fn create_writer(temp_dir: &TempDir) -> SqliteMetadataWriter {
+    let db_path = temp_dir.path().join("test.db");
+    let data_path = temp_dir.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+    let conn_str = format!("sqlite:{}?mode=rwc", db_path.display());
+    let writer = SqliteMetadataWriter::new_with_init(&conn_str)
+        .await
+        .unwrap();
+    writer.set_data_path(data_path.to_str().unwrap()).unwrap();
+    writer
+}
+
+/// Read `(id, val)` from `test.main.t`, ascending by `id`, through the full read
+/// path (which applies any live delete file).
+async fn read_pairs(temp_dir: &TempDir) -> Vec<(i32, i32)> {
+    let db_path = temp_dir.path().join("test.db");
+    let conn_str = format!("sqlite:{}", db_path.display());
+    let provider = SqliteMetadataProvider::new(&conn_str).await.unwrap();
+    let catalog = DuckLakeCatalog::new(provider).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog("test", Arc::new(catalog));
+    let batches = ctx
+        .sql("SELECT id, val FROM test.main.t ORDER BY id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let mut rows = Vec::new();
+    for b in &batches {
+        let ids = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        let vals = b.column(1).as_any().downcast_ref::<Int32Array>().unwrap();
+        for i in 0..b.num_rows() {
+            rows.push((ids.value(i), vals.value(i)));
+        }
+    }
+    rows
+}
+
+/// The `(id, val)` table schema used throughout.
+fn table_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("val", DataType::Int32, false),
+    ]))
+}
+
+/// Resolve the physical positions of rows matching `id == wanted` within
+/// `data_file`, via the crate's `resolve_positions`.
+async fn positions_for_id(conn_str: &str, data_file: &DuckLakeFileData, wanted: i32) -> Vec<i64> {
+    let provider = SqliteMetadataProvider::new(conn_str).await.unwrap();
+    let catalog = DuckLakeCatalog::new(provider).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog("test", Arc::new(catalog));
+    let table_provider = ctx
+        .catalog("test")
+        .unwrap()
+        .schema("main")
+        .unwrap()
+        .table("t")
+        .await
+        .unwrap()
+        .unwrap();
+    let table = (table_provider.as_ref() as &dyn std::any::Any)
+        .downcast_ref::<DuckLakeTable>()
+        .expect("provider is a DuckLakeTable");
+    let data_schema = table_schema();
+    let id: Arc<dyn PhysicalExpr> = col("id", data_schema.as_ref()).unwrap();
+    let predicate: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(id, Operator::Eq, lit(wanted)));
+    let state = ctx.state();
+    let mut positions: Vec<i64> = table
+        .resolve_positions(&state, data_file, predicate)
+        .await
+        .unwrap()
+        .into_iter()
+        .collect();
+    positions.sort_unstable();
+    positions
+}
+
+/// The live data files for `table_id`, in insertion order (ascending
+/// `data_file_id`), each as `(data_file_id, DuckLakeFileData)` ready to scan.
+async fn live_data_files(pool: &SqlitePool, table_id: i64) -> Vec<(i64, DuckLakeFileData)> {
+    let rows = sqlx::query(
+        "SELECT data_file_id, path, path_is_relative, file_size_bytes
+         FROM ducklake_data_file
+         WHERE table_id = ? AND end_snapshot IS NULL
+         ORDER BY data_file_id",
+    )
+    .bind(table_id)
+    .fetch_all(pool)
+    .await
+    .unwrap();
+    rows.into_iter()
+        .map(|r| {
+            let id: i64 = r.try_get(0).unwrap();
+            let path: String = r.try_get(1).unwrap();
+            let rel: bool = r.try_get::<i64, _>(2).unwrap() != 0;
+            let size: i64 = r.try_get(3).unwrap();
+            (id, DuckLakeFileData::new(path, rel, size))
+        })
+        .collect()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_via_finish_with_deletes_is_one_atomic_snapshot() {
+    let temp_dir = TempDir::new().unwrap();
+    let writer = Arc::new(create_writer(&temp_dir).await);
+    let object_store: Arc<dyn object_store::ObjectStore> = Arc::new(LocalFileSystem::new());
+    let schema = table_schema();
+
+    // Seed (id, val): (1,10),(2,20),(3,30),(4,40) as one data file.
+    let seed = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3, 4])),
+            Arc::new(Int32Array::from(vec![10, 20, 30, 40])),
+        ],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(writer.clone(), object_store.clone())
+        .unwrap()
+        .write_table("main", "t", &[seed])
+        .await
+        .unwrap();
+    assert_eq!(
+        read_pairs(&temp_dir).await,
+        vec![(1, 10), (2, 20), (3, 30), (4, 40)],
+        "baseline"
+    );
+
+    let db_path = temp_dir.path().join("test.db");
+    let conn_str = format!("sqlite:{}", db_path.display());
+    let pool = SqlitePool::connect(&conn_str).await.unwrap();
+    let table_id: i64 =
+        sqlx::query_scalar("SELECT table_id FROM ducklake_table WHERE end_snapshot IS NULL")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    let files = live_data_files(&pool, table_id).await;
+    assert_eq!(files.len(), 1);
+    let (data_file_id, data_file) = files.into_iter().next().unwrap();
+
+    // Update ids {2, 4}: resolve their positions (1 and 3) and author one
+    // cumulative delete file for the seed data file.
+    let mut positions = positions_for_id(&conn_str, &data_file, 2).await;
+    positions.extend(positions_for_id(&conn_str, &data_file, 4).await);
+    positions.sort_unstable();
+    assert_eq!(positions, vec![1, 3], "ids 2,4 sit at positions 1,3");
+    let del_info = DuckLakeTableWriter::new(writer.clone(), object_store.clone())
+        .unwrap()
+        .write_delete_file("main", "t", &data_file.path, &positions)
+        .await
+        .unwrap();
+
+    // Append the NEW versions (2,200),(4,400) and commit them together with the
+    // delete in ONE snapshot.
+    let new_versions = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from(vec![2, 4])), Arc::new(Int32Array::from(vec![200, 400]))],
+    )
+    .unwrap();
+    let mut session = DuckLakeTableWriter::new(writer.clone(), object_store.clone())
+        .unwrap()
+        .begin_write("main", "t", schema.as_ref(), WriteMode::Append)
+        .unwrap();
+    session.write_batch(&new_versions).unwrap();
+    let entries = vec![DeleteFileEntry {
+        data_file_id,
+        expected_prev_delete_file: None,
+        delete: del_info,
+    }];
+    let result = session.finish_with_deletes(&entries).await.unwrap();
+
+    // Old versions of 2,4 are gone; the new versions are present; 1,3 untouched.
+    assert_eq!(
+        read_pairs(&temp_dir).await,
+        vec![(1, 10), (2, 200), (3, 30), (4, 400)],
+        "rows 2,4 updated in place; 1,3 unchanged"
+    );
+
+    // Atomicity: the delete file and the appended data file carry the SAME
+    // begin_snapshot — the committed head — so they became visible together.
+    let delete_snap: i64 = sqlx::query_scalar(
+        "SELECT begin_snapshot FROM ducklake_delete_file
+         WHERE data_file_id = ? AND end_snapshot IS NULL",
+    )
+    .bind(data_file_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let appended_snap: i64 = sqlx::query_scalar(
+        "SELECT begin_snapshot FROM ducklake_data_file
+         WHERE table_id = ? AND data_file_id <> ? AND end_snapshot IS NULL",
+    )
+    .bind(table_id)
+    .bind(data_file_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        delete_snap, appended_snap,
+        "delete file and appended data file share one snapshot"
+    );
+    assert_eq!(
+        delete_snap, result.snapshot_id,
+        "that shared snapshot is the committed head"
+    );
+
+    // Exactly one delete file is live for the seed file.
+    let live: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ducklake_delete_file
+         WHERE data_file_id = ? AND end_snapshot IS NULL",
+    )
+    .bind(data_file_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(live, 1, "one live delete file for the seed data file");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_spanning_two_data_files_commits_one_snapshot() {
+    let temp_dir = TempDir::new().unwrap();
+    let writer = Arc::new(create_writer(&temp_dir).await);
+    let object_store: Arc<dyn object_store::ObjectStore> = Arc::new(LocalFileSystem::new());
+    let schema = table_schema();
+
+    // Two data files: A = (1,10),(2,20); B = (3,30),(4,40).
+    let file_a = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from(vec![1, 2])), Arc::new(Int32Array::from(vec![10, 20]))],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(writer.clone(), object_store.clone())
+        .unwrap()
+        .write_table("main", "t", &[file_a])
+        .await
+        .unwrap();
+    let file_b = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from(vec![3, 4])), Arc::new(Int32Array::from(vec![30, 40]))],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(writer.clone(), object_store.clone())
+        .unwrap()
+        .append_table("main", "t", &[file_b])
+        .await
+        .unwrap();
+    assert_eq!(
+        read_pairs(&temp_dir).await,
+        vec![(1, 10), (2, 20), (3, 30), (4, 40)],
+        "baseline across two files"
+    );
+
+    let db_path = temp_dir.path().join("test.db");
+    let conn_str = format!("sqlite:{}", db_path.display());
+    let pool = SqlitePool::connect(&conn_str).await.unwrap();
+    let table_id: i64 =
+        sqlx::query_scalar("SELECT table_id FROM ducklake_table WHERE end_snapshot IS NULL")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    let files = live_data_files(&pool, table_id).await;
+    assert_eq!(files.len(), 2, "two live data files");
+    let (file_a_id, file_a_data) = files[0].clone();
+    let (file_b_id, file_b_data) = files[1].clone();
+
+    // Update id 2 (in file A) and id 3 (in file B): one delete entry per file,
+    // one appended data file with both new versions — all in one commit.
+    let pos_a = positions_for_id(&conn_str, &file_a_data, 2).await;
+    assert_eq!(pos_a, vec![1], "id 2 is at position 1 in file A");
+    let pos_b = positions_for_id(&conn_str, &file_b_data, 3).await;
+    assert_eq!(pos_b, vec![0], "id 3 is at position 0 in file B");
+    let del_a = DuckLakeTableWriter::new(writer.clone(), object_store.clone())
+        .unwrap()
+        .write_delete_file("main", "t", &file_a_data.path, &pos_a)
+        .await
+        .unwrap();
+    let del_b = DuckLakeTableWriter::new(writer.clone(), object_store.clone())
+        .unwrap()
+        .write_delete_file("main", "t", &file_b_data.path, &pos_b)
+        .await
+        .unwrap();
+
+    let new_versions = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from(vec![2, 3])), Arc::new(Int32Array::from(vec![200, 300]))],
+    )
+    .unwrap();
+    let mut session = DuckLakeTableWriter::new(writer.clone(), object_store.clone())
+        .unwrap()
+        .begin_write("main", "t", schema.as_ref(), WriteMode::Append)
+        .unwrap();
+    session.write_batch(&new_versions).unwrap();
+    let entries = vec![
+        DeleteFileEntry {
+            data_file_id: file_a_id,
+            expected_prev_delete_file: None,
+            delete: del_a,
+        },
+        DeleteFileEntry {
+            data_file_id: file_b_id,
+            expected_prev_delete_file: None,
+            delete: del_b,
+        },
+    ];
+    let result = session.finish_with_deletes(&entries).await.unwrap();
+
+    assert_eq!(
+        read_pairs(&temp_dir).await,
+        vec![(1, 10), (2, 200), (3, 300), (4, 40)],
+        "one row updated from each file; the others unchanged"
+    );
+
+    // Both delete files and the appended file share the one committed snapshot.
+    let snaps: Vec<i64> = sqlx::query_scalar(
+        "SELECT begin_snapshot FROM ducklake_delete_file WHERE end_snapshot IS NULL
+         UNION
+         SELECT begin_snapshot FROM ducklake_data_file
+         WHERE table_id = ? AND data_file_id NOT IN (?, ?) AND end_snapshot IS NULL",
+    )
+    .bind(table_id)
+    .bind(file_a_id)
+    .bind(file_b_id)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        snaps,
+        vec![result.snapshot_id],
+        "both deletes and the append committed in exactly one snapshot"
+    );
+}

--- a/tests/append_with_deletes_tests.rs
+++ b/tests/append_with_deletes_tests.rs
@@ -22,8 +22,9 @@ use datafusion::logical_expr::Operator;
 use datafusion::physical_expr::PhysicalExpr;
 use datafusion::physical_expr::expressions::{BinaryExpr, col, lit};
 use datafusion_ducklake::{
-    DeleteFileEntry, DuckLakeCatalog, DuckLakeFileData, DuckLakeTable, DuckLakeTableWriter,
-    MetadataWriter, SqliteMetadataProvider, SqliteMetadataWriter, WriteMode,
+    DataFileInfo, DeleteFileEntry, DeleteFileInfo, DuckLakeCatalog, DuckLakeError,
+    DuckLakeFileData, DuckLakeTable, DuckLakeTableWriter, MetadataWriter, SqliteMetadataProvider,
+    SqliteMetadataWriter, WriteMode,
 };
 use sqlx::Row;
 use sqlx::sqlite::SqlitePool;
@@ -361,5 +362,62 @@ async fn update_spanning_two_data_files_commits_one_snapshot() {
         snaps,
         vec![result.snapshot_id],
         "both deletes and the append committed in exactly one snapshot"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn register_data_file_with_deletes_rejects_invalid_entries() {
+    let temp_dir = TempDir::new().unwrap();
+    let writer = create_writer(&temp_dir).await;
+
+    // The entries are validated before any database work, so no table need exist;
+    // the file/delete infos are placeholders.
+    let file = DataFileInfo::new("new.parquet", 1, 1);
+    let entry = |data_file_id: i64| DeleteFileEntry {
+        data_file_id,
+        expected_prev_delete_file: None,
+        delete: DeleteFileInfo::new("del.parquet", 1, 1),
+    };
+
+    // Replace + deletes is rejected up front: Replace retires the very files the
+    // deletes target, so the combination can never succeed.
+    let err = writer
+        .register_data_file_with_deletes(
+            1,
+            "main",
+            "t",
+            0,
+            &file,
+            &[entry(1)],
+            WriteMode::Replace,
+            0,
+            &[],
+            &[],
+        )
+        .expect_err("Replace + deletes must be rejected");
+    assert!(
+        matches!(err, DuckLakeError::InvalidConfig(_)),
+        "got {err:?}"
+    );
+
+    // Two entries for the same data file are rejected (positions must be unioned
+    // into one entry per file).
+    let err = writer
+        .register_data_file_with_deletes(
+            1,
+            "main",
+            "t",
+            0,
+            &file,
+            &[entry(7), entry(7)],
+            WriteMode::Append,
+            0,
+            &[],
+            &[],
+        )
+        .expect_err("duplicate data_file_id must be rejected");
+    assert!(
+        matches!(err, DuckLakeError::InvalidConfig(_)),
+        "got {err:?}"
     );
 }


### PR DESCRIPTION
## Summary

Adds `MetadataWriter::register_data_file_with_deletes` — register a new data file **and** apply positional delete files to existing data files in a **single snapshot** — plus `TableWriteSession::finish_with_deletes` to drive it from the streaming writer.

This is the commit primitive for a row **update/upsert** modeled as *delete + insert*: supersede rows and insert their new versions atomically, so a reader never observes a half-applied intermediate (the delete without the insert, or vice versa). Today `register_data_file` and `set_delete_file` each commit their own snapshot, so composing them sequentially leaves a two-snapshot lineage and an intermediate delete-only (or insert-only) state visible to time travel; this collapses them into one.

## What it does

In one transaction, mirroring the existing primitives:

1. `finalize_snapshot` — allocate one snapshot + reconcile schema/columns.
2. Insert the new data file + advance stats/row-lineage (as `register_data_file`).
3. For each `DeleteFileEntry`: target-file fence + compare-and-swap on the live delete file + retire prior + insert the cumulative delete file (as `set_delete_file`), stamped with that same snapshot.
4. `advance_catalog_head` last — so the append and every delete become visible together.

Aborts with `Conflict` on the first entry whose target data file was retired since `base_snapshot`, or whose live delete file no longer matches `expected_prev_delete_file`. `deletes` may be empty (equivalent to `register_data_file`); each entry must target a distinct data file. Deletes are accounted at read time (`delete_count`), so the new data file's `record_count` is added to stats gross, exactly as a plain append.

## API

- New `DeleteFileEntry { data_file_id, expected_prev_delete_file, delete }`.
- `MetadataWriter::register_data_file_with_deletes(...)` — default-unsupported; implemented for the multicatalog Postgres and single-catalog SQLite backends.
- `TableWriteSession::finish_with_deletes(&[DeleteFileEntry])` — uploads the staged parquet (shared with `finish()`), then commits via the new primitive.

`finish()` is refactored to share the staged-parquet upload with `finish_with_deletes()`; its behaviour is unchanged.

## Tests

- SQLite (`tests/append_with_deletes_tests.rs`): an update rounds-trip in one snapshot (values asserted; the delete file + appended file share the committed snapshot); an update spanning two data files commits both deletes + the append in one snapshot.
- Postgres (`tests/append_with_deletes_postgres_tests.rs`, Docker-gated): the multicatalog path, same round-trip + one-snapshot assertion.

`cargo fmt --check`, `cargo clippy --all-features --tests`, and the SQLite + Postgres suites pass.
