### PR TITLE
feat(write): register_existing_data_file — adopt a copied file's column ids

### DIFF
--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -751,9 +751,16 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
     /// parquet copied verbatim from another catalog — adopting `column_ids` as
     /// the destination table's column ids so the file's embedded field-ids
     /// resolve on read. Self-contained (no `begin_write_transaction`): creates
-    /// the table/columns on first write, appends after. `columns[i]` takes
-    /// `column_ids[i]`. Default: unsupported; only multicatalog Postgres, whose
-    /// column ids are reusable across catalogs, implements it.
+    /// the table/columns on first write, appends after.
+    ///
+    /// `column_ids` must be non-empty and 1:1 with `columns` (`column_ids[i]` is
+    /// the id assigned to `columns[i]`, in column order); a mismatch is rejected
+    /// with [`crate::DuckLakeError::InvalidConfig`]. Rowids are freshly assigned
+    /// (the source `row_id_start` is not preserved), so indexes keyed on the
+    /// source's rowids do not carry over.
+    ///
+    /// Default: unsupported; only multicatalog Postgres, whose column ids are
+    /// reusable across catalogs, implements it.
     #[allow(clippy::too_many_arguments)]
     fn register_existing_data_file(
         &self,

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -747,6 +747,28 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
         ))
     }
 
+    /// Register a data file that already carries DuckLake field-ids — e.g. a
+    /// parquet copied verbatim from another catalog — adopting `column_ids` as
+    /// the destination table's column ids so the file's embedded field-ids
+    /// resolve on read. Self-contained (no `begin_write_transaction`): creates
+    /// the table/columns on first write, appends after. `columns[i]` takes
+    /// `column_ids[i]`. Default: unsupported; only multicatalog Postgres, whose
+    /// column ids are reusable across catalogs, implements it.
+    #[allow(clippy::too_many_arguments)]
+    fn register_existing_data_file(
+        &self,
+        _schema_name: &str,
+        _table_name: &str,
+        _columns: &[ColumnDef],
+        _column_ids: &[i64],
+        _file: &DataFileInfo,
+        _mode: WriteMode,
+    ) -> Result<CommitIds> {
+        Err(DuckLakeError::InvalidConfig(
+            "register_existing_data_file is not supported by this metadata writer".to_string(),
+        ))
+    }
+
     /// Publish a write's snapshot as the catalog head with no data file (CREATE
     /// TABLE, zero-row Replace). For `Replace`, retires the prior generation.
     /// See [`MetadataWriter::register_data_file`] for the parameters.

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -1418,6 +1418,22 @@ impl MetadataWriter for PostgresMetadataWriter {
         file: &DataFileInfo,
         mode: WriteMode,
     ) -> Result<CommitIds> {
+        // This method bypasses begin_write_transaction, so it must do begin's
+        // input validation itself. `column_ids[i]` is inserted for `columns[i]`
+        // (finalize_snapshot zips them), so a length mismatch would silently drop
+        // the trailing columns.
+        if columns.is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "register_existing_data_file requires at least one column".to_string(),
+            ));
+        }
+        if column_ids.len() != columns.len() {
+            return Err(crate::DuckLakeError::InvalidConfig(format!(
+                "register_existing_data_file: column_ids (len {}) must be 1:1 with columns (len {})",
+                column_ids.len(),
+                columns.len()
+            )));
+        }
         block_on(async {
             let mut tx = self.pool.begin().await?;
             lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -1409,6 +1409,103 @@ impl MetadataWriter for PostgresMetadataWriter {
         })
     }
 
+    fn register_existing_data_file(
+        &self,
+        schema_name: &str,
+        table_name: &str,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+        file: &DataFileInfo,
+        mode: WriteMode,
+    ) -> Result<CommitIds> {
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
+
+            // No begin_write_transaction: derive the conflict base (catalog head)
+            // and a table-id hint (used only if the table doesn't exist yet) here.
+            let base_snapshot: i64 = sqlx::query_scalar(
+                "SELECT COALESCE(MAX(snapshot_id), 0) FROM ducklake_catalog_snapshot_map
+                 WHERE catalog_id = $1",
+            )
+            .bind(self.catalog_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            let table_id_hint = reserve_ids("ducklake_table", "table_id", 1, &mut tx).await?[0];
+
+            // finalize inserts the columns with the adopted `column_ids`
+            // (OVERRIDING SYSTEM VALUE), so the file's field-ids match.
+            let (snapshot_id, schema_id, table_id) = finalize_snapshot(
+                self.catalog_id,
+                schema_name,
+                table_name,
+                table_id_hint,
+                columns,
+                column_ids,
+                mode,
+                base_snapshot,
+                &mut tx,
+            )
+            .await?;
+
+            // rowids get a fresh range from the table counter — the source range
+            // isn't preserved (index copy, which would need it, is out of scope).
+            sqlx::query(
+                "INSERT INTO ducklake_table_stats (table_id, record_count, next_row_id, file_size_bytes)
+                 VALUES ($1, 0, 0, 0)
+                 ON CONFLICT (table_id) DO NOTHING",
+            )
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            let row_id_start: i64 = sqlx::query_scalar(
+                "SELECT next_row_id FROM ducklake_table_stats WHERE table_id = $1",
+            )
+            .bind(table_id)
+            .fetch_one(&mut *tx)
+            .await?;
+
+            sqlx::query(
+                "INSERT INTO ducklake_data_file
+                     (table_id, path, path_is_relative, file_size_bytes,
+                      footer_size, record_count, row_id_start, begin_snapshot)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+            )
+            .bind(table_id)
+            .bind(&file.path)
+            .bind(file.path_is_relative)
+            .bind(file.file_size_bytes)
+            .bind(file.footer_size)
+            .bind(file.record_count)
+            .bind(row_id_start)
+            .bind(snapshot_id)
+            .execute(&mut *tx)
+            .await?;
+
+            sqlx::query(
+                "UPDATE ducklake_table_stats
+                 SET next_row_id     = next_row_id + $1,
+                     record_count    = record_count + $2,
+                     file_size_bytes = file_size_bytes + $3
+                 WHERE table_id = $4",
+            )
+            .bind(file.record_count)
+            .bind(file.record_count)
+            .bind(file.file_size_bytes)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+
+            advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
+            tx.commit().await?;
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
+        })
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn set_delete_file(
         &self,

--- a/tests/multicatalog_postgres_tests.rs
+++ b/tests/multicatalog_postgres_tests.rs
@@ -4485,3 +4485,137 @@ async fn multicatalog_append_racing_promote_does_not_bump_schema_version() {
         "all rows present and correct after the race"
     );
 }
+
+/// `register_existing_data_file` adopts the caller's `column_ids` (so a copied
+/// parquet's embedded field-ids resolve), creates the table/file/snapshot, and
+/// advances the catalog head — replace then append, without re-minting ids.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn register_existing_data_file_adopts_column_ids() {
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("pg_adopt").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path("/data").unwrap();
+
+    // Adopt non-sequential ids: a real IDENTITY-assigned pair would be (1, 2),
+    // so (100, 200) proves the ids come from the caller, not the sequence.
+    let ids = vec![100_i64, 200_i64];
+    let out = w
+        .register_existing_data_file(
+            "public",
+            "orders",
+            &cols(),
+            &ids,
+            &DataFileInfo::new("f1.parquet", 1024, 3),
+            WriteMode::Replace,
+        )
+        .unwrap();
+    assert_eq!(
+        current_head(&pool, cat).await,
+        out.snapshot_id,
+        "head advances to the committed snapshot"
+    );
+
+    let cols_got: Vec<(String, i64)> = sqlx::query(
+        "SELECT column_name, column_id FROM ducklake_column
+         WHERE table_id = $1 AND end_snapshot IS NULL ORDER BY column_order",
+    )
+    .bind(out.table_id)
+    .fetch_all(&pool)
+    .await
+    .unwrap()
+    .into_iter()
+    .map(|r| {
+        (
+            r.try_get::<String, _>(0).unwrap(),
+            r.try_get::<i64, _>(1).unwrap(),
+        )
+    })
+    .collect();
+    assert_eq!(
+        cols_got,
+        vec![("id".to_string(), 100), ("name".to_string(), 200)],
+        "columns adopt the caller's ids (== the parquet field-ids)"
+    );
+
+    // Append a second file with the SAME ids — no drift, both files live.
+    let out2 = w
+        .register_existing_data_file(
+            "public",
+            "orders",
+            &cols(),
+            &ids,
+            &DataFileInfo::new("f2.parquet", 512, 2),
+            WriteMode::Append,
+        )
+        .unwrap();
+    assert_eq!(out2.table_id, out.table_id, "same table");
+    assert_eq!(current_head(&pool, cat).await, out2.snapshot_id);
+
+    let live_files: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_data_file WHERE table_id = $1 AND end_snapshot IS NULL",
+    )
+    .bind(out.table_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap();
+    assert_eq!(live_files, 2, "replace + append -> two live data files");
+
+    let ids_after: Vec<i64> = sqlx::query(
+        "SELECT column_id FROM ducklake_column
+         WHERE table_id = $1 AND end_snapshot IS NULL ORDER BY column_order",
+    )
+    .bind(out.table_id)
+    .fetch_all(&pool)
+    .await
+    .unwrap()
+    .into_iter()
+    .map(|r| r.try_get::<i64, _>(0).unwrap())
+    .collect();
+    assert_eq!(
+        ids_after,
+        vec![100, 200],
+        "append does not re-mint column ids"
+    );
+}
+
+/// `column_ids` must be 1:1 with `columns`; a mismatch is rejected before any
+/// write (otherwise `finalize_snapshot`'s zip would silently drop columns).
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn register_existing_data_file_rejects_mismatched_column_ids() {
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("pg_adopt_bad").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path("/data").unwrap();
+
+    let res = w.register_existing_data_file(
+        "public",
+        "orders",
+        &cols(), // 2 columns
+        &[100],  // 1 id
+        &DataFileInfo::new("f.parquet", 10, 1),
+        WriteMode::Replace,
+    );
+    assert!(
+        matches!(res, Err(DuckLakeError::InvalidConfig(_))),
+        "mismatched column_ids must be rejected"
+    );
+    assert_eq!(
+        current_head(&pool, cat).await,
+        0,
+        "nothing is committed on a validation failure"
+    );
+}


### PR DESCRIPTION
## Summary

Adds `MetadataWriter::register_existing_data_file` — register a parquet that **already carries DuckLake field-ids** (e.g. a file copied verbatim from another catalog) by **adopting caller-supplied `column_id`s** for the destination table's columns, so the file's embedded `PARQUET:field_id`s resolve on read. Self-contained (no `begin_write_transaction`): creates the table/columns on first write, appends after.

## Motivation

Enables copying a whole managed database — schemas, tables, and data — by **server-side-copying the parquet files** into a new catalog and re-registering them, with **no re-encode**. A naïve register mints fresh column ids, so the copied file's embedded field-ids no longer match and every column reads back NULL; adopting the source's ids fixes that.

## Scope & safety

- **Pure addition.** New trait method with a default `Unsupported` impl + a `PostgresMetadataWriter` implementation. No existing signatures change; the single-catalog (SQLite/DuckDB/MySQL) writers are untouched (they inherit the default).
- **Multicatalog-only.** Lives entirely in the experimental, library-specific multi-catalog layout; the DuckLake-spec single-catalog path is unaffected.
- **Reuses existing machinery.** It goes through `finalize_snapshot`, which already inserts columns with `OVERRIDING SYSTEM VALUE` for schema-evolution id reuse — this just supplies the ids from another catalog's columns. Safe because reads scope `ducklake_column` by `table_id`, and the multicatalog writer allocates ids from an IDENTITY sequence (not `MAX(column_id)+1`), so reused lower ids can't collide with future allocations.
- **Rowids are freshly assigned** (the source `row_id_start` is not preserved), so indexes keyed on the source's rowids do not carry over. Documented on the method.

## Validation & tests

- Rejects empty `columns` and `column_ids` not 1:1 with `columns` (a length mismatch would otherwise silently drop trailing columns via `finalize_snapshot`'s zip).
- Multicatalog Postgres tests: adopting non-sequential ids across replace + append (verifying no re-mint), and the mismatched-length rejection.