### PR TITLE
feat(write): SQL DELETE via TableProvider::delete_from

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -95,6 +95,7 @@ the read backend: `--no-default-features --features metadata-duckdb` (requires
 | `CREATE TABLE AS SELECT` (SQL DDL; SQLite single-catalog only — not on the PostgreSQL multi-catalog path) | 🟧 |
 | `DROP TABLE` (via `MetadataWriter`)                     |   ✅   |
 | Row-level deletes (Merge-On-Read delete files, read)    |   ✅   |
+| SQL `DELETE FROM t [WHERE ...]` (positional deletes + metadata-only truncate; SQLite & PostgreSQL) | ✅ |
 | Snapshot-based consistency (bound at catalog creation)  |   ✅   |
 | Filter pushdown to Parquet (row-group / page pruning)   |   ✅   |
 | Parquet footer size hints (1 read/file instead of 2)    |   ✅   |
@@ -179,6 +180,14 @@ Known edges:
   the snapshot programmatically — `DuckLakeCatalog::with_snapshot(provider, snapshot_id)`
   binds to a specific one, and querying another point in time means creating another
   catalog. What's missing is SQL-level historical querying (`AS OF`) within one handle.
+- **One mutation per session, then re-open the catalog.** Because a catalog pins its
+  snapshot at creation and never refreshes, a `SessionContext` observes a single generation
+  for its lifetime. After a `DELETE` (or `INSERT`) commits, the same session keeps reading
+  the pre-mutation state; a `SELECT` won't see the change, a just-inserted row can't be
+  deleted, and a **second `DELETE` re-touching a file the first modified aborts with a
+  conflict** (the compare-and-swap that also guards genuine concurrency — it is what prevents
+  a stale delete file from resurrecting deleted rows). Re-open the catalog (or create a fresh
+  `SessionContext`) between mutating statements so it binds to the latest snapshot.
 - **No partition-based file pruning** on read.
 - **Complex / nested types** have minimal support.
 - **DuckDB-encrypted (non-PME) Parquet files** are not supported (only PME).

--- a/src/delete_exec.rs
+++ b/src/delete_exec.rs
@@ -18,6 +18,27 @@
 //! v1 handles insert-only data files. Files rewritten by an UPDATE/compaction
 //! (an embedded row-id column) cannot be resolved by physical position, so the
 //! filtered path cleanly errors on them rather than risk mis-deleting.
+//!
+//! # Session lifecycle (important)
+//!
+//! A [`DuckLakeCatalog`](crate::DuckLakeCatalog) pins its snapshot at creation
+//! and never refreshes it, so a `SessionContext` observes ONE catalog generation
+//! for its whole lifetime. A `DELETE` commits a new snapshot, but the same
+//! session keeps reading the old one. Consequences:
+//!
+//! - A second filtered `DELETE` in the same session that re-touches a data file
+//!   modified by an earlier `DELETE` (in that same session) aborts with a
+//!   [`Conflict`](crate::DuckLakeError::Conflict): it resolves against the pinned
+//!   (pre-delete) view, so its compare-and-swap disagrees with the live catalog.
+//!   This is the SAME guard that (correctly) rejects a genuinely concurrent
+//!   writer — and it is what prevents a stale, non-cumulative delete file from
+//!   resurrecting already-deleted rows.
+//! - A `SELECT` after a `DELETE` (or `INSERT`) in the same session returns the
+//!   pre-mutation rows; a just-inserted row cannot be deleted in the same
+//!   session (it is invisible to the pinned snapshot).
+//!
+//! To perform multiple mutations, re-open the catalog (or create a fresh
+//! `SessionContext`) between statements so it binds to the latest snapshot.
 
 use std::collections::HashSet;
 use std::fmt::{self, Debug};

--- a/src/delete_exec.rs
+++ b/src/delete_exec.rs
@@ -1,0 +1,348 @@
+//! DuckLake `DELETE` execution plan.
+//!
+//! Backs [`crate::table::DuckLakeTable`]'s `TableProvider::delete_from`. When
+//! executed, it performs the delete and yields a single `count: UInt64` row
+//! (rows affected), mirroring the count contract of
+//! [`DuckLakeInsertExec`](crate::insert_exec::DuckLakeInsertExec).
+//!
+//! Two paths:
+//! - **Filtered delete** (a `WHERE` clause): for each live data file, resolve the
+//!   physical row positions matching the predicate, union them with the file's
+//!   already-deleted positions, write ONE cumulative positional delete file, and
+//!   commit every affected file's delete file in a SINGLE snapshot (atomic
+//!   multi-file delete). The read path is already delete-aware, so a subsequent
+//!   `SELECT` excludes the deleted rows automatically.
+//! - **Delete-all** (no `WHERE`): a metadata-only truncate — end every live data
+//!   file in one new snapshot. Much cheaper than positional-deleting every row.
+//!
+//! v1 handles insert-only data files. Files rewritten by an UPDATE/compaction
+//! (an embedded row-id column) cannot be resolved by physical position, so the
+//! filtered path cleanly errors on them rather than risk mis-deleting.
+
+use std::collections::HashSet;
+use std::fmt::{self, Debug};
+use std::sync::Arc;
+
+use arrow::array::{ArrayRef, RecordBatch, UInt64Array};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::catalog::Session;
+use datafusion::error::{DataFusionError, Result as DataFusionResult};
+use datafusion::execution::object_store::ObjectStoreUrl;
+use datafusion::execution::{SendableRecordBatchStream, SessionState, TaskContext};
+use datafusion::physical_expr::{EquivalenceProperties, Partitioning, PhysicalExpr};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use futures::stream;
+
+use crate::metadata_writer::{DeleteFileEntry, MetadataWriter};
+use crate::table::DuckLakeTable;
+use crate::table_writer::DuckLakeTableWriter;
+
+/// Schema for the output of a delete operation: the count of rows deleted.
+/// Same shape DataFusion expects from `insert_into`.
+fn make_delete_count_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![Field::new(
+        "count",
+        DataType::UInt64,
+        false,
+    )]))
+}
+
+/// Execution plan that deletes rows from a DuckLake table.
+///
+/// Takes no input stream (unlike insert): the rows to delete are discovered by
+/// scanning the table's own data files against `predicate`. `None` predicate
+/// means delete ALL rows.
+pub struct DuckLakeDeleteExec {
+    /// A clone of the target table, used for its reader methods
+    /// (`resolve_positions`, `read_delete_file_positions`,
+    /// `file_has_embedded_rowid`).
+    table: Arc<DuckLakeTable>,
+    /// Session captured at plan time. A bare `TaskContext` cannot build physical
+    /// exprs or drive the positional sub-plans; `SessionState` is the concrete
+    /// `Session` impl that can, so the delete work can run at execute time.
+    session_state: SessionState,
+    /// Physical predicate over the table's physical columns. `None` => delete
+    /// ALL rows (metadata-only truncate).
+    predicate: Option<Arc<dyn PhysicalExpr>>,
+    /// Metadata writer for the atomic commit.
+    writer: Arc<dyn MetadataWriter>,
+    /// Object store URL for writing positional delete files.
+    object_store_url: Arc<ObjectStoreUrl>,
+    schema_name: String,
+    table_name: String,
+    table_id: i64,
+    /// Snapshot the table was opened at (the generation the positions were
+    /// resolved against); threaded to the commit for conflict diagnostics.
+    base_snapshot: i64,
+    cache: Arc<PlanProperties>,
+}
+
+impl DuckLakeDeleteExec {
+    /// Create a new `DuckLakeDeleteExec`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        table: Arc<DuckLakeTable>,
+        session_state: SessionState,
+        predicate: Option<Arc<dyn PhysicalExpr>>,
+        writer: Arc<dyn MetadataWriter>,
+        schema_name: String,
+        table_name: String,
+        table_id: i64,
+        base_snapshot: i64,
+        object_store_url: Arc<ObjectStoreUrl>,
+    ) -> Self {
+        let cache = Self::compute_properties();
+        Self {
+            table,
+            session_state,
+            predicate,
+            writer,
+            object_store_url,
+            schema_name,
+            table_name,
+            table_id,
+            base_snapshot,
+            cache,
+        }
+    }
+
+    fn compute_properties() -> Arc<PlanProperties> {
+        Arc::new(PlanProperties::new(
+            EquivalenceProperties::new(make_delete_count_schema()),
+            Partitioning::UnknownPartitioning(1),
+            datafusion::physical_plan::execution_plan::EmissionType::Final,
+            datafusion::physical_plan::execution_plan::Boundedness::Bounded,
+        ))
+    }
+}
+
+impl Debug for DuckLakeDeleteExec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DuckLakeDeleteExec")
+            .field("schema_name", &self.schema_name)
+            .field("table_name", &self.table_name)
+            .field("table_id", &self.table_id)
+            .field("delete_all", &self.predicate.is_none())
+            .finish_non_exhaustive()
+    }
+}
+
+impl DisplayAs for DuckLakeDeleteExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        match t {
+            DisplayFormatType::Default
+            | DisplayFormatType::Verbose
+            | DisplayFormatType::TreeRender => {
+                write!(
+                    f,
+                    "DuckLakeDeleteExec: table={}.{}, predicate={}",
+                    self.schema_name,
+                    self.table_name,
+                    if self.predicate.is_some() {
+                        "filter"
+                    } else {
+                        "all-rows"
+                    }
+                )
+            },
+        }
+    }
+}
+
+impl ExecutionPlan for DuckLakeDeleteExec {
+    fn name(&self) -> &str {
+        "DuckLakeDeleteExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.cache
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        // No input plan: rows to delete are found by scanning the table's files.
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        if !children.is_empty() {
+            return Err(DataFusionError::Internal(
+                "DuckLakeDeleteExec does not take any children".to_string(),
+            ));
+        }
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        if partition != 0 {
+            return Err(DataFusionError::Internal(format!(
+                "DuckLakeDeleteExec only supports partition 0, got {}",
+                partition
+            )));
+        }
+
+        let table = Arc::clone(&self.table);
+        let session_state = self.session_state.clone();
+        let predicate = self.predicate.clone();
+        let writer = Arc::clone(&self.writer);
+        let object_store_url = Arc::clone(&self.object_store_url);
+        let schema_name = self.schema_name.clone();
+        let table_name = self.table_name.clone();
+        let table_id = self.table_id;
+        let base_snapshot = self.base_snapshot;
+        let output_schema = make_delete_count_schema();
+
+        let stream = stream::once(async move {
+            let deleted = run_delete(
+                table,
+                &session_state,
+                predicate,
+                writer,
+                object_store_url,
+                &schema_name,
+                &table_name,
+                table_id,
+                base_snapshot,
+            )
+            .await?;
+            let count: ArrayRef = Arc::new(UInt64Array::from(vec![deleted]));
+            Ok(RecordBatch::try_new(output_schema, vec![count])?)
+        });
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            make_delete_count_schema(),
+            stream,
+        )))
+    }
+}
+
+/// Run the delete and return the number of rows deleted. See the module docs for
+/// the two paths (filtered positional delete vs. delete-all truncate).
+#[allow(clippy::too_many_arguments)]
+async fn run_delete(
+    table: Arc<DuckLakeTable>,
+    session_state: &SessionState,
+    predicate: Option<Arc<dyn PhysicalExpr>>,
+    writer: Arc<dyn MetadataWriter>,
+    object_store_url: Arc<ObjectStoreUrl>,
+    schema_name: &str,
+    table_name: &str,
+    table_id: i64,
+    base_snapshot: i64,
+) -> DataFusionResult<u64> {
+    let state: &dyn Session = session_state;
+
+    // Delete-all (no WHERE): metadata-only truncate — end every live data file in
+    // one snapshot. Skip the empty table entirely (no-op, no snapshot).
+    let predicate = match predicate {
+        None => {
+            if table.files().is_empty() {
+                return Ok(0);
+            }
+            return writer
+                .commit_truncate(table_id, schema_name, table_name, base_snapshot)
+                .map_err(|e| DataFusionError::External(Box::new(e)));
+        },
+        Some(p) => p,
+    };
+
+    // Object store for writing delete files — the same store the positional reads
+    // resolve against.
+    let object_store = state
+        .runtime_env()
+        .object_store(object_store_url.as_ref())?;
+    let table_writer = DuckLakeTableWriter::new(Arc::clone(&writer), object_store)
+        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+    let mut entries: Vec<DeleteFileEntry> = Vec::new();
+    let mut total_deleted: u64 = 0;
+
+    for tf in table.files() {
+        // v1 refuses files rewritten by an UPDATE/compaction: their surviving
+        // rows carry embedded rowids whose physical order need not match the
+        // DuckLake `pos` space, so positional resolution could mis-delete. Clean
+        // error, never a silent wrong delete.
+        if table.file_has_embedded_rowid(state, &tf.file).await? {
+            return Err(DataFusionError::NotImplemented(format!(
+                "DELETE on data file '{}' is not supported: the file was rewritten by an \
+                 UPDATE or compaction (it embeds a row-id column), and v1 resolves delete \
+                 positions only for insert-only files",
+                tf.file.path
+            )));
+        }
+
+        // Physical positions matching the predicate (raw scan; delete files NOT
+        // applied — resolution is over the file's own rows).
+        let matched = table
+            .resolve_positions(state, &tf.file, Arc::clone(&predicate))
+            .await?;
+        if matched.is_empty() {
+            continue;
+        }
+
+        // Already-deleted positions for this file (if a delete file is live).
+        // Rows already deleted are neither re-counted nor re-deleted.
+        let existing = match tf.delete_file {
+            Some(ref df) => table.read_delete_file_positions(state, df).await?,
+            None => HashSet::new(),
+        };
+
+        let newly_deleted = matched.difference(&existing).count() as u64;
+        if newly_deleted == 0 {
+            // Every matched row was already deleted: nothing changes here.
+            continue;
+        }
+
+        // Cumulative (prior ∪ new) still-deleted set: at most one delete file is
+        // live per data file, so each write carries the full set.
+        let mut cumulative: Vec<i64> = existing.union(&matched).copied().collect();
+        cumulative.sort_unstable();
+
+        let delete_info = table_writer
+            .write_delete_file(schema_name, table_name, &tf.file.path, &cumulative)
+            .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+        entries.push(DeleteFileEntry {
+            data_file_id: tf.data_file_id,
+            expected_prev_delete_file: tf.delete_file_id,
+            delete: delete_info,
+        });
+        total_deleted += newly_deleted;
+    }
+
+    if entries.is_empty() {
+        // Predicate matched nothing new anywhere: no commit, no snapshot.
+        return Ok(0);
+    }
+
+    // Commit every affected file's cumulative delete file in ONE snapshot
+    // (atomic multi-file DELETE). No new data file is appended, so this uses the
+    // dedicated delete-only commit rather than `register_data_file_with_deletes`
+    // (which requires an appended file).
+    writer
+        .commit_positional_deletes(table_id, schema_name, table_name, base_snapshot, &entries)
+        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+    Ok(total_deleted)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_delete_count_schema() {
+        let schema = make_delete_count_schema();
+        assert_eq!(schema.fields().len(), 1);
+        assert_eq!(schema.field(0).name(), "count");
+        assert_eq!(schema.field(0).data_type(), &DataType::UInt64);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,8 @@ pub mod metadata_provider_sqlite;
 
 // Write support (feature-gated)
 #[cfg(feature = "write")]
+pub mod delete_exec;
+#[cfg(feature = "write")]
 pub mod insert_exec;
 #[cfg(feature = "write")]
 pub mod maintenance;
@@ -107,6 +109,8 @@ pub use metadata_provider_postgres::PostgresMetadataProvider;
 pub use metadata_provider_sqlite::SqliteMetadataProvider;
 
 // Re-export write types (feature-gated)
+#[cfg(feature = "write")]
+pub use delete_exec::DuckLakeDeleteExec;
 #[cfg(feature = "write")]
 pub use insert_exec::DuckLakeInsertExec;
 #[cfg(feature = "write")]

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -537,6 +537,67 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
         ))
     }
 
+    /// Apply positional deletes to one or more existing data files in a SINGLE
+    /// new snapshot, WITHOUT appending any data file — the commit behind a SQL
+    /// `DELETE ... WHERE`. This is [`register_data_file_with_deletes`] minus the
+    /// append: it does not require (and never writes) a new data file, so a pure
+    /// delete does not create a spurious empty data file.
+    ///
+    /// [`register_data_file_with_deletes`]: MetadataWriter::register_data_file_with_deletes
+    ///
+    /// In one transaction: allocate one snapshot (carrying `schema_version`
+    /// forward — a delete is not DDL); then for each [`DeleteFileEntry`] apply the
+    /// same target-file fence + compare-and-swap + retire-prior + insert-cumulative
+    /// as [`set_delete_file`](MetadataWriter::set_delete_file), all stamped with
+    /// that one snapshot; advance the catalog head LAST, so every file's delete
+    /// becomes visible together (atomic multi-file DELETE) — never a half-applied
+    /// state. Aborts with [`crate::DuckLakeError::Conflict`] on the first entry
+    /// whose target data file was retired since `base_snapshot`, or whose live
+    /// delete file no longer matches `expected_prev_delete_file`.
+    ///
+    /// `deletes` must be non-empty (an empty delete is a caller-side no-op that
+    /// must NOT reach here — it would create an empty snapshot); each entry must
+    /// target a distinct `data_file_id`.
+    ///
+    /// Default: unsupported; backends override it.
+    fn commit_positional_deletes(
+        &self,
+        _table_id: i64,
+        _schema_name: &str,
+        _table_name: &str,
+        _base_snapshot: i64,
+        _deletes: &[DeleteFileEntry],
+    ) -> Result<CommitIds> {
+        Err(DuckLakeError::InvalidConfig(
+            "positional DELETE is not supported on this metadata backend".to_string(),
+        ))
+    }
+
+    /// Truncate a table: end EVERY live data file (and its live delete file) in
+    /// one new snapshot and zero the visible stat totals, WITHOUT rewriting any
+    /// data — the commit behind a SQL `DELETE FROM t` with no `WHERE`. Mirrors the
+    /// file-ending drop_table performs, but leaves the table's schema live.
+    /// `next_row_id` is deliberately preserved (rowids stay monotonic).
+    ///
+    /// Returns the number of rows removed (the table's live row count immediately
+    /// before the truncate: gross `record_count` minus still-live delete counts),
+    /// which the SQL `DELETE` reports as rows affected. The count is computed
+    /// inside the same transaction that ends the files, so it is consistent with
+    /// what was removed.
+    ///
+    /// Default: unsupported; backends override it.
+    fn commit_truncate(
+        &self,
+        _table_id: i64,
+        _schema_name: &str,
+        _table_name: &str,
+        _base_snapshot: i64,
+    ) -> Result<u64> {
+        Err(DuckLakeError::InvalidConfig(
+            "DELETE (truncate) is not supported on this metadata backend".to_string(),
+        ))
+    }
+
     /// Publish a write's snapshot as the catalog head with no data file (CREATE
     /// TABLE, zero-row Replace). For `Replace`, retires the prior generation.
     /// See [`MetadataWriter::register_data_file`] for the parameters.

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -1522,6 +1522,224 @@ impl MetadataWriter for PostgresMetadataWriter {
         })
     }
 
+    fn commit_positional_deletes(
+        &self,
+        table_id: i64,
+        _schema_name: &str,
+        _table_name: &str,
+        base_snapshot: i64,
+        deletes: &[DeleteFileEntry],
+    ) -> Result<CommitIds> {
+        if deletes.is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit_positional_deletes requires at least one delete entry".to_string(),
+            ));
+        }
+        // A positional delete never retires the data files it targets, so it is
+        // Append-semantics for validation (also enforces distinct data files).
+        validate_delete_entries(WriteMode::Append, deletes)?;
+        block_on(async {
+            // Single atomic commit under the catalog lock for an N-file positional
+            // DELETE with no append: fence + compare-and-swap + retire + insert per
+            // entry, all stamped with one snapshot; advance_catalog_head LAST so
+            // the whole multi-file delete becomes visible together.
+            let mut tx = self.pool.begin().await?;
+            lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
+            assert_table_not_in_other_catalog(self.catalog_id, table_id, &mut tx).await?;
+
+            // Allocate the snapshot (commit-ordered IDENTITY). A delete is
+            // non-DDL, so carry the per-catalog schema_version forward.
+            let snapshot_id: i64 = sqlx::query(
+                "INSERT INTO ducklake_snapshot (snapshot_time, schema_version)
+                 VALUES (NOW(), 0) RETURNING snapshot_id",
+            )
+            .fetch_one(&mut *tx)
+            .await?
+            .try_get(0)?;
+            let prev_max: i64 = sqlx::query(
+                "SELECT COALESCE(MAX(s.schema_version), 0) FROM ducklake_snapshot s
+                 JOIN ducklake_catalog_snapshot_map m ON m.snapshot_id = s.snapshot_id
+                 WHERE m.catalog_id = $1",
+            )
+            .bind(self.catalog_id)
+            .fetch_one(&mut *tx)
+            .await?
+            .try_get(0)?;
+            sqlx::query("UPDATE ducklake_snapshot SET schema_version = $1 WHERE snapshot_id = $2")
+                .bind(prev_max.max(1))
+                .bind(snapshot_id)
+                .execute(&mut *tx)
+                .await?;
+
+            for entry in deletes {
+                // Target-file fence: abort iff the data file is no longer live.
+                // Select the BIGINT data_file_id (not literal 1, which Postgres
+                // types as INT4 and cannot decode into i64) — existence only.
+                let target_live: Option<i64> = sqlx::query_scalar(
+                    "SELECT data_file_id FROM ducklake_data_file
+                     WHERE data_file_id = $1 AND end_snapshot IS NULL",
+                )
+                .bind(entry.data_file_id)
+                .fetch_optional(&mut *tx)
+                .await?;
+                if target_live.is_none() {
+                    return Err(crate::DuckLakeError::Conflict(format!(
+                        "delete targets data file {}, which was retired by a concurrent write \
+                         since snapshot {base_snapshot}; retry against the new generation",
+                        entry.data_file_id
+                    )));
+                }
+
+                // Compare-and-swap on the currently-live delete file.
+                let current_prev: Option<i64> = sqlx::query_scalar(
+                    "SELECT delete_file_id FROM ducklake_delete_file
+                     WHERE data_file_id = $1 AND end_snapshot IS NULL",
+                )
+                .bind(entry.data_file_id)
+                .fetch_optional(&mut *tx)
+                .await?;
+                if current_prev != entry.expected_prev_delete_file {
+                    return Err(crate::DuckLakeError::Conflict(format!(
+                        "delete on data file {} conflicts with a concurrent delete (expected live \
+                         delete file {:?}, found {current_prev:?}); retry against the new generation",
+                        entry.data_file_id, entry.expected_prev_delete_file
+                    )));
+                }
+
+                if let Some(prev) = entry.expected_prev_delete_file {
+                    sqlx::query(
+                        "UPDATE ducklake_delete_file SET end_snapshot = $1
+                         WHERE delete_file_id = $2 AND end_snapshot IS NULL",
+                    )
+                    .bind(snapshot_id)
+                    .bind(prev)
+                    .execute(&mut *tx)
+                    .await?;
+                }
+
+                sqlx::query(
+                    "INSERT INTO ducklake_delete_file
+                         (data_file_id, table_id, path, path_is_relative, file_size_bytes,
+                          footer_size, delete_count, begin_snapshot)
+                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+                )
+                .bind(entry.data_file_id)
+                .bind(table_id)
+                .bind(&entry.delete.path)
+                .bind(entry.delete.path_is_relative)
+                .bind(entry.delete.file_size_bytes)
+                .bind(entry.delete.footer_size)
+                .bind(entry.delete.delete_count)
+                .bind(snapshot_id)
+                .execute(&mut *tx)
+                .await?;
+            }
+
+            let schema_id: i64 =
+                sqlx::query_scalar("SELECT schema_id FROM ducklake_table WHERE table_id = $1")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
+
+            // advance_catalog_head MUST be the last write before commit.
+            advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
+
+            tx.commit().await?;
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
+        })
+    }
+
+    fn commit_truncate(
+        &self,
+        table_id: i64,
+        _schema_name: &str,
+        _table_name: &str,
+        _base_snapshot: i64,
+    ) -> Result<u64> {
+        block_on(async {
+            // Metadata-only truncate in one snapshot under the catalog lock: end
+            // every live data file and its live delete file, zero the visible stat
+            // totals, and advance the head LAST. next_row_id is preserved.
+            let mut tx = self.pool.begin().await?;
+            lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
+            assert_table_in_catalog(self.catalog_id, table_id, &mut tx).await?;
+
+            let snapshot_id: i64 = sqlx::query(
+                "INSERT INTO ducklake_snapshot (snapshot_time, schema_version)
+                 VALUES (NOW(), 0) RETURNING snapshot_id",
+            )
+            .fetch_one(&mut *tx)
+            .await?
+            .try_get(0)?;
+            let prev_max: i64 = sqlx::query(
+                "SELECT COALESCE(MAX(s.schema_version), 0) FROM ducklake_snapshot s
+                 JOIN ducklake_catalog_snapshot_map m ON m.snapshot_id = s.snapshot_id
+                 WHERE m.catalog_id = $1",
+            )
+            .bind(self.catalog_id)
+            .fetch_one(&mut *tx)
+            .await?
+            .try_get(0)?;
+            sqlx::query("UPDATE ducklake_snapshot SET schema_version = $1 WHERE snapshot_id = $2")
+                .bind(prev_max.max(1))
+                .bind(snapshot_id)
+                .execute(&mut *tx)
+                .await?;
+
+            // Rows removed = gross record_count minus still-live delete counts,
+            // computed BEFORE ending anything (so it matches what we retire).
+            // SUM(bigint) is NUMERIC in Postgres; cast back to BIGINT for i64.
+            let gross: Option<i64> = sqlx::query_scalar(
+                "SELECT COALESCE(record_count, 0) FROM ducklake_table_stats WHERE table_id = $1",
+            )
+            .bind(table_id)
+            .fetch_optional(&mut *tx)
+            .await?;
+            let deleted: i64 = sqlx::query_scalar(
+                "SELECT COALESCE(SUM(delete_count), 0)::BIGINT FROM ducklake_delete_file
+                 WHERE table_id = $1 AND end_snapshot IS NULL",
+            )
+            .bind(table_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            let live_rows = (gross.unwrap_or(0) - deleted).max(0) as u64;
+
+            sqlx::query(
+                "UPDATE ducklake_data_file SET end_snapshot = $1
+                 WHERE table_id = $2 AND end_snapshot IS NULL",
+            )
+            .bind(snapshot_id)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            sqlx::query(
+                "UPDATE ducklake_delete_file SET end_snapshot = $1
+                 WHERE table_id = $2 AND end_snapshot IS NULL",
+            )
+            .bind(snapshot_id)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            sqlx::query(
+                "UPDATE ducklake_table_stats SET record_count = 0, file_size_bytes = 0
+                 WHERE table_id = $1",
+            )
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+
+            // advance_catalog_head MUST be the last write before commit.
+            advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
+
+            tx.commit().await?;
+            Ok(live_rows)
+        })
+    }
+
     fn publish_snapshot(
         &self,
         table_id: i64,

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -1584,8 +1584,12 @@ impl MetadataWriter for PostgresMetadataWriter {
                 .await?;
                 if target_live.is_none() {
                     return Err(crate::DuckLakeError::Conflict(format!(
-                        "delete targets data file {}, which was retired by a concurrent write \
-                         since snapshot {base_snapshot}; retry against the new generation",
+                        "DELETE on data file {} could not commit: the file is no longer live as \
+                         of the catalog's current head (retired since snapshot {base_snapshot}). \
+                         This happens when another writer committed a Replace/compaction, OR when \
+                         an earlier write in THIS session already advanced the catalog (the \
+                         catalog pins its snapshot at creation and does not refresh). Re-open the \
+                         catalog at the latest snapshot and retry.",
                         entry.data_file_id
                     )));
                 }
@@ -1600,8 +1604,11 @@ impl MetadataWriter for PostgresMetadataWriter {
                 .await?;
                 if current_prev != entry.expected_prev_delete_file {
                     return Err(crate::DuckLakeError::Conflict(format!(
-                        "delete on data file {} conflicts with a concurrent delete (expected live \
-                         delete file {:?}, found {current_prev:?}); retry against the new generation",
+                        "DELETE on data file {} could not commit: its live delete file changed \
+                         from {:?} to {current_prev:?} since snapshot {base_snapshot}. Another \
+                         writer committed a delete on this file, OR an earlier DELETE in THIS \
+                         session did (the catalog pins its snapshot at creation and does not \
+                         refresh). Re-open the catalog at the latest snapshot and retry.",
                         entry.data_file_id, entry.expected_prev_delete_file
                     )));
                 }
@@ -1667,6 +1674,22 @@ impl MetadataWriter for PostgresMetadataWriter {
             let mut tx = self.pool.begin().await?;
             lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
             assert_table_in_catalog(self.catalog_id, table_id, &mut tx).await?;
+
+            // No-op guard: nothing to truncate if the table has no live data file.
+            // Return Ok(0) BEFORE allocating a snapshot, so a repeated
+            // `DELETE FROM t` under a pinned snapshot does not create a
+            // content-free snapshot. lock_catalog above already serializes, so
+            // this read is stable.
+            let has_live_data: Option<i64> = sqlx::query_scalar(
+                "SELECT data_file_id FROM ducklake_data_file
+                 WHERE table_id = $1 AND end_snapshot IS NULL LIMIT 1",
+            )
+            .bind(table_id)
+            .fetch_optional(&mut *tx)
+            .await?;
+            if has_live_data.is_none() {
+                return Ok(0);
+            }
 
             let snapshot_id: i64 = sqlx::query(
                 "INSERT INTO ducklake_snapshot (snapshot_time, schema_version)

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -1666,6 +1666,180 @@ impl MetadataWriter for SqliteMetadataWriter {
         })
     }
 
+    fn commit_positional_deletes(
+        &self,
+        table_id: i64,
+        // SQLite created the schema/table at begin; names unused (trait parity).
+        _schema_name: &str,
+        _table_name: &str,
+        base_snapshot: i64,
+        deletes: &[DeleteFileEntry],
+    ) -> Result<CommitIds> {
+        if deletes.is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "commit_positional_deletes requires at least one delete entry".to_string(),
+            ));
+        }
+        // A positional delete never retires the data files it targets, so it is
+        // Append-semantics for validation (also enforces distinct data files).
+        validate_delete_entries(WriteMode::Append, deletes)?;
+        block_on(async {
+            // One atomic commit for an N-file positional DELETE with no append.
+            // Mirrors register_data_file_with_deletes' delete loop, but allocates
+            // the snapshot via insert_snapshot (no column generation, no data
+            // file) — a delete carries schema_version forward. The head
+            // (MAX(snapshot_id)) only ever resolves to the fully-applied delete.
+            let mut tx = self.pool.begin().await?;
+
+            // Write-lock-first: the MAX+1 insert takes the SQLite write lock up
+            // front, so concurrent writers can't collide or deadlock.
+            let (snapshot_id, _schema_version) = insert_snapshot(&mut tx).await?;
+
+            for entry in deletes {
+                // Target-file fence: abort iff the data file is no longer live (a
+                // concurrent Replace/compaction retired it, invalidating the
+                // resolved positions).
+                let target_live: Option<i64> = sqlx::query_scalar(
+                    "SELECT 1 FROM ducklake_data_file
+                     WHERE data_file_id = ? AND end_snapshot IS NULL",
+                )
+                .bind(entry.data_file_id)
+                .fetch_optional(&mut *tx)
+                .await?;
+                if target_live.is_none() {
+                    return Err(crate::DuckLakeError::Conflict(format!(
+                        "delete targets data file {}, which was retired by a concurrent write \
+                         since snapshot {base_snapshot}; retry against the new generation",
+                        entry.data_file_id
+                    )));
+                }
+
+                // Compare-and-swap on the currently-live delete file for this data
+                // file; a concurrent delete on the same file makes it differ.
+                let current_prev: Option<i64> = sqlx::query_scalar(
+                    "SELECT delete_file_id FROM ducklake_delete_file
+                     WHERE data_file_id = ? AND end_snapshot IS NULL",
+                )
+                .bind(entry.data_file_id)
+                .fetch_optional(&mut *tx)
+                .await?;
+                if current_prev != entry.expected_prev_delete_file {
+                    return Err(crate::DuckLakeError::Conflict(format!(
+                        "delete on data file {} conflicts with a concurrent delete (expected live \
+                         delete file {:?}, found {current_prev:?}); retry against the new generation",
+                        entry.data_file_id, entry.expected_prev_delete_file
+                    )));
+                }
+
+                // Retire the prior delete file (cumulative: the new file carries
+                // all still-deleted positions, so the old one is superseded).
+                if let Some(prev) = entry.expected_prev_delete_file {
+                    sqlx::query(
+                        "UPDATE ducklake_delete_file SET end_snapshot = ?
+                         WHERE delete_file_id = ? AND end_snapshot IS NULL",
+                    )
+                    .bind(snapshot_id)
+                    .bind(prev)
+                    .execute(&mut *tx)
+                    .await?;
+                }
+
+                sqlx::query(
+                    "INSERT INTO ducklake_delete_file
+                         (data_file_id, table_id, path, path_is_relative, file_size_bytes,
+                          footer_size, delete_count, begin_snapshot)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                )
+                .bind(entry.data_file_id)
+                .bind(table_id)
+                .bind(&entry.delete.path)
+                .bind(entry.delete.path_is_relative)
+                .bind(entry.delete.file_size_bytes)
+                .bind(entry.delete.footer_size)
+                .bind(entry.delete.delete_count)
+                .bind(snapshot_id)
+                .execute(&mut *tx)
+                .await?;
+            }
+
+            let schema_id: i64 =
+                sqlx::query_scalar("SELECT schema_id FROM ducklake_table WHERE table_id = ?")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
+
+            tx.commit().await?;
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
+        })
+    }
+
+    fn commit_truncate(
+        &self,
+        table_id: i64,
+        // SQLite created the schema/table at begin; names unused (trait parity).
+        _schema_name: &str,
+        _table_name: &str,
+        _base_snapshot: i64,
+    ) -> Result<u64> {
+        block_on(async {
+            // Metadata-only truncate in one snapshot: end every live data file and
+            // its live delete file (as drop_table does) and zero the visible stat
+            // totals; next_row_id is preserved (rowids stay monotonic).
+            let mut tx = self.pool.begin().await?;
+
+            // Write-lock-first (carry schema_version forward — not DDL).
+            let (snapshot_id, _schema_version) = insert_snapshot(&mut tx).await?;
+
+            // Rows removed = gross record_count minus still-live delete counts,
+            // computed BEFORE ending anything so it matches what we retire.
+            let gross: Option<i64> = sqlx::query_scalar(
+                "SELECT COALESCE(record_count, 0) FROM ducklake_table_stats WHERE table_id = ?",
+            )
+            .bind(table_id)
+            .fetch_optional(&mut *tx)
+            .await?;
+            let deleted: i64 = sqlx::query_scalar(
+                "SELECT COALESCE(SUM(delete_count), 0) FROM ducklake_delete_file
+                 WHERE table_id = ? AND end_snapshot IS NULL",
+            )
+            .bind(table_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            let live_rows = (gross.unwrap_or(0) - deleted).max(0) as u64;
+
+            sqlx::query(
+                "UPDATE ducklake_data_file SET end_snapshot = ?
+                 WHERE table_id = ? AND end_snapshot IS NULL",
+            )
+            .bind(snapshot_id)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            sqlx::query(
+                "UPDATE ducklake_delete_file SET end_snapshot = ?
+                 WHERE table_id = ? AND end_snapshot IS NULL",
+            )
+            .bind(snapshot_id)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            sqlx::query(
+                "UPDATE ducklake_table_stats SET record_count = 0, file_size_bytes = 0
+                 WHERE table_id = ?",
+            )
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+
+            tx.commit().await?;
+            Ok(live_rows)
+        })
+    }
+
     fn publish_snapshot(
         &self,
         table_id: i64,

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -1708,8 +1708,12 @@ impl MetadataWriter for SqliteMetadataWriter {
                 .await?;
                 if target_live.is_none() {
                     return Err(crate::DuckLakeError::Conflict(format!(
-                        "delete targets data file {}, which was retired by a concurrent write \
-                         since snapshot {base_snapshot}; retry against the new generation",
+                        "DELETE on data file {} could not commit: the file is no longer live as \
+                         of the catalog's current head (retired since snapshot {base_snapshot}). \
+                         This happens when another writer committed a Replace/compaction, OR when \
+                         an earlier write in THIS session already advanced the catalog (the \
+                         catalog pins its snapshot at creation and does not refresh). Re-open the \
+                         catalog at the latest snapshot and retry.",
                         entry.data_file_id
                     )));
                 }
@@ -1725,8 +1729,11 @@ impl MetadataWriter for SqliteMetadataWriter {
                 .await?;
                 if current_prev != entry.expected_prev_delete_file {
                     return Err(crate::DuckLakeError::Conflict(format!(
-                        "delete on data file {} conflicts with a concurrent delete (expected live \
-                         delete file {:?}, found {current_prev:?}); retry against the new generation",
+                        "DELETE on data file {} could not commit: its live delete file changed \
+                         from {:?} to {current_prev:?} since snapshot {base_snapshot}. Another \
+                         writer committed a delete on this file, OR an earlier DELETE in THIS \
+                         session did (the catalog pins its snapshot at creation and does not \
+                         refresh). Re-open the catalog at the latest snapshot and retry.",
                         entry.data_file_id, entry.expected_prev_delete_file
                     )));
                 }
@@ -1793,6 +1800,23 @@ impl MetadataWriter for SqliteMetadataWriter {
 
             // Write-lock-first (carry schema_version forward — not DDL).
             let (snapshot_id, _schema_version) = insert_snapshot(&mut tx).await?;
+
+            // No-op guard: if the table has no live data file there is nothing to
+            // truncate. Return Ok(0) WITHOUT committing so `tx` (and the snapshot
+            // row insert_snapshot just made) rolls back, leaving no trace — same
+            // as `drop_table`'s idempotent early return. Prevents a content-free
+            // snapshot per repeated `DELETE FROM t` when the catalog's pinned
+            // snapshot still sees already-ended files as live.
+            let has_live_data: Option<i64> = sqlx::query_scalar(
+                "SELECT 1 FROM ducklake_data_file
+                 WHERE table_id = ? AND end_snapshot IS NULL LIMIT 1",
+            )
+            .bind(table_id)
+            .fetch_optional(&mut *tx)
+            .await?;
+            if has_live_data.is_none() {
+                return Ok(0);
+            }
 
             // Rows removed = gross record_count minus still-live delete counts,
             // computed BEFORE ending anything so it matches what we retire.

--- a/src/table.rs
+++ b/src/table.rs
@@ -1355,6 +1355,11 @@ impl TableProvider for DuckLakeTable {
     /// truncate for delete-all) and yields a single `count: UInt64` row. All
     /// mutation happens at execute time, so planning (e.g. `EXPLAIN`) is
     /// side-effect free.
+    ///
+    /// The catalog pins its snapshot at creation, so a session sees one
+    /// generation for its lifetime: re-open the catalog between mutating
+    /// statements. See the [`delete_exec`](crate::delete_exec) module docs
+    /// ("Session lifecycle") for why a second in-session `DELETE` can conflict.
     #[cfg(feature = "write")]
     async fn delete_from(
         &self,

--- a/src/table.rs
+++ b/src/table.rs
@@ -20,6 +20,8 @@ use crate::types::{
 };
 
 #[cfg(feature = "write")]
+use crate::delete_exec::DuckLakeDeleteExec;
+#[cfg(feature = "write")]
 use crate::insert_exec::DuckLakeInsertExec;
 #[cfg(feature = "write")]
 use crate::metadata_writer::{MetadataWriter, WriteMode};
@@ -55,6 +57,21 @@ use datafusion::execution::parquet_encryption::EncryptionFactory;
 pub const DELETE_FILE_PATH_COL: &str = "file_path";
 pub const DELETE_POS_COL: &str = "pos";
 
+/// Parquet field-id DuckLake's own `ducklake` extension assigns to a positional
+/// delete file's `file_path` column (its `FILENAME` virtual column). We stamp it
+/// on the delete files we WRITE so DuckDB can read our deletes back. This is the
+/// DuckDB id (`i32::MAX - 1`), NOT Iceberg's positional-delete id `2147483546`.
+pub const DELETE_FILE_PATH_FIELD_ID: i32 = 2_147_483_646;
+/// Parquet field-id DuckLake assigns to a positional delete file's `pos` column
+/// (its `FILE_ROW_NUMBER`/ordinal virtual column) — the DuckDB id (`i32::MAX -
+/// 2`), NOT Iceberg's `2147483545`. See [`DELETE_FILE_PATH_FIELD_ID`].
+pub const DELETE_POS_FIELD_ID: i32 = 2_147_483_645;
+
+/// Build a `PARQUET:field_id` field-metadata map for the given reserved id.
+fn parquet_field_id_metadata(field_id: i32) -> HashMap<String, String> {
+    HashMap::from([("PARQUET:field_id".to_string(), field_id.to_string())])
+}
+
 /// Validate and convert file_size_bytes from i64 (as stored in DuckLake metadata) to u64.
 ///
 /// DuckLake stores file sizes as signed integers in SQL. A negative value indicates
@@ -85,13 +102,19 @@ pub(crate) fn validated_record_count(record_count: i64, file_path: &str) -> Data
 
 /// Returns the expected schema for DuckLake delete files
 ///
-/// Delete files have a standard schema: (file_path: VARCHAR, pos: INT64)
-/// The file_path column is metadata/documentation only (for Iceberg compatibility).
-/// The pos column contains the row positions to delete.
+/// Delete files have a standard schema: (file_path: VARCHAR, pos: INT64).
+/// The file_path column records which data file the positions belong to (only
+/// `pos` is consumed on read; the catalog already maps delete->data file). Both
+/// fields carry DuckLake's reserved parquet field-ids
+/// ([`DELETE_FILE_PATH_FIELD_ID`], [`DELETE_POS_FIELD_ID`]) so that delete files
+/// WE write are readable by DuckDB's `ducklake` extension. Reads match by column
+/// name, so the ids are inert on the read path (files without them still read).
 pub fn delete_file_schema() -> SchemaRef {
     Arc::new(Schema::new(vec![
-        Field::new(DELETE_FILE_PATH_COL, DataType::Utf8, false),
-        Field::new(DELETE_POS_COL, DataType::Int64, false),
+        Field::new(DELETE_FILE_PATH_COL, DataType::Utf8, false)
+            .with_metadata(parquet_field_id_metadata(DELETE_FILE_PATH_FIELD_ID)),
+        Field::new(DELETE_POS_COL, DataType::Int64, false)
+            .with_metadata(parquet_field_id_metadata(DELETE_POS_FIELD_ID)),
     ]))
 }
 
@@ -134,12 +157,23 @@ struct FileReadConfig {
 ///
 /// Represents a table within a DuckLake schema and provides access to data via Parquet files.
 /// Caches snapshot_id and uses it to load all metadata atomically.
+///
+/// `Clone` shares the `file_read_config_cache` (it is `Arc`-wrapped): a clone is
+/// a cheap handle over the same cached parquet metadata. `delete_from` clones the
+/// table into the returned `DuckLakeDeleteExec` so the delete work runs at
+/// `execute` time (never at plan/EXPLAIN time).
+#[derive(Clone)]
 pub struct DuckLakeTable {
     #[allow(dead_code)]
     table_id: i64,
     table_name: String,
     #[allow(dead_code)]
     provider: Arc<dyn MetadataProvider>,
+    /// Snapshot this table was opened at. Threaded to the delete-commit path as
+    /// the `base_snapshot` (the generation the resolved positions were read
+    /// against) for conflict diagnostics.
+    #[cfg_attr(not(feature = "write"), allow(dead_code))]
+    snapshot_id: i64,
     /// Object store URL for resolving file paths (e.g., s3://bucket/ or file:///)
     object_store_url: Arc<ObjectStoreUrl>,
     /// Table path for resolving relative file paths
@@ -159,8 +193,9 @@ pub struct DuckLakeTable {
     /// Per-file row-lineage read config, populated lazily on the rowid scan
     /// path. Each file requires its own parquet metadata read to detect an
     /// embedded `_ducklake_internal_row_id` column; we memoize so repeated
-    /// scans don't re-fetch.
-    file_read_config_cache: std::sync::Mutex<HashMap<String, Arc<FileReadConfig>>>,
+    /// scans don't re-fetch. `Arc`-wrapped so a cloned table (see `delete_from`)
+    /// shares the same memoized configs.
+    file_read_config_cache: Arc<std::sync::Mutex<HashMap<String, Arc<FileReadConfig>>>>,
     /// Encryption factory for decrypting encrypted Parquet files (when encryption feature is enabled)
     #[cfg(feature = "encryption")]
     encryption_factory: Option<Arc<dyn EncryptionFactory>>,
@@ -233,6 +268,7 @@ impl DuckLakeTable {
             table_id,
             table_name: table_name.into(),
             provider,
+            snapshot_id,
             object_store_url,
             table_path,
             schema,
@@ -242,7 +278,7 @@ impl DuckLakeTable {
             table_files,
             #[cfg(feature = "encryption")]
             encryption_factory,
-            file_read_config_cache: std::sync::Mutex::new(HashMap::new()),
+            file_read_config_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
             #[cfg(feature = "write")]
             schema_name: None,
             #[cfg(feature = "write")]
@@ -515,6 +551,26 @@ impl DuckLakeTable {
         }
 
         Ok(positions)
+    }
+
+    /// Whether `file` embeds a `_ducklake_internal_row_id` column (tagged with
+    /// [`ROW_ID_PARQUET_FIELD_ID`]) — i.e. it was rewritten by an UPDATE or
+    /// compaction rather than being insert-only.
+    ///
+    /// [`Self::resolve_positions`] derives delete positions from the physical row
+    /// index, which is only the DuckLake `pos` for insert-only files; a rewritten
+    /// file's surviving rows carry embedded rowids whose physical order need not
+    /// match, so the delete path must refuse such files rather than mis-delete.
+    /// Memoized through the shared `file_read_config_cache`, so calling this right
+    /// before `resolve_positions` costs at most one extra footer read per file.
+    #[cfg(feature = "write")]
+    pub(crate) async fn file_has_embedded_rowid(
+        &self,
+        state: &dyn Session,
+        file: &DuckLakeFileData,
+    ) -> DataFusionResult<bool> {
+        let cfg = self.build_file_read_config(state, file).await?;
+        Ok(cfg.embedded_rowid_parquet_name.is_some())
     }
 
     /// Build a single execution plan for all files without delete files
@@ -1284,6 +1340,82 @@ impl TableProvider for DuckLakeTable {
             self.table_name.clone(),
             self.schema(),
             write_mode,
+            self.object_store_url.clone(),
+        )))
+    }
+
+    /// Plan a `DELETE FROM <table> [WHERE ...]`.
+    ///
+    /// `filters` are the already-analyzed, unqualified, AND-conjunctive
+    /// predicates over this table's own columns (DataFusion strips qualifiers and
+    /// dedups them). An empty `filters` means no `WHERE` => delete ALL rows.
+    ///
+    /// Returns a [`DuckLakeDeleteExec`] that performs the delete when executed
+    /// (positional-delete files + one atomic metadata commit, or a metadata-only
+    /// truncate for delete-all) and yields a single `count: UInt64` row. All
+    /// mutation happens at execute time, so planning (e.g. `EXPLAIN`) is
+    /// side-effect free.
+    #[cfg(feature = "write")]
+    async fn delete_from(
+        &self,
+        state: &dyn Session,
+        filters: Vec<Expr>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        use datafusion::logical_expr::utils::conjunction;
+
+        let writer = self.writer.as_ref().ok_or_else(|| {
+            DataFusionError::Plan(
+                "Table is read-only. Use DuckLakeCatalog::with_writer() to enable writes."
+                    .to_string(),
+            )
+        })?;
+        let schema_name = self.schema_name.as_ref().ok_or_else(|| {
+            DataFusionError::Internal("Schema name not set for writable table".to_string())
+        })?;
+
+        // Build the physical predicate. Empty `filters` (no WHERE) => delete ALL,
+        // signalled by `None` and handled as a metadata-only truncate. We resolve
+        // column references against the PHYSICAL schema (no synthetic `rowid`):
+        // `resolve_positions` evaluates the predicate index-based against the
+        // physically-read columns in logical order, so the physical expression's
+        // column indices must line up with `physical_schema`. A predicate that
+        // references a column absent from `physical_schema` (e.g. the synthetic
+        // `rowid`) fails here rather than mis-deleting.
+        let predicate = match conjunction(filters) {
+            None => None,
+            Some(expr) => {
+                let df_schema =
+                    datafusion::common::DFSchema::try_from(self.physical_schema.as_ref().clone())?;
+                Some(state.create_physical_expr(expr, &df_schema)?)
+            },
+        };
+
+        // The delete work (positional reads, delete-file writes, atomic commit)
+        // MUST run at execute time — planning a DELETE (e.g. `EXPLAIN`) must not
+        // mutate. `DuckLakeDeleteExec` captures the concrete `SessionState` to
+        // drive the positional reads at execute time (a bare `TaskContext` cannot
+        // build physical exprs / sub-plans), plus a clone of this table for its
+        // reader methods.
+        let session_state = state
+            .as_any()
+            .downcast_ref::<datafusion::execution::SessionState>()
+            .ok_or_else(|| {
+                DataFusionError::NotImplemented(
+                    "DELETE on a DuckLake table requires a DataFusion SessionState session"
+                        .to_string(),
+                )
+            })?
+            .clone();
+
+        Ok(Arc::new(DuckLakeDeleteExec::new(
+            Arc::new(self.clone()),
+            session_state,
+            predicate,
+            Arc::clone(writer),
+            schema_name.clone(),
+            self.table_name.clone(),
+            self.table_id,
+            self.snapshot_id,
             self.object_store_url.clone(),
         )))
     }

--- a/tests/sql_delete_postgres_tests.rs
+++ b/tests/sql_delete_postgres_tests.rs
@@ -52,7 +52,11 @@ fn schema() -> Arc<Schema> {
     ]))
 }
 
-async fn writer_for(pool: &PgPool, cat: i64, data_path: &std::path::Path) -> Arc<PostgresMetadataWriter> {
+async fn writer_for(
+    pool: &PgPool,
+    cat: i64,
+    data_path: &std::path::Path,
+) -> Arc<PostgresMetadataWriter> {
     let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
         .await
         .unwrap();
@@ -68,7 +72,9 @@ async fn read_pairs(pool: &PgPool, cat_name: &str) -> Vec<(i32, i32)> {
     let ctx = SessionContext::new();
     ctx.register_catalog(cat_name, Arc::new(catalog));
     let batches = ctx
-        .sql(&format!("SELECT id, val FROM {cat_name}.public.t ORDER BY id"))
+        .sql(&format!(
+            "SELECT id, val FROM {cat_name}.public.t ORDER BY id"
+        ))
         .await
         .unwrap()
         .collect()
@@ -234,8 +240,15 @@ async fn positional_delete_and_truncate_commit_postgres() {
     let removed = writer
         .commit_truncate(table_meta.table_id, "public", "t", head2)
         .unwrap();
-    assert_eq!(removed, 2, "gross 4 minus 2 already-deleted = 2 live rows removed");
-    assert_eq!(read_pairs(&pool, cat_name).await, Vec::<(i32, i32)>::new(), "table empty");
+    assert_eq!(
+        removed, 2,
+        "gross 4 minus 2 already-deleted = 2 live rows removed"
+    );
+    assert_eq!(
+        read_pairs(&pool, cat_name).await,
+        Vec::<(i32, i32)>::new(),
+        "table empty"
+    );
     let snaps_after_truncate = catalog_snapshot_count(&pool, cat).await;
 
     // --- no-op guard: a second truncate must NOT commit a snapshot. ---

--- a/tests/sql_delete_postgres_tests.rs
+++ b/tests/sql_delete_postgres_tests.rs
@@ -1,0 +1,251 @@
+//! Postgres coverage for the SQL-`DELETE` commit primitives added in the
+//! `delete_from` PR: [`MetadataWriter::commit_positional_deletes`] and
+//! [`MetadataWriter::commit_truncate`]. The multicatalog Postgres write path is a
+//! separate implementation from SQLite (catalog-scoped head, `NOW()`,
+//! `schema_version` carry-forward, `::BIGINT` casts, `lock_catalog` /
+//! `advance_catalog_head`), so those ~220 lines of Postgres-specific SQL are
+//! re-validated here end to end rather than trusted from the SQLite tests.
+//!
+//! Driven at the `MetadataWriter` level (the same way
+//! `append_with_deletes_postgres_tests.rs` drives `register_data_file_with_deletes`)
+//! so the test targets the new SQL directly. Docker-gated (testcontainers).
+
+#![cfg(feature = "write-postgres")]
+
+use std::sync::Arc;
+
+use arrow::array::{Array, Int32Array, RecordBatch};
+use arrow::datatypes::{DataType, Field, Schema};
+use datafusion::logical_expr::Operator;
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_expr::expressions::{BinaryExpr, col, lit};
+use datafusion::prelude::*;
+use datafusion_ducklake::{
+    DeleteFileEntry, DuckLakeCatalog, DuckLakeTable, DuckLakeTableWriter, MetadataProvider,
+    MetadataWriter, MulticatalogManager, MulticatalogProvider, PostgresMetadataWriter,
+};
+use object_store::local::LocalFileSystem;
+use sqlx::postgres::{PgPool, PgPoolOptions};
+use tempfile::TempDir;
+use testcontainers::ContainerAsync;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+type ObjStore = Arc<dyn object_store::ObjectStore>;
+
+async fn spin_up_postgres() -> anyhow::Result<(PgPool, ContainerAsync<Postgres>)> {
+    let container = Postgres::default().start().await?;
+    let port = container.get_host_port_ipv4(5432).await?;
+    let conn_str = format!("postgresql://postgres:postgres@127.0.0.1:{}/postgres", port);
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&conn_str)
+        .await?;
+    datafusion_ducklake::initialize_multicatalog_schema(&pool).await?;
+    Ok((pool, container))
+}
+
+fn schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("val", DataType::Int32, false),
+    ]))
+}
+
+async fn writer_for(pool: &PgPool, cat: i64, data_path: &std::path::Path) -> Arc<PostgresMetadataWriter> {
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path(data_path.to_str().unwrap()).unwrap();
+    Arc::new(w)
+}
+
+async fn read_pairs(pool: &PgPool, cat_name: &str) -> Vec<(i32, i32)> {
+    let provider = MulticatalogProvider::with_pool(pool.clone(), cat_name)
+        .await
+        .unwrap();
+    let catalog = DuckLakeCatalog::new(provider).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog(cat_name, Arc::new(catalog));
+    let batches = ctx
+        .sql(&format!("SELECT id, val FROM {cat_name}.public.t ORDER BY id"))
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let mut rows = Vec::new();
+    for b in &batches {
+        let ids = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        let vals = b.column(1).as_any().downcast_ref::<Int32Array>().unwrap();
+        for i in 0..b.num_rows() {
+            rows.push((ids.value(i), vals.value(i)));
+        }
+    }
+    rows
+}
+
+/// Number of snapshots mapped to this catalog (advance_catalog_head inserts one
+/// row per committed snapshot; the no-op truncate guard must insert none).
+async fn catalog_snapshot_count(pool: &PgPool, cat: i64) -> i64 {
+    sqlx::query_scalar("SELECT COUNT(*) FROM ducklake_catalog_snapshot_map WHERE catalog_id = $1")
+        .bind(cat)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+/// Drives the two new commit primitives directly on the Postgres writer:
+/// (1) `commit_positional_deletes` for a WHERE delete, asserting the read
+/// reflects it and it lands as exactly one catalog snapshot; (2) `commit_truncate`
+/// removing the survivors with a correct rows-affected count; (3) a repeated
+/// `commit_truncate` proving the no-op guard commits no spurious snapshot.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn positional_delete_and_truncate_commit_postgres() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let tmp = TempDir::new().unwrap();
+    let data = tmp.path().join("data");
+    std::fs::create_dir_all(&data).unwrap();
+    let os: ObjStore = Arc::new(LocalFileSystem::new());
+    let cat_name = "cat";
+    let cat = MulticatalogManager::new(pool.clone())
+        .create_catalog(cat_name)
+        .await
+        .unwrap();
+    let sch = schema();
+
+    // Seed (1,10),(2,20),(3,30),(4,40) as one data file.
+    let seed = RecordBatch::try_new(
+        sch.clone(),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3, 4])),
+            Arc::new(Int32Array::from(vec![10, 20, 30, 40])),
+        ],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(writer_for(&pool, cat, &data).await, os.clone())
+        .unwrap()
+        .write_table("public", "t", &[seed])
+        .await
+        .unwrap();
+    assert_eq!(
+        read_pairs(&pool, cat_name).await,
+        vec![(1, 10), (2, 20), (3, 30), (4, 40)],
+        "baseline"
+    );
+
+    // Catalog-scoped metadata: head, table, the single live data file.
+    let meta = MulticatalogProvider::with_pool(pool.clone(), cat_name)
+        .await
+        .unwrap();
+    let head = meta.get_current_snapshot().unwrap();
+    let schema_meta = meta.get_schema_by_name("public", head).unwrap().unwrap();
+    let table_meta = meta
+        .get_table_by_name(schema_meta.schema_id, "t", head)
+        .unwrap()
+        .unwrap();
+    let files = meta
+        .get_table_files_for_select(table_meta.table_id, head)
+        .unwrap();
+    assert_eq!(files.len(), 1, "one seed data file");
+    let tf = files[0].clone();
+
+    // Resolve physical positions of ids {2,4} (positions 1,3) on the seed file.
+    let read = MulticatalogProvider::with_pool(pool.clone(), cat_name)
+        .await
+        .unwrap();
+    let catalog = DuckLakeCatalog::new(read).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog(cat_name, Arc::new(catalog));
+    let table_provider = ctx
+        .catalog(cat_name)
+        .unwrap()
+        .schema("public")
+        .unwrap()
+        .table("t")
+        .await
+        .unwrap()
+        .unwrap();
+    let table = (table_provider.as_ref() as &dyn std::any::Any)
+        .downcast_ref::<DuckLakeTable>()
+        .expect("provider is a DuckLakeTable");
+    let data_schema = schema();
+    let id: Arc<dyn PhysicalExpr> = col("id", data_schema.as_ref()).unwrap();
+    let eq2: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(id.clone(), Operator::Eq, lit(2i32)));
+    let eq4: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(id, Operator::Eq, lit(4i32)));
+    let predicate: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(eq2, Operator::Or, eq4));
+    let state = ctx.state();
+    let mut positions: Vec<i64> = table
+        .resolve_positions(&state, &tf.file, predicate)
+        .await
+        .unwrap()
+        .into_iter()
+        .collect();
+    positions.sort_unstable();
+    assert_eq!(positions, vec![1, 3], "ids 2,4 sit at positions 1,3");
+
+    // --- commit_positional_deletes: a WHERE delete, no appended data file. ---
+    let snaps_before_delete = catalog_snapshot_count(&pool, cat).await;
+    let writer = writer_for(&pool, cat, &data).await;
+    let del_info = DuckLakeTableWriter::new(writer.clone(), os.clone())
+        .unwrap()
+        .write_delete_file("public", "t", &tf.file.path, &positions)
+        .await
+        .unwrap();
+    let entries = vec![DeleteFileEntry {
+        data_file_id: tf.data_file_id,
+        expected_prev_delete_file: tf.delete_file_id,
+        delete: del_info,
+    }];
+    let commit = writer
+        .commit_positional_deletes(table_meta.table_id, "public", "t", head, &entries)
+        .unwrap();
+
+    assert_eq!(
+        read_pairs(&pool, cat_name).await,
+        vec![(1, 10), (3, 30)],
+        "ids 2,4 deleted; 1,3 survive"
+    );
+    assert_eq!(
+        catalog_snapshot_count(&pool, cat).await,
+        snaps_before_delete + 1,
+        "positional delete commits exactly one catalog snapshot"
+    );
+    let delete_snap: i64 = sqlx::query_scalar(
+        "SELECT begin_snapshot FROM ducklake_delete_file
+         WHERE data_file_id = $1 AND end_snapshot IS NULL",
+    )
+    .bind(tf.data_file_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        delete_snap, commit.snapshot_id,
+        "delete file's begin_snapshot is the committed head"
+    );
+
+    // --- commit_truncate: remove the two survivors. ---
+    let head2 = MulticatalogProvider::with_pool(pool.clone(), cat_name)
+        .await
+        .unwrap()
+        .get_current_snapshot()
+        .unwrap();
+    let removed = writer
+        .commit_truncate(table_meta.table_id, "public", "t", head2)
+        .unwrap();
+    assert_eq!(removed, 2, "gross 4 minus 2 already-deleted = 2 live rows removed");
+    assert_eq!(read_pairs(&pool, cat_name).await, Vec::<(i32, i32)>::new(), "table empty");
+    let snaps_after_truncate = catalog_snapshot_count(&pool, cat).await;
+
+    // --- no-op guard: a second truncate must NOT commit a snapshot. ---
+    let removed_again = writer
+        .commit_truncate(table_meta.table_id, "public", "t", head2)
+        .unwrap();
+    assert_eq!(removed_again, 0, "nothing left to truncate");
+    assert_eq!(
+        catalog_snapshot_count(&pool, cat).await,
+        snaps_after_truncate,
+        "a no-op truncate must not create a snapshot"
+    );
+}

--- a/tests/sql_delete_tests.rs
+++ b/tests/sql_delete_tests.rs
@@ -1,0 +1,310 @@
+//! Integration tests for SQL `DELETE FROM t [WHERE ...]` on DuckLake tables
+//! (`TableProvider::delete_from` -> `DuckLakeDeleteExec`).
+//!
+//! Correctness is the point: a positional-delete bug silently deletes the wrong
+//! rows, so every test asserts the SURVIVING ids after a fresh read (the read
+//! path applies the committed delete files) plus the reported rows-affected
+//! count. Run against the SQLite backend, the one the crate can exercise without
+//! a container.
+
+#![cfg(all(feature = "write-sqlite", feature = "metadata-sqlite"))]
+
+use std::sync::Arc;
+
+use arrow::array::{Array, Int32Array, UInt64Array};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use datafusion::prelude::*;
+use object_store::local::LocalFileSystem;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use tempfile::TempDir;
+
+use datafusion_ducklake::types::extract_parquet_field_ids;
+use datafusion_ducklake::{
+    DuckLakeCatalog, DuckLakeTableWriter, MetadataWriter, SqliteMetadataProvider,
+    SqliteMetadataWriter,
+};
+use sqlx::sqlite::SqlitePool;
+
+fn object_store() -> Arc<dyn object_store::ObjectStore> {
+    Arc::new(LocalFileSystem::new())
+}
+
+fn id_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]))
+}
+
+fn id_batch(ids: &[i32]) -> RecordBatch {
+    RecordBatch::try_new(id_schema(), vec![Arc::new(Int32Array::from(ids.to_vec()))]).unwrap()
+}
+
+/// A freshly-initialized, writable SQLite catalog + data dir in a temp dir.
+async fn new_writer(temp: &TempDir) -> SqliteMetadataWriter {
+    let db_path = temp.path().join("test.db");
+    let data_path = temp.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+    let conn = format!("sqlite:{}?mode=rwc", db_path.display());
+    let writer = SqliteMetadataWriter::new_with_init(&conn).await.unwrap();
+    writer.set_data_path(data_path.to_str().unwrap()).unwrap();
+    writer
+}
+
+/// A writable `SessionContext` bound to the catalog's CURRENT snapshot. Create
+/// this AFTER seeding data so the table provider sees the seeded files, and
+/// create a fresh one after each committing statement to observe the new head.
+async fn writable_ctx(temp: &TempDir) -> SessionContext {
+    let conn = format!("sqlite:{}?mode=rwc", temp.path().join("test.db").display());
+    let writer = SqliteMetadataWriter::new(&conn).await.unwrap();
+    let provider = SqliteMetadataProvider::new(&conn).await.unwrap();
+    let catalog = DuckLakeCatalog::with_writer(Arc::new(provider), Arc::new(writer)).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog("ducklake", Arc::new(catalog));
+    ctx
+}
+
+/// Read `id`s from `ducklake.main.t`, ascending, through the full read path
+/// (which applies any live delete file), using a fresh read-only context.
+async fn read_ids(temp: &TempDir) -> Vec<i32> {
+    let conn = format!("sqlite:{}", temp.path().join("test.db").display());
+    let provider = SqliteMetadataProvider::new(&conn).await.unwrap();
+    let catalog = DuckLakeCatalog::new(provider).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog("ducklake", Arc::new(catalog));
+    let batches = ctx
+        .sql("SELECT id FROM ducklake.main.t ORDER BY id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let mut ids = Vec::new();
+    for b in &batches {
+        let col = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        for i in 0..b.num_rows() {
+            ids.push(col.value(i));
+        }
+    }
+    ids
+}
+
+/// Number of snapshots in the catalog (to assert a multi-file DELETE commits in
+/// exactly ONE new snapshot).
+async fn snapshot_count(temp: &TempDir) -> i64 {
+    let conn = format!("sqlite:{}", temp.path().join("test.db").display());
+    let pool = SqlitePool::connect(&conn).await.unwrap();
+    sqlx::query_scalar("SELECT COUNT(*) FROM ducklake_snapshot")
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+}
+
+/// Run a DELETE statement and return the reported rows-affected count.
+async fn run_delete(ctx: &SessionContext, sql: &str) -> u64 {
+    let batches = ctx.sql(sql).await.unwrap().collect().await.unwrap();
+    assert_eq!(batches.len(), 1, "DELETE returns a single count batch");
+    assert_eq!(batches[0].num_rows(), 1, "count batch has one row");
+    batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .expect("count column is UInt64")
+        .value(0)
+}
+
+/// Single data file: `DELETE ... WHERE id = N` removes exactly that row.
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_single_file_predicate() {
+    let temp = TempDir::new().unwrap();
+    let writer = Arc::new(new_writer(&temp).await);
+    DuckLakeTableWriter::new(writer, object_store())
+        .unwrap()
+        .write_table("main", "t", &[id_batch(&[1, 2, 3, 4])])
+        .await
+        .unwrap();
+    assert_eq!(read_ids(&temp).await, vec![1, 2, 3, 4], "baseline");
+
+    let ctx = writable_ctx(&temp).await;
+    let count = run_delete(&ctx, "DELETE FROM ducklake.main.t WHERE id = 2").await;
+    assert_eq!(count, 1, "one row deleted");
+    assert_eq!(read_ids(&temp).await, vec![1, 3, 4], "id 2 gone");
+}
+
+/// Rows spread across TWO data files; a predicate hitting both must delete from
+/// both and commit in exactly ONE new snapshot (atomic multi-file DELETE).
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_multi_file_atomic() {
+    let temp = TempDir::new().unwrap();
+    let writer = Arc::new(new_writer(&temp).await);
+    let tw = DuckLakeTableWriter::new(writer, object_store()).unwrap();
+    // File 1: ids [1,2,3]; File 2 (append): ids [4,5,6].
+    tw.write_table("main", "t", &[id_batch(&[1, 2, 3])])
+        .await
+        .unwrap();
+    tw.append_table("main", "t", &[id_batch(&[4, 5, 6])])
+        .await
+        .unwrap();
+    assert_eq!(read_ids(&temp).await, vec![1, 2, 3, 4, 5, 6], "baseline");
+
+    let before = snapshot_count(&temp).await;
+    let ctx = writable_ctx(&temp).await;
+    // id 2 lives in file 1; ids 4 and 6 live in file 2.
+    let count = run_delete(
+        &ctx,
+        "DELETE FROM ducklake.main.t WHERE id = 2 OR id = 4 OR id = 6",
+    )
+    .await;
+    assert_eq!(count, 3, "three rows deleted across two files");
+
+    let after = snapshot_count(&temp).await;
+    assert_eq!(
+        after,
+        before + 1,
+        "multi-file DELETE must commit in exactly one new snapshot"
+    );
+    assert_eq!(
+        read_ids(&temp).await,
+        vec![1, 3, 5],
+        "survivors across files"
+    );
+}
+
+/// `DELETE FROM t` with no WHERE removes ALL rows (metadata-only truncate).
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_all_rows_no_where() {
+    let temp = TempDir::new().unwrap();
+    let writer = Arc::new(new_writer(&temp).await);
+    DuckLakeTableWriter::new(writer, object_store())
+        .unwrap()
+        .write_table("main", "t", &[id_batch(&[1, 2, 3, 4])])
+        .await
+        .unwrap();
+
+    let ctx = writable_ctx(&temp).await;
+    let count = run_delete(&ctx, "DELETE FROM ducklake.main.t").await;
+    assert_eq!(count, 4, "all four rows deleted");
+    assert_eq!(read_ids(&temp).await, Vec::<i32>::new(), "table empty");
+}
+
+/// Two DELETEs against the SAME data file. The second must UNION with the first
+/// (cumulative positions): the row deleted first stays deleted (no
+/// resurrection), and the second row is also removed.
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_after_delete_is_cumulative() {
+    let temp = TempDir::new().unwrap();
+    let writer = Arc::new(new_writer(&temp).await);
+    DuckLakeTableWriter::new(writer, object_store())
+        .unwrap()
+        .write_table("main", "t", &[id_batch(&[1, 2, 3, 4])])
+        .await
+        .unwrap();
+
+    // First delete: id 2 (physical position 1).
+    let ctx1 = writable_ctx(&temp).await;
+    let c1 = run_delete(&ctx1, "DELETE FROM ducklake.main.t WHERE id = 2").await;
+    assert_eq!(c1, 1);
+    assert_eq!(read_ids(&temp).await, vec![1, 3, 4], "after first delete");
+
+    // Second delete (fresh ctx, sees the live delete file): id 4 (position 3).
+    let ctx2 = writable_ctx(&temp).await;
+    let c2 = run_delete(&ctx2, "DELETE FROM ducklake.main.t WHERE id = 4").await;
+    assert_eq!(c2, 1, "only the newly-matched row counts");
+    assert_eq!(
+        read_ids(&temp).await,
+        vec![1, 3],
+        "cumulative: id 2 stayed deleted, id 4 now deleted (no resurrection)"
+    );
+}
+
+/// A predicate that matches only already-deleted rows is a no-op: it deletes
+/// nothing new and does NOT create a snapshot.
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_already_deleted_is_noop() {
+    let temp = TempDir::new().unwrap();
+    let writer = Arc::new(new_writer(&temp).await);
+    DuckLakeTableWriter::new(writer, object_store())
+        .unwrap()
+        .write_table("main", "t", &[id_batch(&[1, 2, 3, 4])])
+        .await
+        .unwrap();
+
+    let ctx1 = writable_ctx(&temp).await;
+    assert_eq!(
+        run_delete(&ctx1, "DELETE FROM ducklake.main.t WHERE id = 2").await,
+        1
+    );
+
+    let snaps = snapshot_count(&temp).await;
+    // Re-delete the same (now already-deleted) row.
+    let ctx2 = writable_ctx(&temp).await;
+    let c = run_delete(&ctx2, "DELETE FROM ducklake.main.t WHERE id = 2").await;
+    assert_eq!(c, 0, "nothing new to delete");
+    assert_eq!(
+        snapshot_count(&temp).await,
+        snaps,
+        "a no-op DELETE creates no snapshot"
+    );
+    assert_eq!(read_ids(&temp).await, vec![1, 3, 4]);
+}
+
+/// A DELETE matching no rows deletes nothing and reports 0.
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_no_match() {
+    let temp = TempDir::new().unwrap();
+    let writer = Arc::new(new_writer(&temp).await);
+    DuckLakeTableWriter::new(writer, object_store())
+        .unwrap()
+        .write_table("main", "t", &[id_batch(&[1, 2, 3])])
+        .await
+        .unwrap();
+
+    let ctx = writable_ctx(&temp).await;
+    let count = run_delete(&ctx, "DELETE FROM ducklake.main.t WHERE id = 999").await;
+    assert_eq!(count, 0);
+    assert_eq!(read_ids(&temp).await, vec![1, 2, 3], "unchanged");
+}
+
+/// Interop: the positional delete parquet we write must carry DuckDB's reserved
+/// field-ids (2147483646 for `file_path`, 2147483645 for `pos`) so DuckDB's own
+/// `ducklake` extension can read our deletes — NOT Iceberg's 2147483546/…545.
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_file_uses_duckdb_field_ids() {
+    let temp = TempDir::new().unwrap();
+    let writer = Arc::new(new_writer(&temp).await);
+    let tw = DuckLakeTableWriter::new(writer, object_store()).unwrap();
+    // Seed the table so the `main/t` data directory exists.
+    tw.write_table("main", "t", &[id_batch(&[1, 2, 3, 4])])
+        .await
+        .unwrap();
+
+    // Author a delete file directly and inspect the parquet we wrote.
+    let info = tw
+        .write_delete_file("main", "t", "data-file.parquet", &[1, 3])
+        .await
+        .unwrap();
+    let del_path = temp
+        .path()
+        .join("data")
+        .join("main")
+        .join("t")
+        .join(&info.path);
+
+    let file = std::fs::File::open(&del_path).expect("delete parquet exists on disk");
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file).unwrap();
+    let field_ids = extract_parquet_field_ids(builder.metadata().as_ref());
+
+    assert_eq!(
+        field_ids.get(&2_147_483_646).map(String::as_str),
+        Some("file_path"),
+        "file_path must use DuckDB's FILENAME field-id 2147483646, got {field_ids:?}"
+    );
+    assert_eq!(
+        field_ids.get(&2_147_483_645).map(String::as_str),
+        Some("pos"),
+        "pos must use DuckDB's ORDINAL field-id 2147483645, got {field_ids:?}"
+    );
+    // Explicitly assert the Iceberg ids are NOT used.
+    assert!(
+        !field_ids.contains_key(&2_147_483_546) && !field_ids.contains_key(&2_147_483_545),
+        "must not use Iceberg positional-delete field-ids: {field_ids:?}"
+    );
+}

--- a/tests/sql_delete_tests.rs
+++ b/tests/sql_delete_tests.rs
@@ -329,7 +329,11 @@ async fn delete_truncate_repeat_same_ctx_no_spurious_snapshot() {
     let c1 = run_delete(&ctx, "DELETE FROM ducklake.main.t").await;
     assert_eq!(c1, 4, "first truncate removes all rows");
     let after_first = snapshot_count(&temp).await;
-    assert_eq!(after_first, before + 1, "first truncate commits exactly one snapshot");
+    assert_eq!(
+        after_first,
+        before + 1,
+        "first truncate commits exactly one snapshot"
+    );
 
     // Second truncate in the SAME (pinned) session: a DB-level no-op.
     let c2 = run_delete(&ctx, "DELETE FROM ducklake.main.t").await;
@@ -339,7 +343,11 @@ async fn delete_truncate_repeat_same_ctx_no_spurious_snapshot() {
         after_first,
         "a no-op truncate must not create a snapshot"
     );
-    assert_eq!(read_ids(&temp).await, Vec::<i32>::new(), "table stays empty");
+    assert_eq!(
+        read_ids(&temp).await,
+        Vec::<i32>::new(),
+        "table stays empty"
+    );
 }
 
 /// A second filtered DELETE in the SAME session that re-touches a file modified by

--- a/tests/sql_delete_tests.rs
+++ b/tests/sql_delete_tests.rs
@@ -308,3 +308,81 @@ async fn delete_file_uses_duckdb_field_ids() {
         "must not use Iceberg positional-delete field-ids: {field_ids:?}"
     );
 }
+
+/// A no-op truncate must NOT create a snapshot. The catalog pins its snapshot, so
+/// a second `DELETE FROM t` in the same session still sees the already-ended files
+/// as live (bypassing the caller's emptiness guard); the DB-level guard in
+/// `commit_truncate` must then decline to allocate a spurious empty snapshot.
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_truncate_repeat_same_ctx_no_spurious_snapshot() {
+    let temp = TempDir::new().unwrap();
+    let writer = Arc::new(new_writer(&temp).await);
+    DuckLakeTableWriter::new(writer, object_store())
+        .unwrap()
+        .write_table("main", "t", &[id_batch(&[1, 2, 3, 4])])
+        .await
+        .unwrap();
+
+    let before = snapshot_count(&temp).await;
+    let ctx = writable_ctx(&temp).await;
+
+    let c1 = run_delete(&ctx, "DELETE FROM ducklake.main.t").await;
+    assert_eq!(c1, 4, "first truncate removes all rows");
+    let after_first = snapshot_count(&temp).await;
+    assert_eq!(after_first, before + 1, "first truncate commits exactly one snapshot");
+
+    // Second truncate in the SAME (pinned) session: a DB-level no-op.
+    let c2 = run_delete(&ctx, "DELETE FROM ducklake.main.t").await;
+    assert_eq!(c2, 0, "nothing left to truncate");
+    assert_eq!(
+        snapshot_count(&temp).await,
+        after_first,
+        "a no-op truncate must not create a snapshot"
+    );
+    assert_eq!(read_ids(&temp).await, Vec::<i32>::new(), "table stays empty");
+}
+
+/// A second filtered DELETE in the SAME session that re-touches a file modified by
+/// the first must abort with a clear conflict (the catalog is pinned to the
+/// pre-delete snapshot) — and, crucially, must NOT resurrect the first delete.
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_second_in_session_conflicts_without_resurrection() {
+    let temp = TempDir::new().unwrap();
+    let writer = Arc::new(new_writer(&temp).await);
+    DuckLakeTableWriter::new(writer, object_store())
+        .unwrap()
+        .write_table("main", "t", &[id_batch(&[1, 2, 3, 4])])
+        .await
+        .unwrap();
+
+    // One session, catalog pinned at the pre-delete snapshot.
+    let ctx = writable_ctx(&temp).await;
+    assert_eq!(
+        run_delete(&ctx, "DELETE FROM ducklake.main.t WHERE id = 2").await,
+        1
+    );
+    assert_eq!(read_ids(&temp).await, vec![1, 3, 4], "id 2 deleted");
+
+    // Second DELETE on the SAME session re-touches the same data file. Its
+    // compare-and-swap disagrees with the now-live delete file, so it aborts.
+    let err = ctx
+        .sql("DELETE FROM ducklake.main.t WHERE id = 4")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .expect_err("second in-session DELETE must conflict, not silently corrupt");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Re-open the catalog") && msg.contains("THIS session"),
+        "conflict message must explain the pinned-snapshot cause, got: {msg}"
+    );
+
+    // The abort must be clean: id 2 stayed deleted, id 4 was NOT deleted, and no
+    // row was resurrected.
+    assert_eq!(
+        read_ids(&temp).await,
+        vec![1, 3, 4],
+        "aborted DELETE must not resurrect id 2 nor delete id 4"
+    );
+}


### PR DESCRIPTION
## Summary
Adds SQL `DELETE FROM t [WHERE ...]` via DataFusion 54's `TableProvider::delete_from`, backed by the crate's positional-delete primitives. sqlite + postgres; single-catalog.

## How it works
- `delete_from` (src/table.rs) returns a `DuckLakeDeleteExec` (src/delete_exec.rs) that, at execute time, builds the physical predicate, resolves matched physical row positions per data file, unions with existing deletes (cumulative), writes the `(file_path,pos)` delete parquet, and commits **all affected files in one snapshot**.
- New `MetadataWriter::commit_positional_deletes` commits N delete files atomically with no phantom append (reusing `set_delete_file`'s fence + compare-and-swap); `commit_truncate` handles filterless delete-all atomically. Both on sqlite + postgres; erroring defaults elsewhere.
- Delete parquet stamps DuckDB FILENAME/ORDINAL field-ids (`2147483646`/`2147483645`) so DuckDB's ducklake extension can read deletes we write.
- The read path is already delete-aware, so `SELECT` reflects deletes immediately.

## Tests (write-sqlite)
7 tests — single-file WHERE, multi-file atomic (one snapshot), filterless delete-all, delete-after-delete cumulative (no resurrection), no-match, already-deleted no-op, field-id assertion — plus all regression suites green.

## Limitations
- sqlite + postgres only (duckdb/mysql return a clean unsupported error).
- Embedded-rowid files (from UPDATE/compaction) are refused rather than deleted by physical position — addressed when UPDATE lands.
