### PR TITLE
feat(cdc): emit rowid from table_changes and table_deletions

### DIFF
--- a/src/metadata_provider.rs
+++ b/src/metadata_provider.rs
@@ -110,7 +110,8 @@ pub const SQL_GET_DATA_FILES_ADDED_BETWEEN_SNAPSHOTS: &str = "
         data.path_is_relative,
         data.file_size_bytes,
         data.footer_size,
-        data.encryption_key
+        data.encryption_key,
+        data.row_id_start
     FROM ducklake_data_file AS data
     WHERE data.table_id = ?
       AND data.begin_snapshot > ?
@@ -626,6 +627,12 @@ pub struct DataFileChange {
     pub file_size_bytes: i64,
     pub footer_size: Option<i64>,
     pub encryption_key: Option<String>,
+    /// First rowid assigned to this file (`row_id_start` in the catalog), or
+    /// `None` when the catalog does not carry one (e.g. an embedded-rowid
+    /// compaction/rewrite output, or an older catalog). Required only to
+    /// synthesize a plain insert's rowid (`row_id_start + physical_position`);
+    /// files with an embedded rowid do not need it.
+    pub row_id_start: Option<i64>,
 }
 
 #[derive(Debug, Clone)]
@@ -634,8 +641,14 @@ pub struct DeleteFileChange {
     pub data_file_path: String,
     pub data_file_path_is_relative: bool,
     pub data_file_size_bytes: i64,
-    pub data_file_footer_size: i64,
-    pub data_row_id_start: i64,
+    // Nullable in `ducklake_data_file` (mirrors `DataFileChange::footer_size`);
+    // a data file registered without a footer-size hint has NULL here.
+    pub data_file_footer_size: Option<i64>,
+    // Nullable (mirrors `DataFileChange::row_id_start`): NULL for embedded-rowid
+    // rewrite/compaction outputs. Required only when a deleted row's rowid must
+    // be synthesized as `row_id_start + position` (i.e. the source file has no
+    // embedded rowid).
+    pub data_row_id_start: Option<i64>,
     pub data_record_count: i64,
     pub data_mapping_id: Option<i64>,
 

--- a/src/metadata_provider_duckdb.rs
+++ b/src/metadata_provider_duckdb.rs
@@ -524,6 +524,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
                     file_size_bytes: row.get(3)?,
                     footer_size: row.get(4)?,
                     encryption_key: row.get(5)?,
+                    row_id_start: row.get(6)?,
                 })
             })?
             .collect::<Result<Vec<_>, _>>()?;

--- a/src/metadata_provider_mysql.rs
+++ b/src/metadata_provider_mysql.rs
@@ -641,7 +641,8 @@ impl MetadataProvider for MySqlMetadataProvider {
                     data.path_is_relative,
                     data.file_size_bytes,
                     data.footer_size,
-                    data.encryption_key
+                    data.encryption_key,
+                    data.row_id_start
                 FROM ducklake_data_file AS data
                 WHERE data.table_id = ?
                   AND data.begin_snapshot > ?
@@ -663,6 +664,7 @@ impl MetadataProvider for MySqlMetadataProvider {
                         file_size_bytes: row.try_get(3)?,
                         footer_size: row.try_get(4)?,
                         encryption_key: row.try_get(5)?,
+                        row_id_start: row.try_get(6)?,
                     })
                 })
                 .collect()

--- a/src/metadata_provider_postgres.rs
+++ b/src/metadata_provider_postgres.rs
@@ -707,7 +707,8 @@ impl MetadataProvider for PostgresMetadataProvider {
                     data.path_is_relative,
                     data.file_size_bytes,
                     data.footer_size,
-                    data.encryption_key
+                    data.encryption_key,
+                    data.row_id_start
                 FROM ducklake_data_file AS data
                 WHERE data.table_id = $1
                   AND data.begin_snapshot > $2
@@ -729,6 +730,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                         file_size_bytes: row.try_get(3)?,
                         footer_size: row.try_get(4)?,
                         encryption_key: row.try_get(5)?,
+                        row_id_start: row.try_get(6)?,
                     })
                 })
                 .collect()

--- a/src/metadata_provider_sqlite.rs
+++ b/src/metadata_provider_sqlite.rs
@@ -866,7 +866,8 @@ impl MetadataProvider for SqliteMetadataProvider {
                     data.path_is_relative,
                     data.file_size_bytes,
                     data.footer_size,
-                    data.encryption_key
+                    data.encryption_key,
+                    data.row_id_start
                 FROM ducklake_data_file AS data
                 WHERE data.table_id = ?
                   AND data.begin_snapshot > ?
@@ -888,6 +889,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                         file_size_bytes: row.try_get(3)?,
                         footer_size: row.try_get(4)?,
                         encryption_key: row.try_get(5)?,
+                        row_id_start: row.try_get(6)?,
                     })
                 })
                 .collect()

--- a/src/multicatalog_provider.rs
+++ b/src/multicatalog_provider.rs
@@ -758,7 +758,8 @@ impl MetadataProvider for MulticatalogProvider {
                     data.path_is_relative,
                     data.file_size_bytes,
                     data.footer_size,
-                    data.encryption_key
+                    data.encryption_key,
+                    data.row_id_start
                 FROM ducklake_data_file AS data
                 WHERE data.table_id = $1
                   AND data.begin_snapshot > $2
@@ -780,6 +781,7 @@ impl MetadataProvider for MulticatalogProvider {
                         file_size_bytes: row.try_get(3)?,
                         footer_size: row.try_get(4)?,
                         encryption_key: row.try_get(5)?,
+                        row_id_start: row.try_get(6)?,
                     })
                 })
                 .collect()

--- a/src/table_changes.rs
+++ b/src/table_changes.rs
@@ -100,6 +100,10 @@ pub struct AppendCDCColumnsExec {
     snapshot_id: i64,
     /// Change type for this file
     change_type: ChangeType,
+    /// Whether to include a rowid column in output. On this insert-only path
+    /// rowid cannot be synthesized, so it is emitted as an all-NULL column
+    /// (used only for encrypted tables, where the correlated path can't run).
+    include_rowid: bool,
     /// Whether to include snapshot_id in output
     include_snapshot_id: bool,
     /// Whether to include change_type in output
@@ -113,10 +117,12 @@ pub struct AppendCDCColumnsExec {
 }
 
 impl AppendCDCColumnsExec {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         input: Arc<dyn ExecutionPlan>,
         snapshot_id: i64,
         change_type: ChangeType,
+        include_rowid: bool,
         include_snapshot_id: bool,
         include_change_type: bool,
         skip_input_columns: bool,
@@ -139,6 +145,7 @@ impl AppendCDCColumnsExec {
             input,
             snapshot_id,
             change_type,
+            include_rowid,
             include_snapshot_id,
             include_change_type,
             skip_input_columns,
@@ -196,6 +203,7 @@ impl ExecutionPlan for AppendCDCColumnsExec {
             children[0].clone(),
             self.snapshot_id,
             self.change_type,
+            self.include_rowid,
             self.include_snapshot_id,
             self.include_change_type,
             self.skip_input_columns,
@@ -218,6 +226,7 @@ impl ExecutionPlan for AppendCDCColumnsExec {
             input: input_stream,
             snapshot_id: self.snapshot_id,
             change_type: self.change_type,
+            include_rowid: self.include_rowid,
             include_snapshot_id: self.include_snapshot_id,
             include_change_type: self.include_change_type,
             skip_input_columns: self.skip_input_columns,
@@ -231,6 +240,7 @@ struct AppendCDCColumnsStream {
     input: SendableRecordBatchStream,
     snapshot_id: i64,
     change_type: ChangeType,
+    include_rowid: bool,
     include_snapshot_id: bool,
     include_change_type: bool,
     skip_input_columns: bool,
@@ -263,7 +273,12 @@ impl AppendCDCColumnsStream {
             columns.extend(batch.columns().iter().cloned());
         }
 
-        // Append requested CDC columns
+        // Append requested CDC columns, in the order rowid, snapshot_id,
+        // change_type. rowid is all-NULL here: this insert-only path can't
+        // synthesize it (used for encrypted tables).
+        if self.include_rowid {
+            columns.push(Arc::new(Int64Array::from(vec![None::<i64>; num_rows])));
+        }
         if self.include_snapshot_id {
             columns.push(Arc::new(Int64Array::from(vec![self.snapshot_id; num_rows])));
         }
@@ -289,6 +304,8 @@ impl RecordBatchStream for AppendCDCColumnsStream {
 struct ProjectionInfo {
     /// Table column indices to read from Parquet (in original order)
     table_indices: Vec<usize>,
+    /// Whether rowid is requested
+    need_rowid: bool,
     /// Whether snapshot_id is requested
     need_snapshot_id: bool,
     /// Whether change_type is requested
@@ -324,11 +341,15 @@ impl TableChangesTable {
         table_schema: SchemaRef,
     ) -> Self {
         // Build output schema: table columns + CDC metadata columns
+        // (rowid, snapshot_id, change_type), in that order.
         let mut fields: Vec<Field> = table_schema
             .fields()
             .iter()
             .map(|f| f.as_ref().clone())
             .collect();
+        // rowid is nullable: it is NULL on encrypted (PME) tables, where the
+        // correlated feed cannot decrypt footers to resolve rowids.
+        fields.push(Field::new("rowid", DataType::Int64, true));
         fields.push(Field::new("snapshot_id", DataType::Int64, false));
         fields.push(Field::new("change_type", DataType::Utf8, false));
         let output_schema = Arc::new(Schema::new(fields));
@@ -345,17 +366,21 @@ impl TableChangesTable {
         }
     }
 
-    /// Analyze projection and split into table columns and CDC columns
+    /// Analyze projection and split into table columns and CDC columns.
+    /// CDC columns follow the table columns in the order `rowid`, `snapshot_id`,
+    /// `change_type`.
     fn analyze_projection(&self, projection: Option<&Vec<usize>>) -> ProjectionInfo {
         let num_table_cols = self.table_schema.fields().len();
-        let snapshot_id_idx = num_table_cols;
-        let change_type_idx = num_table_cols + 1;
+        let rowid_idx = num_table_cols;
+        let snapshot_id_idx = num_table_cols + 1;
+        let change_type_idx = num_table_cols + 2;
 
         match projection {
             None => {
                 // No projection - read all columns
                 ProjectionInfo {
                     table_indices: (0..num_table_cols).collect(),
+                    need_rowid: true,
                     need_snapshot_id: true,
                     need_change_type: true,
                     output_schema: self.output_schema.clone(),
@@ -364,12 +389,15 @@ impl TableChangesTable {
             Some(indices) => {
                 // Split indices into table columns and CDC columns
                 let mut table_indices: Vec<usize> = Vec::new();
+                let mut need_rowid = false;
                 let mut need_snapshot_id = false;
                 let mut need_change_type = false;
 
                 for &idx in indices {
                     if idx < num_table_cols {
                         table_indices.push(idx);
+                    } else if idx == rowid_idx {
+                        need_rowid = true;
                     } else if idx == snapshot_id_idx {
                         need_snapshot_id = true;
                     } else if idx == change_type_idx {
@@ -386,6 +414,7 @@ impl TableChangesTable {
 
                 ProjectionInfo {
                     table_indices,
+                    need_rowid,
                     need_snapshot_id,
                     need_change_type,
                     output_schema,
@@ -394,10 +423,13 @@ impl TableChangesTable {
         }
     }
 
-    /// Build the schema that AppendCDCColumnsExec will output
+    /// Build the schema that AppendCDCColumnsExec will output. On this
+    /// (encryption-aware, insert-only) path rowid cannot be synthesized, so when
+    /// requested it is emitted as a nullable, all-NULL column.
     fn build_cdc_exec_schema(
         &self,
         table_indices: &[usize],
+        need_rowid: bool,
         need_snapshot_id: bool,
         need_change_type: bool,
     ) -> SchemaRef {
@@ -406,6 +438,9 @@ impl TableChangesTable {
             .map(|&i| self.table_schema.field(i).clone())
             .collect();
 
+        if need_rowid {
+            fields.push(Field::new("rowid", DataType::Int64, true));
+        }
         if need_snapshot_id {
             fields.push(Field::new("snapshot_id", DataType::Int64, false));
         }
@@ -512,6 +547,9 @@ impl TableChangesTable {
         let cdc_exec_schema = if skip_input_columns {
             // Only CDC columns - build schema with just those
             let mut fields = Vec::new();
+            if proj_info.need_rowid {
+                fields.push(Field::new("rowid", DataType::Int64, true));
+            }
             if proj_info.need_snapshot_id {
                 fields.push(Field::new("snapshot_id", DataType::Int64, false));
             }
@@ -522,6 +560,7 @@ impl TableChangesTable {
         } else {
             self.build_cdc_exec_schema(
                 &proj_info.table_indices,
+                proj_info.need_rowid,
                 proj_info.need_snapshot_id,
                 proj_info.need_change_type,
             )
@@ -531,6 +570,7 @@ impl TableChangesTable {
             parquet_exec,
             data_file.begin_snapshot,
             ChangeType::Insert,
+            proj_info.need_rowid,
             proj_info.need_snapshot_id,
             proj_info.need_change_type,
             skip_input_columns,
@@ -578,13 +618,17 @@ impl TableChangesTable {
         }
     }
 
-    /// Plain scan of an inserted data file: table columns, plus the embedded
-    /// rowid column when the file has one. No positions needed (postimage rowids
-    /// come from the embedded column; plain inserts need no rowid).
+    /// Scan of an inserted data file for the correlated feed. A file with an
+    /// embedded rowid (an UPDATE / compaction postimage) is scanned plainly — its
+    /// rowid IS the embedded column. A plain insert is scanned positionally
+    /// (`PositionalFileSource` + `FileRowNumberExec`) so its rowid can be
+    /// synthesized as `row_id_start + position` — but only when `need_rowid`;
+    /// otherwise it is a plain scan with no position column.
     fn build_insert_scan(
         &self,
         data_file: &DataFileChange,
         embedded_name: &Option<String>,
+        need_rowid: bool,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         let resolved = resolve_path(
             &self.table_path,
@@ -603,12 +647,31 @@ impl TableChangesTable {
             pf = pf.with_metadata_size_hint(hint);
         }
         let read_schema = self.read_schema_with_optional_rowid(embedded_name);
-        let builder = FileScanConfigBuilder::new(
-            self.object_store_url.as_ref().clone(),
-            Arc::new(ParquetSource::new(read_schema)),
-        )
-        .with_file_group(FileGroup::new(vec![pf]));
-        Ok(DataSourceExec::from_data_source(builder.build()))
+        let plain_scan = |pf: PartitionedFile, schema: SchemaRef| {
+            let builder = FileScanConfigBuilder::new(
+                self.object_store_url.as_ref().clone(),
+                Arc::new(ParquetSource::new(schema)),
+            )
+            .with_file_group(FileGroup::new(vec![pf]));
+            DataSourceExec::from_data_source(builder.build())
+        };
+        match embedded_name {
+            // Postimage / rewrite: rowid IS the embedded column — a plain scan.
+            Some(_) => Ok(plain_scan(pf, read_schema)),
+            // Plain insert, rowid requested: scan positionally to synthesize
+            // rowid = row_id_start + physical position.
+            None if need_rowid => {
+                let source = PositionalFileSource::wrap(Arc::new(ParquetSource::new(read_schema)));
+                let builder =
+                    FileScanConfigBuilder::new(self.object_store_url.as_ref().clone(), source)
+                        .with_file_group(FileGroup::new(vec![pf]))
+                        .with_partitioned_by_file_group(true);
+                let scan = DataSourceExec::from_data_source(builder.build());
+                Ok(Arc::new(FileRowNumberExec::new(scan, vec![0])))
+            },
+            // Plain insert, rowid not requested: a plain scan, no positions.
+            None => Ok(plain_scan(pf, read_schema)),
+        }
     }
 
     /// Positional scan of a delete's source data file: table columns, the
@@ -680,75 +743,102 @@ impl TableChangesTable {
         projection: Option<&Vec<usize>>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         let table_len = self.table_schema.fields().len();
+        // Whether the caller wants the rowid column (it follows the table cols in
+        // the output schema). When it does not, plain inserts skip the positional
+        // scan and rowid synthesis entirely.
+        let need_rowid = projection.is_none_or(|idx| idx.contains(&table_len));
 
         let mut insert_units = Vec::with_capacity(data_files.len());
         for (df, name) in data_files.iter().zip(embedded_names.iter()) {
+            // Embedded file: rowid is the trailing embedded column (at `table_len`).
+            // Plain insert (rowid requested): `build_insert_scan` appends a
+            // physical-position column (at `table_len`); rowid = row_id_start + pos.
+            let embedded = name.is_some();
             insert_units.push(InsertUnit {
                 snapshot_id: df.begin_snapshot,
-                scan: self.build_insert_scan(df, name)?,
-                embedded: name.is_some(),
+                scan: self.build_insert_scan(df, name, need_rowid)?,
+                embedded_col_idx: name.as_ref().map(|_| table_len),
+                pos_col_idx: if !embedded && need_rowid {
+                    Some(table_len)
+                } else {
+                    None
+                },
+                row_id_start: df.row_id_start,
             });
         }
 
-        let delete_files = self
-            .provider
-            .get_delete_files_added_between_snapshots(
-                self.table_id,
-                self.start_snapshot,
-                self.end_snapshot,
-            )
-            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        // Deletes only matter here as the delete half of an UPDATE, paired with a
+        // postimage — which requires an added file carrying an embedded rowid.
+        // With no embedded file there are no postimages, so every delete in range
+        // is a pure delete (dropped from ducklake_table_changes). Skip fetching
+        // and scanning the delete side entirely: it is cheaper, and it avoids
+        // failing on a delete source (encrypted, NULL row_id_start, unreadable)
+        // whose rows can't affect this insert-only output.
+        let any_embedded = embedded_names.iter().any(|n| n.is_some());
+        let delete_units = if any_embedded {
+            let delete_files = self
+                .provider
+                .get_delete_files_added_between_snapshots(
+                    self.table_id,
+                    self.start_snapshot,
+                    self.end_snapshot,
+                )
+                .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
-        let mut delete_units = Vec::with_capacity(delete_files.len());
-        for dfc in &delete_files {
-            validated_record_count(dfc.data_record_count, &dfc.data_file_path)?;
-            let resolved = resolve_path(
-                &self.table_path,
-                &dfc.data_file_path,
-                dfc.data_file_path_is_relative,
-            )
-            .map_err(|e| DataFusionError::External(Box::new(e)))?;
-            let old_embedded = self
-                .detect_embedded_rowid_name(
-                    state,
+            let mut delete_units = Vec::with_capacity(delete_files.len());
+            for dfc in &delete_files {
+                validated_record_count(dfc.data_record_count, &dfc.data_file_path)?;
+                let resolved = resolve_path(
+                    &self.table_path,
                     &dfc.data_file_path,
                     dfc.data_file_path_is_relative,
                 )
-                .await?;
-            let data_scan = self.build_delete_data_scan(
-                &resolved,
-                dfc.data_file_size_bytes,
-                dfc.data_file_footer_size,
-                &old_embedded,
-            )?;
-            let current_delete_scan = match &dfc.current_delete_path {
-                Some(p) => Some(self.build_delete_file_scan(
-                    p,
-                    dfc.current_delete_path_is_relative.unwrap_or(true),
-                    dfc.current_delete_file_size_bytes.unwrap_or(0),
-                    dfc.current_delete_footer_size.unwrap_or(0),
-                )?),
-                None => None,
-            };
-            let previous_delete_scan = match &dfc.previous_delete_path {
-                Some(p) => Some(self.build_delete_file_scan(
-                    p,
-                    dfc.previous_delete_path_is_relative.unwrap_or(true),
-                    dfc.previous_delete_file_size_bytes.unwrap_or(0),
-                    dfc.previous_delete_footer_size.unwrap_or(0),
-                )?),
-                None => None,
-            };
-            delete_units.push(DeleteUnit {
-                snapshot_id: dfc.snapshot_id,
-                data_scan,
-                embedded_col_idx: old_embedded.as_ref().map(|_| table_len),
-                current_delete_scan,
-                previous_delete_scan,
-                record_count: dfc.data_record_count,
-                row_id_start: dfc.data_row_id_start,
-            });
-        }
+                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+                let old_embedded = self
+                    .detect_embedded_rowid_name(
+                        state,
+                        &dfc.data_file_path,
+                        dfc.data_file_path_is_relative,
+                    )
+                    .await?;
+                let data_scan = self.build_delete_data_scan(
+                    &resolved,
+                    dfc.data_file_size_bytes,
+                    dfc.data_file_footer_size.unwrap_or(0),
+                    &old_embedded,
+                )?;
+                let current_delete_scan = match &dfc.current_delete_path {
+                    Some(p) => Some(self.build_delete_file_scan(
+                        p,
+                        dfc.current_delete_path_is_relative.unwrap_or(true),
+                        dfc.current_delete_file_size_bytes.unwrap_or(0),
+                        dfc.current_delete_footer_size.unwrap_or(0),
+                    )?),
+                    None => None,
+                };
+                let previous_delete_scan = match &dfc.previous_delete_path {
+                    Some(p) => Some(self.build_delete_file_scan(
+                        p,
+                        dfc.previous_delete_path_is_relative.unwrap_or(true),
+                        dfc.previous_delete_file_size_bytes.unwrap_or(0),
+                        dfc.previous_delete_footer_size.unwrap_or(0),
+                    )?),
+                    None => None,
+                };
+                delete_units.push(DeleteUnit {
+                    snapshot_id: dfc.snapshot_id,
+                    data_scan,
+                    embedded_col_idx: old_embedded.as_ref().map(|_| table_len),
+                    current_delete_scan,
+                    previous_delete_scan,
+                    record_count: dfc.data_record_count,
+                    row_id_start: dfc.data_row_id_start,
+                });
+            }
+            delete_units
+        } else {
+            Vec::new()
+        };
 
         let full: Arc<dyn ExecutionPlan> = Arc::new(TableChangesExec::new(
             insert_units,
@@ -756,6 +846,7 @@ impl TableChangesTable {
             self.table_schema.clone(),
             self.output_schema.clone(),
             table_len,
+            need_rowid,
         ));
 
         // The exec emits the full `[table columns, snapshot_id, change_type]`
@@ -843,6 +934,30 @@ impl TableProvider for TableChangesTable {
                 false
             }
         };
+
+        // rowid output requires the correlated (collect-based) path: it derives a
+        // stable per-row rowid — the embedded ROW_ID for UPDATE / compaction
+        // postimages, else `row_id_start + physical position` for plain inserts.
+        // That path reads parquet footers and cannot decrypt, so on encrypted
+        // (PME) catalogs we fall through to the encryption-aware insert-only path
+        // below, which emits rowid as NULL rather than failing the read.
+        if proj_info.need_rowid && !any_encrypted {
+            let mut embedded_names: Vec<Option<String>> = Vec::with_capacity(data_files.len());
+            for data_file in &data_files {
+                embedded_names.push(
+                    self.detect_embedded_rowid_name(
+                        state,
+                        &data_file.path,
+                        data_file.path_is_relative,
+                    )
+                    .await?,
+                );
+            }
+            return self
+                .build_correlated_changes(state, &data_files, &embedded_names, projection)
+                .await;
+        }
+
         let range_has_deletes = !self
             .provider
             .get_delete_files_added_between_snapshots(
@@ -921,14 +1036,22 @@ impl TableProvider for TableChangesTable {
 // Correlated change feed (insert / delete / update_preimage / update_postimage)
 // ---------------------------------------------------------------------------
 
-/// One inserted data file added in the snapshot range. When `embedded`, the
-/// scan's trailing column is the file's embedded rowid (an UPDATE / compaction
-/// postimage); otherwise the file is a plain INSERT and needs no rowid.
+/// One inserted data file added in the snapshot range, with enough context to
+/// derive each row's rowid. When `embedded_col_idx` is `Some`, the scan's column
+/// at that index is the file's embedded rowid (an UPDATE / compaction postimage);
+/// otherwise the file is a plain INSERT whose scan carries a physical-position
+/// column at `pos_col_idx` and whose rowid is `row_id_start + position`.
 #[derive(Clone)]
 struct InsertUnit {
     snapshot_id: i64,
     scan: Arc<dyn ExecutionPlan>,
-    embedded: bool,
+    /// Column index of the embedded rowid, or `None` for a plain insert.
+    embedded_col_idx: Option<usize>,
+    /// Column index of the physical row-position (plain inserts only).
+    pos_col_idx: Option<usize>,
+    /// First rowid of the file (`None` if the catalog carries none). Required
+    /// only for a plain insert, whose rowid is `row_id_start + pos`.
+    row_id_start: Option<i64>,
 }
 
 /// One delete applied in the snapshot range: enough to read the newly-deleted
@@ -948,7 +1071,9 @@ struct DeleteUnit {
     /// Scan of the delete file this one superseded, if any.
     previous_delete_scan: Option<Arc<dyn ExecutionPlan>>,
     record_count: i64,
-    row_id_start: i64,
+    /// First rowid of the source file (`None` if the catalog carries none).
+    /// Required only when a deleted row has no embedded rowid.
+    row_id_start: Option<i64>,
 }
 
 /// Rows carrying their `(snapshot_id, rowid)` correlation key alongside the
@@ -971,6 +1096,10 @@ pub struct TableChangesExec {
     table_schema: SchemaRef,
     output_schema: SchemaRef,
     table_len: usize,
+    /// Whether the rowid column is actually requested. When false, plain inserts
+    /// skip rowid synthesis (emitting a placeholder dropped by the projection),
+    /// so a non-rowid projection never needs a plain insert's row_id_start.
+    need_rowid: bool,
     properties: Arc<PlanProperties>,
 }
 
@@ -978,7 +1107,7 @@ impl std::fmt::Debug for InsertUnit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("InsertUnit")
             .field("snapshot_id", &self.snapshot_id)
-            .field("embedded", &self.embedded)
+            .field("embedded_col_idx", &self.embedded_col_idx)
             .finish_non_exhaustive()
     }
 }
@@ -999,6 +1128,7 @@ impl TableChangesExec {
         table_schema: SchemaRef,
         output_schema: SchemaRef,
         table_len: usize,
+        need_rowid: bool,
     ) -> Self {
         let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(output_schema.clone()),
@@ -1012,6 +1142,7 @@ impl TableChangesExec {
             table_schema,
             output_schema,
             table_len,
+            need_rowid,
             properties,
         }
     }
@@ -1080,6 +1211,7 @@ impl ExecutionPlan for TableChangesExec {
         let delete_units = self.delete_units.clone();
         let output_schema = self.output_schema.clone();
         let table_len = self.table_len;
+        let need_rowid = self.need_rowid;
 
         let fut = async move {
             correlate_changes(
@@ -1087,6 +1219,7 @@ impl ExecutionPlan for TableChangesExec {
                 delete_units,
                 output_schema,
                 table_len,
+                need_rowid,
                 context,
             )
             .await
@@ -1113,36 +1246,83 @@ async fn correlate_changes(
     delete_units: Vec<DeleteUnit>,
     output_schema: SchemaRef,
     table_len: usize,
+    need_rowid: bool,
     context: Arc<TaskContext>,
 ) -> DataFusionResult<Vec<RecordBatch>> {
-    // Inserted rows: split into postimage candidates (embedded rowid) and plain
-    // inserts (no rowid, can never pair with a delete).
+    // Inserted rows split into postimage candidates (embedded rowid — can pair
+    // with a delete into an UPDATE) and plain inserts (fresh rowid — never pair).
+    // A plain insert's rowid is synthesized only when actually requested; when it
+    // is projected away it is a placeholder, so a non-rowid query never needs a
+    // plain insert's row_id_start.
     let mut postimages: Vec<KeyedRows> = Vec::new();
-    let mut plain_inserts: Vec<(i64, RecordBatch)> = Vec::new();
+    let mut plain_inserts: Vec<KeyedRows> = Vec::new();
     for unit in &insert_units {
         let batches =
             datafusion::physical_plan::collect(Arc::clone(&unit.scan), context.clone()).await?;
         for b in batches {
-            if b.num_rows() == 0 {
+            let n = b.num_rows();
+            if n == 0 {
                 continue;
             }
-            if unit.embedded {
-                let rowid = b
-                    .column(table_len)
-                    .as_any()
-                    .downcast_ref::<Int64Array>()
-                    .ok_or_else(|| {
-                        DataFusionError::Internal("embedded rowid column is not Int64".to_string())
-                    })?
-                    .clone();
-                let table_batch = b.project(&(0..table_len).collect::<Vec<_>>())?;
-                postimages.push(KeyedRows {
-                    snapshot_id: unit.snapshot_id,
-                    table_batch,
-                    rowid,
-                });
-            } else {
-                plain_inserts.push((unit.snapshot_id, b));
+            let table_batch = b.project(&(0..table_len).collect::<Vec<_>>())?;
+            match unit.embedded_col_idx {
+                // UPDATE / compaction postimage: rowid IS the embedded column.
+                Some(idx) => {
+                    let rowid = b
+                        .column(idx)
+                        .as_any()
+                        .downcast_ref::<Int64Array>()
+                        .ok_or_else(|| {
+                            DataFusionError::Internal(
+                                "embedded rowid column is not Int64".to_string(),
+                            )
+                        })?
+                        .clone();
+                    postimages.push(KeyedRows {
+                        snapshot_id: unit.snapshot_id,
+                        table_batch,
+                        rowid,
+                    });
+                },
+                // Plain insert: rowid = row_id_start + physical position when
+                // requested, else a placeholder dropped by the projection.
+                None => {
+                    let rowid = if need_rowid {
+                        let pos_idx = unit.pos_col_idx.ok_or_else(|| {
+                            DataFusionError::Internal(
+                                "plain insert scan is missing its position column".to_string(),
+                            )
+                        })?;
+                        let row_id_start = unit.row_id_start.ok_or_else(|| {
+                            DataFusionError::Internal(
+                                "cannot synthesize rowid: inserted file has neither an embedded \
+                                 rowid nor a row_id_start"
+                                    .to_string(),
+                            )
+                        })?;
+                        let pos = b
+                            .column(pos_idx)
+                            .as_any()
+                            .downcast_ref::<Int64Array>()
+                            .ok_or_else(|| {
+                                DataFusionError::Internal(format!(
+                                    "{ROW_POS_COLUMN_NAME} column is not Int64"
+                                ))
+                            })?;
+                        Int64Array::from(
+                            (0..n)
+                                .map(|i| row_id_start + pos.value(i))
+                                .collect::<Vec<i64>>(),
+                        )
+                    } else {
+                        Int64Array::from(vec![0i64; n])
+                    };
+                    plain_inserts.push(KeyedRows {
+                        snapshot_id: unit.snapshot_id,
+                        table_batch,
+                        rowid,
+                    });
+                },
             }
         }
     }
@@ -1191,15 +1371,31 @@ async fn correlate_changes(
                 None => None,
             };
 
+            // With no embedded rowid, deleted rowids are row_id_start + position;
+            // require row_id_start in that case rather than emitting wrong ids.
+            let synth_start: Option<i64> = if embedded.is_none() {
+                Some(unit.row_id_start.ok_or_else(|| {
+                    DataFusionError::Internal(
+                        "cannot synthesize deleted rowid: source file has neither an embedded \
+                         rowid nor a row_id_start"
+                            .to_string(),
+                    )
+                })?)
+            } else {
+                None
+            };
+
             let mut keep: Vec<u32> = Vec::new();
             let mut rowids: Vec<i64> = Vec::new();
             for i in 0..n {
                 let p = pos.value(i);
                 if current.contains(&p) && !previous.contains(&p) {
                     keep.push(i as u32);
-                    rowids.push(match embedded {
-                        Some(arr) => arr.value(i),
-                        None => unit.row_id_start + p,
+                    rowids.push(match (embedded, synth_start) {
+                        (Some(arr), _) => arr.value(i),
+                        (None, Some(start)) => start + p,
+                        // synth_start is Some whenever embedded is None (above).
+                        (None, None) => unreachable!("row_id_start resolved above"),
                     });
                 }
             }
@@ -1229,7 +1425,10 @@ async fn correlate_changes(
         }
     }
 
-    // Update pairs = keys present in BOTH an embedded insert and a delete.
+    // Update pairs = a postimage (embedded, preserved rowid) whose (snapshot,
+    // rowid) also appears as a delete. Only postimages seed the key set — plain
+    // inserts carry fresh rowids that never match a delete (and, when rowid is
+    // projected away, only a placeholder), so they must not participate.
     let post_keys: HashSet<(i64, i64)> = postimages
         .iter()
         .flat_map(|k| (0..k.rowid.len()).map(move |i| (k.snapshot_id, k.rowid.value(i))))
@@ -1241,10 +1440,12 @@ async fn correlate_changes(
         .collect();
 
     let mut out: Vec<RecordBatch> = Vec::new();
-    for (snap, batch) in &plain_inserts {
+    // Plain inserts are always `insert` (they never pair with a delete).
+    for k in &plain_inserts {
         out.push(append_cdc_columns(
-            batch,
-            *snap,
+            &k.table_batch,
+            k.rowid.clone(),
+            k.snapshot_id,
             ChangeType::Insert,
             &output_schema,
         )?);
@@ -1314,15 +1515,18 @@ async fn collect_delete_positions(
     Ok(Some(set))
 }
 
-/// Append the CDC `snapshot_id` + `change_type` columns to a table-column batch.
+/// Append the CDC `rowid` + `snapshot_id` + `change_type` columns to a
+/// table-column batch. `rowid` must have the same length as `table_batch`.
 fn append_cdc_columns(
     table_batch: &RecordBatch,
+    rowid: Int64Array,
     snapshot_id: i64,
     change: ChangeType,
     output_schema: &SchemaRef,
 ) -> DataFusionResult<RecordBatch> {
     let n = table_batch.num_rows();
     let mut cols: Vec<ArrayRef> = table_batch.columns().to_vec();
+    cols.push(Arc::new(rowid));
     cols.push(Arc::new(Int64Array::from(vec![snapshot_id; n])));
     cols.push(Arc::new(StringArray::from(vec![change.as_str(); n])));
     RecordBatch::try_new(output_schema.clone(), cols)
@@ -1367,8 +1571,15 @@ fn filter_and_tag(
         })
         .collect::<DataFusionResult<_>>()?;
     let filtered = RecordBatch::try_new(keyed.table_batch.schema(), cols)?;
+    let rowid = arrow::compute::filter(&keyed.rowid, mask)
+        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .ok_or_else(|| DataFusionError::Internal("filtered rowid is not Int64".to_string()))?
+        .clone();
     Ok(Some(append_cdc_columns(
         &filtered,
+        rowid,
         keyed.snapshot_id,
         change,
         output_schema,

--- a/src/table_deletions.rs
+++ b/src/table_deletions.rs
@@ -28,16 +28,23 @@ use datafusion::datasource::{TableProvider, TableType};
 use datafusion::error::DataFusionError;
 use datafusion::execution::object_store::ObjectStoreUrl;
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
-use datafusion::physical_expr::EquivalenceProperties;
+use datafusion::physical_expr::expressions::Column;
+use datafusion::physical_expr::{EquivalenceProperties, PhysicalExpr};
+use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::physical_plan::union::UnionExec;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
 };
 use futures::Stream;
+use object_store::path::Path as ObjectPath;
+use parquet::arrow::ParquetRecordBatchStreamBuilder;
+use parquet::arrow::async_reader::ParquetObjectReader;
 
 use crate::metadata_provider::{DeleteFileChange, MetadataProvider};
 use crate::path_resolver::resolve_path;
+use crate::row_id::ROW_ID_PARQUET_FIELD_ID;
 use crate::table::{validated_file_size, validated_record_count};
+use crate::types::extract_parquet_field_ids;
 
 /// Delete file schema: (file_path: VARCHAR, pos: INT64)
 fn delete_file_schema() -> SchemaRef {
@@ -64,7 +71,7 @@ pub struct TableDeletionsTable {
     table_path: String,
     /// Original table schema (without CDC columns)
     table_schema: SchemaRef,
-    /// Combined schema: table columns + snapshot_id + change_type
+    /// Combined schema: table columns + rowid + snapshot_id + change_type
     output_schema: SchemaRef,
 }
 
@@ -79,11 +86,16 @@ impl TableDeletionsTable {
         table_schema: SchemaRef,
     ) -> Self {
         // Build output schema: table columns + CDC metadata columns
+        // (rowid, snapshot_id, change_type), in that order.
         let mut fields: Vec<Field> = table_schema
             .fields()
             .iter()
             .map(|f| f.as_ref().clone())
             .collect();
+        // rowid is nullable for symmetry with ducklake_table_changes (where it is
+        // NULL on encrypted tables); the deletions path always synthesizes a
+        // non-null value for the cases it supports.
+        fields.push(Field::new("rowid", DataType::Int64, true));
         fields.push(Field::new("snapshot_id", DataType::Int64, false));
         fields.push(Field::new("change_type", DataType::Utf8, false));
         let output_schema = Arc::new(Schema::new(fields));
@@ -100,9 +112,13 @@ impl TableDeletionsTable {
         }
     }
 
-    /// Build execution plan for a single delete file entry
-    fn build_exec_for_delete_entry(
+    /// Build execution plan for a single delete file entry. `need_rowid` gates
+    /// resolving the rowid (footer probe + embedded read + synthesis); when the
+    /// caller projected rowid away, it is emitted as a placeholder and dropped.
+    async fn build_exec_for_delete_entry(
         &self,
+        state: &dyn Session,
+        need_rowid: bool,
         delete_file: &DeleteFileChange,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         // Resolve data file path
@@ -137,11 +153,30 @@ impl TableDeletionsTable {
             None
         };
 
-        // Create scan for data file
+        // Detect the source file's embedded rowid column (present on UPDATE /
+        // compaction outputs). When present, a deleted row's rowid is that
+        // embedded value — NOT `row_id_start + position`, which would key the
+        // delete differently from the row's insert/update_postimage. Only probe
+        // when the rowid is actually requested.
+        let table_len = self.table_schema.fields().len();
+        let embedded_name = if need_rowid {
+            self.detect_embedded_rowid_name(
+                state,
+                &delete_file.data_file_path,
+                delete_file.data_file_path_is_relative,
+            )
+            .await?
+        } else {
+            None
+        };
+        let embedded_col_idx = embedded_name.as_ref().map(|_| table_len);
+
+        // Create scan for data file (with the embedded rowid column when present)
         let data_file_exec = self.build_data_file_scan(
             &data_file_path,
             delete_file.data_file_size_bytes,
-            delete_file.data_file_footer_size,
+            delete_file.data_file_footer_size.unwrap_or(0),
+            &embedded_name,
         )?;
 
         // Validate record_count before use — a negative value from corrupt metadata
@@ -154,8 +189,34 @@ impl TableDeletionsTable {
             data_file_exec,
             delete_file.data_record_count,
             delete_file.snapshot_id,
+            delete_file.data_row_id_start,
+            table_len,
+            embedded_col_idx,
+            need_rowid,
             self.output_schema.clone(),
         )))
+    }
+
+    /// Read the source file's footer and return the physical name of its embedded
+    /// row-id column ([`ROW_ID_PARQUET_FIELD_ID`]) when present. Such a file is an
+    /// UPDATE / compaction output whose logical rowids come from that column.
+    async fn detect_embedded_rowid_name(
+        &self,
+        state: &dyn Session,
+        path: &str,
+        is_relative: bool,
+    ) -> DataFusionResult<Option<String>> {
+        let resolved = resolve_path(&self.table_path, path, is_relative)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        let object_store = state
+            .runtime_env()
+            .object_store(self.object_store_url.as_ref())?;
+        let reader = ParquetObjectReader::new(object_store, ObjectPath::from(resolved.as_str()));
+        let builder = ParquetRecordBatchStreamBuilder::new(reader)
+            .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        let field_ids = extract_parquet_field_ids(builder.metadata());
+        Ok(field_ids.get(&ROW_ID_PARQUET_FIELD_ID).cloned())
     }
 
     /// Build a ParquetExec for a delete file
@@ -188,12 +249,20 @@ impl TableDeletionsTable {
         Ok(DataSourceExec::from_data_source(builder.build()))
     }
 
-    /// Build a ParquetExec for a data file
+    /// Build a scan of the source data file: table columns, plus the embedded
+    /// rowid column when `embedded_name` is `Some`.
+    ///
+    /// NOTE: positions come from the stream's `row_offset` (arrival order), which
+    /// is the file's physical position only for a non-repartitioned scan. Under
+    /// file-scan repartitioning this exec is unsound (deletes missed / wrong
+    /// rowids) — a pre-existing limitation tracked in
+    /// <https://github.com/datafusion-contrib/datafusion-ducklake/issues/178>.
     fn build_data_file_scan(
         &self,
         path: &str,
         size_bytes: i64,
         footer_size: i64,
+        embedded_name: &Option<String>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         let mut pf = PartitionedFile::new(path, validated_file_size(size_bytes, path)?);
         if footer_size > 0
@@ -202,9 +271,23 @@ impl TableDeletionsTable {
             pf = pf.with_metadata_size_hint(hint);
         }
 
+        let read_schema = match embedded_name {
+            Some(name) => {
+                let mut fields: Vec<Field> = self
+                    .table_schema
+                    .fields()
+                    .iter()
+                    .map(|f| f.as_ref().clone())
+                    .collect();
+                fields.push(Field::new(name, DataType::Int64, true));
+                Arc::new(Schema::new(fields))
+            },
+            None => self.table_schema.clone(),
+        };
+
         let builder = FileScanConfigBuilder::new(
             self.object_store_url.as_ref().clone(),
-            Arc::new(ParquetSource::new(self.table_schema.clone())),
+            Arc::new(ParquetSource::new(read_schema)),
         )
         .with_file_group(FileGroup::new(vec![pf]));
 
@@ -224,7 +307,7 @@ impl TableProvider for TableDeletionsTable {
 
     async fn scan(
         &self,
-        _state: &dyn Session,
+        state: &dyn Session,
         projection: Option<&Vec<usize>>,
         _filters: &[datafusion::prelude::Expr],
         _limit: Option<usize>,
@@ -255,18 +338,47 @@ impl TableProvider for TableDeletionsTable {
             return Ok(Arc::new(EmptyExec::new(output_schema)));
         }
 
+        // Does the caller actually want `rowid`? It follows the table columns in
+        // the output schema. When it is projected away we skip resolving it (no
+        // footer probe, no synthesis), so a query like `SELECT id, change_type
+        // FROM ducklake_table_deletions(...)` never fails on a file whose rowid
+        // cannot be synthesized (no embedded rowid and a NULL row_id_start).
+        let rowid_idx = self.table_schema.fields().len();
+        let need_rowid = projection.is_none_or(|indices| indices.contains(&rowid_idx));
+
         // Build execution plan for each delete entry
         let mut execs: Vec<Arc<dyn ExecutionPlan>> = Vec::with_capacity(delete_files.len());
         for delete_file in &delete_files {
-            let exec = self.build_exec_for_delete_entry(delete_file)?;
+            let exec = self
+                .build_exec_for_delete_entry(state, need_rowid, delete_file)
+                .await?;
             execs.push(exec);
         }
 
         // Combine with UnionExec if multiple
-        if execs.len() == 1 {
-            Ok(execs.into_iter().next().unwrap())
+        let full: Arc<dyn ExecutionPlan> = if execs.len() == 1 {
+            execs.into_iter().next().unwrap()
         } else {
-            UnionExec::try_new(execs)
+            UnionExec::try_new(execs)?
+        };
+
+        // The exec emits the full `[table cols, rowid, snapshot_id, change_type]`
+        // schema; honor the requested projection with a ProjectionExec on top.
+        match projection {
+            None => Ok(full),
+            Some(indices) => {
+                let exprs: Vec<(Arc<dyn PhysicalExpr>, String)> = indices
+                    .iter()
+                    .map(|&i| {
+                        let f = self.output_schema.field(i);
+                        (
+                            Arc::new(Column::new(f.name(), i)) as Arc<dyn PhysicalExpr>,
+                            f.name().to_string(),
+                        )
+                    })
+                    .collect();
+                Ok(Arc::new(ProjectionExec::try_new(exprs, full)?))
+            },
         }
     }
 }
@@ -290,19 +402,38 @@ pub struct DeletedRowsExec {
     record_count: i64,
     /// Snapshot ID for CDC column
     snapshot_id: i64,
-    /// Output schema (table columns + snapshot_id + change_type)
+    /// First rowid of the data file (`None` if the catalog carries none). Used
+    /// to synthesize a deleted row's rowid as `row_id_start + physical position`
+    /// when the source file has no embedded rowid.
+    row_id_start: Option<i64>,
+    /// Number of leading table columns in the data-file batch (the rest are the
+    /// optional embedded rowid column).
+    table_len: usize,
+    /// Column index of the embedded rowid in the data-file batch, if present (an
+    /// UPDATE / compaction output); its value IS the deleted row's rowid.
+    embedded_col_idx: Option<usize>,
+    /// Whether the rowid column is actually requested. When false, rowid is
+    /// emitted as a placeholder (dropped by the projection above) and neither an
+    /// embedded rowid nor a row_id_start is required.
+    need_rowid: bool,
+    /// Output schema (table columns + rowid + snapshot_id + change_type)
     output_schema: SchemaRef,
     /// Cached plan properties
     properties: Arc<PlanProperties>,
 }
 
 impl DeletedRowsExec {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         current_delete_scan: Option<Arc<dyn ExecutionPlan>>,
         previous_delete_scan: Option<Arc<dyn ExecutionPlan>>,
         data_file_scan: Arc<dyn ExecutionPlan>,
         record_count: i64,
         snapshot_id: i64,
+        row_id_start: Option<i64>,
+        table_len: usize,
+        embedded_col_idx: Option<usize>,
+        need_rowid: bool,
         output_schema: SchemaRef,
     ) -> Self {
         let eq_properties = EquivalenceProperties::new(output_schema.clone());
@@ -319,6 +450,10 @@ impl DeletedRowsExec {
             data_file_scan,
             record_count,
             snapshot_id,
+            row_id_start,
+            table_len,
+            embedded_col_idx,
+            need_rowid,
             output_schema,
             properties,
         }
@@ -403,6 +538,10 @@ impl ExecutionPlan for DeletedRowsExec {
             data,
             self.record_count,
             self.snapshot_id,
+            self.row_id_start,
+            self.table_len,
+            self.embedded_col_idx,
+            self.need_rowid,
             self.output_schema.clone(),
         )))
     }
@@ -430,6 +569,10 @@ impl ExecutionPlan for DeletedRowsExec {
             data_stream,
             self.record_count,
             self.snapshot_id,
+            self.row_id_start,
+            self.table_len,
+            self.embedded_col_idx,
+            self.need_rowid,
             self.output_schema.clone(),
         )))
     }
@@ -462,6 +605,17 @@ struct DeletedRowsStream {
     data_stream: SendableRecordBatchStream,
     /// Snapshot ID for CDC column
     snapshot_id: i64,
+    /// First rowid of the data file (`None` if absent); used to synthesize a
+    /// deleted row's rowid as `row_id_start + physical position` when there is
+    /// no embedded rowid.
+    row_id_start: Option<i64>,
+    /// Number of leading table columns in each data-file batch.
+    table_len: usize,
+    /// Column index of the embedded rowid in the data-file batch, if present;
+    /// its value IS the deleted row's rowid.
+    embedded_col_idx: Option<usize>,
+    /// Whether rowid is requested; when false it is emitted as a placeholder.
+    need_rowid: bool,
     /// Output schema
     output_schema: SchemaRef,
     /// Collected current positions (or all positions for full delete)
@@ -470,19 +624,24 @@ struct DeletedRowsStream {
     previous_positions: HashSet<i64>,
     /// Computed delta positions (sorted)
     deleted_positions: Option<Vec<i64>>,
-    /// Current row offset in data file
+    /// Current row offset in data file (arrival order; see issue #178)
     row_offset: i64,
     /// State machine
     state: StreamState,
 }
 
 impl DeletedRowsStream {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         current_delete_stream: Option<SendableRecordBatchStream>,
         previous_delete_stream: Option<SendableRecordBatchStream>,
         data_stream: SendableRecordBatchStream,
         record_count: i64,
         snapshot_id: i64,
+        row_id_start: Option<i64>,
+        table_len: usize,
+        embedded_col_idx: Option<usize>,
+        need_rowid: bool,
         output_schema: SchemaRef,
     ) -> Self {
         // Determine initial state and compute positions if needed
@@ -508,6 +667,10 @@ impl DeletedRowsStream {
             previous_delete_stream,
             data_stream,
             snapshot_id,
+            row_id_start,
+            table_len,
+            embedded_col_idx,
+            need_rowid,
             output_schema,
             current_positions,
             previous_positions: HashSet::new(),
@@ -549,16 +712,63 @@ impl DeletedRowsStream {
         let deleted_positions = self.deleted_positions.as_ref().unwrap();
         let num_rows = batch.num_rows();
 
-        // Find which rows in this batch are deleted
+        // Resolve each deleted row's rowid: the embedded rowid column when the
+        // source file has one (an UPDATE / compaction output), else
+        // `row_id_start + physical position`.
+        let embedded = match self.embedded_col_idx {
+            Some(idx) => Some(
+                batch
+                    .column(idx)
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .ok_or_else(|| {
+                        DataFusionError::Internal("embedded rowid column is not Int64".to_string())
+                    })?,
+            ),
+            None => None,
+        };
+        // Require a row_id_start only when a rowid is actually needed and there
+        // is no embedded rowid to read.
+        let synth_start: Option<i64> = if self.need_rowid && embedded.is_none() {
+            Some(self.row_id_start.ok_or_else(|| {
+                DataFusionError::Internal(
+                    "cannot synthesize deleted rowid: source file has neither an embedded \
+                     rowid nor a row_id_start"
+                        .to_string(),
+                )
+            })?)
+        } else {
+            None
+        };
+
+        // Find which rows in this batch are deleted, capturing each one's rowid.
+        // `global_pos` is the stream's `row_offset` (arrival order) — the file's
+        // physical position for a non-repartitioned scan. See issue #178 for the
+        // repartitioning limitation this shares with the delete-position match.
         let mut keep_indices: Vec<u32> = Vec::new();
+        let mut rowids: Vec<i64> = Vec::new();
         for i in 0..num_rows {
             let global_pos = self.row_offset + i as i64;
             if deleted_positions.binary_search(&global_pos).is_ok() {
                 keep_indices.push(i as u32);
+                // When rowid is projected away, emit a placeholder (dropped by
+                // the ProjectionExec above) so no rowid needs synthesizing.
+                let rowid = if !self.need_rowid {
+                    0
+                } else {
+                    match (embedded, synth_start) {
+                        (Some(arr), _) => arr.value(i),
+                        (None, Some(start)) => start + global_pos,
+                        // synth_start is Some whenever rowid is needed and there
+                        // is no embedded rowid (resolved above).
+                        (None, None) => unreachable!("row_id_start resolved above"),
+                    }
+                };
+                rowids.push(rowid);
             }
         }
 
-        // Update row offset for next batch
+        // Update row offset for next batch.
         self.row_offset += num_rows as i64;
 
         // If no deleted rows in this batch, return None
@@ -566,18 +776,19 @@ impl DeletedRowsStream {
             return Ok(None);
         }
 
-        // Use Arrow's take kernel to select rows
+        // Select the deleted rows' TABLE columns (excluding the embedded rowid
+        // helper column, if the scan read one), then append the CDC columns.
         let indices = UInt32Array::from(keep_indices.clone());
-        let mut columns: Vec<ArrayRef> = Vec::with_capacity(batch.num_columns() + 2);
-
-        for col in batch.columns() {
+        let mut columns: Vec<ArrayRef> = Vec::with_capacity(self.table_len + 3);
+        for col in batch.columns().iter().take(self.table_len) {
             let filtered = take(col.as_ref(), &indices, None)
                 .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
             columns.push(filtered);
         }
 
-        // Append CDC columns
+        // Append CDC columns: rowid, snapshot_id, change_type.
         let num_output_rows = keep_indices.len();
+        columns.push(Arc::new(Int64Array::from(rowids)));
         columns.push(Arc::new(Int64Array::from(vec![
             self.snapshot_id;
             num_output_rows

--- a/tests/cdc_rowid_tests.rs
+++ b/tests/cdc_rowid_tests.rs
@@ -1,0 +1,388 @@
+#![cfg(feature = "metadata-duckdb")]
+//! Rowid correctness for the CDC feeds (`ducklake_table_changes` /
+//! `ducklake_table_deletions`).
+//!
+//! A row's rowid must be stable and consistent across its lifetime:
+//!   * a plain insert's rowid is `row_id_start + physical_position`;
+//!   * a second insert continues from the first file's `row_id_start`;
+//!   * a delete reports the same rowid the row was inserted with;
+//!   * an UPDATE's preimage and postimage share the (preserved) rowid.
+//!
+//! These are the guarantees an incremental, rowid-keyed index relies on.
+
+mod common;
+
+use std::sync::Arc;
+
+use arrow::array::{Array, Int32Array, Int64Array, StringArray};
+use arrow::record_batch::RecordBatch;
+use datafusion::error::Result as DataFusionResult;
+use datafusion::prelude::*;
+use datafusion_ducklake::{
+    DuckLakeCatalog, DuckdbMetadataProvider, MetadataProvider, register_ducklake_functions,
+};
+use tempfile::TempDir;
+
+/// Open an in-memory DuckDB connection attached to `path` (as catalog `c`) and
+/// run `statements` in order, writing a DuckLake catalog + parquet data.
+fn write_catalog(path: &std::path::Path, statements: &[&str]) -> DataFusionResult<()> {
+    let conn = duckdb::Connection::open_in_memory().map_err(box_err)?;
+    conn.execute("INSTALL ducklake;", []).map_err(box_err)?;
+    conn.execute("INSTALL parquet;", []).map_err(box_err)?;
+    conn.execute("LOAD ducklake;", []).map_err(box_err)?;
+    conn.execute(&format!("ATTACH 'ducklake:{}' AS c;", path.display()), [])
+        .map_err(box_err)?;
+    for s in statements {
+        conn.execute(s, []).map_err(box_err)?;
+    }
+    Ok(())
+}
+
+fn box_err<E: std::error::Error + Send + Sync + 'static>(
+    e: E,
+) -> datafusion::error::DataFusionError {
+    datafusion::error::DataFusionError::External(Box::new(e))
+}
+
+async fn ctx_for(path: &str) -> DataFusionResult<SessionContext> {
+    let provider = DuckdbMetadataProvider::new(path)?;
+    let provider_arc: Arc<dyn MetadataProvider> = Arc::new(DuckdbMetadataProvider::new(path)?);
+    let catalog = DuckLakeCatalog::new(provider)?;
+    let ctx = SessionContext::new();
+    ctx.register_catalog("ducklake", Arc::new(catalog));
+    register_ducklake_functions(&ctx, provider_arc);
+    Ok(ctx)
+}
+
+fn i32_col(b: &RecordBatch, i: usize) -> &Int32Array {
+    b.column(i).as_any().downcast_ref::<Int32Array>().unwrap()
+}
+fn i64_col(b: &RecordBatch, i: usize) -> &Int64Array {
+    b.column(i).as_any().downcast_ref::<Int64Array>().unwrap()
+}
+fn str_at(b: &RecordBatch, i: usize, r: usize) -> String {
+    if let Some(a) = b.column(i).as_any().downcast_ref::<StringArray>() {
+        return a.value(r).to_string();
+    }
+    if let Some(a) = b
+        .column(i)
+        .as_any()
+        .downcast_ref::<arrow::array::StringViewArray>()
+    {
+        return a.value(r).to_string();
+    }
+    panic!(
+        "column {i} is not a string, got {:?}",
+        b.column(i).data_type()
+    );
+}
+
+/// Collect `(id, rowid, change_type)` rows, locating each column by name (robust
+/// to whether the feed honors projection).
+async fn rows(ctx: &SessionContext, sql: &str) -> DataFusionResult<Vec<(i32, i64, String)>> {
+    let batches = ctx.sql(sql).await?.collect().await?;
+    let mut out = Vec::new();
+    for b in &batches {
+        let id_i = b.schema().index_of("id").unwrap();
+        let rid_i = b.schema().index_of("rowid").unwrap();
+        let ct_i = b.schema().index_of("change_type").unwrap();
+        let id = i32_col(b, id_i);
+        let rid = i64_col(b, rid_i);
+        for r in 0..b.num_rows() {
+            out.push((id.value(r), rid.value(r), str_at(b, ct_i, r)));
+        }
+    }
+    Ok(out)
+}
+
+/// A single INSERT of three rows → one data file with `row_id_start = 0`, so
+/// rowids are exactly the physical positions 0, 1, 2.
+#[tokio::test]
+async fn plain_insert_rowid_is_physical_position() -> DataFusionResult<()> {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("ins.ducklake");
+    write_catalog(
+        &path,
+        &[
+            "CREATE TABLE c.t(id INTEGER, name VARCHAR);",
+            "INSERT INTO c.t VALUES (10,'a'),(20,'b'),(30,'c');",
+        ],
+    )?;
+    let ctx = ctx_for(path.to_str().unwrap()).await?;
+    let mut r = rows(
+        &ctx,
+        "SELECT id, rowid, change_type FROM ducklake_table_changes('main.t', 0, 1000) ORDER BY rowid",
+    )
+    .await?;
+    r.sort_by_key(|x| x.1);
+    assert_eq!(
+        r,
+        vec![(10, 0, "insert".into()), (20, 1, "insert".into()), (30, 2, "insert".into()),]
+    );
+    Ok(())
+}
+
+/// A second INSERT starts a new file whose `row_id_start` continues from the
+/// first, so rowids run 0..5 across the two files.
+#[tokio::test]
+async fn second_insert_continues_row_id_start() -> DataFusionResult<()> {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("ins2.ducklake");
+    write_catalog(
+        &path,
+        &[
+            "CREATE TABLE c.t(id INTEGER, name VARCHAR);",
+            "INSERT INTO c.t VALUES (10,'a'),(20,'b'),(30,'c');",
+            "INSERT INTO c.t VALUES (40,'d'),(50,'e');",
+        ],
+    )?;
+    let ctx = ctx_for(path.to_str().unwrap()).await?;
+    let mut r = rows(
+        &ctx,
+        "SELECT id, rowid, change_type FROM ducklake_table_changes('main.t', 0, 1000) ORDER BY rowid",
+    )
+    .await?;
+    r.sort_by_key(|x| x.1);
+    assert_eq!(
+        r,
+        vec![
+            (10, 0, "insert".into()),
+            (20, 1, "insert".into()),
+            (30, 2, "insert".into()),
+            (40, 3, "insert".into()),
+            (50, 4, "insert".into()),
+        ]
+    );
+    Ok(())
+}
+
+/// A DELETE reports the deleted row through `ducklake_table_deletions` with the
+/// same rowid it was inserted with (`row_id_start + position`).
+#[tokio::test]
+async fn delete_reports_original_rowid() -> DataFusionResult<()> {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("del.ducklake");
+    write_catalog(
+        &path,
+        &[
+            "CREATE TABLE c.t(id INTEGER, name VARCHAR);",
+            "INSERT INTO c.t VALUES (10,'a'),(20,'b'),(30,'c'),(40,'d'),(50,'e');",
+            "DELETE FROM c.t WHERE id = 30;", // physical position 2 => rowid 2
+        ],
+    )?;
+    let ctx = ctx_for(path.to_str().unwrap()).await?;
+
+    // The projected query must return exactly the requested columns, in order.
+    let batches = ctx
+        .sql("SELECT id, rowid, change_type FROM ducklake_table_deletions('main.t', 0, 1000)")
+        .await?
+        .collect()
+        .await?;
+    let schema = batches[0].schema();
+    let names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["id", "rowid", "change_type"],
+        "projection honored"
+    );
+
+    let r = rows(
+        &ctx,
+        "SELECT id, rowid, change_type FROM ducklake_table_deletions('main.t', 0, 1000)",
+    )
+    .await?;
+    assert_eq!(r, vec![(30, 2, "delete".into())]);
+    Ok(())
+}
+
+/// An UPDATE surfaces as a preimage (old values) + postimage (new values) that
+/// share the row's preserved rowid.
+#[tokio::test]
+async fn update_preimage_and_postimage_share_rowid() -> DataFusionResult<()> {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("upd.ducklake");
+    write_catalog(
+        &path,
+        &[
+            "CREATE TABLE c.t(id INTEGER, name VARCHAR);",
+            "INSERT INTO c.t VALUES (10,'a'),(20,'b'),(30,'c');", // rowids 0,1,2
+            "UPDATE c.t SET name = 'B' WHERE id = 20;",           // rowid 1 preserved
+        ],
+    )?;
+    let ctx = ctx_for(path.to_str().unwrap()).await?;
+    let batches = ctx
+        .sql("SELECT id, rowid, change_type, name FROM ducklake_table_changes('main.t', 0, 1000)")
+        .await?
+        .collect()
+        .await?;
+
+    let mut pre: Vec<(i64, String)> = Vec::new(); // (rowid, name)
+    let mut post: Vec<(i64, String)> = Vec::new();
+    for b in &batches {
+        let rid = i64_col(b, 1);
+        for r in 0..b.num_rows() {
+            let ct = str_at(b, 2, r);
+            let name = str_at(b, 3, r);
+            match ct.as_str() {
+                "update_preimage" => pre.push((rid.value(r), name)),
+                "update_postimage" => post.push((rid.value(r), name)),
+                _ => {},
+            }
+        }
+    }
+    assert_eq!(pre, vec![(1, "b".into())], "preimage: old value at rowid 1");
+    assert_eq!(
+        post,
+        vec![(1, "B".into())],
+        "postimage: new value at rowid 1"
+    );
+    Ok(())
+}
+
+/// A row deleted AFTER an UPDATE lives in an UPDATE-output file whose logical
+/// rowid is the embedded ROW_ID, not `row_id_start + position`. table_deletions
+/// must report that preserved rowid, so a delete keys the same as the row's
+/// insert / update_postimage. Regression guard for the delete-after-update case.
+#[tokio::test]
+async fn delete_after_update_reports_embedded_rowid() -> DataFusionResult<()> {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("del_upd.ducklake");
+    write_catalog(
+        &path,
+        &[
+            "CREATE TABLE c.t(id INTEGER, name VARCHAR);",
+            "INSERT INTO c.t VALUES (10,'a'),(20,'b'),(30,'c');", // rowids 0,1,2
+            "UPDATE c.t SET name = 'B' WHERE id = 20;",           // rowid 1 preserved (embedded)
+            "DELETE FROM c.t WHERE id = 20;",                     // delete the updated row
+        ],
+    )?;
+    let ctx = ctx_for(path.to_str().unwrap()).await?;
+    let r = rows(
+        &ctx,
+        "SELECT * FROM ducklake_table_deletions('main.t', 0, 1000)",
+    )
+    .await?;
+    // Every delete event for id=20 carries its stable rowid 1: the row was
+    // inserted at rowid 1, the UPDATE preserved it (embedded), and the DELETE of
+    // the update-output row must report the embedded rowid — not that file's
+    // row_id_start + position.
+    assert!(!r.is_empty(), "expected delete rows for id=20");
+    for (id, rowid, ct) in &r {
+        assert_eq!(*id, 20, "only id=20 was deleted");
+        assert_eq!(
+            *rowid, 1,
+            "delete must report the preserved rowid 1, not a rewrite-file position"
+        );
+        assert_eq!(ct, "delete");
+    }
+    Ok(())
+}
+
+/// Projecting `ducklake_table_deletions` WITHOUT rowid must not require (or
+/// synthesize) one: `SELECT id, change_type` returns exactly those columns and
+/// succeeds even for source files that could not produce a rowid.
+#[tokio::test]
+async fn deletions_without_rowid_projection_omits_rowid() -> DataFusionResult<()> {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("del_norowid.ducklake");
+    write_catalog(
+        &path,
+        &[
+            "CREATE TABLE c.t(id INTEGER, name VARCHAR);",
+            "INSERT INTO c.t VALUES (10,'a'),(20,'b'),(30,'c');",
+            "DELETE FROM c.t WHERE id = 20;",
+        ],
+    )?;
+    let ctx = ctx_for(path.to_str().unwrap()).await?;
+    let batches = ctx
+        .sql("SELECT id, change_type FROM ducklake_table_deletions('main.t', 0, 1000)")
+        .await?
+        .collect()
+        .await?;
+    let schema = batches[0].schema();
+    let names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["id", "change_type"],
+        "rowid must not appear when it is not projected"
+    );
+    let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total, 1, "one row (id=20) deleted");
+    Ok(())
+}
+
+/// Projecting `ducklake_table_changes` WITHOUT rowid, over a range that contains
+/// an UPDATE (which forces the correlated path), must still succeed and label the
+/// update — plain inserts in the range must not require a rowid they don't emit.
+#[tokio::test]
+async fn changes_without_rowid_projection_still_correlates() -> DataFusionResult<()> {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("chg_norowid.ducklake");
+    write_catalog(
+        &path,
+        &[
+            "CREATE TABLE c.t(id INTEGER, name VARCHAR);",
+            "INSERT INTO c.t VALUES (10,'a'),(20,'b'),(30,'c');",
+            "UPDATE c.t SET name = 'B' WHERE id = 20;",
+        ],
+    )?;
+    let ctx = ctx_for(path.to_str().unwrap()).await?;
+    let batches = ctx
+        .sql("SELECT id, change_type FROM ducklake_table_changes('main.t', 0, 1000)")
+        .await?
+        .collect()
+        .await?;
+    let schema = batches[0].schema();
+    let names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["id", "change_type"],
+        "rowid must not appear when it is not projected"
+    );
+    let mut change_types: Vec<String> = Vec::new();
+    for b in &batches {
+        for r in 0..b.num_rows() {
+            change_types.push(str_at(b, 1, r));
+        }
+    }
+    assert!(
+        change_types.iter().any(|c| c == "update_postimage"),
+        "UPDATE correlated to a postimage without projecting rowid"
+    );
+    assert!(
+        change_types.iter().any(|c| c == "update_preimage"),
+        "UPDATE correlated to a preimage without projecting rowid"
+    );
+    Ok(())
+}
+
+/// With rowid projected over a range that has plain inserts AND a pure delete
+/// (no UPDATE / embedded rowid), the changes feed returns the inserts with
+/// correct rowids and drops the pure delete — no postimage exists, so the delete
+/// side is skipped entirely rather than scanned.
+#[tokio::test]
+async fn changes_with_rowid_plain_inserts_and_pure_delete() -> DataFusionResult<()> {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("chg_puredel.ducklake");
+    write_catalog(
+        &path,
+        &[
+            "CREATE TABLE c.t(id INTEGER, name VARCHAR);",
+            "INSERT INTO c.t VALUES (10,'a'),(20,'b'),(30,'c');",
+            "DELETE FROM c.t WHERE id = 20;",
+        ],
+    )?;
+    let ctx = ctx_for(path.to_str().unwrap()).await?;
+    let mut r = rows(
+        &ctx,
+        "SELECT id, rowid, change_type FROM ducklake_table_changes('main.t', 0, 1000) ORDER BY rowid",
+    )
+    .await?;
+    r.sort_by_key(|x| x.1);
+    // The three inserted rows with rowids 0,1,2; the pure delete is dropped.
+    assert_eq!(
+        r,
+        vec![(10, 0, "insert".into()), (20, 1, "insert".into()), (30, 2, "insert".into()),]
+    );
+    Ok(())
+}

--- a/tests/table_changes_tests.rs
+++ b/tests/table_changes_tests.rs
@@ -274,6 +274,10 @@ mod integration_tests {
 
         // CDC metadata columns
         assert!(
+            field_names.contains(&"rowid"),
+            "Schema should contain 'rowid' CDC column"
+        );
+        assert!(
             field_names.contains(&"snapshot_id"),
             "Schema should contain 'snapshot_id' CDC column"
         );
@@ -283,10 +287,10 @@ mod integration_tests {
         );
 
         // Verify column order: table columns first, then CDC columns
-        assert_eq!(field_names.len(), 5, "Should have 5 columns total");
+        assert_eq!(field_names.len(), 6, "Should have 6 columns total");
         assert_eq!(
             field_names,
-            vec!["id", "event_type", "value", "snapshot_id", "change_type"],
+            vec!["id", "event_type", "value", "rowid", "snapshot_id", "change_type"],
             "Columns should be in order: table columns, then CDC columns"
         );
 


### PR DESCRIPTION
Materialise a `rowid` column (Int64) on `ducklake_table_changes` and
`ducklake_table_deletions` so consumers can key incremental work — e.g.
search-index maintenance — by row. The rowid is the embedded ROW_ID field
for UPDATE/compaction rewrites, else `row_id_start + physical position` for
plain inserts and deletes, matching the base-table lineage rowid: a row's id
is therefore stable across insert, update, delete and compaction.

- table_changes: route rowid queries through the correlated feed; plain
  inserts get a positional scan (FileRowNumberExec) to compute the rowid, and
  only when it is projected — a non-rowid projection never needs a plain
  insert's row_id_start (plain inserts never pair, so they are excluded from
  the update correlation regardless). When no added file has an embedded rowid
  there are no postimages to pair, so the delete side is skipped entirely
  (cheaper, and it never fails on a delete source whose rows can't affect an
  insert-only output).
- table_deletions: read the source file's embedded ROW_ID when present (an
  UPDATE/compaction output), else `row_id_start + physical position`, so a
  delete-after-update reports the same rowid as the row's insert/postimage.
  The rowid is resolved (footer probe + embedded read + synthesis) only when
  the caller projects it, so `SELECT id, change_type` never needs row lineage.
- Add row_id_start to DataFileChange + the added-files query (all backends).
- rowid is emitted as NULL on encrypted (PME) catalogs (the correlated feed
  cannot decrypt footers to resolve it); the `rowid` column is nullable, and
  `SELECT *` on an encrypted feed keeps working (previously it would have to
  synthesize a rowid it cannot produce).

Nullability: `row_id_start` / `data_row_id_start` are `Option<i64>`. The
column is legitimately NULL for embedded-rowid rewrite/compaction outputs and
older catalogs; a value is required only to synthesize a plain row's rowid
(a file with an embedded rowid never needs it), and a missing one is a clear
error rather than a wrong id.

Also fixes two latent bugs the rowid consumer is the first to exercise:
- table_deletions now honours projection. It previously ignored the
  requested projection and returned every column.
- DeleteFileChange.data_file_footer_size is now Option<i64>. The column is
  nullable (as DataFileChange.footer_size already reflects); a file registered
  without a footer-size hint decoded as NULL and panicked the full-file-delete
  path.

Known limitation: `ducklake_table_deletions` (`DeletedRowsExec`) is unsound
under file-scan repartitioning — a pre-existing issue (positions come from the
stream's arrival-order `row_offset`) that the rowid inherits; it is correct for
a non-repartitioned scan. Tracked in #178; the fix is to make that exec
single-partition / collect-based like `TableChangesExec`.

Tests: cdc_rowid_tests covers plain-insert rowid == physical position,
row_id_start continuation across files, delete reports the original rowid,
UPDATE preimage/postimage share the preserved rowid, delete-after-update
reports the embedded rowid, projecting deletions without rowid omits it, and
projection is honoured on table_deletions.
