### PR TITLE
chore(release): 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-15
+
 ### Added
 - Read DuckDB data inlining (SQLite).
 - Compaction: `merge_adjacent_files` + `rewrite_data_files` (#167).
@@ -172,6 +174,10 @@ Initial release.
 - Filter pushdown to Parquet
 - Query-scoped snapshot isolation
 
+[Unreleased]: https://github.com/hotdata-dev/datafusion-ducklake/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/hotdata-dev/datafusion-ducklake/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/hotdata-dev/datafusion-ducklake/compare/v0.3.1...v0.4.0
+[0.3.1]: https://github.com/hotdata-dev/datafusion-ducklake/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/hotdata-dev/datafusion-ducklake/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/hotdata-dev/datafusion-ducklake/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/hotdata-dev/datafusion-ducklake/compare/v0.1.2...v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1847,7 +1847,7 @@ checksum = "cb9e7e5d11130c48c8bd4e80c79a9772dd28ce6dc330baca9246205d245b9e2e"
 
 [[package]]
 name = "datafusion-ducklake"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "arrow 58.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "benchmark"]
 
 [package]
 name = "datafusion-ducklake"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 authors = ["zac@hotdata.dev", "shefeek@hotdata.dev", "anoop@hotdata.dev"]
 description = "DuckLake query engine for rust, built with datafusion."

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ backends and write support are opt-in via feature flags — see
 # Cargo.toml — read PostgreSQL catalogs
 # (for the experimental multi-catalog write path, use features = ["write-postgres"])
 [dependencies]
-datafusion-ducklake = { version = "0.4", features = ["metadata-postgres"] }
+datafusion-ducklake = { version = "0.5", features = ["metadata-postgres"] }
 ```
 
 The examples below also use `datafusion`, `object_store`, and `url` directly — add them


### PR DESCRIPTION
Prepare the 0.5.0 release.

## Changes
- **Version:** `0.4.0` → `0.5.0` in `Cargo.toml`, synced in `Cargo.lock` (only the crate's own version line changed).
- **CHANGELOG:** cut the `[0.5.0] - 2026-07-15` section from `[Unreleased]` (DuckDB data inlining, compaction #167), reset `[Unreleased]`, and added the previously-missing compare links (`[Unreleased]`, `[0.5.0]`, `[0.4.0]`, `[0.3.1]`).
- **README:** bumped the dependency example from `"0.4"` to `"0.5"`.

Minor bump: the release adds features (DuckDB data inlining, compaction) with no breaking changes.

## Notes
- The `[Unreleased]` compare link and existing links use the `hotdata-dev` org to match `Cargo.toml`'s `repository` field; if the canonical repo is now `datafusion-contrib`, updating both the crate metadata and the changelog links is a separate follow-up.