### PR TITLE
docs(compaction): CHANGELOG + README + example; add Postgres compaction tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Compaction (`merge_adjacent_files` + `rewrite_data_files`).** Two explicit, triggered maintenance operations on `DuckLakeTable`, each returning a `CompactionResult` (`files_processed` / `files_created` / `rows_written`). `merge_adjacent_files` coalesces several small data files of one table — of the SAME schema version only, never across a DDL boundary — into fewer larger ones; a merged file spanning more than one origin snapshot is written as a DuckLake **partial data file** (embedding each row's original rowid AND a per-row `_ducklake_internal_snapshot_id` column, with `ducklake_data_file.partial_max` recording the max origin), and reads below `partial_max` filter its rows per-origin so time travel and change feeds stay correct. `rewrite_data_files` rewrites a data file whose deleted fraction exceeds a threshold (default `0.95`, configurable), reading only its live rows (delete-aware) and preserving rowids, then retiring both the old data file and its delete file. Both commit atomically in one snapshot (`MetadataWriter::commit_compaction`, SQLite + PostgreSQL), record `compacted_table:<table_id>` in `ducklake_snapshot_changes`, and only *schedule* superseded files for deletion (reclaimed later by `cleanup_old_files`) — the base-snapshot conflict check makes compaction coexist with concurrent appends. Adds the `ducklake_data_file.partial_max` column (v1.0) and the `ducklake_snapshot_changes` table, with in-place idempotent migrations for existing catalogs. See [`examples/compaction_demo.rs`](examples/compaction_demo.rs) (#167).
+
 ## [0.4.0] - 2026-07-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -191,6 +191,23 @@ are backend-gated (`write-sqlite` / `write-postgres`). `DROP TABLE` is available
 [`examples/maintenance_demo.rs`](examples/maintenance_demo.rs) and
 [`examples/orphan_cleanup_demo.rs`](examples/orphan_cleanup_demo.rs).
 
+### Compaction
+
+Two explicit, triggered operations on `DuckLakeTable` rewrite a table's data files
+into a better physical layout without changing its logical rows:
+
+- `merge_adjacent_files(state, MergeOptions)` coalesces several small files (of the
+  same schema version) into fewer larger ones. A merged file spanning multiple
+  origin snapshots is written as a DuckLake *partial data file* (preserving each
+  row's original rowid and origin snapshot), so time travel and change feeds are
+  unaffected.
+- `rewrite_data_files(state, RewriteOptions)` rewrites a file whose deleted fraction
+  exceeds a threshold (default `0.95`), dropping its deleted rows.
+
+Both commit atomically in one snapshot and coexist with concurrent appends; superseded
+files are scheduled for deletion and reclaimed later by `cleanup_old_files`. See
+[`examples/compaction_demo.rs`](examples/compaction_demo.rs).
+
 ---
 
 ## Compatibility

--- a/examples/compaction_demo.rs
+++ b/examples/compaction_demo.rs
@@ -1,0 +1,271 @@
+//! Demo of explicit DuckLake compaction on the single-catalog (SQLite + LocalFS)
+//! write path: `DuckLakeTable::merge_adjacent_files` and `rewrite_data_files`.
+//!
+//! Scenario:
+//!   Table `t`  — three INSERTs -> three small files; `merge_adjacent_files`
+//!                coalesces them into one merged (partial) file. Query results are
+//!                unchanged and time travel to the pre-merge snapshot still works.
+//!   Table `t2` — one INSERT of ten rows, then DELETE most of them;
+//!                `rewrite_data_files` rewrites the file to hold only the live
+//!                rows, retiring the old data + delete files.
+//!
+//! Run with:
+//!     cargo run --no-default-features --features write-sqlite,metadata-sqlite \
+//!         --example compaction_demo
+
+use std::sync::Arc;
+
+use arrow::array::Int32Array;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use datafusion::prelude::*;
+use object_store::local::LocalFileSystem;
+use sqlx::Row;
+use sqlx::sqlite::SqlitePool;
+
+use datafusion_ducklake::{
+    DuckLakeCatalog, DuckLakeTable, DuckLakeTableWriter, MergeOptions, MetadataWriter,
+    RewriteOptions, SqliteMetadataProvider, SqliteMetadataWriter,
+};
+
+type ObjStore = Arc<dyn object_store::ObjectStore>;
+
+fn table_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("val", DataType::Int32, false),
+    ]))
+}
+
+fn batch(ids: Vec<i32>, vals: Vec<i32>) -> RecordBatch {
+    RecordBatch::try_new(
+        table_schema(),
+        vec![Arc::new(Int32Array::from(ids)), Arc::new(Int32Array::from(vals))],
+    )
+    .unwrap()
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let temp = tempfile::TempDir::new()?;
+    let db_path = temp.path().join("catalog.db");
+    let data_path = temp.path().join("data");
+    std::fs::create_dir_all(&data_path)?;
+    let conn = format!("sqlite:{}?mode=rwc", db_path.display());
+    let ro_conn = format!("sqlite:{}", db_path.display());
+    let os: ObjStore = Arc::new(LocalFileSystem::new());
+
+    let writer = SqliteMetadataWriter::new_with_init(&conn).await?;
+    writer.set_data_path(data_path.to_str().unwrap())?;
+    let pool = SqlitePool::connect(&ro_conn).await?;
+
+    // ===================================================================
+    // merge_adjacent_files: three small files -> one merged partial file
+    // ===================================================================
+    DuckLakeTableWriter::new(
+        Arc::new(SqliteMetadataWriter::new(&conn).await?),
+        os.clone(),
+    )?
+    .write_table("main", "t", &[batch(vec![1, 2], vec![10, 20])])
+    .await?;
+    for (ids, vals) in [(vec![3, 4], vec![30, 40]), (vec![5, 6], vec![50, 60])] {
+        DuckLakeTableWriter::new(
+            Arc::new(SqliteMetadataWriter::new(&conn).await?),
+            os.clone(),
+        )?
+        .append_table("main", "t", &[batch(ids, vals)])
+        .await?;
+    }
+    let pre_merge_snapshot = max_snapshot(&pool).await?;
+    println!("== merge_adjacent_files ==");
+    println!("after 3 inserts:");
+    println!("  live files : {}", live_data_files(&pool, "t").await?);
+    println!("  rows       : {:?}", read_rows(&ro_conn, "t", None).await?);
+
+    let result = with_writable_table(&conn, "t", |table, state| async move {
+        table
+            .merge_adjacent_files(&state, MergeOptions::default())
+            .await
+    })
+    .await?;
+    println!("merge_adjacent_files -> {result:?}");
+    println!("  live files : {}", live_data_files(&pool, "t").await?);
+    println!(
+        "  partial_max: {:?}",
+        partial_max_of_live(&pool, "t").await?
+    );
+    println!("  rows       : {:?}", read_rows(&ro_conn, "t", None).await?);
+    println!(
+        "  time travel @{pre_merge_snapshot}: {:?}",
+        read_rows(&ro_conn, "t", Some(pre_merge_snapshot)).await?
+    );
+
+    // ===================================================================
+    // rewrite_data_files: drop a file's deleted rows (insert-only source)
+    // ===================================================================
+    DuckLakeTableWriter::new(
+        Arc::new(SqliteMetadataWriter::new(&conn).await?),
+        os.clone(),
+    )?
+    .write_table(
+        "main",
+        "t2",
+        &[batch((1..=10).collect(), (1..=10).map(|v| v * 10).collect())],
+    )
+    .await?;
+    {
+        // Delete 8 of the 10 rows, producing a data file that is ~80% tombstoned.
+        let ctx = writable_ctx(&conn).await?;
+        ctx.sql("DELETE FROM ducklake.main.t2 WHERE id <= 8")
+            .await?
+            .collect()
+            .await?;
+    }
+    println!("\n== rewrite_data_files ==");
+    println!("after DELETE WHERE id <= 8:");
+    println!("  live files : {}", live_data_files(&pool, "t2").await?);
+    println!(
+        "  rows       : {:?}",
+        read_rows(&ro_conn, "t2", None).await?
+    );
+
+    let result = with_writable_table(&conn, "t2", |table, state| async move {
+        table
+            .rewrite_data_files(
+                &state,
+                RewriteOptions {
+                    delete_threshold: 0.5,
+                },
+            )
+            .await
+    })
+    .await?;
+    println!("rewrite_data_files(threshold=0.5) -> {result:?}");
+    println!(
+        "  live files       : {}",
+        live_data_files(&pool, "t2").await?
+    );
+    println!(
+        "  live delete files: {}",
+        live_delete_files(&pool, "t2").await?
+    );
+    println!(
+        "  rows             : {:?}",
+        read_rows(&ro_conn, "t2", None).await?
+    );
+
+    Ok(())
+}
+
+/// Downcast the writable `main.<table>` provider to a `DuckLakeTable` and run `op`.
+async fn with_writable_table<T, F, Fut>(conn: &str, table: &str, op: F) -> anyhow::Result<T>
+where
+    F: FnOnce(DuckLakeTable, datafusion::execution::SessionState) -> Fut,
+    Fut: std::future::Future<Output = datafusion_ducklake::Result<T>>,
+{
+    let ctx = writable_ctx(conn).await?;
+    let provider = ctx
+        .catalog("ducklake")
+        .unwrap()
+        .schema("main")
+        .unwrap()
+        .table(table)
+        .await?
+        .unwrap();
+    let dl = (provider.as_ref() as &dyn std::any::Any)
+        .downcast_ref::<DuckLakeTable>()
+        .expect("provider is a DuckLakeTable")
+        .clone();
+    Ok(op(dl, ctx.state()).await?)
+}
+
+async fn writable_ctx(conn: &str) -> anyhow::Result<SessionContext> {
+    let writer = SqliteMetadataWriter::new(conn).await?;
+    let provider = SqliteMetadataProvider::new(conn).await?;
+    let catalog = DuckLakeCatalog::with_writer(Arc::new(provider), Arc::new(writer))?;
+    let ctx = SessionContext::new();
+    ctx.register_catalog("ducklake", Arc::new(catalog));
+    Ok(ctx)
+}
+
+/// Read `(id, val)` from `main.<table>`, optionally as of `snapshot` (time travel).
+async fn read_rows(
+    ro_conn: &str,
+    table: &str,
+    snapshot: Option<i64>,
+) -> anyhow::Result<Vec<(i32, i32)>> {
+    let provider = SqliteMetadataProvider::new(ro_conn).await?;
+    let catalog = match snapshot {
+        Some(s) => DuckLakeCatalog::with_snapshot(Arc::new(provider), s)?,
+        None => DuckLakeCatalog::new(provider)?,
+    };
+    let ctx = SessionContext::new();
+    ctx.register_catalog("ducklake", Arc::new(catalog));
+    let batches = ctx
+        .sql(&format!(
+            "SELECT id, val FROM ducklake.main.{table} ORDER BY id"
+        ))
+        .await?
+        .collect()
+        .await?;
+    let mut rows = Vec::new();
+    for b in &batches {
+        let ids = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        let vals = b.column(1).as_any().downcast_ref::<Int32Array>().unwrap();
+        for i in 0..b.num_rows() {
+            rows.push((ids.value(i), vals.value(i)));
+        }
+    }
+    Ok(rows)
+}
+
+async fn scalar(pool: &SqlitePool, sql: &str, table: &str) -> anyhow::Result<i64> {
+    Ok(sqlx::query(sql)
+        .bind(table)
+        .fetch_one(pool)
+        .await?
+        .try_get::<i64, _>(0)?)
+}
+
+async fn live_data_files(pool: &SqlitePool, table: &str) -> anyhow::Result<i64> {
+    scalar(
+        pool,
+        "SELECT COUNT(*) FROM ducklake_data_file df
+         JOIN ducklake_table t ON t.table_id = df.table_id
+         WHERE t.table_name = ? AND df.end_snapshot IS NULL",
+        table,
+    )
+    .await
+}
+
+async fn live_delete_files(pool: &SqlitePool, table: &str) -> anyhow::Result<i64> {
+    scalar(
+        pool,
+        "SELECT COUNT(*) FROM ducklake_delete_file df
+         JOIN ducklake_table t ON t.table_id = df.table_id
+         WHERE t.table_name = ? AND df.end_snapshot IS NULL",
+        table,
+    )
+    .await
+}
+
+async fn partial_max_of_live(pool: &SqlitePool, table: &str) -> anyhow::Result<Option<i64>> {
+    Ok(sqlx::query(
+        "SELECT df.partial_max FROM ducklake_data_file df
+         JOIN ducklake_table t ON t.table_id = df.table_id
+         WHERE t.table_name = ? AND df.end_snapshot IS NULL LIMIT 1",
+    )
+    .bind(table)
+    .fetch_one(pool)
+    .await?
+    .try_get::<Option<i64>, _>(0)?)
+}
+
+async fn max_snapshot(pool: &SqlitePool) -> anyhow::Result<i64> {
+    Ok(
+        sqlx::query("SELECT MAX(snapshot_id) FROM ducklake_snapshot")
+            .fetch_one(pool)
+            .await?
+            .try_get::<i64, _>(0)?,
+    )
+}

--- a/tests/compaction_postgres_tests.rs
+++ b/tests/compaction_postgres_tests.rs
@@ -1,0 +1,324 @@
+//! Postgres multicatalog counterpart of `compaction_sqlite_tests.rs`.
+//!
+//! The multicatalog Postgres write path is a *separate implementation* from the
+//! SQLite one (per-catalog head via `ducklake_catalog_snapshot_map`, catalog-scoped
+//! lookups, `MulticatalogProvider` as the reader), so compaction is re-validated
+//! here end to end: `merge_adjacent_files` produces a partial file with correct
+//! results + time travel, and `rewrite_data_files` drops a file's deleted rows.
+//! This exercises the multicatalog reader surfacing `begin_snapshot` /
+//! `schema_version` / `partial_max` — without which merge would silently no-op.
+//! Docker-gated (testcontainers Postgres).
+
+#![cfg(feature = "write-postgres")]
+
+use std::sync::Arc;
+
+use arrow::array::{Array, Int32Array, RecordBatch};
+use arrow::datatypes::{DataType, Field, Schema};
+use datafusion::prelude::*;
+use datafusion_ducklake::{
+    CompactionResult, DuckLakeCatalog, DuckLakeTable, DuckLakeTableWriter, MergeOptions,
+    MetadataProvider, MetadataWriter, MulticatalogManager, MulticatalogProvider,
+    PostgresMetadataWriter, RewriteOptions,
+};
+use object_store::local::LocalFileSystem;
+use sqlx::Row;
+use sqlx::postgres::{PgPool, PgPoolOptions};
+use tempfile::TempDir;
+use testcontainers::ContainerAsync;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+type ObjStore = Arc<dyn object_store::ObjectStore>;
+
+async fn spin_up_postgres() -> anyhow::Result<(PgPool, ContainerAsync<Postgres>)> {
+    let container = Postgres::default().start().await?;
+    let port = container.get_host_port_ipv4(5432).await?;
+    let conn_str = format!("postgresql://postgres:postgres@127.0.0.1:{}/postgres", port);
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&conn_str)
+        .await?;
+    datafusion_ducklake::initialize_multicatalog_schema(&pool).await?;
+    Ok((pool, container))
+}
+
+fn schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("val", DataType::Int32, false),
+    ]))
+}
+
+fn batch(ids: Vec<i32>, vals: Vec<i32>) -> RecordBatch {
+    RecordBatch::try_new(
+        schema(),
+        vec![Arc::new(Int32Array::from(ids)), Arc::new(Int32Array::from(vals))],
+    )
+    .unwrap()
+}
+
+async fn writer_for(
+    pool: &PgPool,
+    cat: i64,
+    data_path: &std::path::Path,
+) -> Arc<PostgresMetadataWriter> {
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path(data_path.to_str().unwrap()).unwrap();
+    Arc::new(w)
+}
+
+/// Read `(id, val)` from `<cat>.public.t`, optionally as of `snapshot`.
+async fn read_rows(pool: &PgPool, cat_name: &str, snapshot: Option<i64>) -> Vec<(i32, i32)> {
+    let provider = MulticatalogProvider::with_pool(pool.clone(), cat_name)
+        .await
+        .unwrap();
+    let catalog = match snapshot {
+        Some(s) => DuckLakeCatalog::with_snapshot(Arc::new(provider), s).unwrap(),
+        None => DuckLakeCatalog::new(provider).unwrap(),
+    };
+    let ctx = SessionContext::new();
+    ctx.register_catalog(cat_name, Arc::new(catalog));
+    let batches = ctx
+        .sql(&format!(
+            "SELECT id, val FROM {cat_name}.public.t ORDER BY id"
+        ))
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let mut rows = Vec::new();
+    for b in &batches {
+        let ids = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        let vals = b.column(1).as_any().downcast_ref::<Int32Array>().unwrap();
+        for i in 0..b.num_rows() {
+            rows.push((ids.value(i), vals.value(i)));
+        }
+    }
+    rows
+}
+
+/// Live data-file metadata for `<cat>.public.t` at the catalog head, via the
+/// multicatalog provider (also verifies it surfaces the compaction fields).
+async fn live_files(pool: &PgPool, cat_name: &str) -> Vec<datafusion_ducklake::DuckLakeTableFile> {
+    let provider = MulticatalogProvider::with_pool(pool.clone(), cat_name)
+        .await
+        .unwrap();
+    let head = provider.get_current_snapshot().unwrap();
+    let sch = provider
+        .get_schema_by_name("public", head)
+        .unwrap()
+        .unwrap();
+    let tbl = provider
+        .get_table_by_name(sch.schema_id, "t", head)
+        .unwrap()
+        .unwrap();
+    provider
+        .get_table_files_for_select(tbl.table_id, head)
+        .unwrap()
+}
+
+async fn scalar_i64(pool: &PgPool, sql: &str, cat: i64) -> i64 {
+    sqlx::query(sql)
+        .bind(cat)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+        .try_get::<i64, _>(0)
+        .unwrap()
+}
+
+/// Downcast the writable `<cat>.public.t` provider to a `DuckLakeTable` and run `op`.
+async fn with_writable_table<F, Fut>(
+    pool: &PgPool,
+    cat: i64,
+    cat_name: &str,
+    data: &std::path::Path,
+    op: F,
+) -> CompactionResult
+where
+    F: FnOnce(DuckLakeTable, datafusion::execution::SessionState) -> Fut,
+    Fut: std::future::Future<Output = datafusion_ducklake::Result<CompactionResult>>,
+{
+    let provider = MulticatalogProvider::with_pool(pool.clone(), cat_name)
+        .await
+        .unwrap();
+    let writer = writer_for(pool, cat, data).await;
+    let catalog = DuckLakeCatalog::with_writer(Arc::new(provider), writer).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog(cat_name, Arc::new(catalog));
+    let provider = ctx
+        .catalog(cat_name)
+        .unwrap()
+        .schema("public")
+        .unwrap()
+        .table("t")
+        .await
+        .unwrap()
+        .unwrap();
+    let table = (provider.as_ref() as &dyn std::any::Any)
+        .downcast_ref::<DuckLakeTable>()
+        .expect("provider is a DuckLakeTable")
+        .clone();
+    op(table, ctx.state()).await.unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn merge_adjacent_files_postgres() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let tmp = TempDir::new().unwrap();
+    let data = tmp.path().join("data");
+    std::fs::create_dir_all(&data).unwrap();
+    let os: ObjStore = Arc::new(LocalFileSystem::new());
+    let cat_name = "cat";
+    let cat = MulticatalogManager::new(pool.clone())
+        .create_catalog(cat_name)
+        .await
+        .unwrap();
+
+    // Three INSERTs -> three small data files at three origin snapshots.
+    DuckLakeTableWriter::new(writer_for(&pool, cat, &data).await, os.clone())
+        .unwrap()
+        .write_table("public", "t", &[batch(vec![1, 2], vec![10, 20])])
+        .await
+        .unwrap();
+    let first = MulticatalogProvider::with_pool(pool.clone(), cat_name)
+        .await
+        .unwrap()
+        .get_current_snapshot()
+        .unwrap();
+    for (ids, vals) in [(vec![3, 4], vec![30, 40]), (vec![5, 6], vec![50, 60])] {
+        DuckLakeTableWriter::new(writer_for(&pool, cat, &data).await, os.clone())
+            .unwrap()
+            .append_table("public", "t", &[batch(ids, vals)])
+            .await
+            .unwrap();
+    }
+    let pre_merge = MulticatalogProvider::with_pool(pool.clone(), cat_name)
+        .await
+        .unwrap()
+        .get_current_snapshot()
+        .unwrap();
+    assert_eq!(live_files(&pool, cat_name).await.len(), 3, "three files");
+    let rows_before = vec![(1, 10), (2, 20), (3, 30), (4, 40), (5, 50), (6, 60)];
+    assert_eq!(read_rows(&pool, cat_name, None).await, rows_before);
+
+    // Merge: the multicatalog reader must surface begin_snapshot/schema_version
+    // (else this silently no-ops), then commit_compaction removes the sources.
+    let result = with_writable_table(&pool, cat, cat_name, &data, |t, s| async move {
+        t.merge_adjacent_files(&s, MergeOptions::default()).await
+    })
+    .await;
+    assert_eq!(result.files_processed, 3, "all three merged");
+    assert_eq!(result.files_created, 1);
+
+    let files = live_files(&pool, cat_name).await;
+    assert_eq!(files.len(), 1, "one merged file remains");
+    assert_eq!(
+        files[0].partial_max,
+        Some(pre_merge),
+        "partial_max = max origin snapshot"
+    );
+    // Sources removed from the catalog and scheduled for deletion (catalog-scoped).
+    assert_eq!(
+        scalar_i64(
+            &pool,
+            "SELECT COUNT(*) FROM ducklake_files_scheduled_for_deletion WHERE catalog_id = $1",
+            cat,
+        )
+        .await,
+        3,
+    );
+    // Results unchanged, and time travel to the pre-merge snapshot still works
+    // (served by the partial file's per-row origin filtering).
+    assert_eq!(read_rows(&pool, cat_name, None).await, rows_before);
+    assert_eq!(
+        read_rows(&pool, cat_name, Some(pre_merge)).await,
+        rows_before
+    );
+    // Time travel to the first snapshot returns only the first insert's rows —
+    // served entirely by the merged partial file's per-row origin filtering.
+    assert_eq!(
+        read_rows(&pool, cat_name, Some(first)).await,
+        vec![(1, 10), (2, 20)]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn rewrite_data_files_postgres() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let tmp = TempDir::new().unwrap();
+    let data = tmp.path().join("data");
+    std::fs::create_dir_all(&data).unwrap();
+    let os: ObjStore = Arc::new(LocalFileSystem::new());
+    let cat_name = "cat";
+    let cat = MulticatalogManager::new(pool.clone())
+        .create_catalog(cat_name)
+        .await
+        .unwrap();
+
+    // One file of ten rows.
+    DuckLakeTableWriter::new(writer_for(&pool, cat, &data).await, os.clone())
+        .unwrap()
+        .write_table(
+            "public",
+            "t",
+            &[batch((1..=10).collect(), (1..=10).map(|v| v * 10).collect())],
+        )
+        .await
+        .unwrap();
+
+    // Delete eight of ten rows via SQL (a positional delete file).
+    {
+        let provider = MulticatalogProvider::with_pool(pool.clone(), cat_name)
+            .await
+            .unwrap();
+        let writer = writer_for(&pool, cat, &data).await;
+        let catalog = DuckLakeCatalog::with_writer(Arc::new(provider), writer).unwrap();
+        let ctx = SessionContext::new();
+        ctx.register_catalog(cat_name, Arc::new(catalog));
+        ctx.sql(&format!("DELETE FROM {cat_name}.public.t WHERE id <= 8"))
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+    }
+    assert_eq!(
+        read_rows(&pool, cat_name, None).await,
+        vec![(9, 90), (10, 100)]
+    );
+
+    // 8/10 deleted; rewrite with a 0.5 threshold.
+    let result = with_writable_table(&pool, cat, cat_name, &data, |t, s| async move {
+        t.rewrite_data_files(
+            &s,
+            RewriteOptions {
+                delete_threshold: 0.5,
+            },
+        )
+        .await
+    })
+    .await;
+    assert_eq!(result.files_processed, 1);
+    assert_eq!(result.files_created, 1);
+    assert_eq!(result.rows_written, 2);
+
+    // One live data file (the rewrite output), no live delete file, same results.
+    let files = live_files(&pool, cat_name).await;
+    assert_eq!(files.len(), 1);
+    assert_eq!(
+        files[0].partial_max, None,
+        "a rewrite output is not partial"
+    );
+    assert_eq!(files[0].delete_file_id, None, "no live delete file");
+    assert_eq!(
+        read_rows(&pool, cat_name, None).await,
+        vec![(9, 90), (10, 100)]
+    );
+}


### PR DESCRIPTION
Follow-ups to the compaction feature (#167).

## Docs
- **CHANGELOG**: document `merge_adjacent_files` / `rewrite_data_files` under `[Unreleased]`.
- **README**: add a *Compaction* subsection under *Maintenance*.
- **`examples/compaction_demo.rs`**: a runnable SQLite + LocalFS demo — three inserts merged into one partial file (query results unchanged, time travel to the pre-merge snapshot intact), then a delete-then-`rewrite_data_files` that drops the tombstoned rows.

## Tests
- **`tests/compaction_postgres_tests.rs`** (Docker-gated): end-to-end `merge_adjacent_files` and `rewrite_data_files` on the **multicatalog Postgres** path. This path had no compaction test, and its reader (`MulticatalogProvider`) must surface `begin_snapshot` / `schema_version` / `partial_max` — otherwise merge silently no-ops and partial files read without per-row snapshot filtering. The merge test asserts the partial file is produced, sources are removed + scheduled, results are unchanged, and time travel (including to the first snapshot, served purely by the partial file's per-row origin filtering) is correct.

No production code changes; docs, an example, and test coverage only.