### PR TITLE
fix(build): set statistics fields in read_only_clone (merge skew from #161 + #166)

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -1613,6 +1613,8 @@ impl DuckLakeTable {
             row_lineage: false,
             columns: self.columns.clone(),
             table_files: self.table_files.clone(),
+            table_statistics: self.table_statistics.clone(),
+            file_statistics: self.file_statistics.clone(),
             // `snapshot_id`/cache match the post-#163 struct (Arc-wrapped cache,
             // pinned snapshot). A read-only clone starts with an empty cache.
             file_read_config_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),


### PR DESCRIPTION
## Summary

`main` currently fails to compile:

```
error[E0063]: missing fields `file_statistics` and `table_statistics`
              in initializer of `DuckLakeTable`
  --> src/table.rs:1604:9
```

This breaks both the `clippy` and `Test (single-catalog…, Docker)` jobs on `main` (rustfmt is fine — the crate simply doesn't build).

## Root cause — a semantic merge conflict

- **#161** (column statistics) added `table_statistics` and `file_statistics` to `DuckLakeTable` and set them in `new()`.
- **#166** (SQL UPDATE) added a second struct initializer, `read_only_clone()` (used by `DuckLakeUpdateExec`), which was written before those fields existed and never sets them.

Each PR was green on its own branch; the two merged textually clean but leave `read_only_clone` with an incomplete struct literal, so `main` no longer compiles.

## Fix

Set both fields in `read_only_clone`, cloning from `self`:

```rust
table_statistics: self.table_statistics.clone(),
file_statistics: self.file_statistics.clone(),
```

A read-only clone should carry the same scan statistics; both are cheap (`Statistics` and `HashMap<i64, Arc<Statistics>>`), and `row_lineage: false` here matches the physical-schema statistics, so no rowid adjustment is needed. This is the only struct-literal site missing the fields (`new()` already sets them).

## Validation

- `cargo clippy --all-features --all-targets -- -D warnings` ✅ (passes locally with the pinned 1.92.0 toolchain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)