### PR TITLE
feat(write): produce DuckLake column statistics on write

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,10 @@ pub mod multicatalog;
 #[cfg(feature = "multicatalog-postgres")]
 pub mod multicatalog_provider;
 #[cfg(feature = "write")]
+pub mod stats_collect;
+#[cfg(feature = "write")]
+pub mod stats_encode;
+#[cfg(feature = "write")]
 pub mod table_writer;
 #[cfg(feature = "write")]
 pub mod update_exec;
@@ -122,7 +126,7 @@ pub use delete_exec::DuckLakeDeleteExec;
 pub use insert_exec::DuckLakeInsertExec;
 #[cfg(feature = "write")]
 pub use metadata_writer::{
-    ColumnDef, CommitIds, CompactionOutputFile, CompactionSourceFile, DataFileInfo,
+    ColumnDef, ColumnStat, CommitIds, CompactionOutputFile, CompactionSourceFile, DataFileInfo,
     DeleteFileEntry, DeleteFileInfo, MetadataWriter, SourceRetirement, WriteMode, WriteResult,
     WriteSetupResult,
 };

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -160,6 +160,35 @@ pub(crate) fn columns_differ(existing: &[(String, String, bool)], proposed: &[Co
     false
 }
 
+/// Per-column statistics for one data file, persisted to
+/// `ducklake_file_column_stats` and used for file-level pruning.
+///
+/// Mirrors the official DuckLake row shape. `min_value` / `max_value` are the
+/// DuckDB-canonical `VARCHAR` encoding of the bounds (see
+/// [`crate::stats_encode`]); `None` means SQL `NULL` — DuckLake keeps (never
+/// prunes) a file whose bound is NULL, so `None` is always the safe value for a
+/// type or value we cannot faithfully encode.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ColumnStat {
+    /// Catalog `column_id` (DuckLake field id) this stat describes.
+    pub column_id: i64,
+    /// Minimum value, DuckDB-canonical `VARCHAR`, or `None` for SQL `NULL`.
+    pub min_value: Option<String>,
+    /// Maximum value, DuckDB-canonical `VARCHAR`, or `None` for SQL `NULL`.
+    pub max_value: Option<String>,
+    /// Number of NULL values in this column across the file.
+    pub null_count: Option<i64>,
+    /// Number of non-NULL values in this column across the file.
+    pub value_count: Option<i64>,
+    /// For `FLOAT`/`DOUBLE` columns: whether any NaN is present. `None` for
+    /// non-floating columns. When `true`, `min_value`/`max_value` are omitted
+    /// (matching DuckLake), so float pruning is only sound when this is `false`.
+    pub contains_nan: Option<bool>,
+    /// Total compressed size of the column in bytes. Currently always `None`
+    /// (deferred; not needed for pruning). See `[[column-size-bytes]]`.
+    pub column_size_bytes: Option<i64>,
+}
+
 /// Information about a data file to register in the catalog.
 ///
 /// This struct contains the metadata needed to register a Parquet file in the DuckLake catalog.
@@ -175,6 +204,11 @@ pub struct DataFileInfo {
     pub footer_size: Option<i64>,
     /// Number of records in the file
     pub record_count: i64,
+    /// Per-column statistics (min/max/null counts) to persist to
+    /// `ducklake_file_column_stats`. Empty when stats were not computed (e.g. a
+    /// caller that predates stats support); backends must treat an empty vector
+    /// as "no stats rows for this file", which is spec-safe.
+    pub column_stats: Vec<ColumnStat>,
 }
 
 impl DataFileInfo {
@@ -197,12 +231,19 @@ impl DataFileInfo {
             file_size_bytes,
             footer_size: None,
             record_count,
+            column_stats: Vec::new(),
         }
     }
 
     /// Set the footer size for read optimization.
     pub fn with_footer_size(mut self, footer_size: i64) -> Self {
         self.footer_size = Some(footer_size);
+        self
+    }
+
+    /// Attach per-column statistics to persist to `ducklake_file_column_stats`.
+    pub fn with_column_stats(mut self, column_stats: Vec<ColumnStat>) -> Self {
+        self.column_stats = column_stats;
         self
     }
 

--- a/src/metadata_writer_duckdb.rs
+++ b/src/metadata_writer_duckdb.rs
@@ -39,7 +39,7 @@
 use crate::Result;
 use crate::error::{TypeChangeOperation, TypeChangeWriteMode};
 use crate::metadata_writer::{
-    ColumnDef, CommitIds, DataFileInfo, MetadataWriter, WriteMode, WriteSetupResult,
+    ColumnDef, ColumnStat, CommitIds, DataFileInfo, MetadataWriter, WriteMode, WriteSetupResult,
     columns_differ, validate_name,
 };
 use duckdb::{Connection, OptionalExt, Transaction, params};
@@ -139,6 +139,32 @@ CREATE TABLE IF NOT EXISTS ducklake_table_stats (
     record_count BIGINT NOT NULL DEFAULT 0,
     next_row_id BIGINT NOT NULL DEFAULT 0,
     file_size_bytes BIGINT NOT NULL DEFAULT 0
+);
+
+-- Per-file, per-column zone maps (DuckLake spec) — powers file pruning.
+-- Column set mirrors the official extension and the other backends.
+CREATE TABLE IF NOT EXISTS ducklake_file_column_stats (
+    data_file_id BIGINT NOT NULL,
+    table_id BIGINT NOT NULL,
+    column_id BIGINT NOT NULL,
+    column_size_bytes BIGINT,
+    value_count BIGINT,
+    null_count BIGINT,
+    min_value VARCHAR,
+    max_value VARCHAR,
+    contains_nan BOOLEAN,
+    extra_stats VARCHAR
+);
+
+-- Table-wide per-column roll-up (DuckLake spec) — feeds the optimizer.
+CREATE TABLE IF NOT EXISTS ducklake_table_column_stats (
+    table_id BIGINT NOT NULL,
+    column_id BIGINT NOT NULL,
+    contains_null BOOLEAN,
+    contains_nan BOOLEAN,
+    min_value VARCHAR,
+    max_value VARCHAR,
+    extra_stats VARCHAR
 );
 
 CREATE TABLE IF NOT EXISTS ducklake_delete_file (
@@ -348,6 +374,105 @@ fn retire_prior_generation(tx: &Transaction<'_>, table_id: i64, snapshot_id: i64
 /// `finalize_snapshot`; the only structural change is reading the current
 /// columns into an owned `Vec` (dropping the prepared statement) before issuing
 /// further writes on the same connection.
+/// Persist the harvested per-column stats for a just-registered data file
+/// (per-file zone maps). See the SQLite writer's equivalent for the rationale.
+fn insert_file_column_stats(
+    tx: &Transaction<'_>,
+    table_id: i64,
+    data_file_id: i64,
+    column_stats: &[ColumnStat],
+) -> Result<()> {
+    for stat in column_stats {
+        tx.execute(
+            "INSERT INTO ducklake_file_column_stats
+                 (data_file_id, table_id, column_id, column_size_bytes,
+                  value_count, null_count, min_value, max_value, contains_nan, extra_stats)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)",
+            params![
+                data_file_id,
+                table_id,
+                stat.column_id,
+                stat.column_size_bytes,
+                stat.value_count,
+                stat.null_count,
+                stat.min_value.as_deref(),
+                stat.max_value.as_deref(),
+                stat.contains_nan,
+            ],
+        )?;
+    }
+    Ok(())
+}
+
+/// Recompute `ducklake_table_column_stats` from the table's live files and
+/// replace the stored rows. See the SQLite writer's equivalent for the rationale.
+fn recompute_table_column_stats(
+    tx: &Transaction<'_>,
+    table_id: i64,
+    columns: &[ColumnDef],
+    column_ids: &[i64],
+) -> Result<()> {
+    use crate::stats_encode::{FileColumnStat, aggregate_global_column_stats};
+
+    let live_file_count: i64 = tx.query_row(
+        "SELECT COUNT(*) FROM ducklake_data_file WHERE table_id = ? AND end_snapshot IS NULL",
+        params![table_id],
+        |row| row.get(0),
+    )?;
+
+    // Collect first so the prepared statement's borrow of `tx` is released
+    // before we issue the DELETE/INSERT writes below.
+    let per_file: Vec<FileColumnStat> = {
+        let mut stmt = tx.prepare(
+            "SELECT s.column_id, s.min_value, s.max_value, s.null_count, s.contains_nan
+             FROM ducklake_file_column_stats s
+             JOIN ducklake_data_file d ON d.data_file_id = s.data_file_id
+             WHERE d.table_id = ? AND d.end_snapshot IS NULL",
+        )?;
+        let mapped = stmt.query_map(params![table_id], |row| {
+            Ok(FileColumnStat {
+                column_id: row.get::<_, i64>(0)?,
+                min_value: row.get::<_, Option<String>>(1)?,
+                max_value: row.get::<_, Option<String>>(2)?,
+                null_count: row.get::<_, Option<i64>>(3)?,
+                contains_nan: row.get::<_, Option<bool>>(4)?,
+            })
+        })?;
+        mapped.collect::<duckdb::Result<Vec<_>>>()?
+    };
+
+    let numeric_of = |column_id: i64| -> bool {
+        column_ids
+            .iter()
+            .position(|id| *id == column_id)
+            .and_then(|i| columns.get(i))
+            .map(|c| crate::stats_encode::is_numeric_ducklake_type(c.ducklake_type()))
+            .unwrap_or(false)
+    };
+    let globals = aggregate_global_column_stats(&per_file, live_file_count, numeric_of);
+
+    tx.execute(
+        "DELETE FROM ducklake_table_column_stats WHERE table_id = ?",
+        params![table_id],
+    )?;
+    for g in globals {
+        tx.execute(
+            "INSERT INTO ducklake_table_column_stats
+                 (table_id, column_id, contains_null, contains_nan, min_value, max_value, extra_stats)
+             VALUES (?, ?, ?, ?, ?, ?, NULL)",
+            params![
+                table_id,
+                g.column_id,
+                g.contains_null,
+                g.contains_nan,
+                g.min_value,
+                g.max_value,
+            ],
+        )?;
+    }
+    Ok(())
+}
+
 fn finalize_snapshot(
     tx: &Transaction<'_>,
     table_id: i64,
@@ -621,11 +746,13 @@ impl MetadataWriter for DuckdbMetadataWriter {
             |row| row.get(0),
         )?;
 
-        tx.execute(
+        // RETURNING gives us the sequence-allocated data_file_id to tie the
+        // per-column stats rows to, in the same transaction.
+        let data_file_id: i64 = tx.query_row(
             "INSERT INTO ducklake_data_file
                  (table_id, path, path_is_relative, file_size_bytes,
                   footer_size, record_count, row_id_start, begin_snapshot)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING data_file_id",
             params![
                 table_id,
                 file.path.as_str(),
@@ -636,7 +763,11 @@ impl MetadataWriter for DuckdbMetadataWriter {
                 row_id_start,
                 snapshot_id
             ],
+            |row| row.get(0),
         )?;
+
+        insert_file_column_stats(&tx, table_id, data_file_id, &file.column_stats)?;
+        recompute_table_column_stats(&tx, table_id, columns, column_ids)?;
 
         // Advance the counter and accumulate stats. next_row_id monotonically
         // increases over the table's lifetime — rowids are never reused.

--- a/src/metadata_writer_mysql.rs
+++ b/src/metadata_writer_mysql.rs
@@ -34,7 +34,7 @@ use crate::Result;
 use crate::error::{TypeChangeOperation, TypeChangeWriteMode};
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
-    ColumnDef, CommitIds, DataFileInfo, MetadataWriter, WriteMode, WriteSetupResult,
+    ColumnDef, ColumnStat, CommitIds, DataFileInfo, MetadataWriter, WriteMode, WriteSetupResult,
     columns_differ, validate_name,
 };
 use sqlx::Row;
@@ -130,6 +130,31 @@ const SQL_CREATE_TABLES: &[&str] = &[
         record_count BIGINT NOT NULL DEFAULT 0,
         next_row_id BIGINT NOT NULL DEFAULT 0,
         file_size_bytes BIGINT NOT NULL DEFAULT 0
+    ) ENGINE = InnoDB"#,
+    // Per-file, per-column zone maps (DuckLake spec) — powers file pruning.
+    // min/max use TEXT (bounds can be up to the encoder's length cap). Column
+    // set mirrors the official extension and the other backends.
+    r#"CREATE TABLE IF NOT EXISTS ducklake_file_column_stats (
+        data_file_id BIGINT NOT NULL,
+        table_id BIGINT NOT NULL,
+        column_id BIGINT NOT NULL,
+        column_size_bytes BIGINT,
+        value_count BIGINT,
+        null_count BIGINT,
+        min_value TEXT,
+        max_value TEXT,
+        contains_nan BOOLEAN,
+        extra_stats TEXT
+    ) ENGINE = InnoDB"#,
+    // Table-wide per-column roll-up (DuckLake spec) — feeds the optimizer.
+    r#"CREATE TABLE IF NOT EXISTS ducklake_table_column_stats (
+        table_id BIGINT NOT NULL,
+        column_id BIGINT NOT NULL,
+        contains_null BOOLEAN,
+        contains_nan BOOLEAN,
+        min_value TEXT,
+        max_value TEXT,
+        extra_stats TEXT
     ) ENGINE = InnoDB"#,
     // Created for catalog-shape parity and so the provider's LEFT JOINs resolve;
     // this writer never inserts delete files (`set_delete_file` is unsupported).
@@ -396,6 +421,106 @@ async fn record_schema_version(
 /// generation at begin would leak it to concurrent reads during the upload
 /// window. `column_ids` are the ids reserved at begin and already baked into the
 /// staged parquet's `field_id` metadata.
+/// Persist the harvested per-column stats for a just-registered data file
+/// (per-file zone maps). See the SQLite writer's equivalent for the rationale.
+async fn insert_file_column_stats(
+    tx: &mut sqlx::Transaction<'_, sqlx::MySql>,
+    table_id: i64,
+    data_file_id: i64,
+    column_stats: &[ColumnStat],
+) -> Result<()> {
+    for stat in column_stats {
+        sqlx::query(
+            "INSERT INTO ducklake_file_column_stats
+                 (data_file_id, table_id, column_id, column_size_bytes,
+                  value_count, null_count, min_value, max_value, contains_nan, extra_stats)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)",
+        )
+        .bind(data_file_id)
+        .bind(table_id)
+        .bind(stat.column_id)
+        .bind(stat.column_size_bytes)
+        .bind(stat.value_count)
+        .bind(stat.null_count)
+        .bind(stat.min_value.as_deref())
+        .bind(stat.max_value.as_deref())
+        .bind(stat.contains_nan)
+        .execute(&mut **tx)
+        .await?;
+    }
+    Ok(())
+}
+
+/// Recompute `ducklake_table_column_stats` from the table's live files and
+/// replace the stored rows. See the SQLite writer's equivalent for the rationale.
+async fn recompute_table_column_stats(
+    tx: &mut sqlx::Transaction<'_, sqlx::MySql>,
+    table_id: i64,
+    columns: &[ColumnDef],
+    column_ids: &[i64],
+) -> Result<()> {
+    use crate::stats_encode::{FileColumnStat, aggregate_global_column_stats};
+
+    let live_file_count: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_data_file WHERE table_id = ? AND end_snapshot IS NULL",
+    )
+    .bind(table_id)
+    .fetch_one(&mut **tx)
+    .await?
+    .try_get(0)?;
+
+    let mut per_file: Vec<FileColumnStat> = Vec::new();
+    for row in sqlx::query(
+        "SELECT s.column_id, s.min_value, s.max_value, s.null_count, s.contains_nan
+         FROM ducklake_file_column_stats s
+         JOIN ducklake_data_file d ON d.data_file_id = s.data_file_id
+         WHERE d.table_id = ? AND d.end_snapshot IS NULL",
+    )
+    .bind(table_id)
+    .fetch_all(&mut **tx)
+    .await?
+    {
+        per_file.push(FileColumnStat {
+            column_id: row.try_get(0)?,
+            min_value: row.try_get(1)?,
+            max_value: row.try_get(2)?,
+            null_count: row.try_get(3)?,
+            contains_nan: row.try_get(4)?,
+        });
+    }
+
+    let numeric_of = |column_id: i64| -> bool {
+        column_ids
+            .iter()
+            .position(|id| *id == column_id)
+            .and_then(|i| columns.get(i))
+            .map(|c| crate::stats_encode::is_numeric_ducklake_type(c.ducklake_type()))
+            .unwrap_or(false)
+    };
+    let globals = aggregate_global_column_stats(&per_file, live_file_count, numeric_of);
+
+    sqlx::query("DELETE FROM ducklake_table_column_stats WHERE table_id = ?")
+        .bind(table_id)
+        .execute(&mut **tx)
+        .await?;
+    for g in globals {
+        sqlx::query(
+            "INSERT INTO ducklake_table_column_stats
+                 (table_id, column_id, contains_null, contains_nan, min_value, max_value, extra_stats)
+             VALUES (?, ?, ?, ?, ?, ?, NULL)",
+        )
+        .bind(table_id)
+        .bind(g.column_id)
+        .bind(g.contains_null)
+        .bind(g.contains_nan)
+        .bind(g.min_value)
+        .bind(g.max_value)
+        .execute(&mut **tx)
+        .await?;
+    }
+    Ok(())
+}
+
 async fn finalize_snapshot(
     tx: &mut sqlx::Transaction<'_, sqlx::MySql>,
     table_id: i64,
@@ -712,7 +837,7 @@ impl MetadataWriter for MySqlMetadataWriter {
                     .await?
                     .try_get(0)?;
 
-            sqlx::query(
+            let inserted = sqlx::query(
                 "INSERT INTO ducklake_data_file
                      (table_id, path, path_is_relative, file_size_bytes,
                       footer_size, record_count, row_id_start, begin_snapshot)
@@ -728,6 +853,12 @@ impl MetadataWriter for MySqlMetadataWriter {
             .bind(snapshot_id)
             .execute(&mut *tx)
             .await?;
+
+            // MySQL has no RETURNING: the auto-increment PK is read via
+            // last_insert_id(). Persist the file's zone maps + refresh the roll-up.
+            let data_file_id = inserted.last_insert_id() as i64;
+            insert_file_column_stats(&mut tx, table_id, data_file_id, &file.column_stats).await?;
+            recompute_table_column_stats(&mut tx, table_id, columns, column_ids).await?;
 
             // Advance the counter and accumulate stats. `next_row_id`
             // monotonically increases over the table's lifetime.

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -13,8 +13,9 @@ use crate::Result;
 use crate::error::{TypeChangeOperation, TypeChangeWriteMode};
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
-    ColumnDef, CommitIds, DataFileInfo, DeleteFileEntry, DeleteFileInfo, MetadataWriter, WriteMode,
-    WriteSetupResult, columns_differ, validate_delete_entries, validate_name,
+    ColumnDef, ColumnStat, CommitIds, DataFileInfo, DeleteFileEntry, DeleteFileInfo,
+    MetadataWriter, WriteMode, WriteSetupResult, columns_differ, validate_delete_entries,
+    validate_name,
 };
 use sqlx::Row;
 use sqlx::postgres::{PgPool, PgPoolOptions};
@@ -99,6 +100,30 @@ pub(crate) const SQL_CREATE_STANDARD_TABLES: &[&str] = &[
         record_count BIGINT NOT NULL DEFAULT 0,
         next_row_id BIGINT NOT NULL DEFAULT 0,
         file_size_bytes BIGINT NOT NULL DEFAULT 0
+    )"#,
+    // Per-file, per-column zone maps (DuckLake spec) — powers file pruning.
+    // Column set mirrors the official extension and the SQLite writer.
+    r#"CREATE TABLE IF NOT EXISTS ducklake_file_column_stats (
+        data_file_id BIGINT NOT NULL,
+        table_id BIGINT NOT NULL,
+        column_id BIGINT NOT NULL,
+        column_size_bytes BIGINT,
+        value_count BIGINT,
+        null_count BIGINT,
+        min_value VARCHAR,
+        max_value VARCHAR,
+        contains_nan BOOLEAN,
+        extra_stats VARCHAR
+    )"#,
+    // Table-wide per-column roll-up (DuckLake spec) — feeds the optimizer.
+    r#"CREATE TABLE IF NOT EXISTS ducklake_table_column_stats (
+        table_id BIGINT NOT NULL,
+        column_id BIGINT NOT NULL,
+        contains_null BOOLEAN,
+        contains_nan BOOLEAN,
+        min_value VARCHAR,
+        max_value VARCHAR,
+        extra_stats VARCHAR
     )"#,
     r#"CREATE TABLE IF NOT EXISTS ducklake_delete_file (
         delete_file_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
@@ -573,6 +598,107 @@ async fn schedule_compaction_files(
 /// from the sequence — because the reserved schema id from begin is not threaded
 /// through the commit (it is never baked into anything; the parquet path encodes
 /// the catalog id, not the schema id).
+/// Persist the harvested per-column stats for a just-registered data file
+/// (per-file zone maps). See the SQLite writer's equivalent for the rationale.
+async fn insert_file_column_stats(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    table_id: i64,
+    data_file_id: i64,
+    column_stats: &[ColumnStat],
+) -> Result<()> {
+    for stat in column_stats {
+        sqlx::query(
+            "INSERT INTO ducklake_file_column_stats
+                 (data_file_id, table_id, column_id, column_size_bytes,
+                  value_count, null_count, min_value, max_value, contains_nan, extra_stats)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NULL)",
+        )
+        .bind(data_file_id)
+        .bind(table_id)
+        .bind(stat.column_id)
+        .bind(stat.column_size_bytes)
+        .bind(stat.value_count)
+        .bind(stat.null_count)
+        .bind(stat.min_value.as_deref())
+        .bind(stat.max_value.as_deref())
+        .bind(stat.contains_nan)
+        .execute(&mut **tx)
+        .await?;
+    }
+    Ok(())
+}
+
+/// Recompute `ducklake_table_column_stats` from the table's live files and
+/// replace the stored rows. See the SQLite writer's equivalent for the rationale
+/// (widen on insert, never tighten on delete; correct for every write mode).
+async fn recompute_table_column_stats(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    table_id: i64,
+    columns: &[ColumnDef],
+    column_ids: &[i64],
+) -> Result<()> {
+    use crate::stats_encode::{FileColumnStat, aggregate_global_column_stats};
+
+    let live_file_count: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_data_file WHERE table_id = $1 AND end_snapshot IS NULL",
+    )
+    .bind(table_id)
+    .fetch_one(&mut **tx)
+    .await?
+    .try_get(0)?;
+
+    let mut per_file: Vec<FileColumnStat> = Vec::new();
+    for row in sqlx::query(
+        "SELECT s.column_id, s.min_value, s.max_value, s.null_count, s.contains_nan
+         FROM ducklake_file_column_stats s
+         JOIN ducklake_data_file d ON d.data_file_id = s.data_file_id
+         WHERE d.table_id = $1 AND d.end_snapshot IS NULL",
+    )
+    .bind(table_id)
+    .fetch_all(&mut **tx)
+    .await?
+    {
+        per_file.push(FileColumnStat {
+            column_id: row.try_get(0)?,
+            min_value: row.try_get(1)?,
+            max_value: row.try_get(2)?,
+            null_count: row.try_get(3)?,
+            contains_nan: row.try_get(4)?,
+        });
+    }
+
+    let numeric_of = |column_id: i64| -> bool {
+        column_ids
+            .iter()
+            .position(|id| *id == column_id)
+            .and_then(|i| columns.get(i))
+            .map(|c| crate::stats_encode::is_numeric_ducklake_type(c.ducklake_type()))
+            .unwrap_or(false)
+    };
+    let globals = aggregate_global_column_stats(&per_file, live_file_count, numeric_of);
+
+    sqlx::query("DELETE FROM ducklake_table_column_stats WHERE table_id = $1")
+        .bind(table_id)
+        .execute(&mut **tx)
+        .await?;
+    for g in globals {
+        sqlx::query(
+            "INSERT INTO ducklake_table_column_stats
+                 (table_id, column_id, contains_null, contains_nan, min_value, max_value, extra_stats)
+             VALUES ($1, $2, $3, $4, $5, $6, NULL)",
+        )
+        .bind(table_id)
+        .bind(g.column_id)
+        .bind(g.contains_null)
+        .bind(g.contains_nan)
+        .bind(g.min_value)
+        .bind(g.max_value)
+        .execute(&mut **tx)
+        .await?;
+    }
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn finalize_snapshot(
     catalog_id: i64,
@@ -1245,7 +1371,12 @@ impl MetadataWriter for PostgresMetadataWriter {
             .bind(snapshot_id)
             .fetch_one(&mut *tx)
             .await?;
-            let _data_file_id: i64 = inserted.try_get(0)?;
+            let data_file_id: i64 = inserted.try_get(0)?;
+
+            // Persist the file's per-column zone maps + refresh the table roll-up,
+            // in the same commit as the data-file row.
+            insert_file_column_stats(&mut tx, table_id, data_file_id, &file.column_stats).await?;
+            recompute_table_column_stats(&mut tx, table_id, columns, column_ids).await?;
 
             // Advance the counter and accumulate stats. `next_row_id`
             // monotonically increases over the table's lifetime — rowids
@@ -1474,11 +1605,11 @@ impl MetadataWriter for PostgresMetadataWriter {
                     .await?;
             let row_id_start: i64 = stats_row.try_get(0)?;
 
-            sqlx::query(
+            let inserted = sqlx::query(
                 "INSERT INTO ducklake_data_file
                      (table_id, path, path_is_relative, file_size_bytes,
                       footer_size, record_count, row_id_start, begin_snapshot)
-                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING data_file_id",
             )
             .bind(table_id)
             .bind(&file.path)
@@ -1488,8 +1619,11 @@ impl MetadataWriter for PostgresMetadataWriter {
             .bind(file.record_count)
             .bind(row_id_start)
             .bind(snapshot_id)
-            .execute(&mut *tx)
+            .fetch_one(&mut *tx)
             .await?;
+            let data_file_id: i64 = inserted.try_get(0)?;
+            insert_file_column_stats(&mut tx, table_id, data_file_id, &file.column_stats).await?;
+            recompute_table_column_stats(&mut tx, table_id, columns, column_ids).await?;
 
             sqlx::query(
                 "UPDATE ducklake_table_stats
@@ -1851,6 +1985,14 @@ impl MetadataWriter for PostgresMetadataWriter {
                         .bind(&source_data_ids)
                         .execute(&mut *tx)
                         .await?;
+                    // Hard-delete the removed sources' per-column stats too, as
+                    // official DuckLake does on merge (otherwise they orphan).
+                    sqlx::query(
+                        "DELETE FROM ducklake_file_column_stats WHERE data_file_id = ANY($1)",
+                    )
+                    .bind(&source_data_ids)
+                    .execute(&mut *tx)
+                    .await?;
                 },
                 SourceRetirement::Retire => {
                     // Rewrite: the sources still serve time travel to pre-compaction
@@ -1882,11 +2024,11 @@ impl MetadataWriter for PostgresMetadataWriter {
             // from the embedded column); partial_max marks a merged partial file.
             for out in outputs {
                 let begin = out.begin_snapshot.unwrap_or(snapshot_id);
-                sqlx::query(
+                let inserted = sqlx::query(
                     "INSERT INTO ducklake_data_file
                          (table_id, path, path_is_relative, file_size_bytes,
                           footer_size, record_count, row_id_start, begin_snapshot, partial_max)
-                     VALUES ($1, $2, $3, $4, $5, $6, NULL, $7, $8)",
+                     VALUES ($1, $2, $3, $4, $5, $6, NULL, $7, $8) RETURNING data_file_id",
                 )
                 .bind(table_id)
                 .bind(&out.file.path)
@@ -1896,8 +2038,13 @@ impl MetadataWriter for PostgresMetadataWriter {
                 .bind(out.file.record_count)
                 .bind(begin)
                 .bind(out.partial_max)
-                .execute(&mut *tx)
+                .fetch_one(&mut *tx)
                 .await?;
+                // Persist the compacted file's harvested zone maps (same tx),
+                // mirroring official DuckLake's stats-recording for outputs.
+                let data_file_id: i64 = inserted.try_get(0)?;
+                insert_file_column_stats(&mut tx, table_id, data_file_id, &out.file.column_stats)
+                    .await?;
             }
 
             // Recompute the visible stat totals from the surviving files (see the

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -9,8 +9,9 @@ use crate::maintenance::{
 };
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
-    ColumnDef, CommitIds, DataFileInfo, DeleteFileEntry, DeleteFileInfo, MetadataWriter, WriteMode,
-    WriteSetupResult, columns_differ, validate_delete_entries, validate_name,
+    ColumnDef, ColumnStat, CommitIds, DataFileInfo, DeleteFileEntry, DeleteFileInfo,
+    MetadataWriter, WriteMode, WriteSetupResult, columns_differ, validate_delete_entries,
+    validate_name,
 };
 use sqlx::Row;
 use sqlx::sqlite::{SqlitePool, SqlitePoolOptions};
@@ -152,6 +153,39 @@ CREATE TABLE IF NOT EXISTS ducklake_table_stats (
     record_count INTEGER NOT NULL DEFAULT 0,
     next_row_id INTEGER NOT NULL DEFAULT 0,
     file_size_bytes INTEGER NOT NULL DEFAULT 0
+);
+
+-- Per-file, per-column statistics (DuckLake spec zone maps). Powers file-level
+-- pruning: min/max are the DuckDB-canonical VARCHAR encoding of the bounds,
+-- value_count is the non-null count, null_count the null count. Column set
+-- mirrors the official extension exactly (no PK, matching upstream). A brand-
+-- new table for pre-existing catalogs: `CREATE TABLE IF NOT EXISTS` (re-run by
+-- initialize_schema on every open) creates it, which is also what lets DuckDB
+-- attach a catalog we wrote (its global-stats query joins the two stats tables).
+CREATE TABLE IF NOT EXISTS ducklake_file_column_stats (
+    data_file_id INTEGER NOT NULL,
+    table_id INTEGER NOT NULL,
+    column_id INTEGER NOT NULL,
+    column_size_bytes INTEGER,
+    value_count INTEGER,
+    null_count INTEGER,
+    min_value VARCHAR,
+    max_value VARCHAR,
+    contains_nan BOOLEAN,
+    extra_stats VARCHAR
+);
+
+-- Table-wide per-column roll-up (DuckLake spec). Feeds the query optimizer
+-- (cardinality/column bounds), not file pruning. `contains_null` is a boolean
+-- (any null across the table), not a count; min/max widen across all files.
+CREATE TABLE IF NOT EXISTS ducklake_table_column_stats (
+    table_id INTEGER NOT NULL,
+    column_id INTEGER NOT NULL,
+    contains_null BOOLEAN,
+    contains_nan BOOLEAN,
+    min_value VARCHAR,
+    max_value VARCHAR,
+    extra_stats VARCHAR
 );
 
 CREATE TABLE IF NOT EXISTS ducklake_delete_file (
@@ -968,6 +1002,122 @@ async fn record_schema_version(
 /// snapshot-scoped), so inserting the new generation at begin would leak it to
 /// concurrent reads during the upload window. `column_ids` are the ids reserved
 /// at begin and already baked into the staged parquet's `field_id` metadata.
+/// Persist the harvested per-column statistics for a just-registered data file.
+///
+/// Writes one `ducklake_file_column_stats` row per [`ColumnStat`] (the zone maps
+/// that drive file pruning), within the caller's commit transaction so the
+/// stats land atomically with the `ducklake_data_file` row. `data_file_id` is
+/// the id of the row just inserted (SQLite `last_insert_rowid()`). A `None`
+/// bound/count is written as SQL `NULL` — spec-safe: a file with NULL stats is
+/// never pruned.
+async fn insert_file_column_stats(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    table_id: i64,
+    data_file_id: i64,
+    column_stats: &[ColumnStat],
+) -> Result<()> {
+    for stat in column_stats {
+        sqlx::query(
+            "INSERT INTO ducklake_file_column_stats
+                 (data_file_id, table_id, column_id, column_size_bytes,
+                  value_count, null_count, min_value, max_value, contains_nan, extra_stats)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)",
+        )
+        .bind(data_file_id)
+        .bind(table_id)
+        .bind(stat.column_id)
+        .bind(stat.column_size_bytes)
+        .bind(stat.value_count)
+        .bind(stat.null_count)
+        .bind(stat.min_value.as_deref())
+        .bind(stat.max_value.as_deref())
+        .bind(stat.contains_nan)
+        .execute(&mut **tx)
+        .await?;
+    }
+    Ok(())
+}
+
+/// Recompute the table-wide `ducklake_table_column_stats` roll-up (optimizer
+/// stats) from the table's currently-live files, and replace the stored rows.
+///
+/// Recomputing from live files (rather than incrementally widening) is correct
+/// for every write mode without special cases: an Append adds a live file;
+/// Replace/compaction retire the prior generation (their files drop out of the
+/// `end_snapshot IS NULL` set); a positional delete leaves the data file live
+/// with unchanged stats — so global bounds widen on insert and never tighten on
+/// delete, matching official DuckLake. Min/max widen with a type-aware compare
+/// ([`crate::stats_encode::stat_cmp`]); `contains_null`/`contains_nan` are OR-reduced.
+async fn recompute_table_column_stats(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    table_id: i64,
+    columns: &[ColumnDef],
+    column_ids: &[i64],
+) -> Result<()> {
+    use crate::stats_encode::{FileColumnStat, aggregate_global_column_stats};
+
+    // Total live files: the completeness denominator. A live file missing from
+    // the per-column rows below (statless) forces the roll-up to UNKNOWN.
+    let live_file_count: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_data_file WHERE table_id = ? AND end_snapshot IS NULL",
+    )
+    .bind(table_id)
+    .fetch_one(&mut **tx)
+    .await?
+    .try_get(0)?;
+
+    let mut per_file: Vec<FileColumnStat> = Vec::new();
+    for row in sqlx::query(
+        "SELECT s.column_id, s.min_value, s.max_value, s.null_count, s.contains_nan
+         FROM ducklake_file_column_stats s
+         JOIN ducklake_data_file d ON d.data_file_id = s.data_file_id
+         WHERE d.table_id = ? AND d.end_snapshot IS NULL",
+    )
+    .bind(table_id)
+    .fetch_all(&mut **tx)
+    .await?
+    {
+        per_file.push(FileColumnStat {
+            column_id: row.try_get(0)?,
+            min_value: row.try_get(1)?,
+            max_value: row.try_get(2)?,
+            null_count: row.try_get(3)?,
+            contains_nan: row.try_get(4)?,
+        });
+    }
+
+    let numeric_of = |column_id: i64| -> bool {
+        column_ids
+            .iter()
+            .position(|id| *id == column_id)
+            .and_then(|i| columns.get(i))
+            .map(|c| crate::stats_encode::is_numeric_ducklake_type(c.ducklake_type()))
+            .unwrap_or(false)
+    };
+    let globals = aggregate_global_column_stats(&per_file, live_file_count, numeric_of);
+
+    sqlx::query("DELETE FROM ducklake_table_column_stats WHERE table_id = ?")
+        .bind(table_id)
+        .execute(&mut **tx)
+        .await?;
+    for g in globals {
+        sqlx::query(
+            "INSERT INTO ducklake_table_column_stats
+                 (table_id, column_id, contains_null, contains_nan, min_value, max_value, extra_stats)
+             VALUES (?, ?, ?, ?, ?, ?, NULL)",
+        )
+        .bind(table_id)
+        .bind(g.column_id)
+        .bind(g.contains_null)
+        .bind(g.contains_nan)
+        .bind(g.min_value)
+        .bind(g.max_value)
+        .execute(&mut **tx)
+        .await?;
+    }
+    Ok(())
+}
+
 async fn finalize_snapshot(
     tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
     table_id: i64,
@@ -1418,6 +1568,17 @@ impl MetadataWriter for SqliteMetadataWriter {
             .execute(&mut *tx)
             .await?;
 
+            // Persist the file's per-column zone-map stats in the same tx. The
+            // data file is a fresh autoincrement rowid, so `last_insert_rowid()`
+            // (captured before any further INSERT) is its data_file_id.
+            let data_file_id: i64 = sqlx::query("SELECT last_insert_rowid()")
+                .fetch_one(&mut *tx)
+                .await?
+                .try_get(0)?;
+            insert_file_column_stats(&mut tx, table_id, data_file_id, &file.column_stats).await?;
+            // Refresh the table-wide roll-up from the now-current live file set.
+            recompute_table_column_stats(&mut tx, table_id, columns, column_ids).await?;
+
             // Advance the counter and accumulate stats. `next_row_id`
             // monotonically increases over the table's lifetime — rowids
             // are never reused, even after end-snapshot.
@@ -1625,6 +1786,16 @@ impl MetadataWriter for SqliteMetadataWriter {
             .bind(snapshot_id)
             .execute(&mut *tx)
             .await?;
+
+            // Persist the new file's per-column zone-map stats before any other
+            // INSERT (delete-file rows below) moves last_insert_rowid.
+            let data_file_id: i64 = sqlx::query("SELECT last_insert_rowid()")
+                .fetch_one(&mut *tx)
+                .await?
+                .try_get(0)?;
+            insert_file_column_stats(&mut tx, table_id, data_file_id, &file.column_stats).await?;
+            // Refresh the table-wide roll-up from the now-current live file set.
+            recompute_table_column_stats(&mut tx, table_id, columns, column_ids).await?;
 
             sqlx::query(
                 "UPDATE ducklake_table_stats
@@ -1956,6 +2127,14 @@ impl MetadataWriter for SqliteMetadataWriter {
                     ))
                     .execute(&mut *tx)
                     .await?;
+                    // Hard-delete the removed sources' per-column stats too, as
+                    // official DuckLake does on merge (otherwise they orphan).
+                    sqlx::query(&format!(
+                        "DELETE FROM ducklake_file_column_stats WHERE data_file_id IN ({})",
+                        id_list(&source_data_ids)
+                    ))
+                    .execute(&mut *tx)
+                    .await?;
                 },
                 SourceRetirement::Retire => {
                     // Rewrite: the output only holds currently-live rows, so the
@@ -2005,6 +2184,15 @@ impl MetadataWriter for SqliteMetadataWriter {
                 .bind(out.partial_max)
                 .execute(&mut *tx)
                 .await?;
+                // Persist the compacted file's harvested zone maps, tying them to
+                // the row just inserted (same tx). Mirrors how official DuckLake
+                // records stats for compaction outputs via the shared write path.
+                let data_file_id: i64 = sqlx::query("SELECT last_insert_rowid()")
+                    .fetch_one(&mut *tx)
+                    .await?
+                    .try_get(0)?;
+                insert_file_column_stats(&mut tx, table_id, data_file_id, &out.file.column_stats)
+                    .await?;
             }
 
             // Recompute the visible stat totals from the surviving files. Robust
@@ -3057,6 +3245,255 @@ mod tests {
             row.try_get(1).unwrap(),
             row.try_get(2).unwrap(),
         )
+    }
+
+    #[allow(clippy::type_complexity)]
+    async fn read_file_column_stats(
+        writer: &SqliteMetadataWriter,
+        path: &str,
+    ) -> Vec<(
+        i64,
+        Option<String>,
+        Option<String>,
+        Option<i64>,
+        Option<i64>,
+    )> {
+        sqlx::query(
+            "SELECT s.column_id, s.min_value, s.max_value, s.null_count, s.value_count
+             FROM ducklake_file_column_stats s
+             JOIN ducklake_data_file d ON d.data_file_id = s.data_file_id
+             WHERE d.path = ?
+             ORDER BY s.column_id",
+        )
+        .bind(path)
+        .fetch_all(&writer.pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|row| {
+            (
+                row.try_get(0).unwrap(),
+                row.try_get(1).unwrap(),
+                row.try_get(2).unwrap(),
+                row.try_get(3).unwrap(),
+                row.try_get(4).unwrap(),
+            )
+        })
+        .collect()
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn register_data_file_persists_column_stats() {
+        // register_data_file must write one ducklake_file_column_stats row per
+        // ColumnStat carried on the DataFileInfo, tied to the new data file's id.
+        let (writer, _temp) = create_test_writer().await;
+        let snap = reserve_snapshot(&writer).await;
+        let (schema_id, _) = writer.get_or_create_schema("main", None, snap).unwrap();
+        let (table_id, _) = writer
+            .get_or_create_table(schema_id, "t", None, snap)
+            .unwrap();
+
+        let file = DataFileInfo::new("a.parquet", 100, 3).with_column_stats(vec![
+            ColumnStat {
+                column_id: 1,
+                min_value: Some("1".to_string()),
+                max_value: Some("3".to_string()),
+                null_count: Some(0),
+                value_count: Some(3),
+                contains_nan: None,
+                column_size_bytes: None,
+            },
+            ColumnStat {
+                column_id: 2,
+                min_value: Some("Alice".to_string()),
+                max_value: Some("Bob".to_string()),
+                null_count: Some(1),
+                value_count: Some(2),
+                contains_nan: None,
+                column_size_bytes: None,
+            },
+        ]);
+        writer
+            .register_data_file(
+                table_id,
+                "main",
+                "t",
+                snap,
+                &file,
+                WriteMode::Append,
+                0,
+                &[],
+                &[],
+            )
+            .unwrap();
+
+        let rows = read_file_column_stats(&writer, "a.parquet").await;
+        assert_eq!(
+            rows,
+            vec![
+                (
+                    1,
+                    Some("1".to_string()),
+                    Some("3".to_string()),
+                    Some(0),
+                    Some(3)
+                ),
+                (
+                    2,
+                    Some("Alice".to_string()),
+                    Some("Bob".to_string()),
+                    Some(1),
+                    Some(2)
+                ),
+            ]
+        );
+    }
+
+    async fn read_table_column_stats(
+        writer: &SqliteMetadataWriter,
+        table_id: i64,
+    ) -> Vec<(i64, Option<bool>, Option<String>, Option<String>)> {
+        sqlx::query(
+            "SELECT column_id, contains_null, min_value, max_value
+             FROM ducklake_table_column_stats WHERE table_id = ? ORDER BY column_id",
+        )
+        .bind(table_id)
+        .fetch_all(&writer.pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|row| {
+            (
+                row.try_get(0).unwrap(),
+                row.try_get(1).unwrap(),
+                row.try_get(2).unwrap(),
+                row.try_get(3).unwrap(),
+            )
+        })
+        .collect()
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn table_column_stats_widen_numerically_across_files() {
+        // Two appends to a numeric column: global min/max must widen by numeric
+        // value (min "9", max "10"), NOT lexically (which would rank "10" < "9").
+        let (writer, _temp) = create_test_writer().await;
+        let snap1 = reserve_snapshot(&writer).await;
+        let (schema_id, _) = writer.get_or_create_schema("main", None, snap1).unwrap();
+        let (table_id, _) = writer
+            .get_or_create_table(schema_id, "t", None, snap1)
+            .unwrap();
+        let columns = vec![ColumnDef::new("n", "int32", true).unwrap()];
+        let column_ids = vec![1_i64];
+
+        let stat = |min: &str, max: &str, nulls: i64, vals: i64| {
+            vec![ColumnStat {
+                column_id: 1,
+                min_value: Some(min.to_string()),
+                max_value: Some(max.to_string()),
+                null_count: Some(nulls),
+                value_count: Some(vals),
+                contains_nan: None,
+                column_size_bytes: None,
+            }]
+        };
+
+        writer
+            .register_data_file(
+                table_id,
+                "main",
+                "t",
+                snap1,
+                &DataFileInfo::new("a.parquet", 100, 3).with_column_stats(stat("9", "9", 0, 3)),
+                WriteMode::Append,
+                0,
+                &columns,
+                &column_ids,
+            )
+            .unwrap();
+        let snap2 = reserve_snapshot(&writer).await;
+        writer
+            .register_data_file(
+                table_id,
+                "main",
+                "t",
+                snap2,
+                &DataFileInfo::new("b.parquet", 100, 2).with_column_stats(stat("10", "10", 1, 1)),
+                WriteMode::Append,
+                0,
+                &columns,
+                &column_ids,
+            )
+            .unwrap();
+
+        // Two files' per-file stats persisted.
+        assert_eq!(read_file_column_stats(&writer, "a.parquet").await.len(), 1);
+        assert_eq!(read_file_column_stats(&writer, "b.parquet").await.len(), 1);
+
+        // Global roll-up widened numerically, and contains_null OR-reduced true.
+        assert_eq!(
+            read_table_column_stats(&writer, table_id).await,
+            vec![(1, Some(true), Some("9".to_string()), Some("10".to_string()))]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn table_column_stats_null_when_a_live_file_lacks_stats() {
+        // File A has stats (null-free); file B is statless (empty column_stats).
+        // Even though A reports contains_null=false, the roll-up must degrade to
+        // NULL (unknown) — otherwise a reader treats the column as proven
+        // null-free and drops genuine IS NULL rows. (Review finding M1.)
+        let (writer, _temp) = create_test_writer().await;
+        let snap1 = reserve_snapshot(&writer).await;
+        let (schema_id, _) = writer.get_or_create_schema("main", None, snap1).unwrap();
+        let (table_id, _) = writer
+            .get_or_create_table(schema_id, "t", None, snap1)
+            .unwrap();
+        let columns = vec![ColumnDef::new("n", "int32", true).unwrap()];
+        let column_ids = vec![1_i64];
+
+        writer
+            .register_data_file(
+                table_id,
+                "main",
+                "t",
+                snap1,
+                &DataFileInfo::new("a.parquet", 100, 3).with_column_stats(vec![ColumnStat {
+                    column_id: 1,
+                    min_value: Some("1".to_string()),
+                    max_value: Some("1".to_string()),
+                    null_count: Some(0),
+                    value_count: Some(3),
+                    contains_nan: None,
+                    column_size_bytes: None,
+                }]),
+                WriteMode::Append,
+                0,
+                &columns,
+                &column_ids,
+            )
+            .unwrap();
+        let snap2 = reserve_snapshot(&writer).await;
+        writer
+            .register_data_file(
+                table_id,
+                "main",
+                "t",
+                snap2,
+                // Statless: no per-column stats attached.
+                &DataFileInfo::new("b.parquet", 100, 2),
+                WriteMode::Append,
+                0,
+                &columns,
+                &column_ids,
+            )
+            .unwrap();
+
+        assert_eq!(
+            read_table_column_stats(&writer, table_id).await,
+            vec![(1, None, None, None)],
+            "incomplete coverage (a statless live file) must NULL the roll-up"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/stats_collect.rs
+++ b/src/stats_collect.rs
@@ -1,0 +1,211 @@
+//! Harvest per-file column statistics from a finished Parquet file's metadata.
+//!
+//! This mirrors how official DuckLake produces `ducklake_file_column_stats`: it
+//! does **not** re-scan the data, it reads the statistics the Parquet writer
+//! already computed while writing (row-group metadata). DuckLake's C++ path asks
+//! its COPY for `WRITTEN_FILE_STATISTICS` and parses the returned min/max/null
+//! counts (`ducklake_insert.cpp`); we do the equivalent by reading the parquet
+//! file footer we just wrote and aggregating the per-row-group statistics into
+//! one bound per column.
+//!
+//! Values are converted to DuckDB-canonical `VARCHAR` via [`crate::stats_encode`]
+//! so the rows are byte-identical to what DuckDB writes (and thus prunable by
+//! DuckDB and by the read side in #161).
+
+use std::cmp::Ordering;
+use std::path::Path;
+
+use arrow::array::{Array, ArrayRef, Float32Array, Float64Array};
+use arrow::datatypes::DataType;
+use arrow::record_batch::RecordBatch;
+use datafusion::common::ScalarValue;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parquet::arrow::arrow_reader::statistics::StatisticsConverter;
+
+use crate::metadata_writer::ColumnStat;
+use crate::stats_encode;
+
+/// Whether a `FLOAT`/`DOUBLE` array contains a NaN among its non-null values.
+/// Returns `None` for non-floating arrays (NaN is not applicable), so a column's
+/// `contains_nan` stays `NULL` = unknown for those.
+///
+/// The standard Parquet footer records no NaN flag, so — unlike min/max/null
+/// which we harvest from the footer — this is computed directly from the Arrow
+/// data at write time (the batch is already in memory, so it is a cheap CPU pass
+/// with no extra I/O). Lets a reader (e.g. DuckDB) prune float columns, which it
+/// otherwise skips when `contains_nan` is unknown.
+pub fn array_contains_nan(array: &dyn Array) -> Option<bool> {
+    match array.data_type() {
+        DataType::Float32 => {
+            let a = array.as_any().downcast_ref::<Float32Array>()?;
+            Some((0..a.len()).any(|i| a.is_valid(i) && a.value(i).is_nan()))
+        },
+        DataType::Float64 => {
+            let a = array.as_any().downcast_ref::<Float64Array>()?;
+            Some((0..a.len()).any(|i| a.is_valid(i) && a.value(i).is_nan()))
+        },
+        _ => None,
+    }
+}
+
+/// Fold a batch's NaN presence into a running per-column accumulator over the
+/// first `n` columns (the catalog data columns; trailing embedded rowid/snapshot
+/// columns are excluded by choosing `n = column_ids.len()`). `acc` grows to `n`
+/// entries; each is `Some(true)` if any batch's column had a NaN, `Some(false)`
+/// if it's a float column seen without NaN, or `None` for non-float columns.
+pub fn accumulate_nan_flags(acc: &mut Vec<Option<bool>>, batch: &RecordBatch, n: usize) {
+    if acc.len() < n {
+        acc.resize(n, None);
+    }
+    for (slot, col) in acc.iter_mut().zip(batch.columns()).take(n) {
+        if let Some(has) = array_contains_nan(col.as_ref()) {
+            *slot = Some(slot.unwrap_or(false) || has);
+        }
+    }
+}
+
+/// Harvest per-column statistics for the Parquet file at `path`.
+///
+/// `column_ids` are the catalog `column_id`s for the file's columns, in physical
+/// (written) order; `row_count` is the total rows in the file. Returns one
+/// [`ColumnStat`] per column whose stats could be read.
+///
+/// Best-effort and never fatal: any failure to open the file or read a column's
+/// statistics is logged and that column is simply omitted (or its bound left
+/// `None`). A missing/`None` bound is spec-safe — DuckLake keeps (never prunes)
+/// a file whose stat is `NULL` — so a degraded harvest can only cost pruning,
+/// never correctness.
+pub fn collect_column_stats(
+    path: &Path,
+    column_ids: &[i64],
+    row_count: i64,
+    contains_nan_flags: &[Option<bool>],
+) -> Vec<ColumnStat> {
+    match try_collect(path, column_ids, row_count, contains_nan_flags) {
+        Ok(stats) => stats,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                path = %path.display(),
+                "failed to harvest parquet statistics; writing file without column stats"
+            );
+            Vec::new()
+        },
+    }
+}
+
+fn try_collect(
+    path: &Path,
+    column_ids: &[i64],
+    row_count: i64,
+    contains_nan_flags: &[Option<bool>],
+) -> crate::Result<Vec<ColumnStat>> {
+    let file = std::fs::File::open(path)?;
+    // Parses only the footer (no data pages are read).
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file)
+        .map_err(|e| crate::error::DuckLakeError::Internal(format!("parquet metadata: {e}")))?;
+    // Use the reader's own reconstructed Arrow schema + parquet schema so
+    // `StatisticsConverter`'s name/type match check always agrees (avoids the
+    // field-id metadata mismatch a hand-built write schema would trigger).
+    let arrow_schema = builder.schema().clone();
+    let metadata = builder.metadata().clone();
+    let parquet_schema = metadata.file_metadata().schema_descr();
+    let row_groups = metadata.row_groups();
+
+    let fields = arrow_schema.fields();
+    let n = fields.len().min(column_ids.len());
+    let mut out = Vec::with_capacity(n);
+
+    for (idx, column_id) in column_ids.iter().copied().enumerate().take(n) {
+        let field = &fields[idx];
+        let name = field.name();
+
+        let converter = match StatisticsConverter::try_new(name, &arrow_schema, parquet_schema) {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::debug!(column = name, error = %e, "no statistics converter for column");
+                continue;
+            },
+        };
+
+        // Null counts: sum across row groups. Present for files we write
+        // (statistics on by default). If unknown, both counts stay None
+        // (DuckLake stores value_count/null_count NULL together).
+        let (null_count, value_count) = match converter.row_group_null_counts(row_groups.iter()) {
+            Ok(counts) => {
+                let total: u64 = (0..counts.len())
+                    .filter(|i| !counts.is_null(*i))
+                    .map(|i| counts.value(i))
+                    .sum();
+                let null_count = i64::try_from(total).ok();
+                let value_count = null_count.map(|nc| (row_count - nc).max(0));
+                (null_count, value_count)
+            },
+            Err(_) => (None, None),
+        };
+
+        // Computed from the Arrow data at write time (the footer has no NaN
+        // flag); None for non-float columns.
+        let contains_nan = contains_nan_flags.get(idx).copied().flatten();
+
+        // When NaN is present, suppress min/max entirely (store NULL), matching
+        // official DuckLake. The Parquet footer's min/max exclude NaN, but under
+        // DuckDB's NaN ordering (NaN sorts above every value) a reader that
+        // pruned on the NaN-excluded max could wrongly drop the NaN row for a
+        // predicate like `x > 100`. NULL bounds => the file is never pruned on
+        // this column, which is always sound.
+        let (min_scalar, max_scalar) = if contains_nan == Some(true) {
+            (None, None)
+        } else {
+            let min_scalar = converter
+                .row_group_mins(row_groups.iter())
+                .ok()
+                .and_then(|arr| reduce(&arr, Ordering::Less));
+            let max_scalar = converter
+                .row_group_maxes(row_groups.iter())
+                .ok()
+                .and_then(|arr| reduce(&arr, Ordering::Greater));
+            (min_scalar, max_scalar)
+        };
+
+        out.push(ColumnStat {
+            column_id,
+            min_value: min_scalar.as_ref().and_then(stats_encode::encode_scalar),
+            max_value: max_scalar.as_ref().and_then(stats_encode::encode_scalar),
+            null_count,
+            value_count,
+            contains_nan,
+            // Deferred; not used for pruning. See `[[column-size-bytes]]`.
+            column_size_bytes: None,
+        });
+    }
+
+    Ok(out)
+}
+
+/// Reduce a per-row-group statistics array to a single bound: the smallest
+/// element for `Ordering::Less` (min), the largest for `Ordering::Greater`
+/// (max). Null entries mean "statistic unknown for that row group" and are
+/// skipped. Returns `None` if every entry is null/empty.
+fn reduce(array: &ArrayRef, keep: Ordering) -> Option<ScalarValue> {
+    let mut acc: Option<ScalarValue> = None;
+    for i in 0..array.len() {
+        if array.is_null(i) {
+            continue;
+        }
+        let Ok(value) = ScalarValue::try_from_array(array.as_ref(), i) else {
+            continue;
+        };
+        acc = Some(match acc {
+            None => value,
+            Some(current) => {
+                if value.partial_cmp(&current) == Some(keep) {
+                    value
+                } else {
+                    current
+                }
+            },
+        });
+    }
+    acc
+}

--- a/src/stats_encode.rs
+++ b/src/stats_encode.rs
@@ -1,0 +1,775 @@
+//! DuckDB-canonical value → `VARCHAR` encoding for DuckLake column statistics.
+//!
+//! DuckLake stores per-file column `min_value` / `max_value` as `VARCHAR` in
+//! `ducklake_file_column_stats`, using the exact text DuckDB's `Value::ToString()`
+//! produces (see the official extension: `DuckLakeUtil::StatsToString` /
+//! `ColumnStatsUnifier::StatsToString`). For a catalog written here to be prunable
+//! by DuckDB — and for round-trip pruning to agree — these strings must be
+//! **byte-identical** to what DuckDB writes for the same logical value.
+//!
+//! This module is the single source of truth for that encoding. Every rule below
+//! was verified against a real `duckdb` CLI (`CAST(<value> AS VARCHAR)`); the
+//! `tests` module pins those golden outputs.
+//!
+//! ## Coverage
+//!
+//! Encoded exactly (min/max emitted): signed/unsigned integers, `BOOLEAN`,
+//! `FLOAT`/`DOUBLE`, `DECIMAL(p,s)` (128-bit), `DATE`, and `TIMESTAMP` without a
+//! time zone (all Arrow time units).
+//!
+//! Deliberately **not** encoded yet — [`encode_scalar`] returns `None`, so the
+//! caller stores `min_value`/`max_value` as `NULL` and the file is never pruned on
+//! that column (spec-safe: DuckLake keeps files whose stats are NULL). Deferred:
+//! - `TIMESTAMP WITH TIME ZONE` — DuckDB renders it in the *session* time zone, so
+//!   the stored string is not deterministic without pinning a zone; deferred until
+//!   we settle on UTC rendering. See `[[timestamptz-stats]]`.
+//! - `TIME`, `BLOB`/`BINARY` (DuckLake never prunes on blobs anyway), `UUID`,
+//!   `INTERVAL`, `DECIMAL256`, and all nested types (`STRUCT`/`LIST`/`MAP`).
+//! - Over-long strings (see [`MAX_STRING_STAT_BYTES`]) — DuckDB truncates and
+//!   rounds min down / max up; until that is mirrored, long values store `NULL`.
+
+use datafusion::common::ScalarValue;
+
+/// Strings longer than this (in UTF-8 bytes) are not emitted as min/max stats.
+///
+/// DuckDB/Parquet truncate long string stats and adjust the bound (min rounds
+/// down, max rounds up) to stay sound. Reproducing that faithfully is deferred;
+/// until then an over-long value stores `NULL` (⇒ the file is kept), which is
+/// always correct.
+pub const MAX_STRING_STAT_BYTES: usize = 2048;
+
+/// Encode a single statistic value to DuckLake's canonical `VARCHAR` form.
+///
+/// Returns `None` when the value is NULL, of an unsupported type, or otherwise
+/// should not be stored as a min/max bound (see the module docs). A `None` result
+/// means "store SQL `NULL`", never an error.
+pub fn encode_scalar(value: &ScalarValue) -> Option<String> {
+    match value {
+        // Integers — plain decimal, no separators. i128 covers every width.
+        ScalarValue::Int8(Some(v)) => Some(i128::from(*v).to_string()),
+        ScalarValue::Int16(Some(v)) => Some(i128::from(*v).to_string()),
+        ScalarValue::Int32(Some(v)) => Some(i128::from(*v).to_string()),
+        ScalarValue::Int64(Some(v)) => Some(i128::from(*v).to_string()),
+        ScalarValue::UInt8(Some(v)) => Some(i128::from(*v).to_string()),
+        ScalarValue::UInt16(Some(v)) => Some(i128::from(*v).to_string()),
+        ScalarValue::UInt32(Some(v)) => Some(i128::from(*v).to_string()),
+        ScalarValue::UInt64(Some(v)) => Some(i128::from(*v).to_string()),
+
+        ScalarValue::Boolean(Some(v)) => Some(
+            if *v {
+                "true"
+            } else {
+                "false"
+            }
+            .to_string(),
+        ),
+
+        ScalarValue::Float32(Some(v)) => encode_f32(*v),
+        ScalarValue::Float64(Some(v)) => encode_f64(*v),
+
+        ScalarValue::Decimal128(Some(v), _precision, scale) => Some(encode_decimal128(*v, *scale)),
+
+        ScalarValue::Date32(Some(days)) => encode_date32(*days),
+
+        // TIMESTAMP without a time zone. WITH time zone (`tz.is_some()`) is
+        // deferred — see `[[timestamptz-stats]]` in the module docs.
+        ScalarValue::TimestampSecond(Some(v), None) => encode_timestamp(*v, 1),
+        ScalarValue::TimestampMillisecond(Some(v), None) => encode_timestamp(*v, 1_000),
+        ScalarValue::TimestampMicrosecond(Some(v), None) => encode_timestamp(*v, 1_000_000),
+        ScalarValue::TimestampNanosecond(Some(v), None) => encode_timestamp(*v, 1_000_000_000),
+
+        // Strings — stored verbatim, subject to the length guard and the NUL
+        // rule. A `\0` byte is dropped (→ SQL NULL) exactly as official DuckLake's
+        // `DuckLakeUtil::StatsToString` does: Postgres text rejects `0x00` (which
+        // would otherwise abort the whole commit), and a C-string consumer would
+        // truncate at it. Dropping the bound just leaves the column unpruned.
+        ScalarValue::Utf8(Some(s))
+        | ScalarValue::LargeUtf8(Some(s))
+        | ScalarValue::Utf8View(Some(s)) => {
+            if s.len() <= MAX_STRING_STAT_BYTES && !s.contains('\0') {
+                Some(s.clone())
+            } else {
+                None
+            }
+        },
+
+        // NULL payloads and every not-yet-supported type ⇒ store NULL.
+        _ => None,
+    }
+}
+
+/// `true` if `value`'s type is one [`encode_scalar`] can encode (independent of
+/// whether this particular value is NULL). Used to decide whether a column is
+/// eligible for pruning stats at all.
+pub fn is_encodable_type(value: &ScalarValue) -> bool {
+    matches!(
+        value,
+        ScalarValue::Int8(_)
+            | ScalarValue::Int16(_)
+            | ScalarValue::Int32(_)
+            | ScalarValue::Int64(_)
+            | ScalarValue::UInt8(_)
+            | ScalarValue::UInt16(_)
+            | ScalarValue::UInt32(_)
+            | ScalarValue::UInt64(_)
+            | ScalarValue::Boolean(_)
+            | ScalarValue::Float32(_)
+            | ScalarValue::Float64(_)
+            | ScalarValue::Decimal128(_, _, _)
+            | ScalarValue::Date32(_)
+            | ScalarValue::Utf8(_)
+            | ScalarValue::LargeUtf8(_)
+            | ScalarValue::Utf8View(_)
+    ) || matches!(
+        value,
+        ScalarValue::TimestampSecond(_, None)
+            | ScalarValue::TimestampMillisecond(_, None)
+            | ScalarValue::TimestampMicrosecond(_, None)
+            | ScalarValue::TimestampNanosecond(_, None)
+    )
+}
+
+/// Order two already-encoded stat strings, for widening the global
+/// `ducklake_table_column_stats` min/max across files.
+///
+/// DuckDB-canonical encodings of dates, timestamps, booleans and strings are
+/// already lexically ordered (ISO-8601 / natural), so only numeric types need a
+/// parsed comparison — `"10"` must sort after `"9"`, `"-5"` before `"3"`. Pass
+/// `numeric = true` for integer/float/decimal columns (see
+/// [`is_numeric_ducklake_type`]).
+pub fn stat_cmp(a: &str, b: &str, numeric: bool) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    if numeric {
+        // Integers: exact.
+        if let (Ok(x), Ok(y)) = (a.parse::<i128>(), b.parse::<i128>()) {
+            return x.cmp(&y);
+        }
+        // Fixed-point (DECIMAL, and finite floats DuckDB renders without an
+        // exponent): exact, matching official's typed decimal comparison —
+        // avoids the f64 precision loss on high-scale decimals.
+        if let Some(ord) = cmp_fixed_point(a, b) {
+            return ord;
+        }
+        // Scientific / inf / other numeric forms: fall back to float ordering.
+        if let (Ok(x), Ok(y)) = (a.parse::<f64>(), b.parse::<f64>()) {
+            return x.partial_cmp(&y).unwrap_or(Ordering::Equal);
+        }
+    }
+    a.cmp(b)
+}
+
+/// Exact comparison of two fixed-point decimal strings (optional leading `-`,
+/// digits, optional single `.`, digits). Aligns the fractional parts to a common
+/// scale and compares the resulting integers, so it is exact regardless of
+/// magnitude/scale. Returns `None` if either side is not plain fixed-point
+/// (e.g. scientific notation, `inf`, `nan`), so the caller can fall back.
+fn cmp_fixed_point(a: &str, b: &str) -> Option<std::cmp::Ordering> {
+    fn split(s: &str) -> Option<(bool, &str, &str)> {
+        let (neg, rest) = s.strip_prefix('-').map_or((false, s), |r| (true, r));
+        let (int_part, frac_part) = rest.split_once('.').unwrap_or((rest, ""));
+        if int_part.is_empty() && frac_part.is_empty() {
+            return None;
+        }
+        if !int_part.bytes().all(|c| c.is_ascii_digit())
+            || !frac_part.bytes().all(|c| c.is_ascii_digit())
+        {
+            return None;
+        }
+        Some((neg, int_part, frac_part))
+    }
+    let (neg_a, int_a, frac_a) = split(a)?;
+    let (neg_b, int_b, frac_b) = split(b)?;
+    let scale = frac_a.len().max(frac_b.len());
+    // Concatenate integer + fractional digits, right-padding the fraction to the
+    // common scale, then parse the scaled integer (leading zeros are fine).
+    let scaled = |int_part: &str, frac_part: &str| -> Option<i128> {
+        format!("{int_part}{frac_part:0<scale$}")
+            .parse::<i128>()
+            .ok()
+    };
+    let mut x = scaled(int_a, frac_a)?;
+    let mut y = scaled(int_b, frac_b)?;
+    if neg_a {
+        x = -x;
+    }
+    if neg_b {
+        y = -y;
+    }
+    Some(x.cmp(&y))
+}
+
+/// Whether a DuckLake type string denotes a numeric type whose stat strings need
+/// parsed (not lexical) comparison. Conservative: a false positive only changes
+/// how two *present* numeric-looking strings are ordered, never correctness of
+/// non-numeric columns (whose bounds compare lexically either way).
+pub fn is_numeric_ducklake_type(ducklake_type: &str) -> bool {
+    let t = ducklake_type.trim().to_ascii_lowercase();
+    // Covers int8/16/32/64, hugeint, all unsigned uint*/ubigint/uhugeint, and
+    // the bigint/integer/tinyint/smallint spellings — all contain "int".
+    t.contains("int")
+        || t.starts_with("decimal")
+        || matches!(t.as_str(), "float" | "double" | "real")
+}
+
+/// One `ducklake_file_column_stats` row's fields relevant to the global roll-up.
+#[derive(Debug, Clone)]
+pub struct FileColumnStat {
+    pub column_id: i64,
+    pub min_value: Option<String>,
+    pub max_value: Option<String>,
+    pub null_count: Option<i64>,
+    pub contains_nan: Option<bool>,
+}
+
+/// One `ducklake_table_column_stats` row: the table-wide roll-up for a column.
+/// A `None` field is stored as SQL `NULL` (unknown).
+#[derive(Debug, Clone, PartialEq)]
+pub struct GlobalColumnStat {
+    pub column_id: i64,
+    pub min_value: Option<String>,
+    pub max_value: Option<String>,
+    pub contains_null: Option<bool>,
+    pub contains_nan: Option<bool>,
+}
+
+/// Aggregate per-file column stats into the table-wide roll-up.
+///
+/// `per_file` is every `(live file, column)` stats row for the table;
+/// `live_file_count` is the total number of live files. `numeric(column_id)`
+/// says whether a column needs numeric (vs lexical) bound comparison.
+///
+/// The completeness rule mirrors official DuckLake (`has_min`/`has_null_count`):
+/// a global field is emitted only when **every** live file contributed it —
+/// otherwise it degrades to `None` (SQL `NULL` = unknown). This is essential:
+/// a live file with no stats row (harvest failed, written by another tool, or a
+/// compacted file we didn't stat) must NOT let the roll-up claim a definite
+/// `contains_null = false` or an under-covered min/max, which a reader could use
+/// to wrongly drop rows. min/max additionally widen (never tighten); bounds are
+/// widened with a type-aware compare ([`stat_cmp`]).
+///
+/// Output is sorted by `column_id` for determinism.
+pub fn aggregate_global_column_stats(
+    per_file: &[FileColumnStat],
+    live_file_count: i64,
+    numeric: impl Fn(i64) -> bool,
+) -> Vec<GlobalColumnStat> {
+    use std::cmp::Ordering;
+    use std::collections::HashMap;
+
+    struct Agg {
+        min: Option<String>,
+        max: Option<String>,
+        min_present: i64,
+        max_present: i64,
+        nullcount_present: i64,
+        has_null: bool,
+        has_nan: bool,
+        numeric: bool,
+    }
+
+    let mut aggs: HashMap<i64, Agg> = HashMap::new();
+    for f in per_file {
+        let agg = aggs.entry(f.column_id).or_insert_with(|| Agg {
+            min: None,
+            max: None,
+            min_present: 0,
+            max_present: 0,
+            nullcount_present: 0,
+            has_null: false,
+            has_nan: false,
+            numeric: numeric(f.column_id),
+        });
+        if let Some(mn) = &f.min_value {
+            agg.min_present += 1;
+            agg.min = Some(match agg.min.take() {
+                Some(cur) if stat_cmp(&cur, mn, agg.numeric) != Ordering::Greater => cur,
+                _ => mn.clone(),
+            });
+        }
+        if let Some(mx) = &f.max_value {
+            agg.max_present += 1;
+            agg.max = Some(match agg.max.take() {
+                Some(cur) if stat_cmp(&cur, mx, agg.numeric) != Ordering::Less => cur,
+                _ => mx.clone(),
+            });
+        }
+        if let Some(nc) = f.null_count {
+            agg.nullcount_present += 1;
+            if nc > 0 {
+                agg.has_null = true;
+            }
+        }
+        if f.contains_nan == Some(true) {
+            agg.has_nan = true;
+        }
+    }
+
+    let mut out: Vec<GlobalColumnStat> = aggs
+        .into_iter()
+        .map(|(column_id, a)| GlobalColumnStat {
+            column_id,
+            min_value: (a.min_present == live_file_count)
+                .then_some(a.min)
+                .flatten(),
+            max_value: (a.max_present == live_file_count)
+                .then_some(a.max)
+                .flatten(),
+            contains_null: (a.nullcount_present == live_file_count).then_some(a.has_null),
+            // Surface a table-level NaN flag only when NaN is actually present
+            // (Some(true)); otherwise leave it NULL/unknown — matching official
+            // DuckLake, which never records a definite table-level `false`.
+            contains_nan: a.has_nan.then_some(true),
+        })
+        .collect();
+    out.sort_by_key(|g| g.column_id);
+    out
+}
+
+// --------------------------------------------------------------------------
+// Floating point — DuckDB's shortest-round-trip rendering (matches Python
+// `repr`): fixed notation when the decimal exponent of the leading digit is in
+// [-4, 16), else scientific with a signed, ≥2-digit zero-padded exponent. Whole
+// values still carry a `.0`. NaN ⇒ None (DuckLake omits min/max when NaN is
+// present); ±inf ⇒ "inf"/"-inf"; ±0.0 ⇒ "0.0".
+// --------------------------------------------------------------------------
+
+fn encode_f64(v: f64) -> Option<String> {
+    if v.is_nan() {
+        return None;
+    }
+    if v.is_infinite() {
+        return Some(
+            if v < 0.0 {
+                "-inf"
+            } else {
+                "inf"
+            }
+            .to_string(),
+        );
+    }
+    if v == 0.0 {
+        return Some("0.0".to_string());
+    }
+    // Rust's `{:e}` yields the shortest round-trip digits in normalized
+    // `d[.ddd]e<exp>` form (no sign/pad on the exponent); reformat to DuckDB's.
+    Some(format_shortest(
+        &format!("{:e}", v.abs()),
+        v.is_sign_negative(),
+    ))
+}
+
+fn encode_f32(v: f32) -> Option<String> {
+    if v.is_nan() {
+        return None;
+    }
+    if v.is_infinite() {
+        return Some(
+            if v < 0.0 {
+                "-inf"
+            } else {
+                "inf"
+            }
+            .to_string(),
+        );
+    }
+    if v == 0.0 {
+        return Some("0.0".to_string());
+    }
+    // Format from the f32 (not widened to f64) so the shortest digits are the
+    // f32's own, matching DuckDB's FLOAT rendering.
+    Some(format_shortest(
+        &format!("{:e}", v.abs()),
+        v.is_sign_negative(),
+    ))
+}
+
+/// Reformat Rust's `{:e}` output (e.g. `"3.14e0"`, `"1e16"`, `"5e-308"`) for a
+/// non-zero, finite magnitude into DuckDB's canonical form, applying `neg`.
+fn format_shortest(sci: &str, neg: bool) -> String {
+    let (mantissa, exp_str) = sci.split_once('e').expect("`{:e}` always has 'e'");
+    let exp10: i32 = exp_str.parse().expect("`{:e}` exponent is an integer");
+    // Significant digits with no dot; `{:e}` never emits trailing zeros.
+    let digits: String = mantissa.chars().filter(|c| *c != '.').collect();
+
+    let body = if (-4..16).contains(&exp10) {
+        format_fixed(&digits, exp10)
+    } else {
+        format_scientific(&digits, exp10)
+    };
+    if neg {
+        format!("-{body}")
+    } else {
+        body
+    }
+}
+
+/// Fixed-point layout of `digits` whose leading digit has power-of-ten `exp10`
+/// (guaranteed `-4 <= exp10 < 16`).
+fn format_fixed(digits: &str, exp10: i32) -> String {
+    if exp10 >= 0 {
+        let int_len = exp10 as usize + 1;
+        if digits.len() <= int_len {
+            // All digits are integral; pad and add the mandatory ".0".
+            let zeros = int_len - digits.len();
+            format!("{digits}{}.0", "0".repeat(zeros))
+        } else {
+            let (int_part, frac_part) = digits.split_at(int_len);
+            format!("{int_part}.{frac_part}")
+        }
+    } else {
+        // 0.00…<digits>, with (-exp10 - 1) leading zeros after the point.
+        let zeros = (-exp10 - 1) as usize;
+        format!("0.{}{digits}", "0".repeat(zeros))
+    }
+}
+
+/// Scientific layout: `d[.ddd]e±EE` with the exponent signed and ≥2 digits.
+fn format_scientific(digits: &str, exp10: i32) -> String {
+    let mantissa = if digits.len() == 1 {
+        digits.to_string()
+    } else {
+        format!("{}.{}", &digits[..1], &digits[1..])
+    };
+    let sign = if exp10 < 0 {
+        '-'
+    } else {
+        '+'
+    };
+    format!("{mantissa}e{sign}{:02}", exp10.abs())
+}
+
+// --------------------------------------------------------------------------
+// DECIMAL(p, s) — fixed-point text from the 128-bit unscaled value and scale.
+// --------------------------------------------------------------------------
+
+fn encode_decimal128(value: i128, scale: i8) -> String {
+    if scale <= 0 {
+        // Scale 0 (or the rare negative scale) renders as a plain integer.
+        return value.to_string();
+    }
+    let scale = scale as usize;
+    let neg = value < 0;
+    let digits = value.unsigned_abs().to_string();
+    let body = if digits.len() > scale {
+        let (int_part, frac_part) = digits.split_at(digits.len() - scale);
+        format!("{int_part}.{frac_part}")
+    } else {
+        // |value| < 1: "0." then left-pad the fraction to `scale` digits.
+        format!("0.{digits:0>scale$}")
+    };
+    if neg {
+        format!("-{body}")
+    } else {
+        body
+    }
+}
+
+// --------------------------------------------------------------------------
+// DATE / TIMESTAMP (no time zone) via chrono.
+// --------------------------------------------------------------------------
+
+fn epoch_date() -> chrono::NaiveDate {
+    // 1970-01-01 is always valid; unwrap is infallible.
+    chrono::NaiveDate::from_ymd_opt(1970, 1, 1).expect("epoch date is valid")
+}
+
+fn encode_date32(days: i32) -> Option<String> {
+    let date = epoch_date().checked_add_signed(chrono::Duration::days(i64::from(days)))?;
+    Some(date.format("%Y-%m-%d").to_string())
+}
+
+/// Encode a naive timestamp given its value in `units_per_second` sub-second
+/// units (1 = seconds, 1_000 = millis, 1_000_000 = micros, 1e9 = nanos).
+fn encode_timestamp(value: i64, units_per_second: i64) -> Option<String> {
+    let secs = value.div_euclid(units_per_second);
+    let sub = value.rem_euclid(units_per_second); // 0..units_per_second
+    // Convert the sub-second remainder to nanoseconds for chrono.
+    let nanos = (sub as i128 * 1_000_000_000 / units_per_second as i128) as u32;
+    let dt = chrono::DateTime::from_timestamp(secs, nanos)?.naive_utc();
+    let base = dt.format("%Y-%m-%d %H:%M:%S").to_string();
+
+    // Fractional seconds: render with the unit's native width, then trim
+    // trailing zeros; omit entirely when zero (DuckDB: ".12", ".123456", "").
+    let frac = match units_per_second {
+        1 => String::new(),
+        1_000 => format!("{sub:03}"),
+        1_000_000 => format!("{sub:06}"),
+        1_000_000_000 => format!("{sub:09}"),
+        _ => String::new(),
+    };
+    let frac = frac.trim_end_matches('0');
+    if frac.is_empty() {
+        Some(base)
+    } else {
+        Some(format!("{base}.{frac}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    /// Assert `encode_scalar` matches the golden string DuckDB's
+    /// `CAST(<value> AS VARCHAR)` produced (captured from the `duckdb` CLI).
+    fn golden(value: ScalarValue, expected: &str) {
+        assert_eq!(
+            encode_scalar(&value).as_deref(),
+            Some(expected),
+            "encoding of {value:?}"
+        );
+    }
+
+    #[test]
+    fn integers() {
+        golden(ScalarValue::Int32(Some(-2147483648)), "-2147483648");
+        golden(
+            ScalarValue::Int64(Some(9223372036854775807)),
+            "9223372036854775807",
+        );
+        golden(ScalarValue::Int8(Some(-1)), "-1");
+        golden(
+            ScalarValue::UInt64(Some(18446744073709551615)),
+            "18446744073709551615",
+        );
+        golden(ScalarValue::UInt8(Some(0)), "0");
+    }
+
+    #[test]
+    fn booleans() {
+        golden(ScalarValue::Boolean(Some(true)), "true");
+        golden(ScalarValue::Boolean(Some(false)), "false");
+    }
+
+    #[test]
+    #[allow(clippy::approx_constant)] // 3.14 is deliberate test data, not π
+    fn doubles() {
+        // Golden values from `CAST(x::DOUBLE AS VARCHAR)`.
+        golden(ScalarValue::Float64(Some(1.0)), "1.0");
+        golden(ScalarValue::Float64(Some(3.14)), "3.14");
+        golden(ScalarValue::Float64(Some(1e20)), "1e+20");
+        golden(ScalarValue::Float64(Some(1e-20)), "1e-20");
+        golden(ScalarValue::Float64(Some(-0.5)), "-0.5");
+        golden(ScalarValue::Float64(Some(1.0 / 3.0)), "0.3333333333333333");
+        golden(ScalarValue::Float64(Some(12345.0)), "12345.0");
+        golden(ScalarValue::Float64(Some(0.001)), "0.001");
+        golden(ScalarValue::Float64(Some(0.0001)), "0.0001");
+        golden(ScalarValue::Float64(Some(0.00001)), "1e-05");
+        golden(ScalarValue::Float64(Some(1e14)), "100000000000000.0");
+        golden(ScalarValue::Float64(Some(1e15)), "1000000000000000.0");
+        golden(ScalarValue::Float64(Some(1e16)), "1e+16");
+        golden(
+            ScalarValue::Float64(Some(12345678901234567.0)),
+            "1.2345678901234568e+16",
+        );
+        golden(ScalarValue::Float64(Some(-1e20)), "-1e+20");
+        golden(ScalarValue::Float64(Some(1e100)), "1e+100");
+        golden(ScalarValue::Float64(Some(5e-308)), "5e-308");
+        golden(ScalarValue::Float64(Some(0.1)), "0.1");
+        golden(ScalarValue::Float64(Some(2.5)), "2.5");
+        golden(ScalarValue::Float64(Some(-0.0)), "0.0");
+        golden(ScalarValue::Float64(Some(0.0)), "0.0");
+        golden(ScalarValue::Float64(Some(f64::INFINITY)), "inf");
+        golden(ScalarValue::Float64(Some(f64::NEG_INFINITY)), "-inf");
+        assert_eq!(encode_scalar(&ScalarValue::Float64(Some(f64::NAN))), None);
+    }
+
+    #[test]
+    #[allow(clippy::approx_constant)] // 3.14 is deliberate test data, not π
+    fn floats() {
+        golden(ScalarValue::Float32(Some(1.0)), "1.0");
+        golden(ScalarValue::Float32(Some(3.14)), "3.14");
+        golden(ScalarValue::Float32(Some(1e20)), "1e+20");
+        golden(ScalarValue::Float32(Some(1.5e-10)), "1.5e-10");
+    }
+
+    #[test]
+    fn decimals() {
+        golden(ScalarValue::Decimal128(Some(12345), 10, 2), "123.45");
+        golden(ScalarValue::Decimal128(Some(-5), 10, 2), "-0.05");
+        golden(
+            ScalarValue::Decimal128(Some(123456789), 18, 6),
+            "123.456789",
+        );
+        golden(ScalarValue::Decimal128(Some(10000), 10, 2), "100.00");
+        golden(ScalarValue::Decimal128(Some(42), 5, 0), "42");
+        golden(
+            ScalarValue::Decimal128(Some(-123456789), 18, 4),
+            "-12345.6789",
+        );
+        golden(ScalarValue::Decimal128(Some(1), 10, 4), "0.0001");
+    }
+
+    #[test]
+    fn dates() {
+        golden(ScalarValue::Date32(Some(18266)), "2020-01-05");
+        golden(ScalarValue::Date32(Some(0)), "1970-01-01");
+        golden(ScalarValue::Date32(Some(-1)), "1969-12-31");
+    }
+
+    #[test]
+    fn timestamps() {
+        // 2020-01-05 12:34:56.123456 in micros since epoch.
+        let micros = 1_578_227_696_123_456;
+        golden(
+            ScalarValue::TimestampMicrosecond(Some(micros), None),
+            "2020-01-05 12:34:56.123456",
+        );
+        // Whole second — no fractional part.
+        golden(
+            ScalarValue::TimestampMicrosecond(Some(1_578_227_696_000_000), None),
+            "2020-01-05 12:34:56",
+        );
+        // Millis with a trailing-zero fraction (.120 → .12).
+        golden(
+            ScalarValue::TimestampMillisecond(Some(1_578_227_696_120), None),
+            "2020-01-05 12:34:56.12",
+        );
+        // Nanosecond precision.
+        golden(
+            ScalarValue::TimestampNanosecond(Some(1_578_227_696_123_456_789), None),
+            "2020-01-05 12:34:56.123456789",
+        );
+        // Just before the epoch (negative value; div/rem must stay correct).
+        golden(
+            ScalarValue::TimestampSecond(Some(-1), None),
+            "1969-12-31 23:59:59",
+        );
+    }
+
+    #[test]
+    fn strings_verbatim_and_length_guarded() {
+        golden(ScalarValue::Utf8(Some("foo".to_string())), "foo");
+        golden(ScalarValue::LargeUtf8(Some("".to_string())), "");
+        let long = "x".repeat(MAX_STRING_STAT_BYTES + 1);
+        assert_eq!(encode_scalar(&ScalarValue::Utf8(Some(long))), None);
+        // Embedded NUL ⇒ dropped (→ SQL NULL), mirroring official DuckLake.
+        assert_eq!(
+            encode_scalar(&ScalarValue::Utf8(Some("ab\0cd".to_string()))),
+            None
+        );
+    }
+
+    #[test]
+    fn nulls_and_unsupported_are_none() {
+        assert_eq!(encode_scalar(&ScalarValue::Int32(None)), None);
+        assert_eq!(encode_scalar(&ScalarValue::Float64(None)), None);
+        // Time / tz-timestamp / binary are deferred ⇒ None.
+        assert_eq!(
+            encode_scalar(&ScalarValue::TimestampMicrosecond(
+                Some(0),
+                Some(Arc::from("UTC"))
+            )),
+            None
+        );
+        assert_eq!(
+            encode_scalar(&ScalarValue::Binary(Some(vec![0xAB, 0x01]))),
+            None
+        );
+    }
+
+    #[test]
+    fn stat_ordering() {
+        use std::cmp::Ordering;
+        // Numeric: parsed, not lexical.
+        assert_eq!(stat_cmp("9", "10", true), Ordering::Less);
+        assert_eq!(stat_cmp("10", "9", true), Ordering::Greater);
+        assert_eq!(stat_cmp("-5", "3", true), Ordering::Less);
+        assert_eq!(stat_cmp("9.99", "123.45", true), Ordering::Less);
+        // Exact fixed-point: high-magnitude decimals f64 cannot distinguish.
+        assert_eq!(
+            stat_cmp("100000000000000001.00", "100000000000000000.00", true),
+            Ordering::Greater
+        );
+        assert_eq!(stat_cmp("0.05", "0.0001", true), Ordering::Greater);
+        assert_eq!(stat_cmp("-12345.6789", "12345.6788", true), Ordering::Less);
+        assert_eq!(stat_cmp("100.00", "100.00", true), Ordering::Equal);
+        // Scientific/inf still fall back to float ordering.
+        assert_eq!(stat_cmp("1e+20", "9.99", true), Ordering::Greater);
+        // Lexical for non-numeric (ISO dates/timestamps sort chronologically).
+        assert_eq!(stat_cmp("2020-01-05", "2020-02-01", false), Ordering::Less);
+        assert_eq!(
+            stat_cmp("2020-01-05 12:00:00", "2020-01-05 09:00:00", false),
+            Ordering::Greater
+        );
+        assert_eq!(stat_cmp("apple", "banana", false), Ordering::Less);
+    }
+
+    #[test]
+    fn numeric_type_classification() {
+        for t in ["int32", "int64", "hugeint", "ubigint", "decimal(10,2)", "float", "double"] {
+            assert!(is_numeric_ducklake_type(t), "{t} should be numeric");
+        }
+        for t in ["varchar", "date", "timestamp", "timestamptz", "boolean", "uuid", "blob"] {
+            assert!(!is_numeric_ducklake_type(t), "{t} should be non-numeric");
+        }
+    }
+
+    fn fcs(
+        column_id: i64,
+        min: Option<&str>,
+        max: Option<&str>,
+        null_count: Option<i64>,
+    ) -> FileColumnStat {
+        FileColumnStat {
+            column_id,
+            min_value: min.map(str::to_string),
+            max_value: max.map(str::to_string),
+            null_count,
+            contains_nan: None,
+        }
+    }
+
+    #[test]
+    fn global_rollup_complete_coverage() {
+        // Two live files, both with stats for column 1 (numeric): widen min/max
+        // numerically and OR contains_null.
+        let per_file =
+            vec![fcs(1, Some("9"), Some("9"), Some(0)), fcs(1, Some("10"), Some("10"), Some(2))];
+        let out = aggregate_global_column_stats(&per_file, 2, |_| true);
+        assert_eq!(
+            out,
+            vec![GlobalColumnStat {
+                column_id: 1,
+                min_value: Some("9".to_string()),
+                max_value: Some("10".to_string()),
+                contains_null: Some(true),
+                contains_nan: None, // per-file contains_nan always None ⇒ unknown
+            }]
+        );
+    }
+
+    #[test]
+    fn global_rollup_incomplete_coverage_degrades_to_null() {
+        // M1 regression: 2 live files but only ONE has a stats row (the other is
+        // statless — harvest failed / external writer / uncomputed compaction).
+        // Every field must degrade to None (SQL NULL), NEVER a definite
+        // contains_null=false or an under-covered min/max.
+        let per_file = vec![fcs(1, Some("5"), Some("5"), Some(0))];
+        let out = aggregate_global_column_stats(&per_file, 2, |_| true);
+        assert_eq!(
+            out,
+            vec![GlobalColumnStat {
+                column_id: 1,
+                min_value: None,
+                max_value: None,
+                contains_null: None,
+                contains_nan: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn encodable_type_predicate() {
+        assert!(is_encodable_type(&ScalarValue::Int32(None)));
+        assert!(is_encodable_type(&ScalarValue::Float64(None)));
+        assert!(is_encodable_type(&ScalarValue::TimestampMicrosecond(
+            None, None
+        )));
+        assert!(!is_encodable_type(&ScalarValue::TimestampMicrosecond(
+            None,
+            Some(Arc::from("UTC"))
+        )));
+        assert!(!is_encodable_type(&ScalarValue::Binary(None)));
+    }
+}

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -267,6 +267,7 @@ impl DuckLakeTableWriter {
             path_is_relative,
             mode,
             row_count: 0,
+            nan_flags: Vec::new(),
         })
     }
 
@@ -485,7 +486,30 @@ impl DuckLakeTableWriter {
             return Err(e.into());
         }
 
-        Ok(DataFileInfo::new(file_name, file_size, row_count).with_footer_size(footer_size))
+        // Harvest per-column stats for the compacted file, exactly as a normal
+        // write does — mirroring official DuckLake, whose compaction reuses the
+        // same WRITTEN_FILE_STATISTICS path. `data_column_ids` covers only the
+        // catalog data columns, so the trailing embedded rowid/snapshot columns
+        // are skipped by the harvest. NaN flags are computed from the batches
+        // (the footer carries no NaN signal).
+        let mut nan_flags: Vec<Option<bool>> = Vec::new();
+        for batch in batches {
+            crate::stats_collect::accumulate_nan_flags(
+                &mut nan_flags,
+                batch,
+                data_column_ids.len(),
+            );
+        }
+        let column_stats = crate::stats_collect::collect_column_stats(
+            temp.path(),
+            data_column_ids,
+            row_count,
+            &nan_flags,
+        );
+
+        Ok(DataFileInfo::new(file_name, file_size, row_count)
+            .with_footer_size(footer_size)
+            .with_column_stats(column_stats))
     }
 }
 
@@ -531,6 +555,10 @@ pub struct TableWriteSession {
     /// (for Replace) prior-generation retirement commit atomically with the file.
     mode: WriteMode,
     row_count: i64,
+    /// Per-data-column NaN presence, accumulated across written batches (the
+    /// Parquet footer carries no NaN flag). One entry per catalog data column;
+    /// `None` for non-float columns. Fed into `collect_column_stats` at finish.
+    nan_flags: Vec<Option<bool>>,
 }
 
 impl TableWriteSession {
@@ -544,6 +572,13 @@ impl TableWriteSession {
 
         let batch_with_ids =
             RecordBatch::try_new(self.schema_with_ids.clone(), batch.columns().to_vec())?;
+        // Note float-column NaN presence before the batch streams to disk (the
+        // footer we later harvest has no NaN flag). Only the catalog data columns.
+        crate::stats_collect::accumulate_nan_flags(
+            &mut self.nan_flags,
+            &batch_with_ids,
+            self.column_ids.len(),
+        );
         let writer = self.writer.as_mut().unwrap();
         writer.write(&batch_with_ids)?;
         self.row_count += batch.num_rows() as i64;
@@ -687,8 +722,20 @@ impl TableWriteSession {
             return Err(e.into());
         }
 
+        // Harvest per-column statistics from the parquet footer we just wrote
+        // (mirrors DuckLake reading its writer's WRITTEN_FILE_STATISTICS) and
+        // attach them for the catalog commit. Best-effort: on failure the file
+        // is registered without stats, which is spec-safe.
+        let column_stats = crate::stats_collect::collect_column_stats(
+            temp.path(),
+            &self.column_ids,
+            self.row_count,
+            &self.nan_flags,
+        );
+
         let mut file_info = DataFileInfo::new(&self.catalog_path, file_size, self.row_count)
-            .with_footer_size(footer_size);
+            .with_footer_size(footer_size)
+            .with_column_stats(column_stats);
         if !self.path_is_relative {
             file_info = file_info.with_absolute_path();
         }

--- a/tests/column_stats_tests.rs
+++ b/tests/column_stats_tests.rs
@@ -1,0 +1,353 @@
+//! End-to-end validation of the write-side column-statistics pipeline: write
+//! real Parquet through the crate, then read `ducklake_file_column_stats` /
+//! `ducklake_table_column_stats` back out of the SQLite catalog and assert the
+//! stored values are byte-identical to DuckDB's canonical encodings.
+//!
+//! This exercises the whole chain — Parquet footer harvest
+//! (`stats_collect`) → DuckDB-canonical encoding (`stats_encode`) → per-backend
+//! persistence — that the in-crate unit tests only cover in pieces.
+#![cfg(feature = "write-sqlite")]
+// 3.14 etc. below are deliberate float test data, not approximations of π.
+#![allow(clippy::approx_constant)]
+
+use std::sync::Arc;
+
+use arrow::array::{
+    BooleanArray, Date32Array, Decimal128Array, Float64Array, Int32Array, Int64Array, StringArray,
+    TimestampMicrosecondArray,
+};
+use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use arrow::record_batch::RecordBatch;
+use datafusion_ducklake::{DuckLakeTableWriter, MetadataWriter, SqliteMetadataWriter};
+use object_store::local::LocalFileSystem;
+use sqlx::{Row, SqlitePool};
+use tempfile::TempDir;
+
+/// (min_value, max_value, null_count, value_count) per column, ordered by
+/// column_id (i.e. by declared column order).
+type FileStatRow = (Option<String>, Option<String>, Option<i64>, Option<i64>);
+
+#[tokio::test(flavor = "multi_thread")]
+async fn crate_write_produces_duckdb_canonical_column_stats() {
+    let temp = TempDir::new().unwrap();
+    let db_path = temp.path().join("stats.db");
+    let data_path = temp.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+
+    let conn_str = format!("sqlite:{}?mode=rwc", db_path.display());
+    let writer = SqliteMetadataWriter::new_with_init(&conn_str)
+        .await
+        .unwrap();
+    writer.set_data_path(data_path.to_str().unwrap()).unwrap();
+
+    // id: 1..3 (no nulls); name: Alice/Bob/NULL; d: 2020-01-01/-05/-03 (day
+    // numbers since the epoch: 18262 = 2020-01-01, 18266 = 2020-01-05).
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("name", DataType::Utf8, true),
+        Field::new("d", DataType::Date32, true),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3])),
+            Arc::new(StringArray::from(vec![Some("Alice"), Some("Bob"), None])),
+            Arc::new(Date32Array::from(vec![
+                Some(18262),
+                Some(18266),
+                Some(18264),
+            ])),
+        ],
+    )
+    .unwrap();
+
+    let table_writer =
+        DuckLakeTableWriter::new(Arc::new(writer), Arc::new(LocalFileSystem::new())).unwrap();
+    table_writer
+        .write_table("main", "t", &[batch])
+        .await
+        .unwrap();
+
+    // Read the persisted stats straight out of the catalog.
+    let pool = SqlitePool::connect(&format!("sqlite:{}", db_path.display()))
+        .await
+        .unwrap();
+
+    let file_stats: Vec<FileStatRow> = sqlx::query(
+        "SELECT min_value, max_value, null_count, value_count
+         FROM ducklake_file_column_stats ORDER BY column_id",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap()
+    .into_iter()
+    .map(|r| {
+        (
+            r.try_get(0).unwrap(),
+            r.try_get(1).unwrap(),
+            r.try_get(2).unwrap(),
+            r.try_get(3).unwrap(),
+        )
+    })
+    .collect();
+
+    assert_eq!(
+        file_stats,
+        vec![
+            (
+                Some("1".to_string()),
+                Some("3".to_string()),
+                Some(0),
+                Some(3)
+            ),
+            (
+                Some("Alice".to_string()),
+                Some("Bob".to_string()),
+                Some(1),
+                Some(2)
+            ),
+            (
+                Some("2020-01-01".to_string()),
+                Some("2020-01-05".to_string()),
+                Some(0),
+                Some(3)
+            ),
+        ],
+        "per-file zone maps must match DuckDB-canonical encodings"
+    );
+
+    // Global roll-up: one row per column, contains_null true only for `name`.
+    let table_stats: Vec<(Option<bool>, Option<String>, Option<String>)> = sqlx::query(
+        "SELECT contains_null, min_value, max_value
+         FROM ducklake_table_column_stats ORDER BY column_id",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap()
+    .into_iter()
+    .map(|r| {
+        (
+            r.try_get(0).unwrap(),
+            r.try_get(1).unwrap(),
+            r.try_get(2).unwrap(),
+        )
+    })
+    .collect();
+
+    assert_eq!(
+        table_stats,
+        vec![
+            (Some(false), Some("1".to_string()), Some("3".to_string())),
+            (
+                Some(true),
+                Some("Alice".to_string()),
+                Some("Bob".to_string())
+            ),
+            (
+                Some(false),
+                Some("2020-01-01".to_string()),
+                Some("2020-01-05".to_string())
+            ),
+        ],
+        "table-wide roll-up must reflect the single file's bounds"
+    );
+}
+
+/// Differential dump vs official DuckLake: writes the SAME diverse-typed data
+/// the `duckdb` CLI reference used, then prints the persisted per-file and
+/// table-wide stats so they can be diffed against official. Run with:
+///   cargo test --features write-sqlite --test column_stats_tests -- --nocapture differential_dump
+#[tokio::test(flavor = "multi_thread")]
+async fn differential_dump() {
+    let temp = TempDir::new().unwrap();
+    let db_path = temp.path().join("stats.db");
+    let data_path = temp.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+    let conn_str = format!("sqlite:{}?mode=rwc", db_path.display());
+    let writer = SqliteMetadataWriter::new_with_init(&conn_str)
+        .await
+        .unwrap();
+    writer.set_data_path(data_path.to_str().unwrap()).unwrap();
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("big", DataType::Int64, false),
+        Field::new("price", DataType::Float64, true),
+        Field::new("amt", DataType::Decimal128(10, 2), true),
+        Field::new("d", DataType::Date32, true),
+        Field::new("ts", DataType::Timestamp(TimeUnit::Microsecond, None), true),
+        Field::new("name", DataType::Utf8, true),
+        Field::new("flag", DataType::Boolean, true),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3])),
+            Arc::new(Int64Array::from(vec![100000000000, -100000000000, 0])),
+            Arc::new(Float64Array::from(vec![1.5, 3.14, -0.5])),
+            Arc::new(
+                Decimal128Array::from(vec![12345, 5, 10000])
+                    .with_precision_and_scale(10, 2)
+                    .unwrap(),
+            ),
+            Arc::new(Date32Array::from(vec![18262, 18264, 18266])),
+            Arc::new(TimestampMicrosecondArray::from(vec![
+                1_578_227_696_123_456,
+                1_578_268_800_000_000,
+                1_578_125_700_000_000,
+            ])),
+            Arc::new(StringArray::from(vec![Some("Alice"), Some("Bob"), None])),
+            Arc::new(BooleanArray::from(vec![true, false, true])),
+        ],
+    )
+    .unwrap();
+
+    DuckLakeTableWriter::new(Arc::new(writer), Arc::new(LocalFileSystem::new()))
+        .unwrap()
+        .write_table("main", "t", &[batch])
+        .await
+        .unwrap();
+
+    let pool = SqlitePool::connect(&format!("sqlite:{}", db_path.display()))
+        .await
+        .unwrap();
+
+    eprintln!("--- CRATE FILE_STATS (name|min|max|null|value|contains_nan) ---");
+    for row in sqlx::query(
+        "SELECT c.column_name, s.min_value, s.max_value, s.null_count, s.value_count, s.contains_nan
+         FROM ducklake_file_column_stats s
+         JOIN ducklake_column c ON c.column_id = s.column_id AND c.end_snapshot IS NULL
+         ORDER BY c.column_order",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap()
+    {
+        let name: String = row.try_get(0).unwrap();
+        let mn: Option<String> = row.try_get(1).unwrap();
+        let mx: Option<String> = row.try_get(2).unwrap();
+        let nc: Option<i64> = row.try_get(3).unwrap();
+        let vc: Option<i64> = row.try_get(4).unwrap();
+        let nan: Option<bool> = row.try_get(5).unwrap();
+        eprintln!("{name}|{mn:?}|{mx:?}|{nc:?}|{vc:?}|{nan:?}");
+    }
+
+    eprintln!("--- CRATE TABLE_STATS (name|min|max|contains_null|contains_nan) ---");
+    for row in sqlx::query(
+        "SELECT c.column_name, g.min_value, g.max_value, g.contains_null, g.contains_nan
+         FROM ducklake_table_column_stats g
+         JOIN ducklake_column c ON c.column_id = g.column_id AND c.end_snapshot IS NULL
+         ORDER BY c.column_order",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap()
+    {
+        let name: String = row.try_get(0).unwrap();
+        let mn: Option<String> = row.try_get(1).unwrap();
+        let mx: Option<String> = row.try_get(2).unwrap();
+        let cn: Option<bool> = row.try_get(3).unwrap();
+        let nan: Option<bool> = row.try_get(4).unwrap();
+        eprintln!("{name}|{mn:?}|{mx:?}|{cn:?}|{nan:?}");
+    }
+}
+
+/// Emit a crate-written catalog to $LAKE_OUT (skipped if unset) so an external
+/// DuckDB can attach it — the reverse round-trip check.
+#[tokio::test(flavor = "multi_thread")]
+async fn emit_catalog_for_duckdb() {
+    let Ok(out) = std::env::var("LAKE_OUT") else {
+        return;
+    };
+    let data_path = format!("{out}/data");
+    std::fs::create_dir_all(&data_path).unwrap();
+    let conn_str = format!("sqlite:{out}/meta.sqlite?mode=rwc");
+    let writer = SqliteMetadataWriter::new_with_init(&conn_str)
+        .await
+        .unwrap();
+    writer.set_data_path(&data_path).unwrap();
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("price", DataType::Float64, true),
+        Field::new("amt", DataType::Decimal128(10, 2), true),
+        Field::new("d", DataType::Date32, true),
+        Field::new("name", DataType::Utf8, true),
+        Field::new("flag", DataType::Boolean, true),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])),
+            Arc::new(Float64Array::from(vec![1.5, 3.14, -0.5, 9.0, 2.0])),
+            Arc::new(
+                Decimal128Array::from(vec![12345, 5, 10000, 200, 999])
+                    .with_precision_and_scale(10, 2)
+                    .unwrap(),
+            ),
+            Arc::new(Date32Array::from(vec![18262, 18264, 18266, 18263, 18265])),
+            Arc::new(StringArray::from(vec![
+                Some("Alice"),
+                Some("Bob"),
+                None,
+                Some("Dave"),
+                Some("Eve"),
+            ])),
+            Arc::new(BooleanArray::from(vec![true, false, true, false, true])),
+        ],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(Arc::new(writer), Arc::new(LocalFileSystem::new()))
+        .unwrap()
+        .write_table("main", "t", &[batch])
+        .await
+        .unwrap();
+    eprintln!("wrote crate catalog to {out}");
+}
+
+/// Finding-1 regression: a float file containing NaN must store NULL min/max
+/// (never a NaN-excluded finite bound) with contains_nan = true, so no reader
+/// can prune it — matching official DuckLake.
+#[tokio::test(flavor = "multi_thread")]
+async fn float_with_nan_suppresses_minmax() {
+    let temp = TempDir::new().unwrap();
+    let db_path = temp.path().join("stats.db");
+    let data_path = temp.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+    let conn_str = format!("sqlite:{}?mode=rwc", db_path.display());
+    let writer = SqliteMetadataWriter::new_with_init(&conn_str)
+        .await
+        .unwrap();
+    writer.set_data_path(data_path.to_str().unwrap()).unwrap();
+
+    let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Float64, true)]));
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![Arc::new(Float64Array::from(vec![f64::NAN, 1.0, 2.0]))],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(Arc::new(writer), Arc::new(LocalFileSystem::new()))
+        .unwrap()
+        .write_table("main", "t", &[batch])
+        .await
+        .unwrap();
+
+    let pool = SqlitePool::connect(&format!("sqlite:{}", db_path.display()))
+        .await
+        .unwrap();
+    let row = sqlx::query(
+        "SELECT min_value, max_value, contains_nan, value_count
+         FROM ducklake_file_column_stats",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let mn: Option<String> = row.try_get(0).unwrap();
+    let mx: Option<String> = row.try_get(1).unwrap();
+    let nan: Option<bool> = row.try_get(2).unwrap();
+    let vc: Option<i64> = row.try_get(3).unwrap();
+    assert_eq!(mn, None, "min must be NULL when NaN present");
+    assert_eq!(mx, None, "max must be NULL when NaN present");
+    assert_eq!(nan, Some(true), "contains_nan must be true");
+    assert_eq!(vc, Some(3), "NaN counts as a non-null value");
+}

--- a/tests/compaction_sqlite_tests.rs
+++ b/tests/compaction_sqlite_tests.rs
@@ -214,6 +214,60 @@ async fn run_rewrite(temp: &TempDir, opts: RewriteOptions) -> CompactionResult {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn merge_harvests_output_stats_and_removes_source_stats() {
+    // Compaction must record fresh per-file column stats for the merged output
+    // (so it stays prunable) and hard-delete the merged-away sources' stats rows
+    // (no orphans) — mirroring official DuckLake.
+    let temp = TempDir::new().unwrap();
+    seed(&temp, vec![1, 2, 3], vec![10, 20, 30]).await;
+    append(&temp, vec![4, 5, 6], vec![40, 50, 60]).await;
+    let p = pool(&temp).await;
+
+    // Two source files, each with per-column stats rows.
+    assert_eq!(
+        scalar_i64(
+            &p,
+            "SELECT COUNT(*) FROM ducklake_data_file WHERE end_snapshot IS NULL"
+        )
+        .await,
+        2
+    );
+    assert!(
+        scalar_i64(&p, "SELECT COUNT(*) FROM ducklake_file_column_stats").await >= 2,
+        "each source file should have stats rows"
+    );
+
+    run_merge(&temp, MergeOptions::default()).await;
+
+    // No orphaned stats rows: every remaining stats row points at a live data
+    // file (the sources' rows were deleted with their data_file rows).
+    assert_eq!(
+        scalar_i64(
+            &p,
+            "SELECT COUNT(*) FROM ducklake_file_column_stats s
+             LEFT JOIN ducklake_data_file d ON d.data_file_id = s.data_file_id
+             WHERE d.data_file_id IS NULL",
+        )
+        .await,
+        0,
+        "merge must delete the retired sources' stats rows"
+    );
+    // The merged output carries harvested stats spanning both sources: the `id`
+    // column's bound is now [1, 6].
+    assert_eq!(
+        scalar_i64(
+            &p,
+            "SELECT COUNT(*) FROM ducklake_file_column_stats s
+             JOIN ducklake_data_file d ON d.data_file_id = s.data_file_id
+             WHERE d.end_snapshot IS NULL AND s.min_value = '1' AND s.max_value = '6'",
+        )
+        .await,
+        1,
+        "merged file's id-column zone map should span the union of the sources"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn merge_coalesces_small_files_preserving_results_rowids_and_time_travel() {
     let temp = TempDir::new().unwrap();
     // Three inserts -> three small data files, all at schema version 1.


### PR DESCRIPTION
## Summary

Adds **write-side DuckLake column statistics**. Until now the crate wrote data files
and `ducklake_table_stats` counters but never the per-column stats DuckLake uses for
data skipping, so catalogs written here carried no zone maps and could not be attached
by DuckDB (its global-stats query joins `ducklake_table_column_stats`). The read side
that *consumes* these stats already landed in #161; this is the missing write half.

On every write, per-column statistics are now harvested and persisted:

- **`ducklake_file_column_stats`** — per-file min/max/null_count/value_count/contains_nan
  (the zone maps that enable file pruning), and
- **`ducklake_table_column_stats`** — the table-wide roll-up (optimizer stats).

Implemented for all four metadata backends (SQLite, Postgres, MySQL, DuckDB), on the
INSERT/REPLACE path, the append-with-deletes path, and compaction.

## What it does

- **Harvest, don't recompute.** Mirroring official DuckLake (which reads its Parquet
  writer's `WRITTEN_FILE_STATISTICS`), min/max/null/value counts are read back from the
  finished Parquet file's footer metadata (`StatisticsConverter`) — no extra data scan.
- **DuckDB-canonical encoding.** `min`/`max` are stored as the exact `VARCHAR` text
  DuckDB's `Value::ToString()` produces, verified byte-for-byte against a real `duckdb`
  CLI (golden tests) so the rows are prunable by DuckDB and round-trip through the #161
  read path. Covers ints/uints, `BOOLEAN`, `FLOAT`/`DOUBLE` (shortest-round-trip incl.
  `inf`/`±0`), `DECIMAL(p,s)`, `DATE`, and `TIMESTAMP` (no tz, all units).
- **NaN handling.** `contains_nan` is computed from the Arrow data at write time (the
  Parquet footer carries no NaN flag). When NaN is present, min/max are suppressed
  (stored NULL), matching official — so no reader can over-prune a NaN-bearing float file
  under DuckDB's NaN ordering.
- **Table roll-up** widens min/max with a type-aware compare and degrades a field to
  SQL `NULL` unless *every* live file contributed it (mirrors official's
  `has_min`/`has_null_count`) — a statless/unreadable file can never make the roll-up
  claim a false `contains_null` or an under-covered bound.
- **Compaction.** Merged/rewritten outputs get fresh harvested stats; a MERGE
  hard-deletes the retired sources' stats rows (a REWRITE keeps them for time-travel) —
  matching official's lifecycle.
- **DDL.** Both stats tables are added to each backend's bootstrap (created on existing
  catalogs too), which also unblocks DuckDB attaching a crate-written catalog.

## Design notes / fidelity to official

- Stats are written **in the same transaction** as the `ducklake_data_file` row.
- The roll-up is **recomputed from live files** each commit. This agrees with official on
  insert / positional-delete / merge; it differs only in safe, optimizer-only edges
  (delete-free rewrite: ours is looser; truncate-then-reinsert: ours is more current).
  Neither can cause wrong results or over-pruning.
- **Accepted divergence:** per-file boolean min/max are `false`/`true` here vs `0`/`1` in
  official (both `TRY_CAST` identically; the table roll-up matches official's
  `false`/`true`). Cosmetic.
- **Deliberately unsupported → NULL bounds** (spec-safe; file simply not pruned on that
  column): `TIMESTAMP WITH TIME ZONE` (session-tz rendering), `TIME`, `BLOB`/`BINARY`,
  `UUID`, `DECIMAL256`, nested (`STRUCT`/`LIST`/`MAP`), and over-long strings.

## Testing

- Unit: DuckDB-canonical encoder golden tests; roll-up completeness (complete /
  incomplete-coverage → NULL); numeric-vs-lexical ordering; exact fixed-point decimal;
  embedded-NUL string dropped; NaN suppression.
- E2E (SQLite): write real Parquet → assert persisted stats are byte-identical to
  DuckDB-canonical values across ints/strings/dates/nulls; NaN-float suppression;
  a statless live file forces the roll-up to NULL.
- Compaction (SQLite): merged output carries the union zone map; retired sources' stats
  rows are removed (no orphans).
- Validated by a differential comparison against the official `duckdb` DuckLake extension
  on diverse-typed data (byte-identical except the accepted boolean cosmetic), plus a
  multi-agent internal review and an external review (one NaN correctness fix applied;
  other findings resolved against measured official behavior).

## Out of scope (pre-existing, unrelated)

A crate-written catalog is not yet fully attachable by the latest DuckDB due to
schema-version drift independent of stats — `data_path` trailing-slash normalization and
missing `ducklake_snapshot.next_catalog_id`/`next_file_id`. Tracked under the v1.0-parity
epic (#114).
