### PR TITLE
feat(types): read string/binary columns as Utf8View/BinaryView

### DIFF
--- a/examples/compare_rowid_against_duckdb.rs
+++ b/examples/compare_rowid_against_duckdb.rs
@@ -14,7 +14,7 @@
 use std::error::Error;
 use std::sync::Arc;
 
-use arrow::array::{Array, Int32Array, Int64Array, StringArray};
+use arrow::array::{Array, Int32Array, Int64Array, StringArray, StringViewArray};
 use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::prelude::*;
 use datafusion_ducklake::{DuckLakeCatalog, PostgresMetadataProvider};
@@ -321,6 +321,12 @@ fn extract_rows(
                     KeyValue::I64(arr.value(i))
                 }
             } else if let Some(arr) = key_col.as_any().downcast_ref::<StringArray>() {
+                if arr.is_null(i) {
+                    KeyValue::Null
+                } else {
+                    KeyValue::Str(arr.value(i).to_string())
+                }
+            } else if let Some(arr) = key_col.as_any().downcast_ref::<StringViewArray>() {
                 if arr.is_null(i) {
                     KeyValue::Null
                 } else {

--- a/examples/rowid_lifecycle.rs
+++ b/examples/rowid_lifecycle.rs
@@ -18,7 +18,7 @@
 use std::error::Error;
 use std::sync::Arc;
 
-use arrow::array::{Array, Int32Array, Int64Array, StringArray};
+use arrow::array::{Array, Int32Array, Int64Array, StringArray, StringViewArray};
 use arrow::record_batch::RecordBatch;
 use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::prelude::*;
@@ -322,6 +322,12 @@ fn rows_from_batches(batches: &[RecordBatch]) -> Result<Vec<Row>, Box<dyn Error>
             };
 
             let name = if let Some(arr) = name_col.as_any().downcast_ref::<StringArray>() {
+                if arr.is_null(i) {
+                    None
+                } else {
+                    Some(arr.value(i).to_string())
+                }
+            } else if let Some(arr) = name_col.as_any().downcast_ref::<StringViewArray>() {
                 if arr.is_null(i) {
                     None
                 } else {

--- a/src/types.rs
+++ b/src/types.rs
@@ -59,20 +59,30 @@ pub fn ducklake_to_arrow_type(ducklake_type: &str) -> Result<DataType> {
         "timestamp_ns" => Ok(DataType::Timestamp(TimeUnit::Nanosecond, None)),
         "interval" => Ok(DataType::Interval(IntervalUnit::MonthDayNano)),
 
-        // String types
-        "varchar" | "text" | "string" => Ok(DataType::Utf8),
-        "json" => Ok(DataType::Utf8), // JSON stored as UTF8 string
+        // String types. Mapped to the "view" layout (Utf8View) rather than Utf8
+        // to match DataFusion's default parquet read behaviour: its
+        // `schema_force_view_types` option (on by default) rewrites Utf8/LargeUtf8
+        // columns to Utf8View during schema inference. Building the scan from an
+        // explicit catalog-derived schema bypasses that inference, so the view
+        // layout is requested here instead. View arrays avoid the 2 GiB limit on a
+        // single i32-offset value buffer and are cheaper to hash/compare for
+        // group-by; DataFusion's parquet reader decodes the existing BYTE_ARRAY
+        // columns straight into view arrays, so no cast and no data rewrite occurs.
+        "varchar" | "text" | "string" => Ok(DataType::Utf8View),
+        "json" => Ok(DataType::Utf8View), // JSON stored as UTF8 string
 
-        // Binary types
-        "blob" | "binary" | "bytea" => Ok(DataType::Binary),
+        // Binary types. BinaryView for the same reasons as the string types above.
+        "blob" | "binary" | "bytea" => Ok(DataType::BinaryView),
         "uuid" => Ok(DataType::FixedSizeBinary(16)),
 
-        // Geometry types (stored as binary WKB format)
+        // Geometry types (stored as binary WKB format). Kept as Binary (not
+        // promoted to BinaryView): the WKB bytes are consumed by geometry
+        // functions that expect a Binary layout.
         "point" | "linestring" | "polygon" | "multipoint" | "multilinestring" | "multipolygon"
         | "geometrycollection" | "linestring z" | "geometry" => Ok(DataType::Binary),
 
         // Time with timezone - not directly supported, use string
-        "timetz" | "time with time zone" => Ok(DataType::Utf8),
+        "timetz" | "time with time zone" => Ok(DataType::Utf8View),
 
         _ => {
             // Check for complex types (struct, map)
@@ -132,11 +142,13 @@ pub fn arrow_to_ducklake_type(arrow_type: &DataType) -> Result<String> {
         DataType::Timestamp(_, Some(_)) => Ok("timestamptz".to_string()),
         DataType::Interval(_) => Ok("interval".to_string()),
 
-        // String types
-        DataType::Utf8 | DataType::LargeUtf8 => Ok("varchar".to_string()),
+        // String types. Utf8View is the canonical read layout (see
+        // `ducklake_to_arrow_type`); Utf8/LargeUtf8 map here as well so batches
+        // produced by other code paths still round-trip to the same DuckLake type.
+        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => Ok("varchar".to_string()),
 
         // Binary types
-        DataType::Binary | DataType::LargeBinary => Ok("blob".to_string()),
+        DataType::Binary | DataType::LargeBinary | DataType::BinaryView => Ok("blob".to_string()),
         DataType::FixedSizeBinary(16) => Ok("uuid".to_string()),
         DataType::FixedSizeBinary(_) => Ok("blob".to_string()),
 
@@ -708,8 +720,116 @@ mod tests {
             ducklake_to_arrow_type("float64").unwrap(),
             DataType::Float64
         );
-        assert_eq!(ducklake_to_arrow_type("varchar").unwrap(), DataType::Utf8);
-        assert_eq!(ducklake_to_arrow_type("blob").unwrap(), DataType::Binary);
+        assert_eq!(
+            ducklake_to_arrow_type("varchar").unwrap(),
+            DataType::Utf8View
+        );
+        assert_eq!(
+            ducklake_to_arrow_type("blob").unwrap(),
+            DataType::BinaryView
+        );
+    }
+
+    #[test]
+    fn test_string_types_map_to_utf8view() {
+        // String columns use the Utf8View layout so wide, high-cardinality
+        // group-by does not hit the 2 GiB i32-offset buffer limit, matching
+        // DataFusion's default parquet read behaviour (schema_force_view_types).
+        for t in ["varchar", "text", "string", "json", "timetz", "time with time zone"] {
+            assert_eq!(
+                ducklake_to_arrow_type(t).unwrap(),
+                DataType::Utf8View,
+                "{t} should map to Utf8View"
+            );
+        }
+    }
+
+    #[test]
+    fn test_binary_types_map_to_binaryview() {
+        for t in ["blob", "binary", "bytea"] {
+            assert_eq!(
+                ducklake_to_arrow_type(t).unwrap(),
+                DataType::BinaryView,
+                "{t} should map to BinaryView"
+            );
+        }
+    }
+
+    #[test]
+    fn test_geometry_stays_binary() {
+        // Geometry WKB is consumed by geometry functions that expect the Binary
+        // layout, so it is deliberately not promoted to BinaryView.
+        for t in [
+            "geometry",
+            "point",
+            "linestring",
+            "polygon",
+            "multipoint",
+            "multilinestring",
+            "multipolygon",
+            "geometrycollection",
+        ] {
+            assert_eq!(
+                ducklake_to_arrow_type(t).unwrap(),
+                DataType::Binary,
+                "{t} should stay Binary"
+            );
+        }
+    }
+
+    #[test]
+    fn test_uuid_stays_fixed_size_binary() {
+        assert_eq!(
+            ducklake_to_arrow_type("uuid").unwrap(),
+            DataType::FixedSizeBinary(16)
+        );
+    }
+
+    #[test]
+    fn test_view_types_write_back_to_string_and_blob() {
+        // The write direction accepts every string/binary Arrow layout, including
+        // the view layouts now produced on read, so a read/write round-trip keeps
+        // the DuckLake catalog type stable.
+        assert_eq!(
+            arrow_to_ducklake_type(&DataType::Utf8View).unwrap(),
+            "varchar"
+        );
+        assert_eq!(arrow_to_ducklake_type(&DataType::Utf8).unwrap(), "varchar");
+        assert_eq!(
+            arrow_to_ducklake_type(&DataType::LargeUtf8).unwrap(),
+            "varchar"
+        );
+        assert_eq!(
+            arrow_to_ducklake_type(&DataType::BinaryView).unwrap(),
+            "blob"
+        );
+        assert_eq!(arrow_to_ducklake_type(&DataType::Binary).unwrap(), "blob");
+        assert_eq!(
+            arrow_to_ducklake_type(&DataType::LargeBinary).unwrap(),
+            "blob"
+        );
+    }
+
+    #[test]
+    fn test_string_binary_normalize_is_stable() {
+        // normalize = arrow_to_ducklake_type(ducklake_to_arrow_type(t)); it must
+        // still terminate at the canonical DuckLake type now that the read layout
+        // is a view type, otherwise schema-evolution comparisons would error.
+        assert_eq!(normalize_ducklake_type("varchar").unwrap(), "varchar");
+        assert_eq!(normalize_ducklake_type("text").unwrap(), "varchar");
+        assert_eq!(normalize_ducklake_type("json").unwrap(), "varchar");
+        assert_eq!(normalize_ducklake_type("blob").unwrap(), "blob");
+        assert_eq!(normalize_ducklake_type("binary").unwrap(), "blob");
+    }
+
+    #[test]
+    fn test_view_type_list_children() {
+        // list<varchar> recurses through the same mapping, so its element is
+        // Utf8View.
+        assert_eq!(
+            ducklake_to_arrow_type("list<varchar>").unwrap(),
+            DataType::List(Arc::new(Field::new("item", DataType::Utf8View, true)))
+        );
     }
 
     #[test]
@@ -752,7 +872,7 @@ mod tests {
     #[test]
     fn test_list_type_various_elements() {
         let cases = vec![
-            ("list<varchar>", DataType::Utf8),
+            ("list<varchar>", DataType::Utf8View),
             ("list<float64>", DataType::Float64),
             ("list<boolean>", DataType::Boolean),
             ("list<date>", DataType::Date32),
@@ -768,19 +888,19 @@ mod tests {
     #[test]
     fn test_array_type_angle_bracket() {
         let result = ducklake_to_arrow_type("array<varchar>").unwrap();
-        let expected = DataType::List(Arc::new(Field::new("item", DataType::Utf8, true)));
+        let expected = DataType::List(Arc::new(Field::new("item", DataType::Utf8View, true)));
         assert_eq!(result, expected);
     }
 
     #[test]
     fn test_list_type_postgres_bracket_syntax() {
         let cases = vec![
-            ("varchar[]", DataType::Utf8),
+            ("varchar[]", DataType::Utf8View),
             ("float64[]", DataType::Float64),
             ("int32[]", DataType::Int32),
             ("boolean[]", DataType::Boolean),
             ("bigint[]", DataType::Int64),
-            ("text[]", DataType::Utf8),
+            ("text[]", DataType::Utf8View),
             ("float[]", DataType::Float32),
             ("integer[]", DataType::Int32),
         ];
@@ -965,14 +1085,18 @@ mod tests {
 
     #[test]
     fn test_arrow_to_ducklake_roundtrip() {
-        // Verify roundtrip: arrow -> ducklake -> arrow for common types
+        // Verify roundtrip: arrow -> ducklake -> arrow for common types. Strings
+        // and binary use the view layouts (Utf8View/BinaryView) here because that
+        // is the canonical Arrow type `ducklake_to_arrow_type` produces; the
+        // non-view layouts collapse to the same DuckLake type and are covered by
+        // `test_view_types_write_back_to_string_and_blob`.
         let test_types = vec![
             DataType::Boolean,
             DataType::Int32,
             DataType::Int64,
             DataType::Float64,
-            DataType::Utf8,
-            DataType::Binary,
+            DataType::Utf8View,
+            DataType::BinaryView,
             DataType::Date32,
             DataType::Timestamp(TimeUnit::Microsecond, None),
             DataType::Timestamp(TimeUnit::Nanosecond, None),
@@ -980,7 +1104,7 @@ mod tests {
             DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
             DataType::Decimal128(10, 2),
             DataType::List(Arc::new(Field::new("item", DataType::Int32, true))),
-            DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+            DataType::List(Arc::new(Field::new("item", DataType::Utf8View, true))),
         ];
 
         for original in test_types {
@@ -1177,7 +1301,7 @@ mod tests {
         assert_eq!(schema.fields().len(), 2);
         assert_eq!(
             *schema.field(1).data_type(),
-            DataType::List(Arc::new(Field::new("item", DataType::Utf8, true)))
+            DataType::List(Arc::new(Field::new("item", DataType::Utf8View, true)))
         );
     }
 

--- a/tests/encryption_tests.rs
+++ b/tests/encryption_tests.rs
@@ -289,12 +289,10 @@ async fn test_read_pme_encrypted_parquet() -> anyhow::Result<()> {
     assert_eq!(id_col.value(1), 2);
     assert_eq!(id_col.value(2), 3);
 
-    // Check name column
-    let name_col = batch
-        .column(1)
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .unwrap();
+    // Check name column. DuckLake string columns scan as Utf8View; cast to Utf8
+    // so the assertions read the values through a StringArray.
+    let name_col_arr = arrow::compute::cast(batch.column(1), &DataType::Utf8).unwrap();
+    let name_col = name_col_arr.as_any().downcast_ref::<StringArray>().unwrap();
     assert_eq!(name_col.value(0), "Alice");
     assert_eq!(name_col.value(1), "Bob");
     assert_eq!(name_col.value(2), "Charlie");

--- a/tests/hybrid_asyncdb.rs
+++ b/tests/hybrid_asyncdb.rs
@@ -216,7 +216,9 @@ impl AsyncDB for HybridDuckLakeDB {
                         DefaultColumnType::Integer
                     },
                     DataType::Float32 | DataType::Float64 => DefaultColumnType::FloatingPoint,
-                    DataType::Utf8 | DataType::LargeUtf8 => DefaultColumnType::Text,
+                    DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => {
+                        DefaultColumnType::Text
+                    },
                     _ => DefaultColumnType::Any,
                 })
                 .collect::<Vec<_>>();
@@ -276,6 +278,14 @@ fn convert_batch_to_strings(batch: &RecordBatch) -> Result<Vec<Vec<String>>, Hyb
                     },
                     DataType::Utf8 => {
                         let arr = column.as_any().downcast_ref::<StringArray>().unwrap();
+                        arr.value(row_idx).to_string()
+                    },
+                    DataType::LargeUtf8 => {
+                        let arr = column.as_any().downcast_ref::<LargeStringArray>().unwrap();
+                        arr.value(row_idx).to_string()
+                    },
+                    DataType::Utf8View => {
+                        let arr = column.as_any().downcast_ref::<StringViewArray>().unwrap();
                         arr.value(row_idx).to_string()
                     },
                     DataType::Boolean => {

--- a/tests/multicatalog_postgres_tests.rs
+++ b/tests/multicatalog_postgres_tests.rs
@@ -3741,8 +3741,13 @@ async fn multicatalog_write_read_value_roundtrip() {
                 .as_any()
                 .downcast_ref::<Int64Array>()
                 .expect("id column is Int64");
-            let names = b
-                .column(1)
+            // DuckLake string columns scan as Utf8View; cast to Utf8 to read via StringArray.
+            let names_col = datafusion::arrow::compute::cast(
+                b.column(1),
+                &datafusion::arrow::datatypes::DataType::Utf8,
+            )
+            .expect("cast name column to Utf8");
+            let names = names_col
                 .as_any()
                 .downcast_ref::<StringArray>()
                 .expect("name column is Utf8");

--- a/tests/mysql_metadata_provider_test.rs
+++ b/tests/mysql_metadata_provider_test.rs
@@ -969,13 +969,19 @@ async fn test_query_real_parquet_files() {
         .as_any()
         .downcast_ref::<Int32Array>()
         .unwrap();
-    let name_col = batch
-        .column(1)
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .unwrap();
-    let email_col = batch
-        .column(2)
+    // DuckLake string columns scan as Utf8View; cast to Utf8 to read via StringArray.
+    let name_col_arr = datafusion::arrow::compute::cast(
+        batch.column(1),
+        &datafusion::arrow::datatypes::DataType::Utf8,
+    )
+    .unwrap();
+    let name_col = name_col_arr.as_any().downcast_ref::<StringArray>().unwrap();
+    let email_col_arr = datafusion::arrow::compute::cast(
+        batch.column(2),
+        &datafusion::arrow::datatypes::DataType::Utf8,
+    )
+    .unwrap();
+    let email_col = email_col_arr
         .as_any()
         .downcast_ref::<StringArray>()
         .unwrap();
@@ -1015,11 +1021,12 @@ async fn test_query_with_filter() {
     assert_eq!(batch.num_rows(), 2, "Should have 2 rows (Charlie, Diana)");
 
     use datafusion::arrow::array::StringArray;
-    let name_col = batch
-        .column(0)
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .unwrap();
+    let name_col_arr = datafusion::arrow::compute::cast(
+        batch.column(0),
+        &datafusion::arrow::datatypes::DataType::Utf8,
+    )
+    .unwrap();
+    let name_col = name_col_arr.as_any().downcast_ref::<StringArray>().unwrap();
 
     assert_eq!(name_col.value(0), "Charlie");
     assert_eq!(name_col.value(1), "Diana");

--- a/tests/object_store_integration_test.rs
+++ b/tests/object_store_integration_test.rs
@@ -303,8 +303,11 @@ async fn test_minio_object_store_integration() -> anyhow::Result<()> {
         .as_any()
         .downcast_ref::<arrow::array::Int32Array>()
         .expect("id column should be Int32");
-    let name_col = results[0]
-        .column(1)
+    // DuckLake string columns scan as Utf8View; cast to Utf8 to read via StringArray.
+    let name_col_arr =
+        arrow::compute::cast(results[0].column(1), &arrow::datatypes::DataType::Utf8)
+            .expect("cast name column to Utf8");
+    let name_col = name_col_arr
         .as_any()
         .downcast_ref::<arrow::array::StringArray>()
         .expect("name column should be String");

--- a/tests/postgres_metadata_provider_test.rs
+++ b/tests/postgres_metadata_provider_test.rs
@@ -1003,13 +1003,19 @@ async fn test_query_real_parquet_files() {
         .as_any()
         .downcast_ref::<Int32Array>()
         .unwrap();
-    let name_col = batch
-        .column(1)
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .unwrap();
-    let email_col = batch
-        .column(2)
+    // DuckLake string columns scan as Utf8View; cast to Utf8 to read via StringArray.
+    let name_col_arr = datafusion::arrow::compute::cast(
+        batch.column(1),
+        &datafusion::arrow::datatypes::DataType::Utf8,
+    )
+    .unwrap();
+    let name_col = name_col_arr.as_any().downcast_ref::<StringArray>().unwrap();
+    let email_col_arr = datafusion::arrow::compute::cast(
+        batch.column(2),
+        &datafusion::arrow::datatypes::DataType::Utf8,
+    )
+    .unwrap();
+    let email_col = email_col_arr
         .as_any()
         .downcast_ref::<StringArray>()
         .unwrap();
@@ -1049,11 +1055,12 @@ async fn test_query_with_filter() {
     assert_eq!(batch.num_rows(), 2, "Should have 2 rows (Charlie, Diana)");
 
     use datafusion::arrow::array::StringArray;
-    let name_col = batch
-        .column(0)
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .unwrap();
+    let name_col_arr = datafusion::arrow::compute::cast(
+        batch.column(0),
+        &datafusion::arrow::datatypes::DataType::Utf8,
+    )
+    .unwrap();
+    let name_col = name_col_arr.as_any().downcast_ref::<StringArray>().unwrap();
 
     assert_eq!(name_col.value(0), "Charlie");
     assert_eq!(name_col.value(1), "Diana");

--- a/tests/renamed_columns_tests.rs
+++ b/tests/renamed_columns_tests.rs
@@ -117,7 +117,10 @@ fn get_int_column(batch: &RecordBatch, col_idx: usize) -> Vec<i32> {
 
 /// Helper to get string column values from a batch
 fn get_string_column(batch: &RecordBatch, col_idx: usize) -> Vec<String> {
-    let column = batch.column(col_idx);
+    // Cast to Utf8 so the helper reads any string layout the provider produces
+    // (Utf8 / LargeUtf8 / Utf8View); DuckLake string columns now scan as Utf8View.
+    let column =
+        arrow::compute::cast(batch.column(col_idx), &arrow::datatypes::DataType::Utf8).unwrap();
     let array = column.as_any().downcast_ref::<StringArray>().unwrap();
     (0..array.len())
         .map(|i| array.value(i).to_string())
@@ -587,7 +590,9 @@ async fn test_drop_readd_column_reads_null_for_pre_drop_rows() -> Result<()> {
     let mut got: Vec<(i32, Option<String>)> = Vec::new();
     for b in &batches {
         let ids = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
-        let tags = b.column(1).as_any().downcast_ref::<StringArray>().unwrap();
+        let tags_col =
+            arrow::compute::cast(b.column(1), &arrow::datatypes::DataType::Utf8).unwrap();
+        let tags = tags_col.as_any().downcast_ref::<StringArray>().unwrap();
         for i in 0..b.num_rows() {
             let tag = if tags.is_null(i) {
                 None

--- a/tests/sqlite_metadata_provider_test.rs
+++ b/tests/sqlite_metadata_provider_test.rs
@@ -935,13 +935,19 @@ async fn test_query_real_parquet_files() {
         .as_any()
         .downcast_ref::<Int32Array>()
         .unwrap();
-    let name_col = batch
-        .column(1)
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .unwrap();
-    let email_col = batch
-        .column(2)
+    // DuckLake string columns scan as Utf8View; cast to Utf8 to read via StringArray.
+    let name_col_arr = datafusion::arrow::compute::cast(
+        batch.column(1),
+        &datafusion::arrow::datatypes::DataType::Utf8,
+    )
+    .unwrap();
+    let name_col = name_col_arr.as_any().downcast_ref::<StringArray>().unwrap();
+    let email_col_arr = datafusion::arrow::compute::cast(
+        batch.column(2),
+        &datafusion::arrow::datatypes::DataType::Utf8,
+    )
+    .unwrap();
+    let email_col = email_col_arr
         .as_any()
         .downcast_ref::<StringArray>()
         .unwrap();
@@ -980,11 +986,12 @@ async fn test_query_with_filter() {
     assert_eq!(batch.num_rows(), 2, "Should have 2 rows (Charlie, Diana)");
 
     use datafusion::arrow::array::StringArray;
-    let name_col = batch
-        .column(0)
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .unwrap();
+    let name_col_arr = datafusion::arrow::compute::cast(
+        batch.column(0),
+        &datafusion::arrow::datatypes::DataType::Utf8,
+    )
+    .unwrap();
+    let name_col = name_col_arr.as_any().downcast_ref::<StringArray>().unwrap();
 
     assert_eq!(name_col.value(0), "Charlie");
     assert_eq!(name_col.value(1), "Diana");

--- a/tests/table_changes_tests.rs
+++ b/tests/table_changes_tests.rs
@@ -68,8 +68,24 @@ fn get_string_column(batch: &RecordBatch, col_idx: usize) -> Vec<String> {
             .collect();
     }
 
+    // Try StringViewArray (Utf8View) — the layout scanned user string columns use.
+    if let Some(array) = column
+        .as_any()
+        .downcast_ref::<arrow::array::StringViewArray>()
+    {
+        return (0..array.len())
+            .filter_map(|i| {
+                if array.is_null(i) {
+                    None
+                } else {
+                    Some(array.value(i).to_string())
+                }
+            })
+            .collect();
+    }
+
     panic!(
-        "Expected StringArray or LargeStringArray, got {:?}",
+        "Expected StringArray, LargeStringArray, or StringViewArray, got {:?}",
         column.data_type()
     );
 }

--- a/tests/write_tests.rs
+++ b/tests/write_tests.rs
@@ -8,8 +8,9 @@
 use std::sync::Arc;
 
 use arrow::array::{
-    Array, BooleanArray, Date32Array, Float64Array, Int32Array, Int64Array, StringArray,
-    TimestampMicrosecondArray, TimestampNanosecondArray,
+    Array, BinaryViewArray, BooleanArray, Date32Array, Float64Array, Int32Array, Int64Array,
+    ListArray, ListBuilder, StringArray, StringBuilder, StringViewArray, TimestampMicrosecondArray,
+    TimestampNanosecondArray,
 };
 use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 use arrow::record_batch::RecordBatch;
@@ -119,14 +120,157 @@ async fn test_write_and_read_basic_types() {
         .unwrap();
     assert_eq!(ids.values(), &[1, 2, 3]);
 
-    let names = batches[0]
-        .column(1)
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .unwrap();
+    // DuckLake string columns scan as Utf8View; cast to Utf8 to assert via StringArray.
+    let names_arr = arrow::compute::cast(batches[0].column(1), &DataType::Utf8).unwrap();
+    let names = names_arr.as_any().downcast_ref::<StringArray>().unwrap();
     assert_eq!(names.value(0), "Alice");
     assert_eq!(names.value(1), "Bob");
     assert!(names.is_null(2));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_write_read_view_columns_roundtrip() {
+    // A string column scans as Utf8View and a blob column as BinaryView, matching
+    // DataFusion's schema_force_view_types default. This drives the full
+    // write -> scan pipeline with view arrays as input (the layout a write-back
+    // produces once the provider serves view types), and asserts the scan returns
+    // view arrays end to end, not i32-offset Utf8/Binary.
+    let (writer, temp_dir) = create_test_env().await;
+    let object_store = create_object_store();
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("name", DataType::Utf8View, true),
+        Field::new("data", DataType::BinaryView, true),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3])),
+            Arc::new(StringViewArray::from(vec![
+                Some("Alice"),
+                Some("Bob"),
+                None,
+            ])),
+            Arc::new(BinaryViewArray::from(vec![
+                Some(b"xx".as_ref()),
+                Some(b"yyy".as_ref()),
+                None,
+            ])),
+        ],
+    )
+    .unwrap();
+
+    let table_writer = DuckLakeTableWriter::new(Arc::new(writer), object_store).unwrap();
+    table_writer
+        .write_table("main", "views", &[batch])
+        .await
+        .unwrap();
+
+    let ctx = create_read_context(&temp_dir).await;
+    let batches = ctx
+        .sql("SELECT id, name, data FROM test.main.views ORDER BY id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(batches.len(), 1);
+    let batch = &batches[0];
+
+    // The scan must expose the view layouts end to end.
+    assert_eq!(batch.schema().field(1).data_type(), &DataType::Utf8View);
+    assert_eq!(batch.schema().field(2).data_type(), &DataType::BinaryView);
+
+    let names = batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<StringViewArray>()
+        .expect("name should scan as StringViewArray");
+    assert_eq!(names.value(0), "Alice");
+    assert_eq!(names.value(1), "Bob");
+    assert!(names.is_null(2));
+
+    let data = batch
+        .column(2)
+        .as_any()
+        .downcast_ref::<BinaryViewArray>()
+        .expect("data should scan as BinaryViewArray");
+    assert_eq!(data.value(0), b"xx");
+    assert_eq!(data.value(1), b"yyy");
+    assert!(data.is_null(2));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_write_read_list_of_string_roundtrip() {
+    // A list<varchar> column scans with a Utf8View element. The file is written
+    // with a Utf8 list child while the catalog type resolves to List(Utf8View),
+    // so the read path recasts the list element (List(Utf8) -> List(Utf8View)) in
+    // ColumnRenameExec. Exercises that element recast end to end.
+    let (writer, temp_dir) = create_test_env().await;
+    let object_store = create_object_store();
+
+    let mut tags_builder = ListBuilder::new(StringBuilder::new());
+    tags_builder.values().append_value("a");
+    tags_builder.values().append_value("b");
+    tags_builder.append(true);
+    tags_builder.values().append_value("c");
+    tags_builder.append(true);
+    let tags = tags_builder.finish();
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("tags", tags.data_type().clone(), true),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![Arc::new(Int32Array::from(vec![1, 2])), Arc::new(tags)],
+    )
+    .unwrap();
+
+    let table_writer = DuckLakeTableWriter::new(Arc::new(writer), object_store).unwrap();
+    table_writer
+        .write_table("main", "taglists", &[batch])
+        .await
+        .unwrap();
+
+    let ctx = create_read_context(&temp_dir).await;
+    let batches = ctx
+        .sql("SELECT id, tags FROM test.main.taglists ORDER BY id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(batches.len(), 1);
+    let batch = &batches[0];
+
+    // The list element scans as Utf8View.
+    match batch.schema().field(1).data_type() {
+        DataType::List(field) => {
+            assert_eq!(
+                field.data_type(),
+                &DataType::Utf8View,
+                "list element should scan as Utf8View"
+            );
+        },
+        other => panic!("expected List, got {other:?}"),
+    }
+
+    // Values survive the List(Utf8) -> List(Utf8View) element recast. Read each
+    // row's element slice via a Utf8 cast so the assertion is layout-agnostic.
+    let tags = batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .expect("tags should be a ListArray");
+    let row0 = arrow::compute::cast(&tags.value(0), &DataType::Utf8).unwrap();
+    let row0 = row0.as_any().downcast_ref::<StringArray>().unwrap();
+    assert_eq!(row0.value(0), "a");
+    assert_eq!(row0.value(1), "b");
+    let row1 = arrow::compute::cast(&tags.value(1), &DataType::Utf8).unwrap();
+    let row1 = row1.as_any().downcast_ref::<StringArray>().unwrap();
+    assert_eq!(row1.value(0), "c");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -575,20 +719,14 @@ async fn test_multiple_tables_same_schema() {
 
     let df1 = ctx.sql("SELECT name FROM test.main.t1").await.unwrap();
     let batches1 = df1.collect().await.unwrap();
-    let names1 = batches1[0]
-        .column(0)
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .unwrap();
+    let names1_arr = arrow::compute::cast(batches1[0].column(0), &DataType::Utf8).unwrap();
+    let names1 = names1_arr.as_any().downcast_ref::<StringArray>().unwrap();
     assert_eq!(names1.value(0), "table1");
 
     let df2 = ctx.sql("SELECT name FROM test.main.t2").await.unwrap();
     let batches2 = df2.collect().await.unwrap();
-    let names2 = batches2[0]
-        .column(0)
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .unwrap();
+    let names2_arr = arrow::compute::cast(batches2[0].column(0), &DataType::Utf8).unwrap();
+    let names2 = names2_arr.as_any().downcast_ref::<StringArray>().unwrap();
     assert_eq!(names2.value(0), "table2");
 }
 


### PR DESCRIPTION
## Summary

Map DuckLake string/binary columns to Arrow **view** layouts on read:
`varchar`/`text`/`string`/`json`/`timetz` → `Utf8View` and `blob`/`binary`/`bytea` → `BinaryView`
(previously `Utf8`/`Binary`). `geometry` stays `Binary` and `uuid` stays `FixedSizeBinary(16)`.

## Why

Every ordinary DataFusion parquet scan (`ListingTable` / `ParquetFormat`) runs its inferred schema
through `transform_schema_to_view` when `schema_force_view_types` is set — and that option is **on by
default**. This provider builds its scan from an explicit, catalog-derived schema, so it bypasses that
inference and is the one parquet scan that produces i32-offset `Utf8`/`Binary` arrays.

That has two consequences for wide, high-cardinality string workloads:

- A single i32-offset value buffer is capped at 2 GiB, so a large `GROUP BY` over a wide string column
  can exceed it and panic (`... more than can be represented by a i32`).
- View arrays hash/compare/dedup faster and spill less for medium/long strings.

This change makes the provider request view types, aligning it with DataFusion's default behaviour.

## No on-disk change, no migration

Parquet has no "view" physical type — `Utf8`, `LargeUtf8`, and `Utf8View` all serialize to `BYTE_ARRAY`.
Existing files are read back as view arrays natively: DataFusion's parquet opener reconciles the
requested (view) schema against the physical file schema (`apply_file_schema_type_coercions`) and hints
the arrow reader to decode `BYTE_ARRAY` straight into a view array — **no cast, no second allocation, no
file rewrite**. Newly-written files are byte-identical. The DuckLake catalog type is unchanged
(`arrow_to_ducklake_type` maps `Utf8`/`LargeUtf8`/`Utf8View` → `varchar` and
`Binary`/`LargeBinary`/`BinaryView` → `blob`), so `normalize`/schema-evolution comparisons are stable.

## ⚠️ Behaviour change (please read)

Scanned string columns now have Arrow type `Utf8View` (and binary → `BinaryView`). Consumers that
downcast a scanned column to a concrete `StringArray`/`BinaryArray` (i32-offset) must also handle
`StringViewArray`/`BinaryViewArray` (or cast first). This is the same coercion DataFusion applies to
every other parquet scan by default, but it is a visible change for existing users of this crate.
`arrow_typeof` on a string column now reports `Utf8View`.

## Notes / scope

- `geometry` (WKB) is intentionally kept as `Binary` — its bytes are consumed by geometry functions that
  expect a `Binary` layout, and it is unaffected by the string group-by issue.
- `list<varchar>` recurses to `List(Utf8View)`. On read the element is recast from the file's `Utf8`
  child to `Utf8View` in `ColumnRenameExec` (arrow supports this; DataFusion does not force-view list
  children, so the file child stays `Utf8`).
- The reverse (write) mapping accepts view layouts so batches produced elsewhere round-trip to the same
  DuckLake type; the writer encodes view arrays to `BYTE_ARRAY` unchanged.

## Testing

- New write → scan round-trip tests assert a scanned string column is `Utf8View`, a blob column is
  `BinaryView`, and a `list<varchar>` element is `Utf8View`, with values intact — exercising the view
  **write** and **read** paths end to end (including the `List(Utf8) → List(Utf8View)` element recast).
- Existing read-back tests/examples updated to handle the view layout (cast to `Utf8` in assertions;
  `StringViewArray` arms).
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, and the non-docker test
  suite pass locally.
