### PR TITLE
feat(read): prune data files at plan time via column statistics

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -31,14 +31,15 @@ use crate::metadata_writer::{MetadataWriter, WriteMode};
 use crate::update_exec::DuckLakeUpdateExec;
 #[cfg(feature = "write")]
 use arrow::array::ArrayRef;
-#[cfg(feature = "write")]
 use datafusion::common::DFSchema;
+use datafusion::common::pruning::PrunableStatistics;
 #[cfg(feature = "write")]
 use datafusion::logical_expr::Operator;
 #[cfg(feature = "write")]
 use datafusion::physical_expr::PhysicalExpr;
 #[cfg(feature = "write")]
 use datafusion::physical_expr::expressions::BinaryExpr;
+use datafusion::physical_optimizer::pruning::PruningPredicate;
 
 #[cfg(feature = "encryption")]
 use crate::encryption::EncryptionFactoryBuilder;
@@ -808,6 +809,95 @@ impl DuckLakeTable {
             file = file.with_statistics(statistics);
         }
         Ok(file)
+    }
+
+    /// Plan-time file pruning: return the subset of `self.table_files` whose
+    /// catalog column statistics (min/max/null counts) prove they *may* contain
+    /// rows matching `filters`. Files with no recorded statistics are always
+    /// kept.
+    ///
+    /// This complements the parquet opener's execution-time `FilePruner`, which
+    /// applies the same statistics to skip *reading* non-matching files. Pruning
+    /// here shrinks the physical plan itself (file count and the size/row
+    /// estimates aggregated from the surviving files' statistics) so downstream
+    /// join and aggregation planning sees only the relevant files.
+    ///
+    /// Purely an optimisation. Only static predicates are evaluated, so the
+    /// result can only ever be a *superset* of the truly-matching files — it
+    /// never drops a file that could match. On an empty filter set, or any error
+    /// while building the predicate, every file is kept.
+    ///
+    /// Effectiveness note: a file with a live delete file has `Inexact`
+    /// statistics (its recorded min/max may cover already-deleted rows). Because
+    /// `PrunableStatistics` only prunes on `Exact` bounds, such a file is always
+    /// kept — and, since the bounds are aggregated per column across all files,
+    /// one `Inexact` file suppresses pruning by that column for the whole scan.
+    /// Pruning is therefore most effective on append-only / delete-free files.
+    fn prune_table_files<'a>(
+        &'a self,
+        state: &dyn Session,
+        filters: &[Expr],
+    ) -> Vec<&'a DuckLakeTableFile> {
+        if filters.is_empty() || self.table_files.is_empty() {
+            return self.table_files.iter().collect();
+        }
+        match self.file_pruning_mask(state, filters) {
+            Ok(mask) => {
+                // The mask is 1:1 with `table_files` (DataFusion sizes it from
+                // `num_containers`); the zip below relies on that alignment.
+                debug_assert_eq!(mask.len(), self.table_files.len());
+                self.table_files
+                    .iter()
+                    .zip(mask)
+                    .filter_map(|(tf, keep)| keep.then_some(tf))
+                    .collect()
+            },
+            Err(e) => {
+                tracing::debug!(error = %e, "skipping plan-time file pruning");
+                self.table_files.iter().collect()
+            },
+        }
+    }
+
+    /// Build a `PruningPredicate` from `filters` and evaluate it against every
+    /// file's catalog statistics, returning a keep/drop mask 1:1 with
+    /// `self.table_files` (`true` = keep). Filters and statistics are both keyed
+    /// to `physical_schema` (the parquet-backed columns, excluding the synthetic
+    /// rowid), matching how `file_statistics` is indexed.
+    fn file_pruning_mask(
+        &self,
+        state: &dyn Session,
+        filters: &[Expr],
+    ) -> DataFusionResult<Vec<bool>> {
+        use datafusion::logical_expr::utils::conjunction;
+
+        // AND the filters into one predicate and plan it against the physical
+        // schema (no synthetic rowid), so column indices line up with the
+        // per-file statistics. A filter referencing a column absent from
+        // `physical_schema` (e.g. the synthetic rowid) fails here, and the
+        // caller falls back to keeping every file. Mirrors the DELETE path.
+        let Some(expr) = conjunction(filters.iter().cloned()) else {
+            return Ok(vec![true; self.table_files.len()]);
+        };
+        let df_schema = DFSchema::try_from(self.physical_schema.as_ref().clone())?;
+        let predicate = state.create_physical_expr(expr, &df_schema)?;
+        let pruning = PruningPredicate::try_new(predicate, Arc::clone(&self.physical_schema))?;
+
+        // A file lacking recorded statistics (e.g. written before statistics
+        // were produced) contributes `new_unknown`, which the predicate treats
+        // as "cannot prune" — the file is kept.
+        let per_file: Vec<Arc<Statistics>> = self
+            .table_files
+            .iter()
+            .map(|tf| {
+                self.file_statistics
+                    .get(&tf.data_file_id)
+                    .map(Arc::clone)
+                    .unwrap_or_else(|| Arc::new(Statistics::new_unknown(&self.physical_schema)))
+            })
+            .collect();
+        let stats = PrunableStatistics::new(per_file, Arc::clone(&self.physical_schema));
+        pruning.prune(&stats)
     }
 
     /// Create a ParquetSource with encryption support if enabled and needed
@@ -2128,13 +2218,19 @@ impl TableProvider for DuckLakeTable {
         &self,
         state: &dyn Session,
         projection: Option<&Vec<usize>>,
-        // Filters are received here for informational purposes. DataFusion's optimizer
-        // automatically pushes them down to the Parquet scanner for row group pruning and
-        // page-level filtering since we declared support via supports_filters_pushdown().
-        // We mark them as Inexact, so DataFusion will reapply them after our scan.
-        _filters: &[Expr],
+        // Filters drive plan-time file pruning below: `prune_table_files` drops
+        // files whose catalog statistics prove they cannot match. They are also
+        // pushed down to the parquet scanner by DataFusion's optimizer for row
+        // group / page-level filtering. We declare them Inexact in
+        // `supports_filters_pushdown`, so DataFusion reapplies them after our
+        // scan — pruning here only ever removes provably non-matching files.
+        filters: &[Expr],
         limit: Option<usize>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        // Plan-time pruning: restrict the files considered below to those whose
+        // statistics admit a match. Empty filters / missing stats keep every file.
+        let table_files = self.prune_table_files(state, filters);
+
         // Row-lineage detour: when the synthetic `rowid` column is projected,
         // every file needs its own scan because each has a distinct
         // `row_id_start`. `projection == None` with row lineage on means "all
@@ -2153,7 +2249,7 @@ impl TableProvider for DuckLakeTable {
                 .unwrap_or_else(|| (0..self.schema.fields().len()).collect());
 
             let mut execs: Vec<Arc<dyn ExecutionPlan>> = Vec::new();
-            for tf in &self.table_files {
+            for tf in table_files.iter().copied() {
                 // A merged partial file read below its partial_max needs per-row
                 // snapshot filtering; it always embeds its rowid, so the partial
                 // path serves the projected rowid directly.
@@ -2184,9 +2280,8 @@ impl TableProvider for DuckLakeTable {
         // — they need per-row snapshot filtering and are handled per file. Every
         // other file (ordinary, or a partial file at/after its partial_max) takes
         // the existing grouped/with-deletes paths unchanged.
-        let (needs_filter, rest): (Vec<_>, Vec<_>) = self
-            .table_files
-            .iter()
+        let (needs_filter, rest): (Vec<_>, Vec<_>) = table_files
+            .into_iter()
             .partition(|tf| self.needs_snapshot_filter(tf));
         let (files_with_deletes, files_without_deletes): (Vec<_>, Vec<_>) =
             rest.into_iter().partition(|tf| tf.delete_file.is_some());

--- a/tests/table_tests.rs
+++ b/tests/table_tests.rs
@@ -206,6 +206,27 @@ fn collect_partitioned_file_statistics(
     }
 }
 
+/// Collect the paths of every scanned data file in the plan, regardless of
+/// whether statistics are attached. Unlike `collect_partitioned_file_statistics`
+/// (which the delete/positional paths would undercount, since those build files
+/// without statistics), this counts pruning on any scan path.
+fn collect_partitioned_file_paths(plan: &Arc<dyn ExecutionPlan>, output: &mut Vec<String>) {
+    if let Some(exec) = plan.downcast_ref::<DataSourceExec>()
+        && let Some(config) = exec.data_source().downcast_ref::<FileScanConfig>()
+    {
+        for group in &config.file_groups {
+            output.extend(
+                group
+                    .iter()
+                    .map(|file| file.object_meta.location.to_string()),
+            );
+        }
+    }
+    for child in plan.children() {
+        collect_partitioned_file_paths(child, output);
+    }
+}
+
 /// DuckLake's table-, table-column-, and file-column statistic rows are all
 /// surfaced through their corresponding DataFusion statistics objects.
 #[tokio::test]
@@ -402,5 +423,291 @@ async fn test_statistics_zero_for_empty_table() -> DataFusionResult<()> {
         Precision::Exact(0) | Precision::Inexact(0) => {},
         other => panic!("expected zero bytes for empty table, got {:?}", other),
     }
+    Ok(())
+}
+
+/// Two data files with disjoint `a` ranges ([0, 999] and [10000, 10999]),
+/// written as two separate INSERTs so DuckLake emits one file per range.
+fn create_two_file_catalog(catalog_path: &std::path::Path) -> anyhow::Result<()> {
+    let conn = duckdb::Connection::open_in_memory()?;
+    conn.execute("INSTALL ducklake;", [])?;
+    conn.execute("LOAD ducklake;", [])?;
+
+    let data_dir = catalog_path.with_extension("ducklake.files");
+    std::fs::create_dir_all(&data_dir)?;
+
+    let ducklake_path = format!("ducklake:{}", catalog_path.display());
+    conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
+    conn.execute("CREATE TABLE test_catalog.tbl (a INTEGER, b VARCHAR);", [])?;
+    conn.execute(
+        "INSERT INTO test_catalog.tbl SELECT i, repeat('x', 100) FROM range(0, 1000) t(i);",
+        [],
+    )?;
+    conn.execute(
+        "INSERT INTO test_catalog.tbl SELECT i, repeat('x', 100) FROM range(10000, 11000) t(i);",
+        [],
+    )?;
+    Ok(())
+}
+
+/// Files whose min/max cannot satisfy a filter are dropped from the scan plan
+/// at planning time, while a non-selective scan keeps every file. Establishes
+/// the two-file baseline, then checks a selective filter, a filter matching
+/// both files, and a filter matching none.
+#[tokio::test]
+async fn test_scan_prunes_files_by_statistics() -> DataFusionResult<()> {
+    let temp_dir =
+        TempDir::new().map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    let catalog_path = temp_dir.path().join("prune.ducklake");
+    create_two_file_catalog(&catalog_path)
+        .map_err(|e| datafusion::error::DataFusionError::External(e.into()))?;
+
+    let catalog = create_catalog(&catalog_path.to_string_lossy())?;
+    let schema = datafusion::catalog::CatalogProvider::schema(catalog.as_ref(), "main")
+        .expect("main schema exists");
+    let table = schema
+        .table("tbl")
+        .await
+        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?
+        .expect("tbl present in main schema");
+
+    let state = SessionContext::new().state();
+
+    let files_for = |plan: &Arc<dyn ExecutionPlan>| {
+        let mut stats = Vec::new();
+        collect_partitioned_file_statistics(plan, &mut stats);
+        stats
+    };
+
+    // No filter: both files present in the plan.
+    let plan = table.scan(&state, None, &[], None).await?;
+    assert_eq!(
+        files_for(&plan).len(),
+        2,
+        "unfiltered scan keeps every file"
+    );
+
+    // Selective filter `a < 5000` can only match the [0, 999] file; the
+    // [10000, 10999] file is dropped at planning time.
+    let plan = table
+        .scan(&state, None, &[col("a").lt(lit(5000_i32))], None)
+        .await?;
+    let stats = files_for(&plan);
+    assert_eq!(stats.len(), 1, "selective filter prunes the disjoint file");
+    assert_eq!(
+        stats[0].column_statistics[0].max_value,
+        Precision::Exact(ScalarValue::Int32(Some(999))),
+        "the surviving file is the low-range one"
+    );
+
+    // Filter spanning both ranges keeps both files.
+    let plan = table
+        .scan(&state, None, &[col("a").gt(lit(-1_i32))], None)
+        .await?;
+    assert_eq!(files_for(&plan).len(), 2, "non-selective filter keeps both");
+
+    // Filter matching neither file prunes everything.
+    let plan = table
+        .scan(&state, None, &[col("a").gt(lit(999_999_i32))], None)
+        .await?;
+    assert_eq!(files_for(&plan).len(), 0, "unmatchable filter prunes all");
+
+    // Correctness: pruning must not change results. Count through a full SQL
+    // scan (filter reapplied on top) should equal the low file's row count.
+    let ctx = SessionContext::new();
+    ctx.register_catalog("c", catalog);
+    let batches = ctx
+        .sql("SELECT COUNT(*) FROM c.main.tbl WHERE a < 5000")
+        .await?
+        .collect()
+        .await?;
+    let count = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .expect("count is Int64")
+        .value(0);
+    assert_eq!(
+        count, 1000,
+        "pruned query returns the full low-range result"
+    );
+
+    Ok(())
+}
+
+/// Pruning composes correctly with the with-deletes scan path: a table where
+/// one file carries a live delete returns correct, delete-applied results under
+/// a selective filter. (A file with a live delete has inexact statistics and is
+/// intentionally never pruned — and its presence suppresses pruning by that
+/// column for the whole scan — so this asserts correctness, not a file-count
+/// reduction. See `prune_table_files`.)
+#[tokio::test]
+async fn test_scan_with_live_deletes_is_correct() -> DataFusionResult<()> {
+    let temp_dir =
+        TempDir::new().map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    let catalog_path = temp_dir.path().join("prune_deletes.ducklake");
+
+    // Two disjoint files, then delete one row from the low-range file so it
+    // acquires a live delete file.
+    {
+        let conn = duckdb::Connection::open_in_memory()
+            .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+        let exec = |sql: &str| -> DataFusionResult<()> {
+            conn.execute(sql, [])
+                .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+            Ok(())
+        };
+        exec("INSTALL ducklake;")?;
+        exec("LOAD ducklake;")?;
+        std::fs::create_dir_all(catalog_path.with_extension("ducklake.files"))
+            .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+        exec(&format!(
+            "ATTACH 'ducklake:{}' AS test_catalog;",
+            catalog_path.display()
+        ))?;
+        exec("CREATE TABLE test_catalog.tbl (a INTEGER, b VARCHAR);")?;
+        exec("INSERT INTO test_catalog.tbl SELECT i, repeat('x', 100) FROM range(0, 1000) t(i);")?;
+        exec(
+            "INSERT INTO test_catalog.tbl SELECT i, repeat('x', 100) FROM range(10000, 11000) t(i);",
+        )?;
+        exec("DELETE FROM test_catalog.tbl WHERE a = 42;")?;
+    }
+
+    let catalog = create_catalog(&catalog_path.to_string_lossy())?;
+    let schema = datafusion::catalog::CatalogProvider::schema(catalog.as_ref(), "main")
+        .expect("main schema exists");
+    let table = schema
+        .table("tbl")
+        .await
+        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?
+        .expect("tbl present in main schema");
+
+    // Pruning runs over the with-deletes path without error, and the plan still
+    // includes the file that carries the live delete (it is never pruned).
+    let state = SessionContext::new().state();
+    let plan = table
+        .scan(&state, None, &[col("a").lt(lit(5000_i32))], None)
+        .await?;
+    let mut paths = Vec::new();
+    collect_partitioned_file_paths(&plan, &mut paths);
+    assert!(
+        !paths.is_empty(),
+        "the file with a live delete is kept, not pruned"
+    );
+
+    // Correctness across the full range: the delete is applied exactly once, and
+    // no live rows are lost, whether or not a filter is present.
+    let ctx = SessionContext::new();
+    ctx.register_catalog("c", catalog);
+    for (sql, expected, msg) in [
+        (
+            "SELECT COUNT(*) FROM c.main.tbl WHERE a < 5000",
+            999_i64,
+            "one row deleted from the low-range file",
+        ),
+        (
+            "SELECT COUNT(*) FROM c.main.tbl WHERE a > 5000",
+            1000,
+            "the unaffected high-range file is unchanged",
+        ),
+        (
+            "SELECT COUNT(*) FROM c.main.tbl",
+            1999,
+            "total reflects exactly one deleted row",
+        ),
+    ] {
+        let batches = ctx.sql(sql).await?.collect().await?;
+        let count = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("count is Int64")
+            .value(0);
+        assert_eq!(count, expected, "{msg}");
+    }
+
+    Ok(())
+}
+
+/// Pruning also applies on the row-lineage scan path (rowid projected), which
+/// builds a separate per-file exec for each surviving file. Verified by file
+/// path since that path does not always attach statistics.
+#[tokio::test]
+async fn test_scan_prunes_files_on_rowid_path() -> DataFusionResult<()> {
+    let temp_dir =
+        TempDir::new().map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    let catalog_path = temp_dir.path().join("prune_rowid.ducklake");
+    create_two_file_catalog(&catalog_path)
+        .map_err(|e| datafusion::error::DataFusionError::External(e.into()))?;
+
+    // Enable row lineage so the table exposes a synthetic `rowid` column and
+    // `scan` routes through the per-file row-lineage path.
+    let provider = DuckdbMetadataProvider::new(catalog_path.to_string_lossy().to_string())
+        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    let catalog = Arc::new(
+        DuckLakeCatalog::new(provider)
+            .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?
+            .with_row_lineage(true),
+    );
+    let schema = datafusion::catalog::CatalogProvider::schema(catalog.as_ref(), "main")
+        .expect("main schema exists");
+    let table = schema
+        .table("tbl")
+        .await
+        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?
+        .expect("tbl present in main schema");
+
+    let state = SessionContext::new().state();
+    let paths_for = |plan: &Arc<dyn ExecutionPlan>| {
+        let mut paths = Vec::new();
+        collect_partitioned_file_paths(plan, &mut paths);
+        paths
+    };
+
+    // Projection `None` with row lineage on means "all columns including rowid",
+    // routing through the row-lineage path. A selective filter still prunes.
+    let plan = table
+        .scan(&state, None, &[col("a").lt(lit(5000_i32))], None)
+        .await?;
+    assert_eq!(
+        paths_for(&plan).len(),
+        1,
+        "row-lineage scan prunes the disjoint file"
+    );
+
+    let plan = table.scan(&state, None, &[], None).await?;
+    assert_eq!(
+        paths_for(&plan).len(),
+        2,
+        "unfiltered row-lineage scan keeps every file"
+    );
+
+    // Correctness: rowid projection over the pruned scan returns every low-range
+    // row exactly once.
+    let ctx = SessionContext::new();
+    ctx.register_catalog("c", catalog);
+    let batches = ctx
+        .sql("SELECT COUNT(*), COUNT(DISTINCT rowid) FROM c.main.tbl WHERE a < 5000")
+        .await?
+        .collect()
+        .await?;
+    let rows = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .expect("count is Int64")
+        .value(0);
+    let distinct_rowids = batches[0]
+        .column(1)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .expect("count is Int64")
+        .value(0);
+    assert_eq!(rows, 1000, "all low-range rows returned");
+    assert_eq!(
+        distinct_rowids, 1000,
+        "each surviving row has a distinct rowid"
+    );
+
     Ok(())
 }


### PR DESCRIPTION
## Summary

`TableProvider::scan()` receives the query's pushdown filters but ignored them when building the file list, so the physical plan spanned **every** data file even for a highly selective query. This uses the per-file column statistics (min/max/null counts) already decoded into `file_statistics` (from #161/#171) to build a `PruningPredicate` and drop files that cannot match — at planning time, before the plan is built.

Applied to all three scan paths: the grouped no-delete path, the with-deletes path, and the row-lineage (rowid) path.

## Relationship to execution-time pruning (#161)

This is complementary to, not a replacement for, the opener's `FilePruner`:

- **#161** attaches per-file stats so the opener **skips reading** non-matching files at run time — that saves the I/O.
- **This PR** removes non-matching files from the plan itself. The stats come from the catalog (already in memory), so it's a free in-memory comparison — no extra file reads.

The incremental benefit is therefore **planning-side**, not raw I/O:

- Accurate scan-size/row estimates aggregated over surviving files → better join/aggregation planning.
- No scan task scheduled per non-matching file (less startup/coordination overhead on high-file-count tables).
- Smaller physical plan.

## Correctness

Purely an optimisation. Only static predicates are evaluated, so the result is always a **superset** of the truly-matching files — it can never drop a file that could match. Fallbacks that keep every file: an empty filter set, a predicate that can't be planned against the physical schema (e.g. one referencing the synthetic `rowid`), and files with missing statistics. Reuses DataFusion's `PruningPredicate` over the same stats the opener's `FilePruner` already applies, so the pruning decision is identical, one step earlier.

Filters and statistics are keyed to the physical schema (excluding the synthetic rowid), matching how `file_statistics` is indexed.

## Effectiveness notes

- Pruning is effective only when a file's min/max is narrow for the filtered column (clustered/sorted or naturally ordered data); with overlapping ranges nothing prunes.
- A file with a live delete has `Inexact` statistics and is never pruned. Because min/max are aggregated per column across all files, one such file suppresses pruning by that column for the whole scan. Pruning is therefore most effective on append-only / delete-free files.

## Tests

Three end-to-end tests in `table_tests.rs` (real Parquet, real catalog, real plan):

- `test_scan_prunes_files_by_statistics` — grouped scan: selective filter prunes the disjoint file; a filter matching both keeps both; an unmatchable filter prunes all; plus a result-equality check.
- `test_scan_prunes_files_on_rowid_path` — row-lineage path prunes, with a distinct-rowid correctness check.
- `test_scan_with_live_deletes_is_correct` — the with-deletes path returns correct, delete-applied results.
