### PR TITLE
feat(write): add DuckDB and MySQL metadata writers (legacy single-catalog)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,8 @@ encryption = ["parquet/encryption", "datafusion/parquet_encryption", "dep:base64
 write = ["dep:uuid", "dep:chrono", "dep:tempfile"]
 write-sqlite = ["write", "metadata-sqlite"]
 write-postgres = ["write", "metadata-postgres", "multicatalog-postgres"]
+write-duckdb = ["write", "metadata-duckdb"]
+write-mysql = ["write", "metadata-mysql"]
 # Multicatalog read provider (independent of write support)
 multicatalog-postgres = ["metadata-postgres"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,10 @@ pub mod insert_exec;
 pub mod maintenance;
 #[cfg(feature = "write")]
 pub mod metadata_writer;
+#[cfg(feature = "write-duckdb")]
+pub mod metadata_writer_duckdb;
+#[cfg(feature = "write-mysql")]
+pub mod metadata_writer_mysql;
 #[cfg(feature = "write-postgres")]
 pub mod metadata_writer_postgres;
 #[cfg(feature = "write-sqlite")]
@@ -110,6 +114,10 @@ pub use metadata_writer::{
     ColumnDef, CommitIds, DataFileInfo, DeleteFileInfo, MetadataWriter, WriteMode, WriteResult,
     WriteSetupResult,
 };
+#[cfg(feature = "write-duckdb")]
+pub use metadata_writer_duckdb::DuckdbMetadataWriter;
+#[cfg(feature = "write-mysql")]
+pub use metadata_writer_mysql::MySqlMetadataWriter;
 #[cfg(feature = "write-postgres")]
 pub use metadata_writer_postgres::PostgresMetadataWriter;
 #[cfg(feature = "write-sqlite")]

--- a/src/metadata_writer_duckdb.rs
+++ b/src/metadata_writer_duckdb.rs
@@ -892,8 +892,7 @@ impl MetadataWriter for DuckdbMetadataWriter {
                 .collect();
 
             for new_col in columns.iter() {
-                if let Some((existing_type, _existing_nullable)) =
-                    existing_map.get(new_col.name())
+                if let Some((existing_type, _existing_nullable)) = existing_map.get(new_col.name())
                 {
                     if !crate::types::types_equal_canonical(existing_type, new_col.ducklake_type())
                     {
@@ -1015,7 +1014,9 @@ mod tests {
             .expect("table 'users' must exist");
         assert_eq!(table.table_name, "users");
 
-        let cols = provider.get_table_structure(table.table_id, snapshot).unwrap();
+        let cols = provider
+            .get_table_structure(table.table_id, snapshot)
+            .unwrap();
         assert_eq!(cols.len(), 2, "both columns must read back");
         assert_eq!(cols[0].column_name, "id");
         assert_eq!(cols[0].column_type, "int64");
@@ -1033,7 +1034,11 @@ mod tests {
         assert_eq!(files[0].file.file_size_bytes, 1024);
         assert_eq!(files[0].file.footer_size, Some(256));
         assert_eq!(files[0].max_row_count, Some(3));
-        assert_eq!(files[0].row_id_start, Some(0), "first file starts at rowid 0");
+        assert_eq!(
+            files[0].row_id_start,
+            Some(0),
+            "first file starts at rowid 0"
+        );
     }
 
     /// A second Append hands out a fresh, non-overlapping rowid range and

--- a/src/metadata_writer_duckdb.rs
+++ b/src/metadata_writer_duckdb.rs
@@ -1,0 +1,1120 @@
+//! DuckDB implementation of [`MetadataWriter`].
+//!
+//! A byte-compatible sibling of [`crate::metadata_writer_sqlite::SqliteMetadataWriter`]:
+//! it writes the *exact same* DuckLake catalog tables (same names, same columns) so
+//! that DuckDB's own `ducklake` extension — and this crate's
+//! [`crate::DuckdbMetadataProvider`] — can read back what it writes.
+//!
+//! Scope is deliberately narrow (see `write-duckdb` feature): **legacy /
+//! single-catalog only** — INSERT / REPLACE / CREATE TABLE (including zero-row).
+//! No deletes, no upsert, no compaction, no partitioning, no multicatalog. The
+//! erroring trait defaults for [`MetadataWriter::promote_column_type`] and
+//! [`MetadataWriter::set_delete_file`] are inherited, and
+//! [`MetadataWriter::catalog_id`] returns `None`.
+//!
+//! ## How this differs from the SQLite writer
+//!
+//! 1. **Synchronous driver.** The `duckdb` crate is rusqlite-like and sync, not
+//!    sqlx/async, so there is no `block_on`: the trait's sync `fn`s run directly
+//!    against a `duckdb::Connection`. A single connection guarded by a `Mutex`
+//!    makes the writer `Send + Sync` and — since DuckLake file catalogs are
+//!    single-writer — serializes commits, which is exactly the "write lock" the
+//!    SQLite writer leans on. Each mutating method opens one DuckDB transaction
+//!    (`BEGIN`/`COMMIT`, auto-rollback on drop) for atomicity.
+//! 2. **Id allocation.** SQLite relies on `INTEGER PRIMARY KEY` rowid
+//!    autoincrement for `schema_id` / `table_id` / `data_file_id` /
+//!    `delete_file_id`; a plain DuckDB PK does *not* autoincrement, so those
+//!    columns default from DuckDB **sequences** (`nextval(...)`). `snapshot_id`
+//!    keeps SQLite's commit-ordered `MAX(snapshot_id)+1` allocation (assigned at
+//!    the commit, never reserved at begin) and `column_id` keeps SQLite's
+//!    monotonic counter row in `ducklake_metadata` bumped with `UPDATE ...
+//!    RETURNING`. The column *layouts* are otherwise identical to the SQLite
+//!    DDL; only the id-default mechanism and the SQL type spellings
+//!    (BIGINT/VARCHAR/BOOLEAN/TIMESTAMP) change.
+//! 3. **Ordering + conflict detection preserved.** The snapshot is allocated
+//!    before the table reads, and a `Replace` commit aborts with
+//!    [`crate::DuckLakeError::Conflict`] if any data file of the table has a
+//!    `begin_snapshot`/`end_snapshot` newer than the base observed at begin.
+
+use crate::Result;
+use crate::error::{TypeChangeOperation, TypeChangeWriteMode};
+use crate::metadata_writer::{
+    ColumnDef, CommitIds, DataFileInfo, MetadataWriter, WriteMode, WriteSetupResult,
+    columns_differ, validate_name,
+};
+use duckdb::{Connection, OptionalExt, Transaction, params};
+use std::sync::{Arc, Mutex, MutexGuard};
+
+/// DuckLake catalog DDL for DuckDB.
+///
+/// Column-for-column identical to `SQL_CREATE_SCHEMA` in the SQLite writer; the
+/// only changes are DuckDB spellings (BIGINT/VARCHAR/BOOLEAN/TIMESTAMP,
+/// `DEFAULT true`) and the id-default mechanism. The `*_id_seq` sequences supply
+/// the autoincrement that a plain DuckDB `PRIMARY KEY` does not; they are created
+/// *before* the tables that reference them via `DEFAULT nextval(...)`. DuckDB
+/// persists a sequence's value in the database file, so re-opening a catalog this
+/// writer created continues handing out fresh, non-overlapping ids.
+const SQL_CREATE_SCHEMA: &str = r#"
+CREATE SEQUENCE IF NOT EXISTS ducklake_schema_id_seq START 1;
+CREATE SEQUENCE IF NOT EXISTS ducklake_table_id_seq START 1;
+CREATE SEQUENCE IF NOT EXISTS ducklake_data_file_id_seq START 1;
+CREATE SEQUENCE IF NOT EXISTS ducklake_delete_file_id_seq START 1;
+
+CREATE TABLE IF NOT EXISTS ducklake_metadata (
+    key VARCHAR NOT NULL,
+    value VARCHAR NOT NULL,
+    scope VARCHAR
+);
+
+CREATE TABLE IF NOT EXISTS ducklake_snapshot (
+    snapshot_id BIGINT PRIMARY KEY,
+    snapshot_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    schema_version BIGINT NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS ducklake_schema_versions (
+    begin_snapshot BIGINT NOT NULL,
+    schema_version BIGINT NOT NULL,
+    table_id BIGINT NOT NULL,
+    UNIQUE (table_id, begin_snapshot)
+);
+
+CREATE TABLE IF NOT EXISTS ducklake_schema (
+    schema_id BIGINT PRIMARY KEY DEFAULT nextval('ducklake_schema_id_seq'),
+    schema_name VARCHAR NOT NULL,
+    path VARCHAR NOT NULL DEFAULT '',
+    path_is_relative BOOLEAN NOT NULL DEFAULT true,
+    begin_snapshot BIGINT NOT NULL,
+    end_snapshot BIGINT
+);
+
+CREATE TABLE IF NOT EXISTS ducklake_table (
+    table_id BIGINT PRIMARY KEY DEFAULT nextval('ducklake_table_id_seq'),
+    schema_id BIGINT NOT NULL,
+    table_name VARCHAR NOT NULL,
+    path VARCHAR NOT NULL DEFAULT '',
+    path_is_relative BOOLEAN NOT NULL DEFAULT true,
+    begin_snapshot BIGINT NOT NULL,
+    end_snapshot BIGINT
+);
+
+-- Bare table (no PK, no NOT NULL), upstream's exact column order, so a column
+-- can be versioned by [begin_snapshot, end_snapshot) and a type promotion can
+-- write a second row sharing the same column_id. Mirrors the SQLite writer's
+-- `ducklake_column`. The four `*default*` columns + `parent_column` are left
+-- NULL (no nested-type / column-default writes here).
+CREATE TABLE IF NOT EXISTS ducklake_column (
+    column_id BIGINT,
+    begin_snapshot BIGINT,
+    end_snapshot BIGINT,
+    table_id BIGINT,
+    column_order BIGINT,
+    column_name VARCHAR,
+    column_type VARCHAR,
+    initial_default VARCHAR,
+    default_value VARCHAR,
+    nulls_allowed BOOLEAN,
+    parent_column BIGINT,
+    default_value_type VARCHAR,
+    default_value_dialect VARCHAR
+);
+
+CREATE TABLE IF NOT EXISTS ducklake_data_file (
+    data_file_id BIGINT PRIMARY KEY DEFAULT nextval('ducklake_data_file_id_seq'),
+    table_id BIGINT NOT NULL,
+    path VARCHAR NOT NULL,
+    path_is_relative BOOLEAN NOT NULL DEFAULT true,
+    file_size_bytes BIGINT NOT NULL,
+    footer_size BIGINT,
+    encryption_key VARCHAR,
+    record_count BIGINT,
+    row_id_start BIGINT,
+    mapping_id BIGINT,
+    begin_snapshot BIGINT NOT NULL,
+    end_snapshot BIGINT
+);
+
+CREATE TABLE IF NOT EXISTS ducklake_table_stats (
+    table_id BIGINT PRIMARY KEY,
+    record_count BIGINT NOT NULL DEFAULT 0,
+    next_row_id BIGINT NOT NULL DEFAULT 0,
+    file_size_bytes BIGINT NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS ducklake_delete_file (
+    delete_file_id BIGINT PRIMARY KEY DEFAULT nextval('ducklake_delete_file_id_seq'),
+    data_file_id BIGINT NOT NULL,
+    table_id BIGINT NOT NULL,
+    path VARCHAR NOT NULL,
+    path_is_relative BOOLEAN NOT NULL DEFAULT true,
+    file_size_bytes BIGINT NOT NULL,
+    footer_size BIGINT,
+    encryption_key VARCHAR,
+    delete_count BIGINT,
+    begin_snapshot BIGINT NOT NULL,
+    end_snapshot BIGINT
+);
+
+CREATE TABLE IF NOT EXISTS ducklake_files_scheduled_for_deletion (
+    data_file_id BIGINT NOT NULL,
+    path VARCHAR NOT NULL,
+    path_is_relative BOOLEAN NOT NULL DEFAULT true,
+    schedule_start TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+"#;
+
+/// DuckDB-based metadata writer for DuckLake catalogs.
+///
+/// Holds a single read-write `duckdb::Connection` behind a `Mutex` (cloneable via
+/// `Arc`, sharing the one connection). See the module docs for the differences
+/// from the SQLite writer.
+#[derive(Debug, Clone)]
+pub struct DuckdbMetadataWriter {
+    conn: Arc<Mutex<Connection>>,
+    /// Path to the catalog database, retained for logging/debugging.
+    #[allow(dead_code)]
+    catalog_path: String,
+}
+
+impl DuckdbMetadataWriter {
+    /// Open (creating if absent) a DuckDB catalog file for writing.
+    pub fn new(path: impl Into<String>) -> Result<Self> {
+        let catalog_path = path.into();
+        let conn = Connection::open(&catalog_path)?;
+        Ok(Self {
+            conn: Arc::new(Mutex::new(conn)),
+            catalog_path,
+        })
+    }
+
+    /// Open the catalog and initialize the DuckLake schema tables.
+    pub fn new_with_init(path: impl Into<String>) -> Result<Self> {
+        let writer = Self::new(path)?;
+        writer.initialize_schema()?;
+        Ok(writer)
+    }
+
+    /// Lock the shared connection. Panics only if a previous holder panicked
+    /// mid-write (poisoned mutex), which cannot leave partial SQL committed
+    /// because every mutating method wraps its work in a transaction.
+    fn connection(&self) -> MutexGuard<'_, Connection> {
+        self.conn.lock().expect("DuckDB connection mutex poisoned")
+    }
+}
+
+/// Atomically reserve `n` consecutive ids from a monotonic counter row in
+/// `ducklake_metadata` (seeded by `initialize_schema`), returning the LAST id of
+/// the block — the reserved ids are `last - n + 1 ..= last`. Mirrors the SQLite
+/// writer's `reserve_ids`; used for `column_id`, which is reserved at begin and
+/// baked into the staged parquet's `field_id` metadata. `value` is stored as
+/// text and cast through BIGINT so the `UPDATE ... RETURNING` is exact.
+fn reserve_ids(tx: &Transaction<'_>, key: &str, n: i64) -> Result<i64> {
+    let last: i64 = tx.query_row(
+        "UPDATE ducklake_metadata
+         SET value = CAST(CAST(value AS BIGINT) + ? AS VARCHAR)
+         WHERE key = ? AND scope IS NULL
+         RETURNING CAST(value AS BIGINT)",
+        params![n, key],
+        |row| row.get(0),
+    )?;
+    Ok(last)
+}
+
+/// Insert the next `ducklake_snapshot` row in commit order, carrying
+/// `schema_version` forward (the pure-data-write default), and return
+/// `(snapshot_id, schema_version)`.
+///
+/// Mirrors the SQLite writer's `insert_snapshot` — `MAX(snapshot_id)+1` assigned
+/// at the commit, never reserved at begin — but split into a read then an insert
+/// (DuckDB's single-writer connection is held under the `Mutex`, so no
+/// concurrent writer can slip between them; the two-statement form avoids relying
+/// on `INSERT ... SELECT ... RETURNING`). A DDL commit follows this with
+/// [`bump_schema_version`].
+fn insert_snapshot(tx: &Transaction<'_>) -> Result<(i64, i64)> {
+    let (snapshot_id, schema_version): (i64, i64) = tx.query_row(
+        "SELECT COALESCE(MAX(snapshot_id), 0) + 1, COALESCE(MAX(schema_version), 0)
+         FROM ducklake_snapshot",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+    tx.execute(
+        "INSERT INTO ducklake_snapshot (snapshot_id, snapshot_time, schema_version)
+         VALUES (?, CURRENT_TIMESTAMP, ?)",
+        params![snapshot_id, schema_version],
+    )?;
+    Ok((snapshot_id, schema_version))
+}
+
+/// Bump the per-catalog monotonic `schema_version` on a DDL snapshot to
+/// `prev_max + 1` (max over the OTHER snapshots, so re-running is stable) and
+/// return the new value. Mirrors the SQLite writer's `bump_schema_version`.
+fn bump_schema_version(tx: &Transaction<'_>, snapshot_id: i64) -> Result<i64> {
+    let prev_max: i64 = tx.query_row(
+        "SELECT COALESCE(MAX(schema_version), 0) FROM ducklake_snapshot WHERE snapshot_id <> ?",
+        params![snapshot_id],
+        |row| row.get(0),
+    )?;
+    let new_version = prev_max + 1;
+    tx.execute(
+        "UPDATE ducklake_snapshot SET schema_version = ? WHERE snapshot_id = ?",
+        params![new_version, snapshot_id],
+    )?;
+    Ok(new_version)
+}
+
+/// Record a `ducklake_schema_versions` ledger row for a DDL that leaves the table
+/// live (create, column add/remove/reorder). Mirrors the SQLite writer.
+fn record_schema_version(
+    tx: &Transaction<'_>,
+    snapshot_id: i64,
+    schema_version: i64,
+    table_id: i64,
+) -> Result<()> {
+    tx.execute(
+        "INSERT INTO ducklake_schema_versions (begin_snapshot, schema_version, table_id)
+         VALUES (?, ?, ?)",
+        params![snapshot_id, schema_version, table_id],
+    )?;
+    Ok(())
+}
+
+/// Seed the `ducklake_table_stats` row for a brand-new table if it is missing.
+///
+/// Replaces the SQLite writer's `INSERT OR IGNORE` with an explicit
+/// exists-check, avoiding any dependency on DuckDB upsert syntax while producing
+/// the identical result (a single zeroed stats row per table).
+fn seed_stats_if_missing(tx: &Transaction<'_>, table_id: i64) -> Result<()> {
+    let exists: Option<i64> = tx
+        .query_row(
+            "SELECT 1 FROM ducklake_table_stats WHERE table_id = ?",
+            params![table_id],
+            |row| row.get(0),
+        )
+        .optional()?;
+    if exists.is_none() {
+        tx.execute(
+            "INSERT INTO ducklake_table_stats
+                 (table_id, record_count, next_row_id, file_size_bytes)
+             VALUES (?, 0, 0, 0)",
+            params![table_id],
+        )?;
+    }
+    Ok(())
+}
+
+/// Optimistic-concurrency check for a `Replace` commit (mirrors the SQLite
+/// writer). If any data file of the table has `begin_snapshot` or `end_snapshot`
+/// newer than `base_snapshot` (the head observed when this write began), another
+/// writer published a newer generation in the meantime, so this `Replace` aborts
+/// with [`crate::DuckLakeError::Conflict`] rather than clobbering it.
+fn detect_replace_conflict(tx: &Transaction<'_>, table_id: i64, base_snapshot: i64) -> Result<()> {
+    let conflicts: i64 = tx.query_row(
+        "SELECT COUNT(*) FROM ducklake_data_file
+         WHERE table_id = ? AND (begin_snapshot > ? OR end_snapshot > ?)",
+        params![table_id, base_snapshot, base_snapshot],
+        |row| row.get(0),
+    )?;
+    if conflicts > 0 {
+        return Err(crate::DuckLakeError::Conflict(format!(
+            "Replace on table {table_id} conflicts with a concurrent write committed since \
+             snapshot {base_snapshot}; aborting (retry the write against the new generation)"
+        )));
+    }
+    Ok(())
+}
+
+/// Retire the prior generation's still-visible data files at `snapshot_id` and
+/// zero the visible stat totals. The `begin_snapshot < snapshot_id` guard spares
+/// files registered for *this* snapshot. `next_row_id` is left untouched (rowids
+/// stay monotonic across the table's lifetime). Mirrors the SQLite writer.
+fn retire_prior_generation(tx: &Transaction<'_>, table_id: i64, snapshot_id: i64) -> Result<()> {
+    tx.execute(
+        "UPDATE ducklake_data_file SET end_snapshot = ?
+         WHERE table_id = ? AND end_snapshot IS NULL AND begin_snapshot < ?",
+        params![snapshot_id, table_id, snapshot_id],
+    )?;
+    tx.execute(
+        "UPDATE ducklake_table_stats SET record_count = 0, file_size_bytes = 0 WHERE table_id = ?",
+        params![table_id],
+    )?;
+    Ok(())
+}
+
+/// The atomic commit point for a single-catalog write. Inserts the deferred
+/// `ducklake_snapshot` row, finalizes the column generation surgically (stable
+/// `column_id`s), classifies the commit as DDL vs pure data write to bump/carry
+/// `schema_version`, and — for `Replace` — fences on the base snapshot and
+/// retires the prior data generation. A faithful port of the SQLite writer's
+/// `finalize_snapshot`; the only structural change is reading the current
+/// columns into an owned `Vec` (dropping the prepared statement) before issuing
+/// further writes on the same connection.
+fn finalize_snapshot(
+    tx: &Transaction<'_>,
+    table_id: i64,
+    columns: &[ColumnDef],
+    column_ids: &[i64],
+    mode: WriteMode,
+    base_snapshot: i64,
+) -> Result<i64> {
+    use std::collections::{HashMap, HashSet};
+
+    // Allocate the snapshot FIRST (carrying schema_version forward); corrected to
+    // a DDL bump below once the commit is classified.
+    let (snapshot_id, mut schema_version) = insert_snapshot(tx)?;
+
+    // The table's live columns ordered by column_order. Collected into an owned
+    // Vec so the prepared statement is dropped before we mutate the same
+    // connection. An empty set means a brand-new table (its creating write is DDL).
+    let current: Vec<(String, String, i64, bool)> = {
+        let mut stmt = tx.prepare(
+            "SELECT column_name, column_type, column_order, nulls_allowed
+             FROM ducklake_column
+             WHERE table_id = ? AND end_snapshot IS NULL
+             ORDER BY column_order",
+        )?;
+        let mapped = stmt.query_map(params![table_id], |row| {
+            let name: String = row.get(0)?;
+            let ty: String = row.get(1)?;
+            let order: i64 = row.get(2)?;
+            let nullable: Option<bool> = row.get(3)?;
+            Ok((name, ty, order, nullable.unwrap_or(true)))
+        })?;
+        mapped.collect::<std::result::Result<Vec<_>, duckdb::Error>>()?
+    };
+
+    let existing: Vec<(String, String, bool)> = current
+        .iter()
+        .map(|(name, ty, _order, nullable)| (name.clone(), ty.clone(), *nullable))
+        .collect();
+    let is_ddl = existing.is_empty() || columns_differ(&existing, columns);
+    if is_ddl {
+        // A DDL commit bumps schema_version (the insert only carried it forward).
+        schema_version = bump_schema_version(tx, snapshot_id)?;
+    }
+
+    // Reconcile the column generation SURGICALLY so each column keeps a stable
+    // column_id (== parquet field_id): end only removed columns, insert only new
+    // ones, and leave unchanged columns (and their ids) in place.
+    let new_names: HashSet<&str> = columns.iter().map(|c| c.name()).collect();
+    let mut current_by_name: HashMap<String, (i64, bool)> = HashMap::new();
+    for (name, _ty, order, nullable) in &current {
+        if !new_names.contains(name.as_str()) {
+            tx.execute(
+                "UPDATE ducklake_column SET end_snapshot = ?
+                 WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL",
+                params![snapshot_id, table_id, name.as_str()],
+            )?;
+        }
+        current_by_name.insert(name.clone(), (*order, *nullable));
+    }
+
+    for (order, (col, column_id)) in columns.iter().zip(column_ids.iter()).enumerate() {
+        match current_by_name.get(col.name()) {
+            // Existing column kept: its id stays stable. Sync order/nullability
+            // only if they changed (type changes are rejected at begin).
+            Some(&(cur_order, cur_nullable)) => {
+                if cur_order != order as i64 || cur_nullable != col.is_nullable() {
+                    tx.execute(
+                        "UPDATE ducklake_column SET column_order = ?, nulls_allowed = ?
+                         WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL",
+                        params![order as i64, col.is_nullable(), table_id, col.name()],
+                    )?;
+                }
+            },
+            // Newly added column: insert it with its reserved id.
+            None => {
+                tx.execute(
+                    "INSERT INTO ducklake_column
+                         (column_id, table_id, column_name, column_type, column_order, nulls_allowed, begin_snapshot)
+                     VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    params![
+                        column_id,
+                        table_id,
+                        col.name(),
+                        col.ducklake_type(),
+                        order as i64,
+                        col.is_nullable(),
+                        snapshot_id
+                    ],
+                )?;
+            },
+        }
+    }
+
+    if mode == WriteMode::Replace {
+        // Abort if a concurrent writer published a newer generation since begin.
+        detect_replace_conflict(tx, table_id, base_snapshot)?;
+        // Seed the stats row (first write to a brand-new table) so retire's
+        // zero-update has a row, then retire the prior data generation.
+        seed_stats_if_missing(tx, table_id)?;
+        retire_prior_generation(tx, table_id, snapshot_id)?;
+    }
+
+    // Record the schema-change ledger row for a DDL commit. A pure data write
+    // carries schema_version forward and writes no row.
+    if is_ddl {
+        record_schema_version(tx, snapshot_id, schema_version, table_id)?;
+    }
+    Ok(snapshot_id)
+}
+
+impl MetadataWriter for DuckdbMetadataWriter {
+    fn create_snapshot(&self) -> Result<i64> {
+        let mut conn = self.connection();
+        let tx = conn.transaction()?;
+        // A bare snapshot carries no schema change of its own → carry
+        // schema_version forward (no DDL bump, no ledger row).
+        let (snapshot_id, _schema_version) = insert_snapshot(&tx)?;
+        tx.commit()?;
+        Ok(snapshot_id)
+    }
+
+    fn get_or_create_schema(
+        &self,
+        name: &str,
+        path: Option<&str>,
+        snapshot_id: i64,
+    ) -> Result<(i64, bool)> {
+        validate_name(name, "Schema")?;
+        let mut conn = self.connection();
+        let tx = conn.transaction()?;
+
+        let existing: Option<i64> = tx
+            .query_row(
+                "SELECT schema_id FROM ducklake_schema
+                 WHERE schema_name = ? AND end_snapshot IS NULL",
+                params![name],
+                |row| row.get(0),
+            )
+            .optional()?;
+
+        if let Some(schema_id) = existing {
+            tx.commit()?;
+            return Ok((schema_id, false));
+        }
+
+        let schema_path = path.unwrap_or(name);
+        let schema_id: i64 = tx.query_row(
+            "INSERT INTO ducklake_schema (schema_name, path, path_is_relative, begin_snapshot)
+             VALUES (?, ?, true, ?) RETURNING schema_id",
+            params![name, schema_path, snapshot_id],
+            |row| row.get(0),
+        )?;
+        tx.commit()?;
+        Ok((schema_id, true))
+    }
+
+    fn get_or_create_table(
+        &self,
+        schema_id: i64,
+        name: &str,
+        path: Option<&str>,
+        snapshot_id: i64,
+    ) -> Result<(i64, bool)> {
+        validate_name(name, "Table")?;
+        let mut conn = self.connection();
+        let tx = conn.transaction()?;
+
+        let existing: Option<i64> = tx
+            .query_row(
+                "SELECT table_id FROM ducklake_table
+                 WHERE schema_id = ? AND table_name = ? AND end_snapshot IS NULL",
+                params![schema_id, name],
+                |row| row.get(0),
+            )
+            .optional()?;
+
+        if let Some(table_id) = existing {
+            tx.commit()?;
+            return Ok((table_id, false));
+        }
+
+        let table_path = path.unwrap_or(name);
+        let table_id: i64 = tx.query_row(
+            "INSERT INTO ducklake_table (schema_id, table_name, path, path_is_relative, begin_snapshot)
+             VALUES (?, ?, ?, true, ?) RETURNING table_id",
+            params![schema_id, name, table_path, snapshot_id],
+            |row| row.get(0),
+        )?;
+        tx.commit()?;
+        Ok((table_id, true))
+    }
+
+    fn set_columns(
+        &self,
+        table_id: i64,
+        columns: &[ColumnDef],
+        snapshot_id: i64,
+    ) -> Result<Vec<i64>> {
+        if columns.is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "Table must have at least one column".to_string(),
+            ));
+        }
+        let mut conn = self.connection();
+        let tx = conn.transaction()?;
+
+        tx.execute(
+            "UPDATE ducklake_column SET end_snapshot = ?
+             WHERE table_id = ? AND end_snapshot IS NULL",
+            params![snapshot_id, table_id],
+        )?;
+
+        // Reserve a contiguous column_id block from the monotonic counter and
+        // insert with explicit ids, keeping the allocator authoritative.
+        let n = columns.len() as i64;
+        let last_column_id = reserve_ids(&tx, "next_column_id", n)?;
+        let first_column_id = last_column_id - n + 1;
+        let mut column_ids = Vec::with_capacity(columns.len());
+        for (order, col) in columns.iter().enumerate() {
+            let column_id = first_column_id + order as i64;
+            tx.execute(
+                "INSERT INTO ducklake_column (column_id, table_id, column_name, column_type, column_order, nulls_allowed, begin_snapshot)
+                 VALUES (?, ?, ?, ?, ?, ?, ?)",
+                params![
+                    column_id,
+                    table_id,
+                    col.name(),
+                    col.ducklake_type(),
+                    order as i64,
+                    col.is_nullable(),
+                    snapshot_id
+                ],
+            )?;
+            column_ids.push(column_id);
+        }
+
+        tx.commit()?;
+        Ok(column_ids)
+    }
+
+    fn register_data_file(
+        &self,
+        table_id: i64,
+        // The schema/table were created at begin, so the names are unused here;
+        // accepted only to satisfy the trait shared with multicatalog Postgres.
+        _schema_name: &str,
+        _table_name: &str,
+        _snapshot_id: i64,
+        file: &DataFileInfo,
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+    ) -> Result<CommitIds> {
+        let mut conn = self.connection();
+        let tx = conn.transaction()?;
+
+        // Single atomic commit: insert the deferred snapshot row + finalize the
+        // column generation + retire the prior generation (Replace), then
+        // register this file and advance the monotonic row-lineage counter.
+        let snapshot_id =
+            finalize_snapshot(&tx, table_id, columns, column_ids, mode, base_snapshot)?;
+
+        // Seed the stats row for the Append path (Replace already seeded it in
+        // finalize_snapshot); a no-op if it exists.
+        seed_stats_if_missing(&tx, table_id)?;
+
+        let row_id_start: i64 = tx.query_row(
+            "SELECT next_row_id FROM ducklake_table_stats WHERE table_id = ?",
+            params![table_id],
+            |row| row.get(0),
+        )?;
+
+        tx.execute(
+            "INSERT INTO ducklake_data_file
+                 (table_id, path, path_is_relative, file_size_bytes,
+                  footer_size, record_count, row_id_start, begin_snapshot)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            params![
+                table_id,
+                file.path.as_str(),
+                file.path_is_relative,
+                file.file_size_bytes,
+                file.footer_size,
+                file.record_count,
+                row_id_start,
+                snapshot_id
+            ],
+        )?;
+
+        // Advance the counter and accumulate stats. next_row_id monotonically
+        // increases over the table's lifetime — rowids are never reused.
+        tx.execute(
+            "UPDATE ducklake_table_stats
+             SET next_row_id     = next_row_id + ?,
+                 record_count    = record_count + ?,
+                 file_size_bytes = file_size_bytes + ?
+             WHERE table_id = ?",
+            params![file.record_count, file.record_count, file.file_size_bytes, table_id],
+        )?;
+
+        let schema_id: i64 = tx.query_row(
+            "SELECT schema_id FROM ducklake_table WHERE table_id = ?",
+            params![table_id],
+            |row| row.get(0),
+        )?;
+
+        tx.commit()?;
+        Ok(CommitIds {
+            snapshot_id,
+            schema_id,
+            table_id,
+        })
+    }
+
+    fn publish_snapshot(
+        &self,
+        table_id: i64,
+        // The schema/table were created at begin; names unused (trait parity).
+        _schema_name: &str,
+        _table_name: &str,
+        _snapshot_id: i64,
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+    ) -> Result<CommitIds> {
+        // Fileless commit point (CREATE TABLE, zero-row Replace). Single-catalog
+        // DuckDB defers the snapshot-row insert out of begin_write_transaction,
+        // so this is NOT the trait's no-op default: it inserts the deferred
+        // snapshot row + column generation and, for Replace, retires the prior
+        // generation — making the new head visible atomically.
+        let mut conn = self.connection();
+        let tx = conn.transaction()?;
+        let snapshot_id =
+            finalize_snapshot(&tx, table_id, columns, column_ids, mode, base_snapshot)?;
+        let schema_id: i64 = tx.query_row(
+            "SELECT schema_id FROM ducklake_table WHERE table_id = ?",
+            params![table_id],
+            |row| row.get(0),
+        )?;
+        tx.commit()?;
+        Ok(CommitIds {
+            snapshot_id,
+            schema_id,
+            table_id,
+        })
+    }
+
+    fn end_table_files(&self, table_id: i64, snapshot_id: i64) -> Result<u64> {
+        // Used by WriteMode::Replace. End-snapshotting every visible file drops
+        // the table's currently-visible row count and byte total to zero.
+        // next_row_id is deliberately NOT reset (rowids stay monotonic).
+        let mut conn = self.connection();
+        let tx = conn.transaction()?;
+
+        let rows_affected = tx.execute(
+            "UPDATE ducklake_data_file SET end_snapshot = ?
+             WHERE table_id = ? AND end_snapshot IS NULL",
+            params![snapshot_id, table_id],
+        )? as u64;
+
+        tx.execute(
+            "UPDATE ducklake_table_stats
+             SET record_count = 0, file_size_bytes = 0
+             WHERE table_id = ?",
+            params![table_id],
+        )?;
+
+        tx.commit()?;
+        Ok(rows_affected)
+    }
+
+    fn get_data_path(&self) -> Result<String> {
+        let conn = self.connection();
+        let row: Option<String> = conn
+            .query_row(
+                "SELECT value FROM ducklake_metadata WHERE key = ? AND scope IS NULL",
+                params!["data_path"],
+                |row| row.get(0),
+            )
+            .optional()?;
+        match row {
+            Some(path) => Ok(path),
+            None => Err(crate::error::DuckLakeError::InvalidConfig(
+                "Missing required catalog metadata: 'data_path' not configured.".to_string(),
+            )),
+        }
+    }
+
+    fn set_data_path(&self, path: &str) -> Result<()> {
+        let mut conn = self.connection();
+        let tx = conn.transaction()?;
+        tx.execute(
+            "DELETE FROM ducklake_metadata WHERE key = 'data_path' AND scope IS NULL",
+            [],
+        )?;
+        tx.execute(
+            "INSERT INTO ducklake_metadata (key, value, scope) VALUES ('data_path', ?, NULL)",
+            params![path],
+        )?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    fn initialize_schema(&self) -> Result<()> {
+        let conn = self.connection();
+        conn.execute_batch(SQL_CREATE_SCHEMA)?;
+        // Seed the monotonic column_id allocator (snapshot_id uses MAX+1, and
+        // schema/table/data_file/delete_file ids use sequences, so none of those
+        // need a counter). Idempotent on re-open, and seeded from the current MAX
+        // so a pre-existing catalog continues without reusing ids.
+        conn.execute_batch(
+            "INSERT INTO ducklake_metadata (key, value, scope)
+             SELECT 'next_column_id',
+                    CAST(COALESCE((SELECT MAX(column_id) FROM ducklake_column), 0) AS VARCHAR),
+                    NULL
+             WHERE NOT EXISTS (
+                 SELECT 1 FROM ducklake_metadata WHERE key = 'next_column_id' AND scope IS NULL
+             )",
+        )?;
+        Ok(())
+    }
+
+    fn begin_write_transaction(
+        &self,
+        schema_name: &str,
+        table_name: &str,
+        columns: &[ColumnDef],
+        mode: WriteMode,
+    ) -> Result<WriteSetupResult> {
+        validate_name(schema_name, "Schema")?;
+        validate_name(table_name, "Table")?;
+        if columns.is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "Table must have at least one column".to_string(),
+            ));
+        }
+        let mut conn = self.connection();
+        let tx = conn.transaction()?;
+
+        // Reserve the column ids first. These match the staged parquet field ids.
+        let n = columns.len() as i64;
+        let last_column_id = reserve_ids(&tx, "next_column_id", n)?;
+        // Freshly reserved ids. Only a genuinely-new column consumes one below; an
+        // existing column keeps its current id, so some may go unused (harmless
+        // monotonic-counter gaps).
+        let fresh_ids: Vec<i64> = ((last_column_id - n + 1)..=last_column_id).collect();
+
+        // The catalog head this write is based on; a Replace commit aborts if
+        // another writer published a newer generation of the table past it.
+        let base_snapshot_id: i64 = tx.query_row(
+            "SELECT COALESCE(MAX(snapshot_id), 0) FROM ducklake_snapshot",
+            [],
+            |row| row.get(0),
+        )?;
+
+        // Tentative id for WriteSetupResult; the real one is assigned at the
+        // commit (finalize_snapshot), so it may differ under concurrency.
+        let snapshot_id: i64 = base_snapshot_id + 1;
+
+        let schema_id: i64 = {
+            let existing: Option<i64> = tx
+                .query_row(
+                    "SELECT schema_id FROM ducklake_schema
+                     WHERE schema_name = ? AND end_snapshot IS NULL",
+                    params![schema_name],
+                    |row| row.get(0),
+                )
+                .optional()?;
+            match existing {
+                Some(id) => id,
+                None => tx.query_row(
+                    "INSERT INTO ducklake_schema (schema_name, path, path_is_relative, begin_snapshot)
+                     VALUES (?, ?, true, ?) RETURNING schema_id",
+                    params![schema_name, schema_name, snapshot_id],
+                    |row| row.get(0),
+                )?,
+            }
+        };
+
+        let table_id: i64 = {
+            let existing: Option<i64> = tx
+                .query_row(
+                    "SELECT table_id FROM ducklake_table
+                     WHERE schema_id = ? AND table_name = ? AND end_snapshot IS NULL",
+                    params![schema_id, table_name],
+                    |row| row.get(0),
+                )
+                .optional()?;
+            match existing {
+                Some(id) => id,
+                None => tx.query_row(
+                    "INSERT INTO ducklake_table (schema_id, table_name, path, path_is_relative, begin_snapshot)
+                     VALUES (?, ?, ?, true, ?) RETURNING table_id",
+                    params![schema_id, table_name, table_name, snapshot_id],
+                    |row| row.get(0),
+                )?,
+            }
+        };
+
+        // Existing columns to (a) check schema compatibility and (b) REUSE each
+        // column's id (column_id == parquet field_id == a column's stable
+        // identity). Collected into owned Vec so the statement drops before the
+        // commit that follows.
+        let existing_rows: Vec<(String, String, bool, i64)> = {
+            let mut stmt = tx.prepare(
+                "SELECT column_name, column_type, nulls_allowed, column_id
+                 FROM ducklake_column
+                 WHERE table_id = ? AND end_snapshot IS NULL
+                 ORDER BY column_order",
+            )?;
+            let mapped = stmt.query_map(params![table_id], |row| {
+                let name: String = row.get(0)?;
+                let col_type: String = row.get(1)?;
+                let nullable: Option<bool> = row.get(2)?;
+                let cid: i64 = row.get(3)?;
+                Ok((name, col_type, nullable.unwrap_or(true), cid))
+            })?;
+            mapped.collect::<std::result::Result<Vec<_>, duckdb::Error>>()?
+        };
+
+        let mut existing_columns: Vec<(String, String, bool)> =
+            Vec::with_capacity(existing_rows.len());
+        let mut existing_ids: std::collections::HashMap<String, i64> =
+            std::collections::HashMap::new();
+        for (name, col_type, nullable, cid) in existing_rows {
+            existing_ids.insert(name.clone(), cid);
+            existing_columns.push((name, col_type, nullable));
+        }
+
+        // Data-write policy: a data write — Replace OR Append — must NOT change a
+        // column's type (that is schema evolution, which must go through
+        // promote_column_type). Comparison is canonical (int64 ≡ bigint) so an
+        // alias-only restatement is a no-op. Append additionally requires a
+        // genuinely new column to be nullable. Mirrors the SQLite writer.
+        if !existing_columns.is_empty() {
+            use std::collections::HashMap;
+            let existing_map: HashMap<&str, (&str, bool)> = existing_columns
+                .iter()
+                .map(|(name, col_type, nullable)| (name.as_str(), (col_type.as_str(), *nullable)))
+                .collect();
+
+            for new_col in columns.iter() {
+                if let Some((existing_type, _existing_nullable)) =
+                    existing_map.get(new_col.name())
+                {
+                    if !crate::types::types_equal_canonical(existing_type, new_col.ducklake_type())
+                    {
+                        return Err(crate::error::DuckLakeError::UnsupportedTypeChange {
+                            operation: TypeChangeOperation::DataWrite {
+                                mode: match mode {
+                                    WriteMode::Replace => TypeChangeWriteMode::Replace,
+                                    WriteMode::Append => TypeChangeWriteMode::Append,
+                                },
+                            },
+                            column: new_col.name().to_string(),
+                            from: (*existing_type).to_string(),
+                            to: new_col.ducklake_type().to_string(),
+                        });
+                    }
+                } else if mode == WriteMode::Append && !new_col.is_nullable() {
+                    return Err(crate::error::DuckLakeError::InvalidConfig(format!(
+                        "Schema evolution error: new column '{}' must be nullable. Adding non-nullable columns is not allowed.",
+                        new_col.name()
+                    )));
+                }
+            }
+        }
+
+        // Final per-column ids: reuse the existing id for a column already in the
+        // table, consume a freshly reserved id only for a genuinely new column.
+        // These are baked into the staged parquet's field_id metadata, so they
+        // must equal the ids finalize_snapshot commits. The column rows are
+        // written at the commit point (not here).
+        let column_ids: Vec<i64> = columns
+            .iter()
+            .zip(fresh_ids.iter())
+            .map(|(col, &fresh)| existing_ids.get(col.name()).copied().unwrap_or(fresh))
+            .collect();
+
+        // Only the idempotent get-or-create schema/table rows are committed here;
+        // they carry begin_snapshot = the reserved id and stay invisible until the
+        // snapshot publishes, since schema/table reads ARE snapshot-scoped.
+        tx.commit()?;
+
+        Ok(WriteSetupResult {
+            snapshot_id,
+            base_snapshot_id,
+            schema_id,
+            table_id,
+            column_ids,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::DuckdbMetadataProvider;
+    use crate::metadata_provider::MetadataProvider;
+    use tempfile::TempDir;
+
+    /// End-to-end round trip: write a small table through the real write path
+    /// (begin_write_transaction + register_data_file), then read every catalog
+    /// facet back through the DuckdbMetadataProvider and assert the snapshot,
+    /// data_path, table, columns and data-file rows are byte-compatible.
+    #[test]
+    fn duckdb_write_then_read_back_via_provider() {
+        let temp = TempDir::new().unwrap();
+        let db_path = temp.path().join("catalog.ducklake");
+        let db_path_str = db_path.to_str().unwrap().to_string();
+        let data_path = temp.path().join("data");
+        let data_path_str = data_path.to_str().unwrap().to_string();
+
+        // --- write ---
+        {
+            let writer = DuckdbMetadataWriter::new_with_init(&db_path_str).unwrap();
+            writer.set_data_path(&data_path_str).unwrap();
+
+            let columns = vec![
+                ColumnDef::new("id", "int64", false).unwrap(),
+                ColumnDef::new("name", "varchar", true).unwrap(),
+            ];
+
+            let setup = writer
+                .begin_write_transaction("main", "users", &columns, WriteMode::Append)
+                .unwrap();
+            assert_eq!(setup.column_ids.len(), 2);
+            assert_eq!(setup.base_snapshot_id, 0, "fresh catalog: no prior head");
+
+            let file = DataFileInfo::new("users/data-0.parquet", 1024, 3).with_footer_size(256);
+            let commit = writer
+                .register_data_file(
+                    setup.table_id,
+                    "main",
+                    "users",
+                    setup.snapshot_id,
+                    &file,
+                    WriteMode::Append,
+                    setup.base_snapshot_id,
+                    &columns,
+                    &setup.column_ids,
+                )
+                .unwrap();
+            assert_eq!(commit.snapshot_id, 1, "first write commits snapshot 1");
+            // writer (and its read-write lock on the file) dropped at block end.
+        }
+
+        // --- read back through the provider (read-only connection) ---
+        let provider = DuckdbMetadataProvider::new(&db_path_str).unwrap();
+
+        let snapshot = provider.get_current_snapshot().unwrap();
+        assert_eq!(snapshot, 1, "committed head is snapshot 1");
+
+        assert_eq!(provider.get_data_path().unwrap(), data_path_str);
+
+        let schema = provider
+            .get_schema_by_name("main", snapshot)
+            .unwrap()
+            .expect("schema 'main' must exist");
+        let table = provider
+            .get_table_by_name(schema.schema_id, "users", snapshot)
+            .unwrap()
+            .expect("table 'users' must exist");
+        assert_eq!(table.table_name, "users");
+
+        let cols = provider.get_table_structure(table.table_id, snapshot).unwrap();
+        assert_eq!(cols.len(), 2, "both columns must read back");
+        assert_eq!(cols[0].column_name, "id");
+        assert_eq!(cols[0].column_type, "int64");
+        assert!(!cols[0].is_nullable);
+        assert_eq!(cols[1].column_name, "name");
+        assert_eq!(cols[1].column_type, "varchar");
+        assert!(cols[1].is_nullable);
+
+        let files = provider
+            .get_table_files_for_select(table.table_id, snapshot)
+            .unwrap();
+        assert_eq!(files.len(), 1, "exactly one data file");
+        assert_eq!(files[0].file.path, "users/data-0.parquet");
+        assert!(files[0].file.path_is_relative);
+        assert_eq!(files[0].file.file_size_bytes, 1024);
+        assert_eq!(files[0].file.footer_size, Some(256));
+        assert_eq!(files[0].max_row_count, Some(3));
+        assert_eq!(files[0].row_id_start, Some(0), "first file starts at rowid 0");
+    }
+
+    /// A second Append hands out a fresh, non-overlapping rowid range and
+    /// accumulates the table stats — mirrors the SQLite writer's
+    /// `row_id_start_advances_across_inserts`.
+    #[test]
+    fn duckdb_row_id_start_advances_across_appends() {
+        let temp = TempDir::new().unwrap();
+        let db_path = temp.path().join("catalog.ducklake");
+        let db_path_str = db_path.to_str().unwrap().to_string();
+
+        let writer = DuckdbMetadataWriter::new_with_init(&db_path_str).unwrap();
+        writer.set_data_path("/tmp/does-not-matter").unwrap();
+        let columns = vec![ColumnDef::new("id", "int64", false).unwrap()];
+
+        let setup1 = writer
+            .begin_write_transaction("main", "t", &columns, WriteMode::Append)
+            .unwrap();
+        writer
+            .register_data_file(
+                setup1.table_id,
+                "main",
+                "t",
+                setup1.snapshot_id,
+                &DataFileInfo::new("a.parquet", 100, 3),
+                WriteMode::Append,
+                setup1.base_snapshot_id,
+                &columns,
+                &setup1.column_ids,
+            )
+            .unwrap();
+
+        let setup2 = writer
+            .begin_write_transaction("main", "t", &columns, WriteMode::Append)
+            .unwrap();
+        let commit2 = writer
+            .register_data_file(
+                setup2.table_id,
+                "main",
+                "t",
+                setup2.snapshot_id,
+                &DataFileInfo::new("b.parquet", 250, 7),
+                WriteMode::Append,
+                setup2.base_snapshot_id,
+                &columns,
+                &setup2.column_ids,
+            )
+            .unwrap();
+        assert_eq!(commit2.snapshot_id, 2, "second write commits snapshot 2");
+
+        // Read the two files' row_id_start directly to assert non-overlapping ranges.
+        let mut conn = writer.connection();
+        let tx = conn.transaction().unwrap();
+        let a_start: i64 = tx
+            .query_row(
+                "SELECT row_id_start FROM ducklake_data_file WHERE path = 'a.parquet'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let b_start: i64 = tx
+            .query_row(
+                "SELECT row_id_start FROM ducklake_data_file WHERE path = 'b.parquet'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let (records, next, bytes): (i64, i64, i64) = tx
+            .query_row(
+                "SELECT record_count, next_row_id, file_size_bytes
+                 FROM ducklake_table_stats WHERE table_id = ?",
+                params![setup1.table_id],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        tx.commit().unwrap();
+
+        assert_eq!(a_start, 0, "first file starts at 0");
+        assert_eq!(b_start, 3, "second file starts after the first file's rows");
+        assert_eq!(records, 10, "record_count = 3 + 7");
+        assert_eq!(next, 10, "next_row_id advances by sum of record_counts");
+        assert_eq!(bytes, 350, "file_size_bytes accumulates");
+    }
+}

--- a/src/metadata_writer_mysql.rs
+++ b/src/metadata_writer_mysql.rs
@@ -1,0 +1,1090 @@
+//! MySQL implementation of [`MetadataWriter`].
+//!
+//! Single-catalog only — the legacy DuckLake v1.0 layout, mirroring
+//! [`crate::metadata_writer_sqlite::SqliteMetadataWriter`] rather than the
+//! multicatalog Postgres writer. It supports the write primitives the crate's
+//! table-write path needs (INSERT / REPLACE / CREATE TABLE) and deliberately
+//! does NOT support deletes, upserts, compaction, partitioning, type promotion,
+//! or multiple catalogs: [`MetadataWriter::promote_column_type`] and
+//! [`MetadataWriter::set_delete_file`] inherit their erroring defaults, and
+//! [`MetadataWriter::catalog_id`] inherits the `None` default (which keeps
+//! newly-written file paths in the `{data_path}/{schema}/{table}/…` layout).
+//!
+//! Requires a multi-threaded Tokio runtime (`#[tokio::test(flavor =
+//! "multi_thread")]`): the sync trait methods bridge async sqlx via
+//! [`crate::metadata_provider::block_on`], exactly like the SQLite writer.
+//!
+//! ## MySQL dialect adaptations vs the SQLite template
+//!
+//! 1. **No `RETURNING`.** Auto-increment PK ids (`schema_id`, `table_id`,
+//!    `data_file_id`) are read back with `MySqlQueryResult::last_insert_id()`;
+//!    counter-allocated ids (`column_id`, `snapshot_id`) are read back with an
+//!    `UPDATE` followed by a `SELECT` in the same transaction ([`reserve_ids`]).
+//! 2. **DDL type mapping.** `INTEGER`→`BIGINT`, bounded names→`VARCHAR(1024)`,
+//!    long/path values→`TEXT`, `BOOLEAN`→`TINYINT(1)`. Every table is InnoDB so
+//!    transactions + `SELECT … FOR UPDATE`-style row locks actually serialize.
+//! 3. **Reserved words.** `ducklake_metadata`'s `key`/`value` columns are
+//!    backticked everywhere.
+//! 4. **`INSERT OR IGNORE`→`INSERT IGNORE`.**
+//! 5. **No self-referential `INSERT … SELECT`.** MySQL rejects `INSERT INTO t …
+//!    SELECT … FROM t` (error 1093), so `snapshot_id` is allocated from a
+//!    monotonic counter row rather than `SELECT MAX(snapshot_id)+1`.
+
+use crate::Result;
+use crate::error::{TypeChangeOperation, TypeChangeWriteMode};
+use crate::metadata_provider::block_on;
+use crate::metadata_writer::{
+    ColumnDef, CommitIds, DataFileInfo, MetadataWriter, WriteMode, WriteSetupResult, columns_differ,
+    validate_name,
+};
+use sqlx::Row;
+use sqlx::mysql::{MySqlPool, MySqlPoolOptions};
+
+const DEFAULT_MAX_CONNECTIONS: u32 = 5;
+
+/// The DuckLake v1.0 catalog tables in MySQL dialect, one `CREATE TABLE` per
+/// entry. sqlx runs each `query()` as a single prepared statement on MySQL
+/// (unlike the SQLite driver's multi-statement exec), so — like the Postgres
+/// writer — the DDL must be split rather than sent as one `;`-joined script.
+///
+/// Columns and their order match the SQLite writer's `SQL_CREATE_SCHEMA` (and so
+/// upstream DuckLake) for catalog compatibility; only the SQL types are mapped
+/// to MySQL. Auto-increment PKs back the ids read via `last_insert_id()`
+/// (`schema_id`/`table_id`/`data_file_id`/`delete_file_id`). `snapshot_id` is a
+/// plain PK assigned from the `next_snapshot_id` counter, and `ducklake_column`
+/// is a bare table (no PK) so a versioned column can hold multiple rows sharing
+/// a `column_id`.
+const SQL_CREATE_TABLES: &[&str] = &[
+    r#"CREATE TABLE IF NOT EXISTS ducklake_metadata (
+        `key` VARCHAR(1024) NOT NULL,
+        `value` TEXT NOT NULL,
+        scope VARCHAR(1024)
+    ) ENGINE = InnoDB"#,
+    r#"CREATE TABLE IF NOT EXISTS ducklake_snapshot (
+        snapshot_id BIGINT NOT NULL PRIMARY KEY,
+        snapshot_time DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+        schema_version BIGINT NOT NULL DEFAULT 0
+    ) ENGINE = InnoDB"#,
+    r#"CREATE TABLE IF NOT EXISTS ducklake_schema_versions (
+        begin_snapshot BIGINT NOT NULL,
+        schema_version BIGINT NOT NULL,
+        table_id BIGINT NOT NULL,
+        UNIQUE (table_id, begin_snapshot)
+    ) ENGINE = InnoDB"#,
+    r#"CREATE TABLE IF NOT EXISTS ducklake_schema (
+        schema_id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+        schema_name VARCHAR(1024) NOT NULL,
+        path TEXT NOT NULL,
+        path_is_relative TINYINT(1) NOT NULL DEFAULT 1,
+        begin_snapshot BIGINT NOT NULL,
+        end_snapshot BIGINT
+    ) ENGINE = InnoDB"#,
+    r#"CREATE TABLE IF NOT EXISTS ducklake_table (
+        table_id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+        schema_id BIGINT NOT NULL,
+        table_name VARCHAR(1024) NOT NULL,
+        path TEXT NOT NULL,
+        path_is_relative TINYINT(1) NOT NULL DEFAULT 1,
+        begin_snapshot BIGINT NOT NULL,
+        end_snapshot BIGINT
+    ) ENGINE = InnoDB"#,
+    // Bare table (no PRIMARY KEY), mirroring upstream `ducklake_column`: a column
+    // is versioned by `[begin_snapshot, end_snapshot)` and — although this writer
+    // never promotes types — the shape stays identical to SQLite/upstream so
+    // catalogs interoperate. The four `*default*` columns and `parent_column` are
+    // left NULL (no nested-type / column-default writes).
+    r#"CREATE TABLE IF NOT EXISTS ducklake_column (
+        column_id BIGINT,
+        begin_snapshot BIGINT,
+        end_snapshot BIGINT,
+        table_id BIGINT,
+        column_order BIGINT,
+        column_name VARCHAR(1024),
+        column_type VARCHAR(1024),
+        initial_default TEXT,
+        default_value TEXT,
+        nulls_allowed TINYINT(1),
+        parent_column BIGINT,
+        default_value_type VARCHAR(1024),
+        default_value_dialect VARCHAR(1024)
+    ) ENGINE = InnoDB"#,
+    r#"CREATE TABLE IF NOT EXISTS ducklake_data_file (
+        data_file_id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+        table_id BIGINT NOT NULL,
+        path TEXT NOT NULL,
+        path_is_relative TINYINT(1) NOT NULL DEFAULT 1,
+        file_size_bytes BIGINT NOT NULL,
+        footer_size BIGINT,
+        encryption_key VARCHAR(1024),
+        record_count BIGINT,
+        row_id_start BIGINT,
+        mapping_id BIGINT,
+        begin_snapshot BIGINT NOT NULL,
+        end_snapshot BIGINT
+    ) ENGINE = InnoDB"#,
+    // Per-table row-lineage + running totals. `next_row_id` allocates rowids
+    // monotonically over the table's lifetime; `record_count`/`file_size_bytes`
+    // mirror the currently-visible totals for DuckDB's `ducklake_table_info`.
+    r#"CREATE TABLE IF NOT EXISTS ducklake_table_stats (
+        table_id BIGINT NOT NULL PRIMARY KEY,
+        record_count BIGINT NOT NULL DEFAULT 0,
+        next_row_id BIGINT NOT NULL DEFAULT 0,
+        file_size_bytes BIGINT NOT NULL DEFAULT 0
+    ) ENGINE = InnoDB"#,
+    // Created for catalog-shape parity and so the provider's LEFT JOINs resolve;
+    // this writer never inserts delete files (`set_delete_file` is unsupported).
+    r#"CREATE TABLE IF NOT EXISTS ducklake_delete_file (
+        delete_file_id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+        data_file_id BIGINT NOT NULL,
+        table_id BIGINT NOT NULL,
+        path TEXT NOT NULL,
+        path_is_relative TINYINT(1) NOT NULL DEFAULT 1,
+        file_size_bytes BIGINT NOT NULL,
+        footer_size BIGINT,
+        encryption_key VARCHAR(1024),
+        delete_count BIGINT,
+        begin_snapshot BIGINT NOT NULL,
+        end_snapshot BIGINT
+    ) ENGINE = InnoDB"#,
+    r#"CREATE TABLE IF NOT EXISTS ducklake_files_scheduled_for_deletion (
+        data_file_id BIGINT NOT NULL,
+        path TEXT NOT NULL,
+        path_is_relative TINYINT(1) NOT NULL DEFAULT 1,
+        schedule_start DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6)
+    ) ENGINE = InnoDB"#,
+];
+
+/// MySQL-based metadata writer for DuckLake catalogs.
+#[derive(Debug, Clone)]
+pub struct MySqlMetadataWriter {
+    pool: MySqlPool,
+}
+
+impl MySqlMetadataWriter {
+    /// Open a writer against an existing MySQL DuckLake catalog. Does not create
+    /// the catalog tables — call [`Self::initialize_schema`] (or use
+    /// [`Self::new_with_init`]) for a fresh database.
+    pub async fn new(connection_string: &str) -> Result<Self> {
+        Self::with_max_connections(connection_string, DEFAULT_MAX_CONNECTIONS).await
+    }
+
+    /// Open a writer with a bounded connection pool.
+    pub async fn with_max_connections(
+        connection_string: &str,
+        max_connections: u32,
+    ) -> Result<Self> {
+        let pool = MySqlPoolOptions::new()
+            .max_connections(max_connections)
+            .connect(connection_string)
+            .await?;
+        Ok(Self {
+            pool,
+        })
+    }
+
+    /// Open a writer and create/upgrade the DuckLake catalog tables.
+    pub async fn new_with_init(connection_string: &str) -> Result<Self> {
+        let writer = Self::new(connection_string).await?;
+        writer.initialize_schema()?;
+        Ok(writer)
+    }
+}
+
+/// Atomically reserve `n` consecutive ids from a monotonic counter stored in
+/// `ducklake_metadata` (seeded by `initialize_schema`), returning the LAST id of
+/// the block — the reserved ids are `last - n + 1 ..= last`.
+///
+/// MySQL has no `UPDATE … RETURNING`, so this bumps the counter then reads it
+/// back within the same transaction. The `UPDATE` takes an exclusive InnoDB row
+/// lock held until commit, so a concurrent `reserve_ids` on the same `key`
+/// blocks here rather than handing out an overlapping id — the same
+/// serialization SQLite gets from its single-writer lock. Used for `column_id`
+/// and `snapshot_id`.
+async fn reserve_ids(
+    tx: &mut sqlx::Transaction<'_, sqlx::MySql>,
+    key: &str,
+    n: i64,
+) -> Result<i64> {
+    sqlx::query(
+        "UPDATE ducklake_metadata
+         SET `value` = CAST(CAST(`value` AS SIGNED) + ? AS CHAR)
+         WHERE `key` = ? AND scope IS NULL",
+    )
+    .bind(n)
+    .bind(key)
+    .execute(&mut **tx)
+    .await?;
+    let last: i64 = sqlx::query(
+        "SELECT CAST(`value` AS SIGNED) FROM ducklake_metadata WHERE `key` = ? AND scope IS NULL",
+    )
+    .bind(key)
+    .fetch_one(&mut **tx)
+    .await?
+    .try_get(0)?;
+    Ok(last)
+}
+
+/// Seed a monotonic id counter row if it does not already exist, starting from
+/// the current MAX of its backing column so a pre-existing catalog keeps
+/// allocating without reuse. Done as check-then-insert (two statements) rather
+/// than `INSERT … SELECT … WHERE NOT EXISTS`, because that self-referential
+/// `INSERT … SELECT` against `ducklake_metadata` is rejected by MySQL (1093).
+async fn seed_counter(pool: &MySqlPool, key: &str, max_sql: &str) -> Result<()> {
+    let exists: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_metadata WHERE `key` = ? AND scope IS NULL",
+    )
+    .bind(key)
+    .fetch_one(pool)
+    .await?
+    .try_get(0)?;
+    if exists == 0 {
+        let start: i64 = sqlx::query(max_sql).fetch_one(pool).await?.try_get(0)?;
+        sqlx::query("INSERT INTO ducklake_metadata (`key`, `value`, scope) VALUES (?, ?, NULL)")
+            .bind(key)
+            .bind(start.to_string())
+            .execute(pool)
+            .await?;
+    }
+    Ok(())
+}
+
+/// Optimistic-concurrency check for a `Replace` commit (mirrors the SQLite /
+/// Postgres writers). Run before retiring the prior generation: if any data file
+/// of the table has `begin_snapshot` or `end_snapshot` newer than
+/// `base_snapshot` (the head observed when this write began), another writer
+/// published a newer generation in the meantime, so this `Replace` aborts with
+/// [`crate::DuckLakeError::Conflict`] rather than clobbering it. (`Append` does
+/// not call this: concurrent appends commute.)
+async fn detect_replace_conflict(
+    tx: &mut sqlx::Transaction<'_, sqlx::MySql>,
+    table_id: i64,
+    base_snapshot: i64,
+) -> Result<()> {
+    let conflict: Option<i64> = sqlx::query(
+        "SELECT 1 FROM ducklake_data_file
+         WHERE table_id = ? AND (begin_snapshot > ? OR end_snapshot > ?)
+         LIMIT 1",
+    )
+    .bind(table_id)
+    .bind(base_snapshot)
+    .bind(base_snapshot)
+    .fetch_optional(&mut **tx)
+    .await?
+    .map(|row| row.try_get(0))
+    .transpose()?;
+    if conflict.is_some() {
+        return Err(crate::DuckLakeError::Conflict(format!(
+            "Replace on table {table_id} conflicts with a concurrent write committed since \
+             snapshot {base_snapshot}; aborting (retry the write against the new generation)"
+        )));
+    }
+    Ok(())
+}
+
+/// Retire the prior generation's still-visible data files at `snapshot_id` and
+/// zero the visible stat totals. The `begin_snapshot < snapshot_id` guard spares
+/// files registered for *this* snapshot, so a multi-file write does not retire
+/// its own siblings. `next_row_id` is left untouched (rowids stay monotonic).
+async fn retire_prior_generation(
+    tx: &mut sqlx::Transaction<'_, sqlx::MySql>,
+    table_id: i64,
+    snapshot_id: i64,
+) -> Result<()> {
+    sqlx::query(
+        "UPDATE ducklake_data_file SET end_snapshot = ?
+         WHERE table_id = ? AND end_snapshot IS NULL AND begin_snapshot < ?",
+    )
+    .bind(snapshot_id)
+    .bind(table_id)
+    .bind(snapshot_id)
+    .execute(&mut **tx)
+    .await?;
+
+    sqlx::query(
+        "UPDATE ducklake_table_stats SET record_count = 0, file_size_bytes = 0 WHERE table_id = ?",
+    )
+    .bind(table_id)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+/// Insert the next `ducklake_snapshot` row, carrying `schema_version` forward
+/// (the pure-data-write default), and return `(snapshot_id, schema_version)`.
+///
+/// `snapshot_id` is allocated from the `next_snapshot_id` counter. [`reserve_ids`]
+/// takes an exclusive InnoDB lock on that counter row held until this transaction
+/// commits, so this is the "write-lock-first" serialization point of a commit —
+/// every commit transaction contends on the single counter row, so per-catalog
+/// id order equals commit order and the scalar `> base_snapshot` conflict test is
+/// exact. The counter is used (rather than `SELECT MAX(snapshot_id)+1`) because
+/// MySQL rejects `INSERT … SELECT` from the table being inserted into (error
+/// 1093) and has no `RETURNING`; a counter both serializes writers and hands the
+/// id back directly. A DDL commit follows this with [`bump_schema_version`].
+async fn insert_snapshot(tx: &mut sqlx::Transaction<'_, sqlx::MySql>) -> Result<(i64, i64)> {
+    let snapshot_id = reserve_ids(tx, "next_snapshot_id", 1).await?;
+    // Carry the current per-catalog schema_version forward; a DDL commit corrects
+    // this to a bump via `bump_schema_version` below. Read before the INSERT so
+    // the MAX is over the pre-existing rows only (matches the SQLite writer).
+    let schema_version: i64 =
+        sqlx::query("SELECT COALESCE(MAX(schema_version), 0) FROM ducklake_snapshot")
+            .fetch_one(&mut **tx)
+            .await?
+            .try_get(0)?;
+    sqlx::query(
+        "INSERT INTO ducklake_snapshot (snapshot_id, snapshot_time, schema_version)
+         VALUES (?, NOW(6), ?)",
+    )
+    .bind(snapshot_id)
+    .bind(schema_version)
+    .execute(&mut **tx)
+    .await?;
+    Ok((snapshot_id, schema_version))
+}
+
+/// Bump the per-catalog monotonic `schema_version` on a DDL snapshot to
+/// `prev_max + 1` (max over the OTHER snapshots, so re-running is stable) and
+/// return the new value. Mirrors upstream `if (SchemaChangesMade()) schema_version++`.
+async fn bump_schema_version(
+    tx: &mut sqlx::Transaction<'_, sqlx::MySql>,
+    snapshot_id: i64,
+) -> Result<i64> {
+    let prev_max: i64 = sqlx::query(
+        "SELECT COALESCE(MAX(schema_version), 0) FROM ducklake_snapshot WHERE snapshot_id <> ?",
+    )
+    .bind(snapshot_id)
+    .fetch_one(&mut **tx)
+    .await?
+    .try_get(0)?;
+    let new_version = prev_max + 1;
+    sqlx::query("UPDATE ducklake_snapshot SET schema_version = ? WHERE snapshot_id = ?")
+        .bind(new_version)
+        .bind(snapshot_id)
+        .execute(&mut **tx)
+        .await?;
+    Ok(new_version)
+}
+
+/// Record a `ducklake_schema_versions` ledger row for a DDL that leaves the table
+/// live (create, column add/remove/reorder). Not called for a drop.
+async fn record_schema_version(
+    tx: &mut sqlx::Transaction<'_, sqlx::MySql>,
+    snapshot_id: i64,
+    schema_version: i64,
+    table_id: i64,
+) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO ducklake_schema_versions (begin_snapshot, schema_version, table_id)
+         VALUES (?, ?, ?)",
+    )
+    .bind(snapshot_id)
+    .bind(schema_version)
+    .bind(table_id)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+/// The atomic commit point for a single-catalog write. Inserts the deferred
+/// `ducklake_snapshot` row (its counter id was reserved conceptually at begin but
+/// the row is inserted here), finalizes the column generation, and — for
+/// `Replace` — retires the prior data generation. All within the caller's
+/// transaction, so a reader never sees a half-published head.
+///
+/// The column generation is deferred to here (rather than written in
+/// `begin_write_transaction`) because the read path resolves a table's columns by
+/// `end_snapshot IS NULL` only (not snapshot-scoped), so inserting the new
+/// generation at begin would leak it to concurrent reads during the upload
+/// window. `column_ids` are the ids reserved at begin and already baked into the
+/// staged parquet's `field_id` metadata.
+async fn finalize_snapshot(
+    tx: &mut sqlx::Transaction<'_, sqlx::MySql>,
+    table_id: i64,
+    columns: &[ColumnDef],
+    column_ids: &[i64],
+    mode: WriteMode,
+    base_snapshot: i64,
+) -> Result<i64> {
+    // Allocate the snapshot FIRST (carrying schema_version forward): this takes
+    // the counter lock up front, serializing concurrent commits. schema_version is
+    // corrected to a DDL bump below once we've classified the commit.
+    let (snapshot_id, mut schema_version) = insert_snapshot(tx).await?;
+
+    // Classify this commit as DDL vs pure data write. `current` is the table's
+    // live columns ordered by `column_order`; an empty set means a brand-new table
+    // (the creating write is DDL). Mirrors upstream `SchemaChangesMade()`.
+    use std::collections::{HashMap, HashSet};
+    let current = sqlx::query(
+        "SELECT column_name, column_type, column_order, nulls_allowed
+         FROM ducklake_column
+         WHERE table_id = ? AND end_snapshot IS NULL
+         ORDER BY column_order",
+    )
+    .bind(table_id)
+    .fetch_all(&mut **tx)
+    .await?;
+
+    let mut existing: Vec<(String, String, bool)> = Vec::with_capacity(current.len());
+    for row in &current {
+        let name: String = row.try_get("column_name")?;
+        let ty: String = row.try_get("column_type")?;
+        let nullable: bool = row
+            .try_get::<Option<bool>, _>("nulls_allowed")?
+            .unwrap_or(true);
+        existing.push((name, ty, nullable));
+    }
+    let is_ddl = existing.is_empty() || columns_differ(&existing, columns);
+    if is_ddl {
+        // A DDL commit bumps the per-catalog schema_version (the insert above only
+        // carried it forward). A pure data write keeps the carried value.
+        schema_version = bump_schema_version(tx, snapshot_id).await?;
+    }
+
+    // Reconcile the column generation SURGICALLY so each column keeps a stable
+    // column_id (== parquet field_id) across writes: end only removed columns,
+    // insert only new ones, and leave unchanged columns (and their ids) in place.
+    let new_names: HashSet<&str> = columns.iter().map(|c| c.name()).collect();
+    let mut current_by_name: HashMap<String, (i64, bool)> = HashMap::new();
+    for row in &current {
+        let name: String = row.try_get("column_name")?;
+        let order: i64 = row.try_get("column_order")?;
+        let nullable: bool = row
+            .try_get::<Option<bool>, _>("nulls_allowed")?
+            .unwrap_or(true);
+        if !new_names.contains(name.as_str()) {
+            // Column dropped in the new schema: end its generation.
+            sqlx::query(
+                "UPDATE ducklake_column SET end_snapshot = ?
+                 WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL",
+            )
+            .bind(snapshot_id)
+            .bind(table_id)
+            .bind(&name)
+            .execute(&mut **tx)
+            .await?;
+        }
+        current_by_name.insert(name, (order, nullable));
+    }
+
+    for (order, (col, column_id)) in columns.iter().zip(column_ids.iter()).enumerate() {
+        match current_by_name.get(col.name()) {
+            // Existing column kept: its id stays stable. Sync order/nullability
+            // only if they changed (type changes are rejected at begin).
+            Some(&(cur_order, cur_nullable)) => {
+                if cur_order != order as i64 || cur_nullable != col.is_nullable() {
+                    sqlx::query(
+                        "UPDATE ducklake_column SET column_order = ?, nulls_allowed = ?
+                         WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL",
+                    )
+                    .bind(order as i64)
+                    .bind(col.is_nullable())
+                    .bind(table_id)
+                    .bind(col.name())
+                    .execute(&mut **tx)
+                    .await?;
+                }
+            },
+            // Newly added column: insert it with its reserved id.
+            None => {
+                sqlx::query(
+                    "INSERT INTO ducklake_column
+                         (column_id, table_id, column_name, column_type, column_order, nulls_allowed, begin_snapshot)
+                     VALUES (?, ?, ?, ?, ?, ?, ?)",
+                )
+                .bind(column_id)
+                .bind(table_id)
+                .bind(col.name())
+                .bind(col.ducklake_type())
+                .bind(order as i64)
+                .bind(col.is_nullable())
+                .bind(snapshot_id)
+                .execute(&mut **tx)
+                .await?;
+            },
+        }
+    }
+
+    if mode == WriteMode::Replace {
+        // Abort if a concurrent writer published a newer generation since this
+        // write began.
+        detect_replace_conflict(tx, table_id, base_snapshot).await?;
+        // Seed the stats row (first write to a brand-new table) so retire's
+        // zero-update has a row, then retire the prior data generation.
+        sqlx::query(
+            "INSERT IGNORE INTO ducklake_table_stats
+                 (table_id, record_count, next_row_id, file_size_bytes)
+             VALUES (?, 0, 0, 0)",
+        )
+        .bind(table_id)
+        .execute(&mut **tx)
+        .await?;
+        retire_prior_generation(tx, table_id, snapshot_id).await?;
+    }
+
+    // Record the schema-change ledger row for a DDL commit. A pure data write
+    // carries schema_version forward and writes no row.
+    if is_ddl {
+        record_schema_version(tx, snapshot_id, schema_version, table_id).await?;
+    }
+    Ok(snapshot_id)
+}
+
+impl MetadataWriter for MySqlMetadataWriter {
+    fn create_snapshot(&self) -> Result<i64> {
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            // A bare snapshot carries no schema change of its own → carry
+            // schema_version forward (no DDL bump, no ledger row).
+            let (snapshot_id, _schema_version) = insert_snapshot(&mut tx).await?;
+            tx.commit().await?;
+            Ok(snapshot_id)
+        })
+    }
+
+    fn get_or_create_schema(
+        &self,
+        name: &str,
+        path: Option<&str>,
+        snapshot_id: i64,
+    ) -> Result<(i64, bool)> {
+        validate_name(name, "Schema")?;
+        block_on(async {
+            let existing = sqlx::query(
+                "SELECT schema_id FROM ducklake_schema
+                 WHERE schema_name = ? AND end_snapshot IS NULL",
+            )
+            .bind(name)
+            .fetch_optional(&self.pool)
+            .await?;
+
+            if let Some(row) = existing {
+                return Ok((row.try_get(0)?, false));
+            }
+
+            let schema_path = path.unwrap_or(name);
+            // No RETURNING: read the new auto-increment id via last_insert_id().
+            let result = sqlx::query(
+                "INSERT INTO ducklake_schema (schema_name, path, path_is_relative, begin_snapshot)
+                 VALUES (?, ?, 1, ?)",
+            )
+            .bind(name)
+            .bind(schema_path)
+            .bind(snapshot_id)
+            .execute(&self.pool)
+            .await?;
+
+            Ok((result.last_insert_id() as i64, true))
+        })
+    }
+
+    fn get_or_create_table(
+        &self,
+        schema_id: i64,
+        name: &str,
+        path: Option<&str>,
+        snapshot_id: i64,
+    ) -> Result<(i64, bool)> {
+        validate_name(name, "Table")?;
+        block_on(async {
+            let existing = sqlx::query(
+                "SELECT table_id FROM ducklake_table
+                 WHERE schema_id = ? AND table_name = ? AND end_snapshot IS NULL",
+            )
+            .bind(schema_id)
+            .bind(name)
+            .fetch_optional(&self.pool)
+            .await?;
+
+            if let Some(row) = existing {
+                return Ok((row.try_get(0)?, false));
+            }
+
+            let table_path = path.unwrap_or(name);
+            let result = sqlx::query(
+                "INSERT INTO ducklake_table (schema_id, table_name, path, path_is_relative, begin_snapshot)
+                 VALUES (?, ?, ?, 1, ?)",
+            )
+            .bind(schema_id)
+            .bind(name)
+            .bind(table_path)
+            .bind(snapshot_id)
+            .execute(&self.pool)
+            .await?;
+
+            Ok((result.last_insert_id() as i64, true))
+        })
+    }
+
+    fn set_columns(
+        &self,
+        table_id: i64,
+        columns: &[ColumnDef],
+        snapshot_id: i64,
+    ) -> Result<Vec<i64>> {
+        if columns.is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "Table must have at least one column".to_string(),
+            ));
+        }
+        block_on(async {
+            // Transaction for atomicity: if column insertion fails, we don't leave
+            // existing columns marked as ended.
+            let mut tx = self.pool.begin().await?;
+
+            sqlx::query(
+                "UPDATE ducklake_column SET end_snapshot = ?
+                 WHERE table_id = ? AND end_snapshot IS NULL",
+            )
+            .bind(snapshot_id)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+
+            // Reserve a contiguous column_id block from the monotonic counter and
+            // insert with explicit ids, keeping the allocator authoritative.
+            let n = columns.len() as i64;
+            let last_column_id = reserve_ids(&mut tx, "next_column_id", n).await?;
+            let first_column_id = last_column_id - n + 1;
+            let mut column_ids = Vec::with_capacity(columns.len());
+            for (order, col) in columns.iter().enumerate() {
+                let column_id = first_column_id + order as i64;
+                sqlx::query(
+                    "INSERT INTO ducklake_column (column_id, table_id, column_name, column_type, column_order, nulls_allowed, begin_snapshot)
+                     VALUES (?, ?, ?, ?, ?, ?, ?)",
+                )
+                .bind(column_id)
+                .bind(table_id)
+                .bind(col.name())
+                .bind(col.ducklake_type())
+                .bind(order as i64)
+                .bind(col.is_nullable())
+                .bind(snapshot_id)
+                .execute(&mut *tx)
+                .await?;
+                column_ids.push(column_id);
+            }
+
+            tx.commit().await?;
+            Ok(column_ids)
+        })
+    }
+
+    fn register_data_file(
+        &self,
+        table_id: i64,
+        // MySQL created the schema/table at begin, so the names are unused here;
+        // accepted only to satisfy the trait shared with multicatalog Postgres.
+        _schema_name: &str,
+        _table_name: &str,
+        _snapshot_id: i64,
+        file: &DataFileInfo,
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+    ) -> Result<CommitIds> {
+        block_on(async {
+            // Single atomic commit: insert the deferred snapshot row + finalize the
+            // column generation + retire the prior generation (Replace), then
+            // register this file and advance the monotonic row-lineage counter —
+            // all in one transaction, so the head only ever resolves to
+            // fully-populated data.
+            let mut tx = self.pool.begin().await?;
+
+            let snapshot_id =
+                finalize_snapshot(&mut tx, table_id, columns, column_ids, mode, base_snapshot)
+                    .await?;
+
+            // Seed the stats row for the Append path (Replace already seeded it in
+            // finalize_snapshot); INSERT IGNORE is a no-op if it exists.
+            sqlx::query(
+                "INSERT IGNORE INTO ducklake_table_stats
+                     (table_id, record_count, next_row_id, file_size_bytes)
+                 VALUES (?, 0, 0, 0)",
+            )
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+
+            let row_id_start: i64 =
+                sqlx::query("SELECT next_row_id FROM ducklake_table_stats WHERE table_id = ?")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?
+                    .try_get(0)?;
+
+            sqlx::query(
+                "INSERT INTO ducklake_data_file
+                     (table_id, path, path_is_relative, file_size_bytes,
+                      footer_size, record_count, row_id_start, begin_snapshot)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            )
+            .bind(table_id)
+            .bind(&file.path)
+            .bind(file.path_is_relative)
+            .bind(file.file_size_bytes)
+            .bind(file.footer_size)
+            .bind(file.record_count)
+            .bind(row_id_start)
+            .bind(snapshot_id)
+            .execute(&mut *tx)
+            .await?;
+
+            // Advance the counter and accumulate stats. `next_row_id`
+            // monotonically increases over the table's lifetime.
+            sqlx::query(
+                "UPDATE ducklake_table_stats
+                 SET next_row_id     = next_row_id + ?,
+                     record_count    = record_count + ?,
+                     file_size_bytes = file_size_bytes + ?
+                 WHERE table_id = ?",
+            )
+            .bind(file.record_count)
+            .bind(file.record_count)
+            .bind(file.file_size_bytes)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+
+            let schema_id: i64 =
+                sqlx::query("SELECT schema_id FROM ducklake_table WHERE table_id = ?")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?
+                    .try_get(0)?;
+
+            tx.commit().await?;
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
+        })
+    }
+
+    fn publish_snapshot(
+        &self,
+        table_id: i64,
+        // MySQL created the schema/table at begin; names unused (trait parity).
+        _schema_name: &str,
+        _table_name: &str,
+        _snapshot_id: i64,
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+    ) -> Result<CommitIds> {
+        // Fileless commit point (CREATE TABLE, zero-row Replace). Single-catalog
+        // MySQL defers the snapshot-row insert out of begin_write_transaction, so
+        // the trait's default no-op is insufficient: insert the deferred snapshot
+        // row + column generation and, for Replace, retire the prior generation —
+        // making the new head visible atomically.
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            let snapshot_id =
+                finalize_snapshot(&mut tx, table_id, columns, column_ids, mode, base_snapshot)
+                    .await?;
+            let schema_id: i64 =
+                sqlx::query("SELECT schema_id FROM ducklake_table WHERE table_id = ?")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?
+                    .try_get(0)?;
+            tx.commit().await?;
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
+        })
+    }
+
+    fn end_table_files(&self, table_id: i64, snapshot_id: i64) -> Result<u64> {
+        // Used by WriteMode::Replace. End-snapshotting every visible file drops the
+        // table's currently-visible row count and byte total to zero. `next_row_id`
+        // is deliberately NOT reset: rowids must stay monotonic across the table's
+        // lifetime so historical snapshots still resolve uniquely.
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+
+            let result = sqlx::query(
+                "UPDATE ducklake_data_file SET end_snapshot = ?
+                 WHERE table_id = ? AND end_snapshot IS NULL",
+            )
+            .bind(snapshot_id)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+
+            sqlx::query(
+                "UPDATE ducklake_table_stats
+                 SET record_count = 0, file_size_bytes = 0
+                 WHERE table_id = ?",
+            )
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+
+            tx.commit().await?;
+            Ok(result.rows_affected())
+        })
+    }
+
+    fn get_data_path(&self) -> Result<String> {
+        block_on(async {
+            let row = sqlx::query(
+                "SELECT `value` FROM ducklake_metadata WHERE `key` = ? AND scope IS NULL",
+            )
+            .bind("data_path")
+            .fetch_optional(&self.pool)
+            .await?;
+
+            match row {
+                Some(r) => Ok(r.try_get(0)?),
+                None => Err(crate::error::DuckLakeError::InvalidConfig(
+                    "Missing required catalog metadata: 'data_path' not configured.".to_string(),
+                )),
+            }
+        })
+    }
+
+    fn set_data_path(&self, path: &str) -> Result<()> {
+        block_on(async {
+            sqlx::query(
+                "DELETE FROM ducklake_metadata WHERE `key` = 'data_path' AND scope IS NULL",
+            )
+            .execute(&self.pool)
+            .await?;
+
+            sqlx::query(
+                "INSERT INTO ducklake_metadata (`key`, `value`, scope)
+                 VALUES ('data_path', ?, NULL)",
+            )
+            .bind(path)
+            .execute(&self.pool)
+            .await?;
+
+            Ok(())
+        })
+    }
+
+    fn initialize_schema(&self) -> Result<()> {
+        block_on(async {
+            // sqlx runs each query() as a single prepared statement on MySQL, so
+            // create each table separately (see SQL_CREATE_TABLES).
+            for ddl in SQL_CREATE_TABLES {
+                sqlx::query(ddl).execute(&self.pool).await?;
+            }
+            // Seed the monotonic id allocators. snapshot_id and column_id are
+            // reserved inside a transaction and read back (no RETURNING and no
+            // auto-increment for these), so they live in ducklake_metadata. Seeded
+            // from the current MAX so a pre-existing catalog continues without
+            // reusing ids; idempotent on re-open.
+            seed_counter(
+                &self.pool,
+                "next_column_id",
+                "SELECT COALESCE(MAX(column_id), 0) FROM ducklake_column",
+            )
+            .await?;
+            seed_counter(
+                &self.pool,
+                "next_snapshot_id",
+                "SELECT COALESCE(MAX(snapshot_id), 0) FROM ducklake_snapshot",
+            )
+            .await?;
+            Ok(())
+        })
+    }
+
+    fn begin_write_transaction(
+        &self,
+        schema_name: &str,
+        table_name: &str,
+        columns: &[ColumnDef],
+        mode: WriteMode,
+    ) -> Result<WriteSetupResult> {
+        validate_name(schema_name, "Schema")?;
+        validate_name(table_name, "Table")?;
+        if columns.is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "Table must have at least one column".to_string(),
+            ));
+        }
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+
+            // Reserve the column ids first so the counter UPDATE takes the write
+            // lock up front. These ids match the staged parquet field ids.
+            let n = columns.len() as i64;
+            let last_column_id = reserve_ids(&mut tx, "next_column_id", n).await?;
+            // Freshly reserved ids. Only a genuinely-new column actually consumes
+            // one below; an existing column keeps its current id, so some of these
+            // may go unused (harmless monotonic-counter gaps).
+            let fresh_ids: Vec<i64> = ((last_column_id - n + 1)..=last_column_id).collect();
+
+            // The catalog head this write is based on; a Replace commit aborts if
+            // another writer published a newer generation of the table past it.
+            let base_snapshot_id: i64 =
+                sqlx::query("SELECT COALESCE(MAX(snapshot_id), 0) FROM ducklake_snapshot")
+                    .fetch_one(&mut *tx)
+                    .await?
+                    .try_get(0)?;
+
+            // Tentative id for WriteSetupResult; the real one is assigned at the
+            // commit (finalize_snapshot), so it may differ under concurrency.
+            let snapshot_id: i64 = base_snapshot_id + 1;
+
+            let schema_id: i64 = {
+                let existing = sqlx::query(
+                    "SELECT schema_id FROM ducklake_schema
+                     WHERE schema_name = ? AND end_snapshot IS NULL",
+                )
+                .bind(schema_name)
+                .fetch_optional(&mut *tx)
+                .await?;
+
+                if let Some(row) = existing {
+                    row.try_get(0)?
+                } else {
+                    let result = sqlx::query(
+                        "INSERT INTO ducklake_schema (schema_name, path, path_is_relative, begin_snapshot)
+                         VALUES (?, ?, 1, ?)",
+                    )
+                    .bind(schema_name)
+                    .bind(schema_name)
+                    .bind(snapshot_id)
+                    .execute(&mut *tx)
+                    .await?;
+                    result.last_insert_id() as i64
+                }
+            };
+
+            let table_id: i64 = {
+                let existing = sqlx::query(
+                    "SELECT table_id FROM ducklake_table
+                     WHERE schema_id = ? AND table_name = ? AND end_snapshot IS NULL",
+                )
+                .bind(schema_id)
+                .bind(table_name)
+                .fetch_optional(&mut *tx)
+                .await?;
+
+                if let Some(row) = existing {
+                    row.try_get(0)?
+                } else {
+                    let result = sqlx::query(
+                        "INSERT INTO ducklake_table (schema_id, table_name, path, path_is_relative, begin_snapshot)
+                         VALUES (?, ?, ?, 1, ?)",
+                    )
+                    .bind(schema_id)
+                    .bind(table_name)
+                    .bind(table_name)
+                    .bind(snapshot_id)
+                    .execute(&mut *tx)
+                    .await?;
+                    result.last_insert_id() as i64
+                }
+            };
+
+            // Get existing columns to (a) check schema compatibility for appends
+            // and (b) REUSE each column's id (column_id == parquet field_id; an
+            // unchanged column must keep its id, or files already written would
+            // read back as NULL).
+            let rows = sqlx::query(
+                "SELECT column_name, column_type, nulls_allowed, column_id
+                 FROM ducklake_column
+                 WHERE table_id = ? AND end_snapshot IS NULL
+                 ORDER BY column_order",
+            )
+            .bind(table_id)
+            .fetch_all(&mut *tx)
+            .await?;
+
+            let mut existing_columns: Vec<(String, String, bool)> = Vec::with_capacity(rows.len());
+            let mut existing_ids: std::collections::HashMap<String, i64> =
+                std::collections::HashMap::new();
+            for row in rows {
+                let name: String = row.try_get(0)?;
+                let col_type: String = row.try_get(1)?;
+                let nullable: bool = row.try_get::<Option<bool>, _>(2)?.unwrap_or(true);
+                let cid: i64 = row.try_get(3)?;
+                existing_ids.insert(name.clone(), cid);
+                existing_columns.push((name, col_type, nullable));
+            }
+
+            // Data-write policy (§5): a data write — Replace OR Append — must NOT
+            // change a column's type (that is schema evolution and must go through
+            // promote_column_type, which this backend does not support). The
+            // comparison is canonical (`int64` ≡ `bigint`) so an alias-only
+            // restatement is a no-op. Append additionally requires a genuinely new
+            // column to be nullable.
+            if !existing_columns.is_empty() {
+                use std::collections::HashMap;
+
+                let existing_map: HashMap<&str, (&str, bool)> = existing_columns
+                    .iter()
+                    .map(|(name, col_type, nullable)| {
+                        (name.as_str(), (col_type.as_str(), *nullable))
+                    })
+                    .collect();
+
+                for new_col in columns.iter() {
+                    if let Some((existing_type, _existing_nullable)) =
+                        existing_map.get(new_col.name())
+                    {
+                        if !crate::types::types_equal_canonical(
+                            existing_type,
+                            new_col.ducklake_type(),
+                        ) {
+                            return Err(crate::error::DuckLakeError::UnsupportedTypeChange {
+                                operation: TypeChangeOperation::DataWrite {
+                                    mode: match mode {
+                                        WriteMode::Replace => TypeChangeWriteMode::Replace,
+                                        WriteMode::Append => TypeChangeWriteMode::Append,
+                                    },
+                                },
+                                column: new_col.name().to_string(),
+                                from: (*existing_type).to_string(),
+                                to: new_col.ducklake_type().to_string(),
+                            });
+                        }
+                    } else if mode == WriteMode::Append && !new_col.is_nullable() {
+                        return Err(crate::error::DuckLakeError::InvalidConfig(format!(
+                            "Schema evolution error: new column '{}' must be nullable. Adding non-nullable columns is not allowed.",
+                            new_col.name()
+                        )));
+                    }
+                }
+            }
+
+            // Final per-column ids: reuse the existing id for a column already in
+            // the table, consume a freshly reserved id only for a genuinely new
+            // column. These are baked into the staged parquet's field_id metadata,
+            // so they must equal the ids finalize_snapshot commits. Column rows
+            // themselves are written at the commit point (not here): the read path
+            // resolves columns by `end_snapshot IS NULL` only, so inserting at begin
+            // would leak the new generation to concurrent reads.
+            let column_ids: Vec<i64> = columns
+                .iter()
+                .zip(fresh_ids.iter())
+                .map(|(col, &fresh)| existing_ids.get(col.name()).copied().unwrap_or(fresh))
+                .collect();
+
+            // No snapshot row, no column rows, and no Replace retirement are written
+            // here — all are deferred to the atomic commit so the head never
+            // resolves to an incomplete snapshot. This TX commits only the
+            // idempotent get-or-create schema/table rows; they carry begin_snapshot
+            // = the reserved id and stay invisible until the snapshot publishes,
+            // since schema/table reads ARE snapshot-scoped.
+            tx.commit().await?;
+
+            Ok(WriteSetupResult {
+                snapshot_id,
+                base_snapshot_id,
+                schema_id,
+                table_id,
+                column_ids,
+            })
+        })
+    }
+}

--- a/src/metadata_writer_mysql.rs
+++ b/src/metadata_writer_mysql.rs
@@ -12,14 +12,14 @@
 //!
 //! Requires a multi-threaded Tokio runtime (`#[tokio::test(flavor =
 //! "multi_thread")]`): the sync trait methods bridge async sqlx via
-//! [`crate::metadata_provider::block_on`], exactly like the SQLite writer.
+//! `crate::metadata_provider::block_on`, exactly like the SQLite writer.
 //!
 //! ## MySQL dialect adaptations vs the SQLite template
 //!
 //! 1. **No `RETURNING`.** Auto-increment PK ids (`schema_id`, `table_id`,
 //!    `data_file_id`) are read back with `MySqlQueryResult::last_insert_id()`;
 //!    counter-allocated ids (`column_id`, `snapshot_id`) are read back with an
-//!    `UPDATE` followed by a `SELECT` in the same transaction ([`reserve_ids`]).
+//!    `UPDATE` followed by a `SELECT` in the same transaction (`reserve_ids`).
 //! 2. **DDL type mapping.** `INTEGER`→`BIGINT`, bounded names→`VARCHAR(1024)`,
 //!    long/path values→`TEXT`, `BOOLEAN`→`TINYINT(1)`. Every table is InnoDB so
 //!    transactions + `SELECT … FOR UPDATE`-style row locks actually serialize.

--- a/src/metadata_writer_mysql.rs
+++ b/src/metadata_writer_mysql.rs
@@ -34,8 +34,8 @@ use crate::Result;
 use crate::error::{TypeChangeOperation, TypeChangeWriteMode};
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
-    ColumnDef, CommitIds, DataFileInfo, MetadataWriter, WriteMode, WriteSetupResult, columns_differ,
-    validate_name,
+    ColumnDef, CommitIds, DataFileInfo, MetadataWriter, WriteMode, WriteSetupResult,
+    columns_differ, validate_name,
 };
 use sqlx::Row;
 use sqlx::mysql::{MySqlPool, MySqlPoolOptions};
@@ -230,13 +230,12 @@ async fn reserve_ids(
 /// than `INSERT … SELECT … WHERE NOT EXISTS`, because that self-referential
 /// `INSERT … SELECT` against `ducklake_metadata` is rejected by MySQL (1093).
 async fn seed_counter(pool: &MySqlPool, key: &str, max_sql: &str) -> Result<()> {
-    let exists: i64 = sqlx::query(
-        "SELECT COUNT(*) FROM ducklake_metadata WHERE `key` = ? AND scope IS NULL",
-    )
-    .bind(key)
-    .fetch_one(pool)
-    .await?
-    .try_get(0)?;
+    let exists: i64 =
+        sqlx::query("SELECT COUNT(*) FROM ducklake_metadata WHERE `key` = ? AND scope IS NULL")
+            .bind(key)
+            .fetch_one(pool)
+            .await?
+            .try_get(0)?;
     if exists == 0 {
         let start: i64 = sqlx::query(max_sql).fetch_one(pool).await?.try_get(0)?;
         sqlx::query("INSERT INTO ducklake_metadata (`key`, `value`, scope) VALUES (?, ?, NULL)")

--- a/tests/mysql_metadata_writer_test.rs
+++ b/tests/mysql_metadata_writer_test.rs
@@ -1,0 +1,137 @@
+#![cfg(feature = "write-mysql")]
+//! MySQL metadata WRITER round-trip tests.
+//!
+//! Writes a catalog with [`MySqlMetadataWriter`] and reads it back with
+//! [`MySqlMetadataProvider`], asserting the write path produced exactly the
+//! snapshot / schema / table / column / data-file rows the provider resolves.
+//!
+//! Uses testcontainers to spin up a throwaway MySQL, so it is gated the same way
+//! as `tests/mysql_metadata_provider_test.rs`: it is ignored under
+//! `skip-tests-with-docker` on macOS (Docker unavailable there).
+
+use datafusion_ducklake::{
+    ColumnDef, DataFileInfo, MetadataProvider, MetadataWriter, MySqlMetadataProvider,
+    MySqlMetadataWriter, WriteMode,
+};
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::mysql::Mysql;
+
+/// Full write -> read round-trip through both a data-file commit
+/// (`register_data_file`) and a fileless CREATE-TABLE commit
+/// (`publish_snapshot`).
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn mysql_writer_roundtrip_write_then_read() {
+    let container = Mysql::default().start().await.unwrap();
+    let host = "127.0.0.1";
+    let port = container.get_host_port_ipv4(3306).await.unwrap();
+    let conn_str = format!("mysql://root@{}:{}/test", host, port);
+
+    // --- Write side --------------------------------------------------------
+    let writer = MySqlMetadataWriter::new_with_init(&conn_str).await.unwrap();
+    writer.set_data_path("file:///tmp/ducklake_data/").unwrap();
+
+    let columns = vec![
+        ColumnDef::new("id", "int64", false).unwrap(),
+        ColumnDef::new("name", "varchar", true).unwrap(),
+    ];
+
+    // Real write path: begin (reserve ids, get-or-create schema/table) then
+    // commit by registering a data file.
+    let setup = writer
+        .begin_write_transaction("main", "users", &columns, WriteMode::Replace)
+        .unwrap();
+    let file = DataFileInfo::new("data_001.parquet", 1024, 4).with_footer_size(128);
+    let committed = writer
+        .register_data_file(
+            setup.table_id,
+            "main",
+            "users",
+            setup.snapshot_id,
+            &file,
+            WriteMode::Replace,
+            setup.base_snapshot_id,
+            &columns,
+            &setup.column_ids,
+        )
+        .unwrap();
+    // First write commits snapshot 1 on a fresh catalog.
+    assert_eq!(committed.snapshot_id, 1, "first write commits snapshot 1");
+
+    // A fileless CREATE TABLE exercises the publish_snapshot override.
+    let cols2 = vec![ColumnDef::new("c1", "int32", true).unwrap()];
+    let setup2 = writer
+        .begin_write_transaction("main", "empty_t", &cols2, WriteMode::Replace)
+        .unwrap();
+    let committed2 = writer
+        .publish_snapshot(
+            setup2.table_id,
+            "main",
+            "empty_t",
+            setup2.snapshot_id,
+            WriteMode::Replace,
+            setup2.base_snapshot_id,
+            &cols2,
+            &setup2.column_ids,
+        )
+        .unwrap();
+    assert!(
+        committed2.snapshot_id > committed.snapshot_id,
+        "second commit advances the head"
+    );
+
+    // --- Read side ---------------------------------------------------------
+    let provider = MySqlMetadataProvider::new(&conn_str).await.unwrap();
+
+    let snap = provider.get_current_snapshot().unwrap();
+    assert_eq!(snap, committed2.snapshot_id, "head is the latest commit");
+    assert_eq!(
+        provider.get_data_path().unwrap(),
+        "file:///tmp/ducklake_data/"
+    );
+
+    // The schema written by the first commit is visible at the head.
+    let schemas = provider.list_schemas(snap).unwrap();
+    assert_eq!(schemas.len(), 1, "one schema");
+    assert_eq!(schemas[0].schema_name, "main");
+
+    // Both tables live under it.
+    let tables = provider.list_tables(committed.schema_id, snap).unwrap();
+    let names: Vec<_> = tables.iter().map(|t| t.table_name.as_str()).collect();
+    assert!(names.contains(&"users"), "users table present");
+    assert!(names.contains(&"empty_t"), "empty_t table present");
+
+    // Column generation of `users` reads back in order with the written types.
+    let structure = provider
+        .get_table_structure(committed.table_id, snap)
+        .unwrap();
+    assert_eq!(structure.len(), 2, "users has two columns");
+    assert_eq!(structure[0].column_name, "id");
+    assert_eq!(structure[0].column_type, "int64");
+    assert!(!structure[0].is_nullable);
+    assert_eq!(structure[1].column_name, "name");
+    assert_eq!(structure[1].column_type, "varchar");
+    assert!(structure[1].is_nullable);
+
+    // The registered data file reads back with its metadata; no delete file.
+    let files = provider
+        .get_table_files_for_select(committed.table_id, snap)
+        .unwrap();
+    assert_eq!(files.len(), 1, "one data file");
+    assert_eq!(files[0].file.path, "data_001.parquet");
+    assert_eq!(files[0].file.file_size_bytes, 1024);
+    assert_eq!(files[0].file.footer_size, Some(128));
+    assert!(files[0].delete_file.is_none(), "no delete file");
+
+    // The fileless CREATE TABLE published a table with columns but no files.
+    let empty_id = tables
+        .iter()
+        .find(|t| t.table_name == "empty_t")
+        .unwrap()
+        .table_id;
+    let empty_structure = provider.get_table_structure(empty_id, snap).unwrap();
+    assert_eq!(empty_structure.len(), 1, "empty_t has one column");
+    assert_eq!(empty_structure[0].column_name, "c1");
+    let empty_files = provider.get_table_files_for_select(empty_id, snap).unwrap();
+    assert!(empty_files.is_empty(), "empty_t has no data files");
+}


### PR DESCRIPTION
## Summary

Adds **DuckDB** and **MySQL** metadata writers so both join SQLite/Postgres as write backends — write parity with the four read providers. Legacy **single-catalog** only (append / replace / `CREATE TABLE`); `delete`/`upsert`/`promote_column_type` inherit the erroring trait defaults; no multicatalog (`catalog_id() -> None`).

## Changes

- **`src/metadata_writer_duckdb.rs`** (new) — `DuckdbMetadataWriter` over the sync `duckdb` crate. PK ids via `CREATE SEQUENCE`/`nextval`, `column_id` via the `ducklake_metadata` counter, `snapshot_id` via `MAX+1`. Mirrors the SQLite writer's DDL, write-lock-first ordering, and `Replace`-conflict detection. Connection guarded by a `Mutex` for `Send + Sync`.
- **`src/metadata_writer_mysql.rs`** (new) — `MySqlMetadataWriter` over `sqlx/mysql`. MySQL dialect: `LAST_INSERT_ID()` for `AUTO_INCREMENT` PKs and `UPDATE`+`SELECT` counter read-back (no `RETURNING`); `TINYINT(1)` booleans, `TEXT`/`VARCHAR(1024)`, backticked `` `key` ``/`` `value` ``, `ENGINE=InnoDB`; a `next_snapshot_id` counter to avoid MySQL's self-referential `INSERT ... SELECT` (err 1093).
- **`tests/mysql_metadata_writer_test.rs`** (new) — docker-gated round-trip test, mirroring the gating in `tests/mysql_metadata_provider_test.rs`.
- **`Cargo.toml`**, **`src/lib.rs`** — new `write-duckdb` / `write-mysql` features + module and re-export wiring.

Both implement the required `MetadataWriter` surface (`create_snapshot`, `get_or_create_schema`/`table`, `set_columns`, `register_data_file`, `end_table_files`, `get_data_path`/`set_data_path`, `initialize_schema`, `begin_write_transaction`) and override `publish_snapshot` for the fileless CREATE-TABLE / zero-row path. Catalog DDL columns match the DuckLake v1.0 layout so catalogs written here stay readable by DuckDB's ducklake extension.


