### PR TITLE
feat(write): SQL UPDATE via TableProvider::update

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -95,6 +95,7 @@ the read backend: `--no-default-features --features metadata-duckdb` (requires
 | `CREATE TABLE AS SELECT` (SQL DDL; SQLite single-catalog only — not on the PostgreSQL multi-catalog path) | 🟧 |
 | `DROP TABLE` (via `MetadataWriter`)                     |   ✅   |
 | Row-level deletes (Merge-On-Read delete files, read)    |   ✅   |
+| SQL `UPDATE t SET c = e [, ...] [WHERE p]` (rewrite + positional delete, one snapshot; SQLite & PostgreSQL) | ✅ |
 | Snapshot-based consistency (bound at catalog creation)  |   ✅   |
 | Filter pushdown to Parquet (row-group / page pruning)   |   ✅   |
 | Parquet footer size hints (1 read/file instead of 2)    |   ✅   |
@@ -179,6 +180,19 @@ Known edges:
   the snapshot programmatically — `DuckLakeCatalog::with_snapshot(provider, snapshot_id)`
   binds to a specific one, and querying another point in time means creating another
   catalog. What's missing is SQL-level historical querying (`AS OF`) within one handle.
+- **One mutation per session, then re-open the catalog.** Because a catalog pins its
+  snapshot at creation and never refreshes, a `SessionContext` observes a single generation
+  for its lifetime. After an `UPDATE`/`DELETE`/`INSERT` commits, the same session keeps
+  reading the pre-mutation state; a `SELECT` won't see the change, a just-inserted row can't
+  be updated, and a **second `UPDATE`/`DELETE` re-touching a file the first modified aborts
+  with a conflict** (the compare-and-swap that also guards genuine concurrency — it is what
+  prevents a stale rewrite from resurrecting superseded rows). Re-open the catalog (or create
+  a fresh `SessionContext`) between mutating statements so it binds to the latest snapshot.
+- **`UPDATE` change-feed correlation is not available on encrypted (PME) catalogs.**
+  `ducklake_table_changes` still works on encrypted catalogs, but a range containing an
+  `UPDATE` surfaces its rewritten rows as plain `insert`s rather than being correlated into
+  `update_preimage`/`update_postimage` (the correlation reads parquet footers/rows the
+  change-feed path does not decrypt). Non-encrypted catalogs correlate normally.
 - **No partition-based file pruning** on read.
 - **Complex / nested types** have minimal support.
 - **DuckDB-encrypted (non-PME) Parquet files** are not supported (only PME).

--- a/src/column_rename.rs
+++ b/src/column_rename.rs
@@ -210,7 +210,7 @@ impl RecordBatchStream for ColumnRenameStream {
 /// and would fail `RecordBatch::try_new`. After casting we therefore re-stamp the
 /// array's `DataType` to the target when only nested field metadata differs —
 /// the buffer layout is identical, so this is a zero-copy metadata swap.
-fn coerce_column(
+pub(crate) fn coerce_column(
     col: &arrow::array::ArrayRef,
     target: &arrow::datatypes::DataType,
 ) -> DataFusionResult<arrow::array::ArrayRef> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,8 @@ pub mod multicatalog;
 pub mod multicatalog_provider;
 #[cfg(feature = "write")]
 pub mod table_writer;
+#[cfg(feature = "write")]
+pub mod update_exec;
 
 // Result type for DuckLake operations
 pub type Result<T> = std::result::Result<T, DuckLakeError>;
@@ -128,3 +130,5 @@ pub use multicatalog::{MulticatalogManager, initialize_multicatalog_schema};
 pub use multicatalog_provider::MulticatalogProvider;
 #[cfg(feature = "write")]
 pub use table_writer::{DuckLakeTableWriter, TableWriteSession};
+#[cfg(feature = "write")]
+pub use update_exec::DuckLakeUpdateExec;

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -597,6 +597,19 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
     fn catalog_id(&self) -> Option<i64> {
         None
     }
+
+    /// Whether this backend supports row-level `UPDATE` (append the rewritten
+    /// rows + apply positional deletes in one snapshot via
+    /// [`register_data_file_with_deletes`](MetadataWriter::register_data_file_with_deletes)).
+    ///
+    /// Default `false`. Backends that implement the atomic append-with-deletes
+    /// commit (SQLite, multicatalog Postgres) override it to `true`. The `UPDATE`
+    /// planner path (`DuckLakeTable::update`) checks this up front and returns a
+    /// clean "not supported" error for backends that don't (DuckDB, MySQL),
+    /// rather than doing the file rewrites and only failing at commit.
+    fn supports_update(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -1460,8 +1460,12 @@ impl MetadataWriter for PostgresMetadataWriter {
                 .await?;
                 if target_live.is_none() {
                     return Err(crate::DuckLakeError::Conflict(format!(
-                        "delete targets data file {}, which was retired by a concurrent write \
-                         since snapshot {base_snapshot}; retry against the new generation",
+                        "UPDATE/DELETE on data file {} could not commit: the file is no longer \
+                         live as of the catalog's current head (retired since snapshot \
+                         {base_snapshot}). This happens when another writer committed a \
+                         Replace/compaction, OR when an earlier write in THIS session already \
+                         advanced the catalog (the catalog pins its snapshot at creation and does \
+                         not refresh). Re-open the catalog at the latest snapshot and retry.",
                         entry.data_file_id
                     )));
                 }
@@ -1475,8 +1479,12 @@ impl MetadataWriter for PostgresMetadataWriter {
                 .await?;
                 if current_prev != entry.expected_prev_delete_file {
                     return Err(crate::DuckLakeError::Conflict(format!(
-                        "delete on data file {} conflicts with a concurrent delete (expected live \
-                         delete file {:?}, found {current_prev:?}); retry against the new generation",
+                        "UPDATE/DELETE on data file {} could not commit: its live delete file \
+                         changed from {:?} to {current_prev:?} since snapshot {base_snapshot}. \
+                         Another writer committed a delete on this file, OR an earlier \
+                         UPDATE/DELETE in THIS session did (the catalog pins its snapshot at \
+                         creation and does not refresh). Re-open the catalog at the latest \
+                         snapshot and retry.",
                         entry.data_file_id, entry.expected_prev_delete_file
                     )));
                 }

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -1875,6 +1875,12 @@ impl MetadataWriter for PostgresMetadataWriter {
     fn catalog_id(&self) -> Option<i64> {
         Some(self.catalog_id)
     }
+
+    /// Multicatalog Postgres implements the atomic append-with-deletes commit,
+    /// so it supports row-level `UPDATE`.
+    fn supports_update(&self) -> bool {
+        true
+    }
 }
 
 #[cfg(test)]

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -1062,6 +1062,12 @@ async fn finalize_snapshot(
 }
 
 impl MetadataWriter for SqliteMetadataWriter {
+    /// SQLite implements the atomic append-with-deletes commit, so it supports
+    /// row-level `UPDATE`.
+    fn supports_update(&self) -> bool {
+        true
+    }
+
     fn create_snapshot(&self) -> Result<i64> {
         block_on(async {
             let mut tx = self.pool.begin().await?;

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -1607,8 +1607,12 @@ impl MetadataWriter for SqliteMetadataWriter {
                 .await?;
                 if target_live.is_none() {
                     return Err(crate::DuckLakeError::Conflict(format!(
-                        "delete targets data file {}, which was retired by a concurrent write \
-                         since snapshot {base_snapshot}; retry against the new generation",
+                        "UPDATE/DELETE on data file {} could not commit: the file is no longer \
+                         live as of the catalog's current head (retired since snapshot \
+                         {base_snapshot}). This happens when another writer committed a \
+                         Replace/compaction, OR when an earlier write in THIS session already \
+                         advanced the catalog (the catalog pins its snapshot at creation and does \
+                         not refresh). Re-open the catalog at the latest snapshot and retry.",
                         entry.data_file_id
                     )));
                 }
@@ -1622,8 +1626,12 @@ impl MetadataWriter for SqliteMetadataWriter {
                 .await?;
                 if current_prev != entry.expected_prev_delete_file {
                     return Err(crate::DuckLakeError::Conflict(format!(
-                        "delete on data file {} conflicts with a concurrent delete (expected live \
-                         delete file {:?}, found {current_prev:?}); retry against the new generation",
+                        "UPDATE/DELETE on data file {} could not commit: its live delete file \
+                         changed from {:?} to {current_prev:?} since snapshot {base_snapshot}. \
+                         Another writer committed a delete on this file, OR an earlier \
+                         UPDATE/DELETE in THIS session did (the catalog pins its snapshot at \
+                         creation and does not refresh). Re-open the catalog at the latest \
+                         snapshot and retry.",
                         entry.data_file_id, entry.expected_prev_delete_file
                     )));
                 }

--- a/src/row_id.rs
+++ b/src/row_id.rs
@@ -65,6 +65,27 @@ pub const ROW_POS_COLUMN_NAME: &str = "__ducklake_row_pos";
 /// survive across file rewrites.
 pub const ROW_ID_PARQUET_FIELD_ID: i32 = 2_147_483_540;
 
+/// Parquet column name our writer uses for the embedded row-id column on files
+/// produced by `UPDATE` / compaction. The read path matches the column by its
+/// [`ROW_ID_PARQUET_FIELD_ID`] field-id, not this name, so the exact string is
+/// cosmetic; we mirror the DuckLake extension's `_ducklake_internal_row_id`.
+pub const EMBEDDED_ROW_ID_COLUMN_NAME: &str = "_ducklake_internal_row_id";
+
+/// Build the Arrow [`Field`] for the embedded row-id column written into
+/// `UPDATE` / compaction output parquet. Carries the reserved
+/// [`ROW_ID_PARQUET_FIELD_ID`] as its `PARQUET:field_id` metadata so a later
+/// read detects it (see `table.rs::build_file_read_config`) and serves the
+/// original rowids inline rather than synthesizing `row_id_start + position`.
+/// Nullable to match the read-side `rowid` field.
+pub fn embedded_rowid_field() -> Field {
+    let mut metadata = std::collections::HashMap::new();
+    metadata.insert(
+        "PARQUET:field_id".to_string(),
+        ROW_ID_PARQUET_FIELD_ID.to_string(),
+    );
+    Field::new(EMBEDDED_ROW_ID_COLUMN_NAME, DataType::Int64, true).with_metadata(metadata)
+}
+
 /// Build the Arrow Field for the rowid column. Nullable so we can emit NULL
 /// for files whose catalog row_id_start is unrecorded (e.g. older catalogs).
 pub fn rowid_field() -> Field {

--- a/src/table.rs
+++ b/src/table.rs
@@ -23,6 +23,18 @@ use crate::types::{
 use crate::insert_exec::DuckLakeInsertExec;
 #[cfg(feature = "write")]
 use crate::metadata_writer::{MetadataWriter, WriteMode};
+#[cfg(feature = "write")]
+use crate::update_exec::DuckLakeUpdateExec;
+#[cfg(feature = "write")]
+use arrow::array::ArrayRef;
+#[cfg(feature = "write")]
+use datafusion::common::DFSchema;
+#[cfg(feature = "write")]
+use datafusion::logical_expr::Operator;
+#[cfg(feature = "write")]
+use datafusion::physical_expr::PhysicalExpr;
+#[cfg(feature = "write")]
+use datafusion::physical_expr::expressions::BinaryExpr;
 
 #[cfg(feature = "encryption")]
 use crate::encryption::EncryptionFactoryBuilder;
@@ -1097,6 +1109,321 @@ impl DuckLakeTable {
         }
         Arc::new(Schema::new(fields))
     }
+
+    /// A read-only clone of this table (no writer, no rowid projection, fresh
+    /// per-file read-config cache) carrying exactly the metadata a scan needs.
+    /// [`DuckLakeUpdateExec`] holds one so it can drive the per-file update
+    /// scans ([`Self::compute_file_update`]) at execute time — `update()` only
+    /// has `&self`, so it cannot hand the exec an `Arc<Self>` directly.
+    #[cfg(feature = "write")]
+    fn read_only_clone(&self) -> DuckLakeTable {
+        DuckLakeTable {
+            table_id: self.table_id,
+            table_name: self.table_name.clone(),
+            provider: Arc::clone(&self.provider),
+            object_store_url: self.object_store_url.clone(),
+            table_path: self.table_path.clone(),
+            schema: self.physical_schema.clone(),
+            physical_schema: self.physical_schema.clone(),
+            row_lineage: false,
+            columns: self.columns.clone(),
+            table_files: self.table_files.clone(),
+            file_read_config_cache: std::sync::Mutex::new(HashMap::new()),
+            #[cfg(feature = "encryption")]
+            encryption_factory: self.encryption_factory.clone(),
+            schema_name: None,
+            writer: None,
+        }
+    }
+
+    /// Physical (data-column) schema this table reads/writes, without the
+    /// synthetic `rowid`. Used by [`DuckLakeUpdateExec`] to author the rewritten
+    /// data file.
+    #[cfg(feature = "write")]
+    pub(crate) fn physical_schema(&self) -> SchemaRef {
+        self.physical_schema.clone()
+    }
+
+    /// Build the positional read plan (and the metadata needed to interpret it)
+    /// for one source file of an `UPDATE`. Runs at PLAN time: it reads the
+    /// parquet footer (field-ids, row-group layout) and the file's live delete
+    /// positions — the same plan-time reads `scan()` performs — but executes NO
+    /// data scan and mutates nothing. The returned [`UpdateSourceScan::scan`]
+    /// yields the physical data columns (logical order), the embedded rowid
+    /// column when the file has one, and the internal physical-position column;
+    /// [`Self::apply_update_to_batches`] turns its collected batches into the
+    /// rewritten rows at execute time.
+    ///
+    /// Errors if the file has neither an embedded `_ducklake_internal_row_id`
+    /// column nor a catalog `row_id_start`: its lineage cannot be reconstructed,
+    /// so rewriting it would fabricate rowids.
+    #[cfg(feature = "write")]
+    pub(crate) async fn build_update_scan(
+        &self,
+        state: &dyn Session,
+        table_file: &DuckLakeTableFile,
+    ) -> DataFusionResult<UpdateSourceScan> {
+        let file_cfg = self.build_file_read_config(state, &table_file.file).await?;
+        let has_embedded = file_cfg.embedded_rowid_parquet_name.is_some();
+
+        if !has_embedded && table_file.row_id_start.is_none() {
+            return Err(DataFusionError::Execution(format!(
+                "File \"{}\" has no embedded `_ducklake_internal_row_id` column and no \
+                 `row_id_start` in the catalog — cannot preserve row lineage through UPDATE",
+                table_file.file.path
+            )));
+        }
+
+        // Rows already masked by a live delete file must not be re-updated, and
+        // must remain masked in the file's new cumulative delete.
+        let existing_deleted: HashSet<i64> = if let Some(ref delete_file) = table_file.delete_file {
+            self.read_delete_file_positions(state, delete_file).await?
+        } else {
+            HashSet::new()
+        };
+
+        // Positional scan: row-group-aligned partitions + a non-repartition,
+        // non-pruning source so `FileRowNumberExec` yields true physical
+        // positions. Project the physical columns (logical order) and, for an
+        // embedded file, the embedded rowid column too.
+        let physical_len = self.physical_schema.fields().len();
+        let target_partitions = state.config().target_partitions();
+        let (file_groups, partition_starts) =
+            self.build_row_group_partitions(&table_file.file, &file_cfg, target_partitions)?;
+        let source = PositionalFileSource::wrap(Arc::new(
+            self.create_parquet_source(file_cfg.read_schema.clone()),
+        ));
+        let mut proj: Vec<usize> = (0..physical_len).collect();
+        let embedded_batch_idx = if has_embedded {
+            proj.push(file_cfg.read_schema.fields().len() - 1);
+            Some(physical_len)
+        } else {
+            None
+        };
+        let scan = DataSourceExec::from_data_source(
+            FileScanConfigBuilder::new(self.object_store_url.as_ref().clone(), source)
+                .with_file_groups(file_groups)
+                .with_partitioned_by_file_group(true)
+                .with_projection_indices(Some(proj))?
+                .build(),
+        );
+        let mut plan: Arc<dyn ExecutionPlan> =
+            Arc::new(FileRowNumberExec::new(scan, partition_starts));
+        if !existing_deleted.is_empty() {
+            plan = Arc::new(DeleteFilterExec::try_new(
+                plan,
+                table_file.file.path.clone(),
+                Arc::new(existing_deleted.clone()),
+            )?);
+        }
+        let pos_index = plan.schema().index_of(ROW_POS_COLUMN_NAME)?;
+
+        Ok(UpdateSourceScan {
+            scan: plan,
+            physical_len,
+            embedded_batch_idx,
+            pos_index,
+            row_id_start: table_file.row_id_start,
+            existing_deleted,
+            data_file_id: table_file.data_file_id,
+            delete_file_id: table_file.delete_file_id,
+            source_path: table_file.file.path.clone(),
+        })
+    }
+
+    /// Turn the batches collected from an [`UpdateSourceScan`] into the rewritten
+    /// row versions for one source file: select the rows matching `predicate`
+    /// (or every live row when it is `None`), apply `assignments`, and RETAIN
+    /// each row's original rowid so lineage survives the rewrite. Pure and
+    /// synchronous — the exec runs it at execute time after `collect`ing the
+    /// scan, so no [`Session`] is required.
+    ///
+    /// `assignments` are `(physical_column_index, new_value_expr)`; unlisted
+    /// columns carry through unchanged. Returned batches are
+    /// `[physical columns (catalog types)..., rowid]`, ready for
+    /// [`DuckLakeTableWriter::begin_write_with_embedded_rowid`](crate::table_writer::DuckLakeTableWriter::begin_write_with_embedded_rowid).
+    /// The original rowid is the embedded column when the file has one, else
+    /// `row_id_start + physical_position`.
+    #[cfg(feature = "write")]
+    pub(crate) fn apply_update_to_batches(
+        &self,
+        scan: &UpdateSourceScan,
+        batches: &[RecordBatch],
+        predicate: Option<&Arc<dyn PhysicalExpr>>,
+        assignments: &[(usize, Arc<dyn PhysicalExpr>)],
+    ) -> DataFusionResult<FileUpdateOutput> {
+        let physical_len = scan.physical_len;
+
+        // Output schema for the rewritten rows: physical columns + rowid.
+        let mut out_fields: Vec<Arc<Field>> =
+            self.physical_schema.fields().iter().cloned().collect();
+        out_fields.push(Arc::new(rowid_field()));
+        let out_schema = Arc::new(Schema::new(out_fields));
+
+        let mut updated_batches: Vec<RecordBatch> = Vec::new();
+        let mut new_positions: Vec<i64> = Vec::new();
+
+        for batch in batches {
+            let n = batch.num_rows();
+            if n == 0 {
+                continue;
+            }
+
+            // Coerce physical columns to the catalog types the assignment /
+            // predicate exprs (and the writer) expect.
+            let mut phys_cols: Vec<ArrayRef> = Vec::with_capacity(physical_len);
+            for i in 0..physical_len {
+                phys_cols.push(crate::column_rename::coerce_column(
+                    batch.column(i),
+                    self.physical_schema.field(i).data_type(),
+                )?);
+            }
+            let phys_batch = RecordBatch::try_new(self.physical_schema.clone(), phys_cols.clone())?;
+
+            let row_pos = batch
+                .column(scan.pos_index)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .ok_or_else(|| {
+                    DataFusionError::Internal(format!("{ROW_POS_COLUMN_NAME} column is not Int64"))
+                })?;
+
+            // Predicate mask (all rows when there is no WHERE). A NULL predicate
+            // result is a non-match (SQL semantics).
+            let mask: BooleanArray = match predicate {
+                Some(p) => {
+                    let arr = p.evaluate(&phys_batch)?.into_array(n)?;
+                    let b = arr.as_any().downcast_ref::<BooleanArray>().ok_or_else(|| {
+                        DataFusionError::Execution(
+                            "UPDATE predicate did not evaluate to a boolean".to_string(),
+                        )
+                    })?;
+                    BooleanArray::from(
+                        (0..n)
+                            .map(|i| b.is_valid(i) && b.value(i))
+                            .collect::<Vec<bool>>(),
+                    )
+                },
+                None => BooleanArray::from(vec![true; n]),
+            };
+            if mask.true_count() == 0 {
+                continue;
+            }
+
+            // Keep only matched rows, then apply the assignments to them.
+            let matched_phys: Vec<ArrayRef> = phys_cols
+                .iter()
+                .map(|c| arrow::compute::filter(c.as_ref(), &mask))
+                .collect::<std::result::Result<_, _>>()
+                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+            let matched_batch =
+                RecordBatch::try_new(self.physical_schema.clone(), matched_phys.clone())?;
+            let matched_rows = matched_batch.num_rows();
+
+            let mut out_cols = matched_phys;
+            for (col_idx, expr) in assignments {
+                let val = expr.evaluate(&matched_batch)?.into_array(matched_rows)?;
+                out_cols[*col_idx] = crate::column_rename::coerce_column(
+                    &val,
+                    self.physical_schema.field(*col_idx).data_type(),
+                )?;
+            }
+
+            // Original rowids: embedded column when present, else synthesized.
+            let matched_pos = arrow::compute::filter(row_pos, &mask)
+                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+            let matched_pos = matched_pos
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("filtered Int64Array");
+            let rowid_col: ArrayRef = if let Some(idx) = scan.embedded_batch_idx {
+                let embedded = batch
+                    .column(idx)
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .ok_or_else(|| {
+                        DataFusionError::Internal("embedded rowid column is not Int64".to_string())
+                    })?;
+                let embedded: ArrayRef = Arc::new(embedded.clone());
+                arrow::compute::filter(embedded.as_ref(), &mask)
+                    .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?
+            } else {
+                let start = scan
+                    .row_id_start
+                    .expect("row_id_start checked in build_update_scan");
+                Arc::new(Int64Array::from(
+                    matched_pos
+                        .values()
+                        .iter()
+                        .map(|p| start + p)
+                        .collect::<Vec<i64>>(),
+                ))
+            };
+            out_cols.push(rowid_col);
+            updated_batches.push(RecordBatch::try_new(out_schema.clone(), out_cols)?);
+
+            new_positions.extend(matched_pos.values().iter().copied());
+        }
+
+        let matched_count = new_positions.len();
+        let mut cumulative = scan.existing_deleted.clone();
+        cumulative.extend(new_positions);
+        let mut cumulative_positions: Vec<i64> = cumulative.into_iter().collect();
+        cumulative_positions.sort_unstable();
+
+        Ok(FileUpdateOutput {
+            updated_batches,
+            matched_count,
+            cumulative_positions,
+        })
+    }
+}
+
+/// Per-source-file read plan + metadata for an `UPDATE`, produced by
+/// [`DuckLakeTable::build_update_scan`] at plan time and consumed by
+/// [`DuckLakeUpdateExec`] at execute time.
+#[cfg(feature = "write")]
+#[derive(Clone)]
+pub(crate) struct UpdateSourceScan {
+    /// Positional read plan yielding `[physical columns..., (embedded rowid),
+    /// __ducklake_row_pos]` for the source file, already masking rows removed by
+    /// its live delete file.
+    pub(crate) scan: Arc<dyn ExecutionPlan>,
+    /// Number of physical (data) columns at the front of each scanned batch.
+    pub(crate) physical_len: usize,
+    /// Column index of the embedded rowid in each scanned batch, or `None` when
+    /// the file has no embedded rowid (rowids are synthesized from
+    /// `row_id_start + position`).
+    pub(crate) embedded_batch_idx: Option<usize>,
+    /// Column index of the internal physical-position column in each batch.
+    pub(crate) pos_index: usize,
+    /// The source file's catalog `row_id_start` (used to synthesize rowids for a
+    /// non-embedded file).
+    pub(crate) row_id_start: Option<i64>,
+    /// Positions already masked by the file's live delete file, carried forward
+    /// into the new cumulative delete.
+    pub(crate) existing_deleted: HashSet<i64>,
+    /// Catalog id of the source data file (the positional delete's target).
+    pub(crate) data_file_id: i64,
+    /// Catalog id of the file's currently-live delete file (compare-and-swap
+    /// guard when superseding it), or `None`.
+    pub(crate) delete_file_id: Option<i64>,
+    /// The source data file's catalog path (records the delete's provenance).
+    pub(crate) source_path: String,
+}
+
+/// The rewrite produced for one source data file by
+/// [`DuckLakeTable::apply_update_to_batches`].
+#[cfg(feature = "write")]
+pub(crate) struct FileUpdateOutput {
+    /// Rewritten row versions, `[physical columns..., rowid]`, carrying each
+    /// row's original rowid. Empty when no rows matched.
+    pub(crate) updated_batches: Vec<RecordBatch>,
+    /// Number of rows this update rewrote in the source file.
+    pub(crate) matched_count: usize,
+    /// Physical positions to mask on the source file afterwards: the rows this
+    /// update supersedes unioned with any already-deleted rows (sorted).
+    pub(crate) cumulative_positions: Vec<i64>,
 }
 
 #[async_trait]
@@ -1284,6 +1611,91 @@ impl TableProvider for DuckLakeTable {
             self.table_name.clone(),
             self.schema(),
             write_mode,
+            self.object_store_url.clone(),
+        )))
+    }
+
+    /// Plan an `UPDATE t SET col = expr [, ...] [WHERE ...]`.
+    ///
+    /// `assignments` are `(column_name, new_value_expr)` for each SET (identity
+    /// `c = c` assignments are already dropped by the planner). `filters` are the
+    /// unqualified, AND-conjunctive WHERE predicates; an empty `filters` updates
+    /// every live row. The returned [`DuckLakeUpdateExec`] performs the update at
+    /// execute time and yields a single `count: UInt64` row — planning here is
+    /// side-effect-free (no scans, no writes), so `EXPLAIN` never mutates data.
+    #[cfg(feature = "write")]
+    async fn update(
+        &self,
+        state: &dyn Session,
+        assignments: Vec<(String, Expr)>,
+        filters: Vec<Expr>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let writer = self.writer.as_ref().ok_or_else(|| {
+            DataFusionError::Plan(
+                "Table is read-only. Use DuckLakeCatalog::with_writer() to enable writes."
+                    .to_string(),
+            )
+        })?;
+        let schema_name = self.schema_name.as_ref().ok_or_else(|| {
+            DataFusionError::Internal("Schema name not set for writable table".to_string())
+        })?;
+
+        // DuckDB / MySQL metadata writers do not implement the atomic
+        // append-with-deletes commit UPDATE needs. Reject up front rather than
+        // rewriting files and only failing at commit.
+        if !writer.supports_update() {
+            return Err(DataFusionError::NotImplemented(
+                "UPDATE not supported on this metadata backend".to_string(),
+            ));
+        }
+
+        // Assignment / filter expressions reference the table's DATA columns
+        // (unqualified), never the synthetic `rowid`. Plan them against the
+        // physical schema so column indices line up with the scanned batches.
+        let df_schema = DFSchema::try_from(self.physical_schema.as_ref().clone())
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+        let mut phys_assignments: Vec<(usize, Arc<dyn PhysicalExpr>)> =
+            Vec::with_capacity(assignments.len());
+        for (col_name, expr) in assignments {
+            let idx = self.physical_schema.index_of(&col_name).map_err(|_| {
+                DataFusionError::Plan(format!(
+                    "UPDATE assignment targets unknown column '{col_name}'"
+                ))
+            })?;
+            let pexpr = state.create_physical_expr(expr, &df_schema)?;
+            phys_assignments.push((idx, pexpr));
+        }
+
+        // AND the WHERE predicates into one physical expression; empty => update
+        // all rows (represented as `None`).
+        let mut predicate: Option<Arc<dyn PhysicalExpr>> = None;
+        for f in filters {
+            let pe = state.create_physical_expr(f, &df_schema)?;
+            predicate = Some(match predicate {
+                None => pe,
+                Some(prev) => Arc::new(BinaryExpr::new(prev, Operator::And, pe)),
+            });
+        }
+
+        // Build the per-file positional read plans now (plan time). This reads
+        // parquet footers + live delete positions — the same plan-time reads
+        // `scan()` does — but no data scan and no mutation happen here; the exec
+        // collects each scan and performs the rewrite + atomic commit at execute
+        // time.
+        let mut scans = Vec::with_capacity(self.table_files.len());
+        for tf in &self.table_files {
+            scans.push(self.build_update_scan(state, tf).await?);
+        }
+
+        Ok(Arc::new(DuckLakeUpdateExec::new(
+            Arc::new(self.read_only_clone()),
+            Arc::clone(writer),
+            schema_name.clone(),
+            self.table_name.clone(),
+            scans,
+            phys_assignments,
+            predicate,
             self.object_store_url.clone(),
         )))
     }

--- a/src/table_changes.rs
+++ b/src/table_changes.rs
@@ -5,12 +5,14 @@
 //!
 //! Note: Ordering across files is undefined unless explicitly requested via ORDER BY.
 
+use std::collections::HashSet;
 use std::fmt;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use arrow::array::{ArrayRef, Int64Array, StringArray};
+use arrow::array::{Array, ArrayRef, BooleanArray, Int64Array, StringArray, UInt32Array};
+use arrow::compute::take;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
@@ -23,27 +25,46 @@ use datafusion::datasource::{TableProvider, TableType};
 use datafusion::error::DataFusionError;
 use datafusion::execution::object_store::ObjectStoreUrl;
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
-use datafusion::physical_expr::EquivalenceProperties;
+use datafusion::physical_expr::expressions::Column;
+use datafusion::physical_expr::{EquivalenceProperties, PhysicalExpr};
+use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::physical_plan::union::UnionExec;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
 };
-use futures::Stream;
+use futures::{Stream, StreamExt};
+use object_store::path::Path as ObjectPath;
+use parquet::arrow::ParquetRecordBatchStreamBuilder;
+use parquet::arrow::async_reader::ParquetObjectReader;
 
 use crate::metadata_provider::{DataFileChange, MetadataProvider};
 use crate::path_resolver::resolve_path;
-use crate::table::validated_file_size;
+use crate::positional_source::PositionalFileSource;
+use crate::row_id::{FileRowNumberExec, ROW_ID_PARQUET_FIELD_ID, ROW_POS_COLUMN_NAME};
+use crate::table::{delete_file_schema, validated_file_size, validated_record_count};
+use crate::types::extract_parquet_field_ids;
 
 #[cfg(feature = "encryption")]
 use crate::encryption::EncryptionFactoryBuilder;
 #[cfg(feature = "encryption")]
 use datafusion::execution::parquet_encryption::EncryptionFactory;
 
-/// Type of change captured in CDC output
+/// Type of change captured in CDC output.
+///
+/// [`UpdatePreimage`](ChangeType::UpdatePreimage) /
+/// [`UpdatePostimage`](ChangeType::UpdatePostimage) are the paired old/new row
+/// versions of an `UPDATE`: `ducklake_table_changes` correlates a same-snapshot
+/// delete + insert that share a rowid into this pair (the DuckLake spirit of an
+/// update in a change feed) instead of surfacing them as an unrelated delete and
+/// insert. The `as_str` values match the DuckLake change-feed spec strings.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChangeType {
     Insert,
     Delete,
+    /// The old version of a row that an `UPDATE` rewrote in this snapshot.
+    UpdatePreimage,
+    /// The new version of a row that an `UPDATE` rewrote in this snapshot.
+    UpdatePostimage,
 }
 
 impl ChangeType {
@@ -52,6 +73,8 @@ impl ChangeType {
         match self {
             ChangeType::Insert => "insert",
             ChangeType::Delete => "delete",
+            ChangeType::UpdatePreimage => "update_preimage",
+            ChangeType::UpdatePostimage => "update_postimage",
         }
     }
 }
@@ -514,6 +537,246 @@ impl TableChangesTable {
             cdc_exec_schema,
         )))
     }
+
+    /// Read a file's parquet footer and return the physical name of its embedded
+    /// row-id column ([`ROW_ID_PARQUET_FIELD_ID`]) when present. A file that
+    /// carries one is the postimage side of an `UPDATE` / compaction.
+    async fn detect_embedded_rowid_name(
+        &self,
+        state: &dyn Session,
+        path: &str,
+        is_relative: bool,
+    ) -> DataFusionResult<Option<String>> {
+        let resolved = resolve_path(&self.table_path, path, is_relative)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        let object_store = state
+            .runtime_env()
+            .object_store(self.object_store_url.as_ref())?;
+        let reader = ParquetObjectReader::new(object_store, ObjectPath::from(resolved.as_str()));
+        let builder = ParquetRecordBatchStreamBuilder::new(reader)
+            .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        let field_ids = extract_parquet_field_ids(builder.metadata());
+        Ok(field_ids.get(&ROW_ID_PARQUET_FIELD_ID).cloned())
+    }
+
+    /// The read schema for a data file: the table columns, plus the embedded
+    /// rowid column (under its physical name) when `embedded_name` is `Some`.
+    fn read_schema_with_optional_rowid(&self, embedded_name: &Option<String>) -> SchemaRef {
+        match embedded_name {
+            Some(name) => {
+                let mut fields: Vec<Field> = self
+                    .table_schema
+                    .fields()
+                    .iter()
+                    .map(|f| f.as_ref().clone())
+                    .collect();
+                fields.push(Field::new(name, DataType::Int64, true));
+                Arc::new(Schema::new(fields))
+            },
+            None => self.table_schema.clone(),
+        }
+    }
+
+    /// Plain scan of an inserted data file: table columns, plus the embedded
+    /// rowid column when the file has one. No positions needed (postimage rowids
+    /// come from the embedded column; plain inserts need no rowid).
+    fn build_insert_scan(
+        &self,
+        data_file: &DataFileChange,
+        embedded_name: &Option<String>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let resolved = resolve_path(
+            &self.table_path,
+            &data_file.path,
+            data_file.path_is_relative,
+        )
+        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        let mut pf = PartitionedFile::new(
+            &resolved,
+            validated_file_size(data_file.file_size_bytes, &resolved)?,
+        );
+        if let Some(footer) = data_file.footer_size
+            && footer > 0
+            && let Ok(hint) = usize::try_from(footer)
+        {
+            pf = pf.with_metadata_size_hint(hint);
+        }
+        let read_schema = self.read_schema_with_optional_rowid(embedded_name);
+        let builder = FileScanConfigBuilder::new(
+            self.object_store_url.as_ref().clone(),
+            Arc::new(ParquetSource::new(read_schema)),
+        )
+        .with_file_group(FileGroup::new(vec![pf]));
+        Ok(DataSourceExec::from_data_source(builder.build()))
+    }
+
+    /// Positional scan of a delete's source data file: table columns, the
+    /// embedded rowid column when present, and the internal physical-position
+    /// column. `PositionalFileSource` + `FileRowNumberExec` guarantee true
+    /// physical positions so deleted rows can be matched to the delete file's
+    /// `pos` set regardless of scan partitioning.
+    fn build_delete_data_scan(
+        &self,
+        resolved_path: &str,
+        size_bytes: i64,
+        footer_size: i64,
+        embedded_name: &Option<String>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let mut pf = PartitionedFile::new(
+            resolved_path,
+            validated_file_size(size_bytes, resolved_path)?,
+        );
+        if footer_size > 0
+            && let Ok(hint) = usize::try_from(footer_size)
+        {
+            pf = pf.with_metadata_size_hint(hint);
+        }
+        let read_schema = self.read_schema_with_optional_rowid(embedded_name);
+        let source = PositionalFileSource::wrap(Arc::new(ParquetSource::new(read_schema)));
+        let builder = FileScanConfigBuilder::new(self.object_store_url.as_ref().clone(), source)
+            .with_file_group(FileGroup::new(vec![pf]))
+            .with_partitioned_by_file_group(true);
+        let scan = DataSourceExec::from_data_source(builder.build());
+        Ok(Arc::new(FileRowNumberExec::new(scan, vec![0])))
+    }
+
+    /// Scan of a positional delete file (the standard `(file_path, pos)` schema);
+    /// the correlation path reads its `pos` column to find newly-deleted rows.
+    fn build_delete_file_scan(
+        &self,
+        path: &str,
+        is_relative: bool,
+        size_bytes: i64,
+        footer_size: i64,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let resolved = resolve_path(&self.table_path, path, is_relative)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        let mut pf = PartitionedFile::new(&resolved, validated_file_size(size_bytes, &resolved)?);
+        if footer_size > 0
+            && let Ok(hint) = usize::try_from(footer_size)
+        {
+            pf = pf.with_metadata_size_hint(hint);
+        }
+        let builder = FileScanConfigBuilder::new(
+            self.object_store_url.as_ref().clone(),
+            Arc::new(ParquetSource::new(delete_file_schema())),
+        )
+        .with_file_group(FileGroup::new(vec![pf]));
+        Ok(DataSourceExec::from_data_source(builder.build()))
+    }
+
+    /// Build the correlated change feed: pair a same-snapshot delete + insert
+    /// that share a rowid into `update_preimage` (old) + `update_postimage`
+    /// (new); surface unmatched inserts as `insert`; and DROP unmatched deletes
+    /// (pure deletes stay out of `ducklake_table_changes`, matching its historical
+    /// insert-oriented behaviour — they remain available via
+    /// `ducklake_table_deletions`).
+    async fn build_correlated_changes(
+        &self,
+        state: &dyn Session,
+        data_files: &[DataFileChange],
+        embedded_names: &[Option<String>],
+        projection: Option<&Vec<usize>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let table_len = self.table_schema.fields().len();
+
+        let mut insert_units = Vec::with_capacity(data_files.len());
+        for (df, name) in data_files.iter().zip(embedded_names.iter()) {
+            insert_units.push(InsertUnit {
+                snapshot_id: df.begin_snapshot,
+                scan: self.build_insert_scan(df, name)?,
+                embedded: name.is_some(),
+            });
+        }
+
+        let delete_files = self
+            .provider
+            .get_delete_files_added_between_snapshots(
+                self.table_id,
+                self.start_snapshot,
+                self.end_snapshot,
+            )
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+        let mut delete_units = Vec::with_capacity(delete_files.len());
+        for dfc in &delete_files {
+            validated_record_count(dfc.data_record_count, &dfc.data_file_path)?;
+            let resolved = resolve_path(
+                &self.table_path,
+                &dfc.data_file_path,
+                dfc.data_file_path_is_relative,
+            )
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+            let old_embedded = self
+                .detect_embedded_rowid_name(
+                    state,
+                    &dfc.data_file_path,
+                    dfc.data_file_path_is_relative,
+                )
+                .await?;
+            let data_scan = self.build_delete_data_scan(
+                &resolved,
+                dfc.data_file_size_bytes,
+                dfc.data_file_footer_size,
+                &old_embedded,
+            )?;
+            let current_delete_scan = match &dfc.current_delete_path {
+                Some(p) => Some(self.build_delete_file_scan(
+                    p,
+                    dfc.current_delete_path_is_relative.unwrap_or(true),
+                    dfc.current_delete_file_size_bytes.unwrap_or(0),
+                    dfc.current_delete_footer_size.unwrap_or(0),
+                )?),
+                None => None,
+            };
+            let previous_delete_scan = match &dfc.previous_delete_path {
+                Some(p) => Some(self.build_delete_file_scan(
+                    p,
+                    dfc.previous_delete_path_is_relative.unwrap_or(true),
+                    dfc.previous_delete_file_size_bytes.unwrap_or(0),
+                    dfc.previous_delete_footer_size.unwrap_or(0),
+                )?),
+                None => None,
+            };
+            delete_units.push(DeleteUnit {
+                snapshot_id: dfc.snapshot_id,
+                data_scan,
+                embedded_col_idx: old_embedded.as_ref().map(|_| table_len),
+                current_delete_scan,
+                previous_delete_scan,
+                record_count: dfc.data_record_count,
+                row_id_start: dfc.data_row_id_start,
+            });
+        }
+
+        let full: Arc<dyn ExecutionPlan> = Arc::new(TableChangesExec::new(
+            insert_units,
+            delete_units,
+            self.table_schema.clone(),
+            self.output_schema.clone(),
+            table_len,
+        ));
+
+        // The exec emits the full `[table columns, snapshot_id, change_type]`
+        // schema; honor the requested projection with a ProjectionExec on top.
+        match projection {
+            None => Ok(full),
+            Some(indices) => {
+                let exprs: Vec<(Arc<dyn PhysicalExpr>, String)> = indices
+                    .iter()
+                    .map(|&i| {
+                        let f = self.output_schema.field(i);
+                        (
+                            Arc::new(Column::new(f.name(), i)) as Arc<dyn PhysicalExpr>,
+                            f.name().to_string(),
+                        )
+                    })
+                    .collect();
+                Ok(Arc::new(ProjectionExec::try_new(exprs, full)?))
+            },
+        }
+    }
 }
 
 #[async_trait]
@@ -550,6 +813,26 @@ impl TableProvider for TableChangesTable {
         if data_files.is_empty() {
             use datafusion::physical_plan::empty::EmptyExec;
             return Ok(Arc::new(EmptyExec::new(proj_info.output_schema)));
+        }
+
+        // Detect which added data files carry an embedded rowid column: those are
+        // the postimages of an UPDATE / compaction. Only when at least one is
+        // present do we correlate delete+insert pairs — a catalog of plain
+        // INSERTs (no embedded files) stays on the historical insert-only path
+        // below, byte-for-byte unchanged (no delete reads, no reclassification).
+        let mut embedded_names: Vec<Option<String>> = Vec::with_capacity(data_files.len());
+        let mut any_embedded = false;
+        for data_file in &data_files {
+            let name = self
+                .detect_embedded_rowid_name(state, &data_file.path, data_file.path_is_relative)
+                .await?;
+            any_embedded |= name.is_some();
+            embedded_names.push(name);
+        }
+        if any_embedded {
+            return self
+                .build_correlated_changes(state, &data_files, &embedded_names, projection)
+                .await;
         }
 
         // Build encryption factory from file encryption keys (when encryption feature is enabled)
@@ -594,4 +877,462 @@ impl TableProvider for TableChangesTable {
             UnionExec::try_new(execs)
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Correlated change feed (insert / delete / update_preimage / update_postimage)
+// ---------------------------------------------------------------------------
+
+/// One inserted data file added in the snapshot range. When `embedded`, the
+/// scan's trailing column is the file's embedded rowid (an UPDATE / compaction
+/// postimage); otherwise the file is a plain INSERT and needs no rowid.
+#[derive(Clone)]
+struct InsertUnit {
+    snapshot_id: i64,
+    scan: Arc<dyn ExecutionPlan>,
+    embedded: bool,
+}
+
+/// One delete applied in the snapshot range: enough to read the newly-deleted
+/// rows of the source data file (the delete positions minus the previous
+/// generation's) together with each row's rowid.
+#[derive(Clone)]
+struct DeleteUnit {
+    snapshot_id: i64,
+    /// Positional scan of the source data file: `[table columns..., (embedded
+    /// rowid), __ducklake_row_pos]`.
+    data_scan: Arc<dyn ExecutionPlan>,
+    /// Column index of the source file's embedded rowid, or `None` (rowids are
+    /// then `row_id_start + position`).
+    embedded_col_idx: Option<usize>,
+    /// Scan of the current delete file, or `None` for a full-file delete.
+    current_delete_scan: Option<Arc<dyn ExecutionPlan>>,
+    /// Scan of the delete file this one superseded, if any.
+    previous_delete_scan: Option<Arc<dyn ExecutionPlan>>,
+    record_count: i64,
+    row_id_start: i64,
+}
+
+/// Rows carrying their `(snapshot_id, rowid)` correlation key alongside the
+/// table columns, ready to be tagged once update pairs are known.
+struct KeyedRows {
+    snapshot_id: i64,
+    table_batch: RecordBatch,
+    rowid: Int64Array,
+}
+
+/// Execution plan for the correlated `ducklake_table_changes` feed. Collects the
+/// inserted rows (with embedded rowids) and the newly-deleted rows (with
+/// synthesized/embedded rowids), pairs those sharing a `(snapshot_id, rowid)`
+/// into preimage/postimage, and emits the tagged rows. Single output partition.
+#[derive(Debug)]
+pub struct TableChangesExec {
+    insert_units: Vec<InsertUnit>,
+    delete_units: Vec<DeleteUnit>,
+    #[allow(dead_code)]
+    table_schema: SchemaRef,
+    output_schema: SchemaRef,
+    table_len: usize,
+    properties: Arc<PlanProperties>,
+}
+
+impl std::fmt::Debug for InsertUnit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InsertUnit")
+            .field("snapshot_id", &self.snapshot_id)
+            .field("embedded", &self.embedded)
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Debug for DeleteUnit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DeleteUnit")
+            .field("snapshot_id", &self.snapshot_id)
+            .field("embedded_col_idx", &self.embedded_col_idx)
+            .finish_non_exhaustive()
+    }
+}
+
+impl TableChangesExec {
+    fn new(
+        insert_units: Vec<InsertUnit>,
+        delete_units: Vec<DeleteUnit>,
+        table_schema: SchemaRef,
+        output_schema: SchemaRef,
+        table_len: usize,
+    ) -> Self {
+        let properties = Arc::new(PlanProperties::new(
+            EquivalenceProperties::new(output_schema.clone()),
+            datafusion::physical_expr::Partitioning::UnknownPartitioning(1),
+            datafusion::physical_plan::execution_plan::EmissionType::Final,
+            datafusion::physical_plan::execution_plan::Boundedness::Bounded,
+        ));
+        Self {
+            insert_units,
+            delete_units,
+            table_schema,
+            output_schema,
+            table_len,
+            properties,
+        }
+    }
+}
+
+impl DisplayAs for TableChangesExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default
+            | DisplayFormatType::Verbose
+            | DisplayFormatType::TreeRender => {
+                write!(
+                    f,
+                    "TableChangesExec: inserts={}, deletes={}",
+                    self.insert_units.len(),
+                    self.delete_units.len()
+                )
+            },
+        }
+    }
+}
+
+impl ExecutionPlan for TableChangesExec {
+    fn name(&self) -> &str {
+        "TableChangesExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    /// No DataFusion children: the per-file scans are internal and executed
+    /// directly, so the optimizer never rewrites them.
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        if !children.is_empty() {
+            return Err(DataFusionError::Internal(
+                "TableChangesExec has no children".to_string(),
+            ));
+        }
+        Ok(self)
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.output_schema.clone()
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        if partition != 0 {
+            return Err(DataFusionError::Internal(format!(
+                "TableChangesExec only supports partition 0, got {partition}"
+            )));
+        }
+
+        let insert_units = self.insert_units.clone();
+        let delete_units = self.delete_units.clone();
+        let output_schema = self.output_schema.clone();
+        let table_len = self.table_len;
+
+        let fut = async move {
+            correlate_changes(
+                insert_units,
+                delete_units,
+                output_schema,
+                table_len,
+                context,
+            )
+            .await
+        };
+
+        let schema = self.output_schema.clone();
+        let stream = futures::stream::once(fut)
+            .map(|res: DataFusionResult<Vec<RecordBatch>>| match res {
+                Ok(batches) => futures::stream::iter(batches.into_iter().map(Ok)).boxed(),
+                Err(e) => futures::stream::iter(std::iter::once(Err(e))).boxed(),
+            })
+            .flatten();
+
+        Ok(Box::pin(
+            datafusion::physical_plan::stream::RecordBatchStreamAdapter::new(schema, stream),
+        ))
+    }
+}
+
+/// Collect the inserted and deleted rows, correlate update pairs by
+/// `(snapshot_id, rowid)`, and produce the tagged output batches.
+async fn correlate_changes(
+    insert_units: Vec<InsertUnit>,
+    delete_units: Vec<DeleteUnit>,
+    output_schema: SchemaRef,
+    table_len: usize,
+    context: Arc<TaskContext>,
+) -> DataFusionResult<Vec<RecordBatch>> {
+    // Inserted rows: split into postimage candidates (embedded rowid) and plain
+    // inserts (no rowid, can never pair with a delete).
+    let mut postimages: Vec<KeyedRows> = Vec::new();
+    let mut plain_inserts: Vec<(i64, RecordBatch)> = Vec::new();
+    for unit in &insert_units {
+        let batches =
+            datafusion::physical_plan::collect(Arc::clone(&unit.scan), context.clone()).await?;
+        for b in batches {
+            if b.num_rows() == 0 {
+                continue;
+            }
+            if unit.embedded {
+                let rowid = b
+                    .column(table_len)
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .ok_or_else(|| {
+                        DataFusionError::Internal("embedded rowid column is not Int64".to_string())
+                    })?
+                    .clone();
+                let table_batch = b.project(&(0..table_len).collect::<Vec<_>>())?;
+                postimages.push(KeyedRows {
+                    snapshot_id: unit.snapshot_id,
+                    table_batch,
+                    rowid,
+                });
+            } else {
+                plain_inserts.push((unit.snapshot_id, b));
+            }
+        }
+    }
+
+    // Deleted rows: the positions newly masked at this snapshot, with each row's
+    // rowid (embedded column when the source file has one, else row_id_start +
+    // physical position).
+    let mut preimages: Vec<KeyedRows> = Vec::new();
+    for unit in &delete_units {
+        let current = collect_delete_positions(&unit.current_delete_scan, context.clone()).await?;
+        let current: HashSet<i64> = match current {
+            Some(set) => set,
+            None => (0..unit.record_count).collect(),
+        };
+        let previous = collect_delete_positions(&unit.previous_delete_scan, context.clone())
+            .await?
+            .unwrap_or_default();
+
+        let data_batches =
+            datafusion::physical_plan::collect(Arc::clone(&unit.data_scan), context.clone())
+                .await?;
+        for b in data_batches {
+            let n = b.num_rows();
+            if n == 0 {
+                continue;
+            }
+            let pos_idx = b.schema().index_of(ROW_POS_COLUMN_NAME)?;
+            let pos = b
+                .column(pos_idx)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .ok_or_else(|| {
+                    DataFusionError::Internal(format!("{ROW_POS_COLUMN_NAME} column is not Int64"))
+                })?;
+            let embedded = match unit.embedded_col_idx {
+                Some(idx) => Some(
+                    b.column(idx)
+                        .as_any()
+                        .downcast_ref::<Int64Array>()
+                        .ok_or_else(|| {
+                            DataFusionError::Internal(
+                                "embedded rowid column is not Int64".to_string(),
+                            )
+                        })?,
+                ),
+                None => None,
+            };
+
+            let mut keep: Vec<u32> = Vec::new();
+            let mut rowids: Vec<i64> = Vec::new();
+            for i in 0..n {
+                let p = pos.value(i);
+                if current.contains(&p) && !previous.contains(&p) {
+                    keep.push(i as u32);
+                    rowids.push(match embedded {
+                        Some(arr) => arr.value(i),
+                        None => unit.row_id_start + p,
+                    });
+                }
+            }
+            if keep.is_empty() {
+                continue;
+            }
+            let indices = UInt32Array::from(keep);
+            let table_cols: Vec<ArrayRef> = (0..table_len)
+                .map(|c| {
+                    take(b.column(c).as_ref(), &indices, None)
+                        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+                })
+                .collect::<DataFusionResult<_>>()?;
+            let table_batch = RecordBatch::try_new(
+                Arc::new(Schema::new(
+                    (0..table_len)
+                        .map(|c| b.schema().field(c).clone())
+                        .collect::<Vec<_>>(),
+                )),
+                table_cols,
+            )?;
+            preimages.push(KeyedRows {
+                snapshot_id: unit.snapshot_id,
+                table_batch,
+                rowid: Int64Array::from(rowids),
+            });
+        }
+    }
+
+    // Update pairs = keys present in BOTH an embedded insert and a delete.
+    let post_keys: HashSet<(i64, i64)> = postimages
+        .iter()
+        .flat_map(|k| (0..k.rowid.len()).map(move |i| (k.snapshot_id, k.rowid.value(i))))
+        .collect();
+    let update_keys: HashSet<(i64, i64)> = preimages
+        .iter()
+        .flat_map(|k| (0..k.rowid.len()).map(move |i| (k.snapshot_id, k.rowid.value(i))))
+        .filter(|key| post_keys.contains(key))
+        .collect();
+
+    let mut out: Vec<RecordBatch> = Vec::new();
+    for (snap, batch) in &plain_inserts {
+        out.push(append_cdc_columns(
+            batch,
+            *snap,
+            ChangeType::Insert,
+            &output_schema,
+        )?);
+    }
+    for k in &postimages {
+        // Rows whose key is an update pair become postimages; the rest are plain
+        // inserts (embedded file with no matching delete, e.g. compaction).
+        if let Some(b) = filter_and_tag(
+            k,
+            &key_mask(k, &update_keys, true),
+            ChangeType::UpdatePostimage,
+            &output_schema,
+        )? {
+            out.push(b);
+        }
+        if let Some(b) = filter_and_tag(
+            k,
+            &key_mask(k, &update_keys, false),
+            ChangeType::Insert,
+            &output_schema,
+        )? {
+            out.push(b);
+        }
+    }
+    for k in &preimages {
+        // Only rows paired with an insert are surfaced (as preimages); pure
+        // deletes stay out of the changes feed.
+        if let Some(b) = filter_and_tag(
+            k,
+            &key_mask(k, &update_keys, true),
+            ChangeType::UpdatePreimage,
+            &output_schema,
+        )? {
+            out.push(b);
+        }
+    }
+    Ok(out)
+}
+
+/// Collect the `pos` set from a delete-file scan (`None` scan => `None`).
+async fn collect_delete_positions(
+    scan: &Option<Arc<dyn ExecutionPlan>>,
+    context: Arc<TaskContext>,
+) -> DataFusionResult<Option<HashSet<i64>>> {
+    let Some(scan) = scan else {
+        return Ok(None);
+    };
+    let batches = datafusion::physical_plan::collect(Arc::clone(scan), context).await?;
+    let mut set = HashSet::new();
+    for b in &batches {
+        if b.num_columns() < 2 {
+            continue;
+        }
+        let pos = b
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .ok_or_else(|| {
+                DataFusionError::Internal("delete `pos` column is not Int64".to_string())
+            })?;
+        for i in 0..pos.len() {
+            if !pos.is_null(i) {
+                set.insert(pos.value(i));
+            }
+        }
+    }
+    Ok(Some(set))
+}
+
+/// Append the CDC `snapshot_id` + `change_type` columns to a table-column batch.
+fn append_cdc_columns(
+    table_batch: &RecordBatch,
+    snapshot_id: i64,
+    change: ChangeType,
+    output_schema: &SchemaRef,
+) -> DataFusionResult<RecordBatch> {
+    let n = table_batch.num_rows();
+    let mut cols: Vec<ArrayRef> = table_batch.columns().to_vec();
+    cols.push(Arc::new(Int64Array::from(vec![snapshot_id; n])));
+    cols.push(Arc::new(StringArray::from(vec![change.as_str(); n])));
+    RecordBatch::try_new(output_schema.clone(), cols)
+        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+}
+
+/// A row-selection mask over `keyed`: `want_update` selects rows whose
+/// `(snapshot_id, rowid)` is (or is not) an update pair.
+fn key_mask(
+    keyed: &KeyedRows,
+    update_keys: &HashSet<(i64, i64)>,
+    want_update: bool,
+) -> BooleanArray {
+    BooleanArray::from(
+        (0..keyed.rowid.len())
+            .map(|i| {
+                let is_update = update_keys.contains(&(keyed.snapshot_id, keyed.rowid.value(i)));
+                is_update == want_update
+            })
+            .collect::<Vec<bool>>(),
+    )
+}
+
+/// Filter `keyed`'s table columns by `mask`, tag with `change`, and append the
+/// CDC columns. Returns `None` when the mask selects no rows.
+fn filter_and_tag(
+    keyed: &KeyedRows,
+    mask: &BooleanArray,
+    change: ChangeType,
+    output_schema: &SchemaRef,
+) -> DataFusionResult<Option<RecordBatch>> {
+    if mask.true_count() == 0 {
+        return Ok(None);
+    }
+    let cols: Vec<ArrayRef> = keyed
+        .table_batch
+        .columns()
+        .iter()
+        .map(|c| {
+            arrow::compute::filter(c.as_ref(), mask)
+                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+        })
+        .collect::<DataFusionResult<_>>()?;
+    let filtered = RecordBatch::try_new(keyed.table_batch.schema(), cols)?;
+    Ok(Some(append_cdc_columns(
+        &filtered,
+        keyed.snapshot_id,
+        change,
+        output_schema,
+    )?))
 }

--- a/src/table_changes.rs
+++ b/src/table_changes.rs
@@ -815,24 +815,62 @@ impl TableProvider for TableChangesTable {
             return Ok(Arc::new(EmptyExec::new(proj_info.output_schema)));
         }
 
-        // Detect which added data files carry an embedded rowid column: those are
-        // the postimages of an UPDATE / compaction. Only when at least one is
-        // present do we correlate delete+insert pairs — a catalog of plain
-        // INSERTs (no embedded files) stays on the historical insert-only path
-        // below, byte-for-byte unchanged (no delete reads, no reclassification).
-        let mut embedded_names: Vec<Option<String>> = Vec::with_capacity(data_files.len());
-        let mut any_embedded = false;
-        for data_file in &data_files {
-            let name = self
-                .detect_embedded_rowid_name(state, &data_file.path, data_file.path_is_relative)
-                .await?;
-            any_embedded |= name.is_some();
-            embedded_names.push(name);
-        }
-        if any_embedded {
-            return self
-                .build_correlated_changes(state, &data_files, &embedded_names, projection)
-                .await;
+        // Decide whether to take the correlated path (pairing an UPDATE's
+        // delete+insert into preimage/postimage). Two guards, BOTH cheap and
+        // metadata-only, keep the common cases off the expensive/unsafe footer
+        // probing that the correlated path needs:
+        //
+        //  1. Deletes-present: an UPDATE (or compaction) ALWAYS adds a positional
+        //     delete, so a range with no added delete files cannot contain an
+        //     UPDATE — there is nothing to correlate. Skipping detection here
+        //     means a plain-INSERT catalog does ZERO per-file parquet footer
+        //     reads at plan time (previously it probed every added file).
+        //  2. Not encrypted: the correlated path reads parquet footers (to detect
+        //     the embedded-rowid postimage) and the source rows of deletes, none
+        //     of which it can decrypt (the delete-side change record carries no
+        //     key). On a PME catalog we therefore stay on the historical
+        //     insert-only path below — which IS encryption-aware — so CDC never
+        //     fails; the tradeoff is that UPDATEs are not correlated into
+        //     preimage/postimage there (they surface as plain inserts). See
+        //     COMPATIBILITY.md.
+        let any_encrypted = {
+            #[cfg(feature = "encryption")]
+            {
+                data_files.iter().any(|d| d.encryption_key.is_some())
+            }
+            #[cfg(not(feature = "encryption"))]
+            {
+                false
+            }
+        };
+        let range_has_deletes = !self
+            .provider
+            .get_delete_files_added_between_snapshots(
+                self.table_id,
+                self.start_snapshot,
+                self.end_snapshot,
+            )
+            .map_err(|e| DataFusionError::External(Box::new(e)))?
+            .is_empty();
+
+        if range_has_deletes && !any_encrypted {
+            // Detect which added data files carry an embedded rowid column (the
+            // postimages of an UPDATE / compaction). Only probe footers now that
+            // we know a delete exists and the files are readable un-decrypted.
+            let mut embedded_names: Vec<Option<String>> = Vec::with_capacity(data_files.len());
+            let mut any_embedded = false;
+            for data_file in &data_files {
+                let name = self
+                    .detect_embedded_rowid_name(state, &data_file.path, data_file.path_is_relative)
+                    .await?;
+                any_embedded |= name.is_some();
+                embedded_names.push(name);
+            }
+            if any_embedded {
+                return self
+                    .build_correlated_changes(state, &data_files, &embedded_names, projection)
+                    .await;
+            }
         }
 
         // Build encryption factory from file encryption keys (when encryption feature is enabled)

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -22,6 +22,7 @@ use crate::metadata_writer::{
     WriteResult, validate_delete_entries,
 };
 use crate::path_resolver::join_paths;
+use crate::row_id::embedded_rowid_field;
 use crate::table::delete_file_schema;
 
 /// High-level writer for DuckLake tables.
@@ -118,6 +119,49 @@ impl DuckLakeTableWriter {
             file_name.clone(),
             file_name,
             true,
+            false,
+            mode,
+        )
+    }
+
+    /// Begin a streaming write session whose parquet output carries an extra
+    /// embedded row-id column (field-id [`ROW_ID_PARQUET_FIELD_ID`]) appended
+    /// after the table's data columns, so rewritten rows preserve their DuckLake
+    /// row lineage across the file rewrite (the commit behind `UPDATE` /
+    /// compaction).
+    ///
+    /// `arrow_schema` describes ONLY the table's data columns (no rowid), exactly
+    /// as for [`begin_write`](Self::begin_write); the embedded column is added to
+    /// the parquet schema here and is NOT registered as a catalog column. Batches
+    /// passed to [`TableWriteSession::write_batch`] must therefore have the data
+    /// columns in order followed by a trailing `Int64` rowid column holding each
+    /// row's original rowid. A later read detects the embedded column by its
+    /// field-id and serves those rowids inline instead of synthesizing
+    /// `row_id_start + position`.
+    ///
+    /// [`ROW_ID_PARQUET_FIELD_ID`]: crate::row_id::ROW_ID_PARQUET_FIELD_ID
+    pub fn begin_write_with_embedded_rowid(
+        &self,
+        schema_name: &str,
+        table_name: &str,
+        arrow_schema: &Schema,
+        mode: WriteMode,
+    ) -> Result<TableWriteSession> {
+        let scoped_base = match self.metadata.catalog_id() {
+            Some(id) => join_paths(&self.base_key_path, &format!("cat_{id}"))?,
+            None => self.base_key_path.clone(),
+        };
+        let table_key = join_paths(&join_paths(&scoped_base, schema_name)?, table_name)?;
+        let file_name = format!("{}.parquet", Uuid::new_v4());
+        self.begin_write_internal(
+            schema_name,
+            table_name,
+            arrow_schema,
+            table_key,
+            file_name.clone(),
+            file_name,
+            true,
+            true,
             mode,
         )
     }
@@ -141,6 +185,7 @@ impl DuckLakeTableWriter {
             file_name,
             full_path,
             false,
+            false,
             mode,
         )
     }
@@ -155,14 +200,27 @@ impl DuckLakeTableWriter {
         file_name: String,
         catalog_path: String,
         path_is_relative: bool,
+        embed_rowid: bool,
         mode: WriteMode,
     ) -> Result<TableWriteSession> {
         let columns = arrow_schema_to_column_defs(arrow_schema)?;
         let setup =
             self.metadata
                 .begin_write_transaction(schema_name, table_name, &columns, mode)?;
-        let schema_with_ids =
-            Arc::new(build_schema_with_field_ids(arrow_schema, &setup.column_ids));
+        // Data columns carry their catalog field-ids. When embedding row lineage,
+        // append the reserved-field-id rowid column AFTER them; it is a parquet-only
+        // column (not a catalog column), so it is absent from `columns`/`column_ids`
+        // and the metadata commit never sees it.
+        let schema_with_ids = {
+            let mut schema = build_schema_with_field_ids(arrow_schema, &setup.column_ids);
+            if embed_rowid {
+                let mut fields: Vec<Field> =
+                    schema.fields().iter().map(|f| f.as_ref().clone()).collect();
+                fields.push(embedded_rowid_field());
+                schema = Schema::new_with_metadata(fields, schema.metadata().clone());
+            }
+            Arc::new(schema)
+        };
 
         let object_path_str = join_paths(&file_dir, &file_name)?;
         // Strip leading slash for object_store Path (it expects relative keys)

--- a/src/update_exec.rs
+++ b/src/update_exec.rs
@@ -1,0 +1,287 @@
+//! DuckLake `UPDATE` execution plan.
+//!
+//! [`DuckLakeUpdateExec`] is the physical operator DataFusion's planner lowers
+//! `UPDATE t SET col = expr ... [WHERE p]` onto (via
+//! [`TableProvider::update`](datafusion::catalog::TableProvider::update)). All
+//! work is deferred to execute time so planning / `EXPLAIN` never mutate data:
+//!
+//! 1. For each source data file that may hold matching rows, collect its
+//!    pre-built positional scan, select the rows matching the predicate, apply
+//!    the assignments, and produce rewritten row versions that RETAIN each row's
+//!    original rowid (written into a NEW data file that embeds the rowid column,
+//!    so lineage survives the rewrite).
+//! 2. Resolve, per source file, the cumulative positional delete masking the old
+//!    row versions (superseded rows unioned with any already-deleted rows).
+//! 3. Commit ATOMICALLY: the appended data file AND every positional delete land
+//!    in ONE snapshot via
+//!    [`MetadataWriter::register_data_file_with_deletes`]
+//!    (driven by `TableWriteSession::finish_with_deletes`).
+//! 4. Yield a single row `count: UInt64` = rows updated.
+//!
+//! Limitations (shared with [`DuckLakeInsertExec`](crate::insert_exec)):
+//! collects matched rows into memory before writing; single partition only.
+
+use std::fmt::{self, Debug};
+use std::sync::Arc;
+
+use arrow::array::{ArrayRef, RecordBatch, UInt64Array};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::error::{DataFusionError, Result as DataFusionResult};
+use datafusion::execution::object_store::ObjectStoreUrl;
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_expr::{EquivalenceProperties, Partitioning, PhysicalExpr};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use futures::stream::{self, TryStreamExt};
+
+use crate::metadata_writer::{DeleteFileEntry, MetadataWriter, WriteMode};
+use crate::table::{DuckLakeTable, UpdateSourceScan};
+use crate::table_writer::DuckLakeTableWriter;
+
+/// Schema for the output of update operations (count of rows updated).
+fn make_update_count_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![Field::new(
+        "count",
+        DataType::UInt64,
+        false,
+    )]))
+}
+
+/// Execution plan that applies an `UPDATE` to a DuckLake table.
+pub struct DuckLakeUpdateExec {
+    /// Read-only handle to the target table, used to turn each source file's
+    /// collected scan batches into rewritten rows at execute time.
+    table: Arc<DuckLakeTable>,
+    /// Metadata writer for the atomic append-with-deletes commit.
+    writer: Arc<dyn MetadataWriter>,
+    schema_name: String,
+    table_name: String,
+    /// Per-source-file positional read plans (built at plan time).
+    scans: Vec<UpdateSourceScan>,
+    /// `(physical_column_index, new_value_expr)` for each assigned column.
+    assignments: Vec<(usize, Arc<dyn PhysicalExpr>)>,
+    /// AND of the WHERE predicates, or `None` to update all rows.
+    predicate: Option<Arc<dyn PhysicalExpr>>,
+    object_store_url: Arc<ObjectStoreUrl>,
+    cache: Arc<PlanProperties>,
+}
+
+impl DuckLakeUpdateExec {
+    /// Create a new `DuckLakeUpdateExec`.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        table: Arc<DuckLakeTable>,
+        writer: Arc<dyn MetadataWriter>,
+        schema_name: String,
+        table_name: String,
+        scans: Vec<UpdateSourceScan>,
+        assignments: Vec<(usize, Arc<dyn PhysicalExpr>)>,
+        predicate: Option<Arc<dyn PhysicalExpr>>,
+        object_store_url: Arc<ObjectStoreUrl>,
+    ) -> Self {
+        let cache = Self::compute_properties();
+        Self {
+            table,
+            writer,
+            schema_name,
+            table_name,
+            scans,
+            assignments,
+            predicate,
+            object_store_url,
+            cache,
+        }
+    }
+
+    fn compute_properties() -> Arc<PlanProperties> {
+        Arc::new(PlanProperties::new(
+            EquivalenceProperties::new(make_update_count_schema()),
+            Partitioning::UnknownPartitioning(1),
+            datafusion::physical_plan::execution_plan::EmissionType::Final,
+            datafusion::physical_plan::execution_plan::Boundedness::Bounded,
+        ))
+    }
+}
+
+impl Debug for DuckLakeUpdateExec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DuckLakeUpdateExec")
+            .field("schema_name", &self.schema_name)
+            .field("table_name", &self.table_name)
+            .field("source_files", &self.scans.len())
+            .field("assignments", &self.assignments.len())
+            .field("has_predicate", &self.predicate.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+impl DisplayAs for DuckLakeUpdateExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        match t {
+            DisplayFormatType::Default
+            | DisplayFormatType::Verbose
+            | DisplayFormatType::TreeRender => {
+                write!(
+                    f,
+                    "DuckLakeUpdateExec: schema={}, table={}, assignments={}, where={}",
+                    self.schema_name,
+                    self.table_name,
+                    self.assignments.len(),
+                    if self.predicate.is_some() {
+                        "yes"
+                    } else {
+                        "no"
+                    }
+                )
+            },
+        }
+    }
+}
+
+impl ExecutionPlan for DuckLakeUpdateExec {
+    fn name(&self) -> &str {
+        "DuckLakeUpdateExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.cache
+    }
+
+    /// No DataFusion children: the per-file source scans are internal and are
+    /// executed directly at execute time, so the optimizer treats this as a
+    /// leaf and never rewrites (e.g. repartitions) those scans.
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        if !children.is_empty() {
+            return Err(DataFusionError::Internal(
+                "DuckLakeUpdateExec has no children".to_string(),
+            ));
+        }
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        if partition != 0 {
+            return Err(DataFusionError::Internal(format!(
+                "DuckLakeUpdateExec only supports partition 0, got {partition}"
+            )));
+        }
+
+        let table = Arc::clone(&self.table);
+        let writer = Arc::clone(&self.writer);
+        let schema_name = self.schema_name.clone();
+        let table_name = self.table_name.clone();
+        let scans = self.scans.clone();
+        let assignments = self.assignments.clone();
+        let predicate = self.predicate.clone();
+        let object_store_url = self.object_store_url.clone();
+        let output_schema = make_update_count_schema();
+
+        let stream = stream::once(async move {
+            let object_store = context
+                .runtime_env()
+                .object_store(object_store_url.as_ref())?;
+            let table_writer = DuckLakeTableWriter::new(writer, object_store)
+                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+            // Rewrite each source file's matching rows and author its cumulative
+            // positional delete. Delete parquet files are uploaded here; the
+            // catalog commit that makes them visible happens once, atomically,
+            // below — so a failure before the commit leaves the live snapshot
+            // untouched (only orphan objects, cleaned by maintenance).
+            let mut updated_batches: Vec<RecordBatch> = Vec::new();
+            let mut delete_entries: Vec<DeleteFileEntry> = Vec::new();
+            let mut total_updated: u64 = 0;
+
+            for scan in &scans {
+                let batches =
+                    datafusion::physical_plan::collect(Arc::clone(&scan.scan), context.clone())
+                        .await?;
+                let out = table.apply_update_to_batches(
+                    scan,
+                    &batches,
+                    predicate.as_ref(),
+                    &assignments,
+                )?;
+                if out.matched_count == 0 {
+                    continue;
+                }
+                total_updated += out.matched_count as u64;
+                updated_batches.extend(out.updated_batches);
+
+                let delete_info = table_writer
+                    .write_delete_file(
+                        &schema_name,
+                        &table_name,
+                        &scan.source_path,
+                        &out.cumulative_positions,
+                    )
+                    .await
+                    .map_err(|e| DataFusionError::External(Box::new(e)))?;
+                delete_entries.push(DeleteFileEntry {
+                    data_file_id: scan.data_file_id,
+                    expected_prev_delete_file: scan.delete_file_id,
+                    delete: delete_info,
+                });
+            }
+
+            // No matching rows: genuine no-op, publish nothing.
+            if total_updated == 0 {
+                let count: ArrayRef = Arc::new(UInt64Array::from(vec![0u64]));
+                return Ok(RecordBatch::try_new(output_schema, vec![count])?);
+            }
+
+            // Append the rewritten rows (embedding their original rowids) AND
+            // apply every positional delete in ONE snapshot.
+            let physical_schema = table.physical_schema();
+            let mut session = table_writer
+                .begin_write_with_embedded_rowid(
+                    &schema_name,
+                    &table_name,
+                    physical_schema.as_ref(),
+                    WriteMode::Append,
+                )
+                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+            for batch in &updated_batches {
+                session
+                    .write_batch(batch)
+                    .map_err(|e| DataFusionError::External(Box::new(e)))?;
+            }
+            session
+                .finish_with_deletes(&delete_entries)
+                .await
+                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+            let count: ArrayRef = Arc::new(UInt64Array::from(vec![total_updated]));
+            Ok(RecordBatch::try_new(output_schema, vec![count])?)
+        });
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            make_update_count_schema(),
+            stream.map_err(|e: DataFusionError| e),
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_update_count_schema() {
+        let schema = make_update_count_schema();
+        assert_eq!(schema.fields().len(), 1);
+        assert_eq!(schema.field(0).name(), "count");
+        assert_eq!(schema.field(0).data_type(), &DataType::UInt64);
+    }
+}

--- a/src/update_exec.rs
+++ b/src/update_exec.rs
@@ -20,6 +20,27 @@
 //!
 //! Limitations (shared with [`DuckLakeInsertExec`](crate::insert_exec)):
 //! collects matched rows into memory before writing; single partition only.
+//!
+//! # Session lifecycle (important)
+//!
+//! A [`DuckLakeCatalog`](crate::DuckLakeCatalog) pins its snapshot at creation
+//! and never refreshes it, so a `SessionContext` observes ONE catalog generation
+//! for its whole lifetime. An `UPDATE` commits a new snapshot, but the same
+//! session keeps reading the old one. Consequences:
+//!
+//! - A second `UPDATE` in the same session that re-touches a data file modified
+//!   by an earlier `UPDATE` (in that same session) aborts with a
+//!   [`Conflict`](crate::DuckLakeError::Conflict): it resolves against the pinned
+//!   (pre-update) view, so the atomic commit's compare-and-swap disagrees with
+//!   the live catalog. This is the same guard that (correctly) rejects a
+//!   genuinely concurrent writer, so it is safe (the first update is preserved),
+//!   just not retryable in-session.
+//! - A `SELECT` after an `UPDATE`/`INSERT` in the same session returns the
+//!   pre-mutation rows; a just-inserted row cannot be updated in the same
+//!   session (it is invisible to the pinned snapshot).
+//!
+//! To perform multiple mutations, re-open the catalog (or create a fresh
+//! `SessionContext`) between statements so it binds to the latest snapshot.
 
 use std::fmt::{self, Debug};
 use std::sync::Arc;

--- a/tests/sql_update_postgres_tests.rs
+++ b/tests/sql_update_postgres_tests.rs
@@ -1,0 +1,153 @@
+//! Postgres (multicatalog) coverage for SQL `UPDATE` end to end.
+//!
+//! The UPDATE commit reuses `register_data_file_with_deletes` (already validated
+//! on Postgres by `append_with_deletes_postgres_tests.rs`); this PR only flips
+//! `PostgresMetadataWriter::supports_update()` to true. What was untested is the
+//! full `TableProvider::update` path driven by SQL against a writable multicatalog
+//! catalog, which this test exercises: affected-row count, the resulting values,
+//! and rowid-lineage preservation across the embedded-rowid file rewrite.
+//! Docker-gated (testcontainers Postgres).
+
+#![cfg(feature = "write-postgres")]
+
+use std::sync::Arc;
+
+use arrow::array::{Array, Int32Array, Int64Array, RecordBatch, UInt64Array};
+use arrow::datatypes::{DataType, Field, Schema};
+use datafusion::prelude::*;
+use datafusion_ducklake::{
+    DuckLakeCatalog, DuckLakeTableWriter, MetadataWriter, MulticatalogManager, MulticatalogProvider,
+    PostgresMetadataWriter,
+};
+use object_store::local::LocalFileSystem;
+use sqlx::postgres::{PgPool, PgPoolOptions};
+use tempfile::TempDir;
+use testcontainers::ContainerAsync;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+type ObjStore = Arc<dyn object_store::ObjectStore>;
+
+async fn spin_up_postgres() -> anyhow::Result<(PgPool, ContainerAsync<Postgres>)> {
+    let container = Postgres::default().start().await?;
+    let port = container.get_host_port_ipv4(5432).await?;
+    let conn_str = format!("postgresql://postgres:postgres@127.0.0.1:{}/postgres", port);
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&conn_str)
+        .await?;
+    datafusion_ducklake::initialize_multicatalog_schema(&pool).await?;
+    Ok((pool, container))
+}
+
+fn schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("val", DataType::Int32, false),
+    ]))
+}
+
+async fn writer_for(pool: &PgPool, cat: i64, data_path: &std::path::Path) -> Arc<PostgresMetadataWriter> {
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path(data_path.to_str().unwrap()).unwrap();
+    Arc::new(w)
+}
+
+/// A writable SessionContext over the multicatalog catalog (provider + writer).
+async fn writable_ctx(pool: &PgPool, cat_name: &str, cat: i64, data: &std::path::Path) -> SessionContext {
+    let provider = MulticatalogProvider::with_pool(pool.clone(), cat_name).await.unwrap();
+    let writer = PostgresMetadataWriter::with_pool(pool.clone(), cat).await.unwrap();
+    writer.set_data_path(data.to_str().unwrap()).unwrap();
+    let catalog = DuckLakeCatalog::with_writer(Arc::new(provider), Arc::new(writer)).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog(cat_name, Arc::new(catalog));
+    ctx
+}
+
+async fn read_rowid_rows(pool: &PgPool, cat_name: &str) -> Vec<(i64, i32, i32)> {
+    let provider = MulticatalogProvider::with_pool(pool.clone(), cat_name).await.unwrap();
+    let catalog = DuckLakeCatalog::new(provider).unwrap().with_row_lineage(true);
+    let ctx = SessionContext::new();
+    ctx.register_catalog(cat_name, Arc::new(catalog));
+    let batches = ctx
+        .sql(&format!("SELECT rowid, id, val FROM {cat_name}.public.t ORDER BY id"))
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let mut rows = Vec::new();
+    for b in &batches {
+        let ri = b.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+        let i = b.column(1).as_any().downcast_ref::<Int32Array>().unwrap();
+        let v = b.column(2).as_any().downcast_ref::<Int32Array>().unwrap();
+        for r in 0..b.num_rows() {
+            assert!(!ri.is_null(r), "rowid must not be NULL after UPDATE");
+            rows.push((ri.value(r), i.value(r), v.value(r)));
+        }
+    }
+    rows
+}
+
+/// SQL `UPDATE ... WHERE` end to end on multicatalog Postgres: correct count,
+/// correct new/old values, row count unchanged, and rowid lineage preserved.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn update_where_end_to_end_postgres() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let tmp = TempDir::new().unwrap();
+    let data = tmp.path().join("data");
+    std::fs::create_dir_all(&data).unwrap();
+    let os: ObjStore = Arc::new(LocalFileSystem::new());
+    let cat_name = "cat";
+    let cat = MulticatalogManager::new(pool.clone())
+        .create_catalog(cat_name)
+        .await
+        .unwrap();
+
+    // Seed (1,10),(2,20),(3,40),(4,40) as one data file (rowids 0..3).
+    let seed = RecordBatch::try_new(
+        schema(),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3, 4])),
+            Arc::new(Int32Array::from(vec![10, 20, 30, 40])),
+        ],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(writer_for(&pool, cat, &data).await, os.clone())
+        .unwrap()
+        .write_table("public", "t", &[seed])
+        .await
+        .unwrap();
+    assert_eq!(
+        read_rowid_rows(&pool, cat_name).await,
+        vec![(0, 1, 10), (1, 2, 20), (2, 3, 30), (3, 4, 40)],
+        "baseline rowids"
+    );
+
+    // UPDATE via SQL through a writable catalog.
+    let ctx = writable_ctx(&pool, cat_name, cat, &data).await;
+    let batches = ctx
+        .sql(&format!("UPDATE {cat_name}.public.t SET val = val * 10 WHERE id IN (2, 4)"))
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let count = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .expect("count is UInt64")
+        .value(0);
+    assert_eq!(count, 2, "ids 2 and 4 matched");
+
+    // Updated rows keep their ORIGINAL rowids (1 and 3); others unchanged.
+    assert_eq!(
+        read_rowid_rows(&pool, cat_name).await,
+        vec![(0, 1, 10), (1, 2, 200), (2, 3, 30), (3, 4, 400)],
+        "values updated in place; rowids 1 and 3 preserved across the rewrite"
+    );
+}

--- a/tests/sql_update_postgres_tests.rs
+++ b/tests/sql_update_postgres_tests.rs
@@ -16,8 +16,8 @@ use arrow::array::{Array, Int32Array, Int64Array, RecordBatch, UInt64Array};
 use arrow::datatypes::{DataType, Field, Schema};
 use datafusion::prelude::*;
 use datafusion_ducklake::{
-    DuckLakeCatalog, DuckLakeTableWriter, MetadataWriter, MulticatalogManager, MulticatalogProvider,
-    PostgresMetadataWriter,
+    DuckLakeCatalog, DuckLakeTableWriter, MetadataWriter, MulticatalogManager,
+    MulticatalogProvider, PostgresMetadataWriter,
 };
 use object_store::local::LocalFileSystem;
 use sqlx::postgres::{PgPool, PgPoolOptions};
@@ -47,7 +47,11 @@ fn schema() -> Arc<Schema> {
     ]))
 }
 
-async fn writer_for(pool: &PgPool, cat: i64, data_path: &std::path::Path) -> Arc<PostgresMetadataWriter> {
+async fn writer_for(
+    pool: &PgPool,
+    cat: i64,
+    data_path: &std::path::Path,
+) -> Arc<PostgresMetadataWriter> {
     let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
         .await
         .unwrap();
@@ -56,9 +60,18 @@ async fn writer_for(pool: &PgPool, cat: i64, data_path: &std::path::Path) -> Arc
 }
 
 /// A writable SessionContext over the multicatalog catalog (provider + writer).
-async fn writable_ctx(pool: &PgPool, cat_name: &str, cat: i64, data: &std::path::Path) -> SessionContext {
-    let provider = MulticatalogProvider::with_pool(pool.clone(), cat_name).await.unwrap();
-    let writer = PostgresMetadataWriter::with_pool(pool.clone(), cat).await.unwrap();
+async fn writable_ctx(
+    pool: &PgPool,
+    cat_name: &str,
+    cat: i64,
+    data: &std::path::Path,
+) -> SessionContext {
+    let provider = MulticatalogProvider::with_pool(pool.clone(), cat_name)
+        .await
+        .unwrap();
+    let writer = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
     writer.set_data_path(data.to_str().unwrap()).unwrap();
     let catalog = DuckLakeCatalog::with_writer(Arc::new(provider), Arc::new(writer)).unwrap();
     let ctx = SessionContext::new();
@@ -67,12 +80,18 @@ async fn writable_ctx(pool: &PgPool, cat_name: &str, cat: i64, data: &std::path:
 }
 
 async fn read_rowid_rows(pool: &PgPool, cat_name: &str) -> Vec<(i64, i32, i32)> {
-    let provider = MulticatalogProvider::with_pool(pool.clone(), cat_name).await.unwrap();
-    let catalog = DuckLakeCatalog::new(provider).unwrap().with_row_lineage(true);
+    let provider = MulticatalogProvider::with_pool(pool.clone(), cat_name)
+        .await
+        .unwrap();
+    let catalog = DuckLakeCatalog::new(provider)
+        .unwrap()
+        .with_row_lineage(true);
     let ctx = SessionContext::new();
     ctx.register_catalog(cat_name, Arc::new(catalog));
     let batches = ctx
-        .sql(&format!("SELECT rowid, id, val FROM {cat_name}.public.t ORDER BY id"))
+        .sql(&format!(
+            "SELECT rowid, id, val FROM {cat_name}.public.t ORDER BY id"
+        ))
         .await
         .unwrap()
         .collect()
@@ -130,7 +149,9 @@ async fn update_where_end_to_end_postgres() {
     // UPDATE via SQL through a writable catalog.
     let ctx = writable_ctx(&pool, cat_name, cat, &data).await;
     let batches = ctx
-        .sql(&format!("UPDATE {cat_name}.public.t SET val = val * 10 WHERE id IN (2, 4)"))
+        .sql(&format!(
+            "UPDATE {cat_name}.public.t SET val = val * 10 WHERE id IN (2, 4)"
+        ))
         .await
         .unwrap()
         .collect()

--- a/tests/sql_update_tests.rs
+++ b/tests/sql_update_tests.rs
@@ -450,3 +450,131 @@ async fn update_change_feed_ignores_unrelated_inserts() {
         "only the correlated pair is surfaced"
     );
 }
+
+/// A second UPDATE in the SAME session that re-touches a file the first UPDATE
+/// modified must abort with a clear conflict (the catalog pins its snapshot to
+/// the pre-update generation) — and must NOT corrupt: the first update's result
+/// is preserved and the second row is left unchanged.
+#[tokio::test(flavor = "multi_thread")]
+async fn update_second_in_session_conflicts_without_corruption() {
+    let temp_dir = TempDir::new().unwrap();
+    seed_table(&temp_dir, vec![1, 2, 3, 4], vec![10, 20, 30, 40]).await;
+
+    let ctx = writable_ctx(&temp_dir).await;
+    assert_eq!(
+        run_dml_count(&ctx, "UPDATE ducklake.main.t SET val = 200 WHERE id = 2").await,
+        1
+    );
+    assert_eq!(read_pairs(&temp_dir).await, vec![(1, 10), (2, 200), (3, 30), (4, 40)]);
+
+    // Second UPDATE (same session, same file) — aborts on the commit CAS.
+    let err = ctx
+        .sql("UPDATE ducklake.main.t SET val = 300 WHERE id = 3")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .expect_err("second in-session UPDATE must conflict, not silently corrupt");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Re-open the catalog") && msg.contains("THIS session"),
+        "conflict message must explain the pinned-snapshot cause, got: {msg}"
+    );
+
+    // Clean abort: id=2 stays updated, id=3 unchanged, no row lost/duplicated.
+    assert_eq!(
+        read_pairs(&temp_dir).await,
+        vec![(1, 10), (2, 200), (3, 30), (4, 40)],
+        "aborted UPDATE leaves the first update intact and id=3 unchanged"
+    );
+}
+
+/// CDC over a range that mixes an unrelated plain INSERT with an UPDATE: the
+/// insert must surface as `insert`, and the update as a preimage/postimage pair.
+/// Exercises the correlated path together with a non-embedded insert file (the
+/// `update_change_feed_ignores_unrelated_inserts` test does not actually insert).
+#[tokio::test(flavor = "multi_thread")]
+async fn update_change_feed_mixed_insert_and_update() {
+    let temp_dir = TempDir::new().unwrap();
+    seed_table(&temp_dir, vec![1, 2], vec![10, 20]).await;
+    let before = max_snapshot(&temp_dir).await;
+
+    // Snapshot +1: a plain INSERT (no embedded rowid).
+    run_dml_count(&writable_ctx(&temp_dir).await, "INSERT INTO ducklake.main.t VALUES (9, 90)").await;
+    // Snapshot +2: an UPDATE.
+    run_dml_count(&writable_ctx(&temp_dir).await, "UPDATE ducklake.main.t SET val = 100 WHERE id = 1").await;
+    let after = max_snapshot(&temp_dir).await;
+
+    let fctx = functions_ctx(&temp_dir).await;
+    let sql = format!(
+        "SELECT id, val, change_type FROM ducklake_table_changes('main.t', {before}, {after}) \
+         ORDER BY change_type, id"
+    );
+    let batches = fctx.sql(&sql).await.unwrap().collect().await.unwrap();
+    let mut got: Vec<(i32, i32, String)> = Vec::new();
+    for b in &batches {
+        let ids = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        let vals = b.column(1).as_any().downcast_ref::<Int32Array>().unwrap();
+        let ct = b.column(2);
+        let cts: Vec<String> = ct
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .map(|a| (0..a.len()).map(|i| a.value(i).to_string()).collect())
+            .or_else(|| {
+                ct.as_any()
+                    .downcast_ref::<arrow::array::StringViewArray>()
+                    .map(|a| (0..a.len()).map(|i| a.value(i).to_string()).collect())
+            })
+            .expect("change_type is a string column");
+        for (i, c) in cts.iter().enumerate() {
+            got.push((ids.value(i), vals.value(i), c.clone()));
+        }
+    }
+    assert_eq!(
+        got,
+        vec![
+            (9, 90, "insert".to_string()),
+            (1, 100, "update_postimage".to_string()),
+            (1, 10, "update_preimage".to_string()),
+        ],
+        "unrelated insert stays an insert; the update is a preimage/postimage pair"
+    );
+}
+
+/// CDC over an INSERT-only range (no UPDATE/DELETE): every added row is an
+/// `insert` and nothing is reclassified. Guards the fast path that must NOT do
+/// the correlated delete+insert probing when the range applied no deletes.
+#[tokio::test(flavor = "multi_thread")]
+async fn change_feed_insert_only_range_is_all_inserts() {
+    let temp_dir = TempDir::new().unwrap();
+    seed_table(&temp_dir, vec![1, 2], vec![10, 20]).await;
+    let before = max_snapshot(&temp_dir).await;
+    run_dml_count(&writable_ctx(&temp_dir).await, "INSERT INTO ducklake.main.t VALUES (3, 30)").await;
+    let after = max_snapshot(&temp_dir).await;
+
+    let fctx = functions_ctx(&temp_dir).await;
+    let sql = format!(
+        "SELECT change_type, COUNT(*) AS n FROM ducklake_table_changes('main.t', {before}, {after}) \
+         GROUP BY change_type ORDER BY change_type"
+    );
+    let batches = fctx.sql(&sql).await.unwrap().collect().await.unwrap();
+    let mut counts: Vec<(String, i64)> = Vec::new();
+    for b in &batches {
+        let ct = b.column(0);
+        let cts: Vec<String> = ct
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .map(|a| (0..a.len()).map(|i| a.value(i).to_string()).collect())
+            .or_else(|| {
+                ct.as_any()
+                    .downcast_ref::<arrow::array::StringViewArray>()
+                    .map(|a| (0..a.len()).map(|i| a.value(i).to_string()).collect())
+            })
+            .unwrap();
+        let n = b.column(1).as_any().downcast_ref::<Int64Array>().unwrap();
+        for (i, c) in cts.iter().enumerate() {
+            counts.push((c.clone(), n.value(i)));
+        }
+    }
+    assert_eq!(counts, vec![("insert".to_string(), 1)], "insert-only range yields only inserts");
+}

--- a/tests/sql_update_tests.rs
+++ b/tests/sql_update_tests.rs
@@ -1,0 +1,452 @@
+//! Integration tests for SQL `UPDATE` support (SQLite metadata backend).
+//!
+//! Exercises `UPDATE t SET col = expr [, ...] [WHERE ...]` end-to-end through
+//! DataFusion's SQL interface against a writable DuckLake catalog: affected-row
+//! count, the resulting values, atomicity (one snapshot), rowid-lineage
+//! preservation across the file rewrite, the change feed (preimage/postimage),
+//! and update-all.
+
+#![cfg(all(feature = "write-sqlite", feature = "metadata-sqlite"))]
+
+use std::sync::Arc;
+
+use arrow::array::{Array, Int32Array, Int64Array, UInt64Array};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use datafusion::prelude::*;
+use object_store::local::LocalFileSystem;
+use sqlx::sqlite::SqlitePool;
+use tempfile::TempDir;
+
+use datafusion_ducklake::{
+    DuckLakeCatalog, DuckLakeTableWriter, MetadataProvider, MetadataWriter, SqliteMetadataProvider,
+    SqliteMetadataWriter, register_ducklake_functions,
+};
+
+/// The `(id, val)` schema used throughout.
+fn table_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("val", DataType::Int32, false),
+    ]))
+}
+
+fn object_store() -> Arc<dyn object_store::ObjectStore> {
+    Arc::new(LocalFileSystem::new())
+}
+
+/// A writable SQLite-backed catalog + data dir in `temp_dir`.
+async fn make_writer(temp_dir: &TempDir) -> SqliteMetadataWriter {
+    let db_path = temp_dir.path().join("test.db");
+    let data_path = temp_dir.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+    let conn_str = format!("sqlite:{}?mode=rwc", db_path.display());
+    let writer = SqliteMetadataWriter::new_with_init(&conn_str)
+        .await
+        .unwrap();
+    writer.set_data_path(data_path.to_str().unwrap()).unwrap();
+    writer
+}
+
+/// Seed a single data file `t(id, val)` from the given rows via the low-level
+/// writer (deterministic file layout: `row_id_start = 0`, positions `0..n`).
+async fn seed_table(temp_dir: &TempDir, ids: Vec<i32>, vals: Vec<i32>) {
+    let writer = Arc::new(make_writer(temp_dir).await);
+    let batch = RecordBatch::try_new(
+        table_schema(),
+        vec![Arc::new(Int32Array::from(ids)), Arc::new(Int32Array::from(vals))],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(writer, object_store())
+        .unwrap()
+        .write_table("main", "t", &[batch])
+        .await
+        .unwrap();
+}
+
+/// Append a second data file to `t`.
+async fn append_file(temp_dir: &TempDir, ids: Vec<i32>, vals: Vec<i32>) {
+    let db_path = temp_dir.path().join("test.db");
+    let conn_str = format!("sqlite:{}?mode=rwc", db_path.display());
+    let writer = Arc::new(SqliteMetadataWriter::new(&conn_str).await.unwrap());
+    let batch = RecordBatch::try_new(
+        table_schema(),
+        vec![Arc::new(Int32Array::from(ids)), Arc::new(Int32Array::from(vals))],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(writer, object_store())
+        .unwrap()
+        .append_table("main", "t", &[batch])
+        .await
+        .unwrap();
+}
+
+/// A writable SessionContext bound to the seeded catalog.
+async fn writable_ctx(temp_dir: &TempDir) -> SessionContext {
+    let db_path = temp_dir.path().join("test.db");
+    let conn_str = format!("sqlite:{}?mode=rwc", db_path.display());
+    let writer = SqliteMetadataWriter::new(&conn_str).await.unwrap();
+    let provider = SqliteMetadataProvider::new(&conn_str).await.unwrap();
+    let catalog = DuckLakeCatalog::with_writer(Arc::new(provider), Arc::new(writer)).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog("ducklake", Arc::new(catalog));
+    ctx
+}
+
+/// A read-only SessionContext; when `row_lineage`, tables expose the `rowid`
+/// column.
+async fn read_ctx(temp_dir: &TempDir, row_lineage: bool) -> SessionContext {
+    let db_path = temp_dir.path().join("test.db");
+    let conn_str = format!("sqlite:{}", db_path.display());
+    let provider = SqliteMetadataProvider::new(&conn_str).await.unwrap();
+    let catalog = DuckLakeCatalog::new(provider)
+        .unwrap()
+        .with_row_lineage(row_lineage);
+    let ctx = SessionContext::new();
+    ctx.register_catalog("ducklake", Arc::new(catalog));
+    ctx
+}
+
+/// A SessionContext with the `ducklake_*()` table functions registered.
+async fn functions_ctx(temp_dir: &TempDir) -> SessionContext {
+    let db_path = temp_dir.path().join("test.db");
+    let conn_str = format!("sqlite:{}", db_path.display());
+    let provider = SqliteMetadataProvider::new(&conn_str).await.unwrap();
+    let provider_arc: Arc<dyn MetadataProvider> =
+        Arc::new(SqliteMetadataProvider::new(&conn_str).await.unwrap());
+    let catalog = DuckLakeCatalog::new(provider).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog("ducklake", Arc::new(catalog));
+    register_ducklake_functions(&ctx, provider_arc);
+    ctx
+}
+
+/// Run `sql` and return the single `count` (UInt64) it yields (INSERT/UPDATE).
+async fn run_dml_count(ctx: &SessionContext, sql: &str) -> u64 {
+    let batches = ctx.sql(sql).await.unwrap().collect().await.unwrap();
+    assert_eq!(batches.len(), 1, "DML should yield exactly one batch");
+    assert_eq!(batches[0].num_rows(), 1, "DML count batch has one row");
+    batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .expect("count column is UInt64")
+        .value(0)
+}
+
+/// `(id, val)` from `t`, ascending by id, through the full read path.
+async fn read_pairs(temp_dir: &TempDir) -> Vec<(i32, i32)> {
+    let ctx = read_ctx(temp_dir, false).await;
+    let batches = ctx
+        .sql("SELECT id, val FROM ducklake.main.t ORDER BY id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let mut rows = Vec::new();
+    for b in &batches {
+        let ids = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        let vals = b.column(1).as_any().downcast_ref::<Int32Array>().unwrap();
+        for i in 0..b.num_rows() {
+            rows.push((ids.value(i), vals.value(i)));
+        }
+    }
+    rows
+}
+
+/// `(rowid, id, val)` from `t`, ascending by id, via the row-lineage read path.
+async fn read_rowid_rows(temp_dir: &TempDir) -> Vec<(i64, i32, i32)> {
+    let ctx = read_ctx(temp_dir, true).await;
+    let batches = ctx
+        .sql("SELECT rowid, id, val FROM ducklake.main.t ORDER BY id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let mut rows = Vec::new();
+    for b in &batches {
+        let rowids = b.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+        let ids = b.column(1).as_any().downcast_ref::<Int32Array>().unwrap();
+        let vals = b.column(2).as_any().downcast_ref::<Int32Array>().unwrap();
+        for i in 0..b.num_rows() {
+            assert!(!rowids.is_null(i), "rowid must not be NULL after UPDATE");
+            rows.push((rowids.value(i), ids.value(i), vals.value(i)));
+        }
+    }
+    rows
+}
+
+async fn snapshot_count(temp_dir: &TempDir) -> i64 {
+    let db_path = temp_dir.path().join("test.db");
+    let conn_str = format!("sqlite:{}", db_path.display());
+    let pool = SqlitePool::connect(&conn_str).await.unwrap();
+    sqlx::query_scalar("SELECT COUNT(*) FROM ducklake_snapshot")
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+}
+
+async fn max_snapshot(temp_dir: &TempDir) -> i64 {
+    let db_path = temp_dir.path().join("test.db");
+    let conn_str = format!("sqlite:{}", db_path.display());
+    let pool = SqlitePool::connect(&conn_str).await.unwrap();
+    sqlx::query_scalar("SELECT COALESCE(MAX(snapshot_id), 0) FROM ducklake_snapshot")
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+}
+
+async fn live_data_file_count(temp_dir: &TempDir) -> i64 {
+    let db_path = temp_dir.path().join("test.db");
+    let conn_str = format!("sqlite:{}", db_path.display());
+    let pool = SqlitePool::connect(&conn_str).await.unwrap();
+    sqlx::query_scalar("SELECT COUNT(*) FROM ducklake_data_file WHERE end_snapshot IS NULL")
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+}
+
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_sets_value_where_id() {
+    let temp_dir = TempDir::new().unwrap();
+    seed_table(&temp_dir, vec![1, 2, 3, 4], vec![10, 20, 30, 40]).await;
+    assert_eq!(
+        read_pairs(&temp_dir).await,
+        vec![(1, 10), (2, 20), (3, 30), (4, 40)],
+        "baseline"
+    );
+
+    let ctx = writable_ctx(&temp_dir).await;
+    let count = run_dml_count(&ctx, "UPDATE ducklake.main.t SET val = 200 WHERE id = 2").await;
+    assert_eq!(count, 1, "one row matched id = 2");
+
+    let rows = read_pairs(&temp_dir).await;
+    assert_eq!(
+        rows,
+        vec![(1, 10), (2, 200), (3, 30), (4, 40)],
+        "id=2 gets the new value; others unchanged"
+    );
+    assert_eq!(rows.len(), 4, "row count is unchanged by UPDATE");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_expression_referencing_column() {
+    let temp_dir = TempDir::new().unwrap();
+    seed_table(&temp_dir, vec![1, 2, 3], vec![10, 20, 30]).await;
+
+    let ctx = writable_ctx(&temp_dir).await;
+    // Assignment expression references the column being updated.
+    let count = run_dml_count(
+        &ctx,
+        "UPDATE ducklake.main.t SET val = val + 5 WHERE id >= 2",
+    )
+    .await;
+    assert_eq!(count, 2, "ids 2 and 3 match");
+
+    assert_eq!(
+        read_pairs(&temp_dir).await,
+        vec![(1, 10), (2, 25), (3, 35)],
+        "matched rows get val + 5"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_multi_row_multi_file_is_one_snapshot() {
+    let temp_dir = TempDir::new().unwrap();
+    // Two data files: A=(1,10),(2,20); B=(3,30),(4,40).
+    seed_table(&temp_dir, vec![1, 2], vec![10, 20]).await;
+    append_file(&temp_dir, vec![3, 4], vec![30, 40]).await;
+    assert_eq!(
+        read_pairs(&temp_dir).await,
+        vec![(1, 10), (2, 20), (3, 30), (4, 40)],
+        "baseline across two files"
+    );
+    assert_eq!(
+        live_data_file_count(&temp_dir).await,
+        2,
+        "two live data files"
+    );
+
+    let before = snapshot_count(&temp_dir).await;
+
+    // Update one row from each file in a single statement.
+    let ctx = writable_ctx(&temp_dir).await;
+    let count = run_dml_count(
+        &ctx,
+        "UPDATE ducklake.main.t SET val = val + 1 WHERE id IN (2, 3)",
+    )
+    .await;
+    assert_eq!(count, 2, "one row from each file matched");
+
+    assert_eq!(
+        read_pairs(&temp_dir).await,
+        vec![(1, 10), (2, 21), (3, 31), (4, 40)],
+        "one row updated in each file; the rest unchanged"
+    );
+
+    let after = snapshot_count(&temp_dir).await;
+    assert_eq!(
+        after - before,
+        1,
+        "the whole multi-file update is exactly ONE new snapshot (atomic)"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_preserves_rowid_lineage() {
+    let temp_dir = TempDir::new().unwrap();
+    // One file: rowids 0,1,2,3 for ids 1,2,3,4.
+    seed_table(&temp_dir, vec![1, 2, 3, 4], vec![10, 20, 30, 40]).await;
+    assert_eq!(
+        read_rowid_rows(&temp_dir).await,
+        vec![(0, 1, 10), (1, 2, 20), (2, 3, 30), (3, 4, 40)],
+        "baseline rowids"
+    );
+
+    let ctx = writable_ctx(&temp_dir).await;
+    let count = run_dml_count(
+        &ctx,
+        "UPDATE ducklake.main.t SET val = val * 10 WHERE id IN (2, 4)",
+    )
+    .await;
+    assert_eq!(count, 2);
+
+    // The updated rows keep their ORIGINAL rowids (1 and 3), proving lineage
+    // survives the file rewrite via the embedded row-id column.
+    assert_eq!(
+        read_rowid_rows(&temp_dir).await,
+        vec![(0, 1, 10), (1, 2, 200), (2, 3, 30), (3, 4, 400)],
+        "rowids 1 and 3 are retained by their updated rows"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_all_rows_without_where() {
+    let temp_dir = TempDir::new().unwrap();
+    seed_table(&temp_dir, vec![1, 2, 3], vec![10, 20, 30]).await;
+
+    let ctx = writable_ctx(&temp_dir).await;
+    let count = run_dml_count(&ctx, "UPDATE ducklake.main.t SET val = 99").await;
+    assert_eq!(count, 3, "no WHERE updates every row");
+
+    assert_eq!(
+        read_pairs(&temp_dir).await,
+        vec![(1, 99), (2, 99), (3, 99)],
+        "all rows set to 99"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_change_feed_emits_preimage_and_postimage() {
+    let temp_dir = TempDir::new().unwrap();
+    seed_table(&temp_dir, vec![1, 2, 3], vec![10, 20, 30]).await;
+
+    let before = max_snapshot(&temp_dir).await;
+    let ctx = writable_ctx(&temp_dir).await;
+    let count = run_dml_count(&ctx, "UPDATE ducklake.main.t SET val = 200 WHERE id = 2").await;
+    assert_eq!(count, 1);
+    let after = max_snapshot(&temp_dir).await;
+    assert_eq!(after - before, 1, "one update snapshot");
+
+    // The change feed over the update snapshot pairs the delete + insert that
+    // share rowid 1 into update_preimage (old) + update_postimage (new).
+    let fctx = functions_ctx(&temp_dir).await;
+    let sql = format!(
+        "SELECT id, val, change_type \
+         FROM ducklake_table_changes('main.t', {before}, {after}) \
+         ORDER BY change_type, id"
+    );
+    let batches = fctx.sql(&sql).await.unwrap().collect().await.unwrap();
+
+    let mut got: Vec<(i32, i32, String)> = Vec::new();
+    for b in &batches {
+        let ids = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        let vals = b.column(1).as_any().downcast_ref::<Int32Array>().unwrap();
+        let ct = b.column(2);
+        let ct = ct
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .map(|a| {
+                (0..a.len())
+                    .map(|i| a.value(i).to_string())
+                    .collect::<Vec<_>>()
+            })
+            .or_else(|| {
+                ct.as_any()
+                    .downcast_ref::<arrow::array::StringViewArray>()
+                    .map(|a| {
+                        (0..a.len())
+                            .map(|i| a.value(i).to_string())
+                            .collect::<Vec<_>>()
+                    })
+            })
+            .expect("change_type is a string column");
+        for (i, ct_val) in ct.iter().enumerate() {
+            got.push((ids.value(i), vals.value(i), ct_val.clone()));
+        }
+    }
+
+    assert_eq!(
+        got,
+        vec![(2, 200, "update_postimage".to_string()), (2, 20, "update_preimage".to_string()),],
+        "the update surfaces as a preimage (old) + postimage (new) pair"
+    );
+}
+
+/// A pure delete (no matching insert) must NOT surface in `ducklake_table_changes`
+/// as an update: the correlation only pairs a delete + insert sharing a rowid.
+#[tokio::test(flavor = "multi_thread")]
+async fn update_change_feed_ignores_unrelated_inserts() {
+    let temp_dir = TempDir::new().unwrap();
+    seed_table(&temp_dir, vec![1, 2], vec![10, 20]).await;
+
+    let before = max_snapshot(&temp_dir).await;
+    let ctx = writable_ctx(&temp_dir).await;
+    run_dml_count(&ctx, "UPDATE ducklake.main.t SET val = 99 WHERE id = 1").await;
+    let after = max_snapshot(&temp_dir).await;
+
+    // Exactly one preimage + one postimage for the single updated row; no
+    // spurious plain insert/delete rows.
+    let fctx = functions_ctx(&temp_dir).await;
+    let sql = format!(
+        "SELECT change_type, COUNT(*) AS n \
+         FROM ducklake_table_changes('main.t', {before}, {after}) \
+         GROUP BY change_type ORDER BY change_type"
+    );
+    let batches = fctx.sql(&sql).await.unwrap().collect().await.unwrap();
+    let mut counts: Vec<(String, i64)> = Vec::new();
+    for b in &batches {
+        let ct = b.column(0);
+        let ct = ct
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .map(|a| {
+                (0..a.len())
+                    .map(|i| a.value(i).to_string())
+                    .collect::<Vec<_>>()
+            })
+            .or_else(|| {
+                ct.as_any()
+                    .downcast_ref::<arrow::array::StringViewArray>()
+                    .map(|a| {
+                        (0..a.len())
+                            .map(|i| a.value(i).to_string())
+                            .collect::<Vec<_>>()
+                    })
+            })
+            .unwrap();
+        let n = b.column(1).as_any().downcast_ref::<Int64Array>().unwrap();
+        for (i, ct_val) in ct.iter().enumerate() {
+            counts.push((ct_val.clone(), n.value(i)));
+        }
+    }
+    assert_eq!(
+        counts,
+        vec![("update_postimage".to_string(), 1), ("update_preimage".to_string(), 1),],
+        "only the correlated pair is surfaced"
+    );
+}

--- a/tests/sql_update_tests.rs
+++ b/tests/sql_update_tests.rs
@@ -465,7 +465,10 @@ async fn update_second_in_session_conflicts_without_corruption() {
         run_dml_count(&ctx, "UPDATE ducklake.main.t SET val = 200 WHERE id = 2").await,
         1
     );
-    assert_eq!(read_pairs(&temp_dir).await, vec![(1, 10), (2, 200), (3, 30), (4, 40)]);
+    assert_eq!(
+        read_pairs(&temp_dir).await,
+        vec![(1, 10), (2, 200), (3, 30), (4, 40)]
+    );
 
     // Second UPDATE (same session, same file) — aborts on the commit CAS.
     let err = ctx
@@ -500,9 +503,17 @@ async fn update_change_feed_mixed_insert_and_update() {
     let before = max_snapshot(&temp_dir).await;
 
     // Snapshot +1: a plain INSERT (no embedded rowid).
-    run_dml_count(&writable_ctx(&temp_dir).await, "INSERT INTO ducklake.main.t VALUES (9, 90)").await;
+    run_dml_count(
+        &writable_ctx(&temp_dir).await,
+        "INSERT INTO ducklake.main.t VALUES (9, 90)",
+    )
+    .await;
     // Snapshot +2: an UPDATE.
-    run_dml_count(&writable_ctx(&temp_dir).await, "UPDATE ducklake.main.t SET val = 100 WHERE id = 1").await;
+    run_dml_count(
+        &writable_ctx(&temp_dir).await,
+        "UPDATE ducklake.main.t SET val = 100 WHERE id = 1",
+    )
+    .await;
     let after = max_snapshot(&temp_dir).await;
 
     let fctx = functions_ctx(&temp_dir).await;
@@ -549,7 +560,11 @@ async fn change_feed_insert_only_range_is_all_inserts() {
     let temp_dir = TempDir::new().unwrap();
     seed_table(&temp_dir, vec![1, 2], vec![10, 20]).await;
     let before = max_snapshot(&temp_dir).await;
-    run_dml_count(&writable_ctx(&temp_dir).await, "INSERT INTO ducklake.main.t VALUES (3, 30)").await;
+    run_dml_count(
+        &writable_ctx(&temp_dir).await,
+        "INSERT INTO ducklake.main.t VALUES (3, 30)",
+    )
+    .await;
     let after = max_snapshot(&temp_dir).await;
 
     let fctx = functions_ctx(&temp_dir).await;
@@ -576,5 +591,9 @@ async fn change_feed_insert_only_range_is_all_inserts() {
             counts.push((c.clone(), n.value(i)));
         }
     }
-    assert_eq!(counts, vec![("insert".to_string(), 1)], "insert-only range yields only inserts");
+    assert_eq!(
+        counts,
+        vec![("insert".to_string(), 1)],
+        "insert-only range yields only inserts"
+    );
 }


### PR DESCRIPTION
## Summary
Adds SQL `UPDATE t SET c = e [, ...] [WHERE p]` via DataFusion 54's `TableProvider::update`, plus update change-feed support. sqlite + postgres; single-catalog.

## How it works
- `update` (src/table.rs) returns a `DuckLakeUpdateExec` (src/update_exec.rs): scans matched rows, applies the SET expressions, and writes the rewritten rows into a **new data file that embeds each row's original rowid** — the writer now emits the `ROW_ID_PARQUET_FIELD_ID` column (src/row_id.rs, src/table_writer.rs), so rowid lineage survives the rewrite. The appended file and the positional deletes of the old rows commit **atomically in one snapshot** via `register_data_file_with_deletes`.
- Change feed: `ChangeType` gains `UpdatePreimage`/`UpdatePostimage`; `ducklake_table_changes` correlates a same-snapshot delete+insert sharing a rowid into a paired old/new image (src/table_changes.rs).

## Tests (write-sqlite)
7 tests — set-value-where, expression assignment, update-all, rowid-lineage preserved, multi-row/multi-file atomic (one snapshot), CDC preimage+postimage, CDC ignores unrelated inserts — plus regressions green (lib 239, table_changes 12, row_id 6, write 23, positional_delete 5).

## Limitations
- sqlite + postgres only (duckdb/mysql return a clean unsupported error).
- Source files that already carry embedded rowids (from a prior UPDATE/compaction) are refused rather than updated by physical position (v1).
