### PR TITLE
Stream file metadata while planning scans

### DIFF
--- a/src/compaction.rs
+++ b/src/compaction.rs
@@ -182,8 +182,8 @@ impl DuckLakeTable {
         // Candidates: live, delete-free, below-target files with a known origin
         // snapshot + schema version, ordered so adjacency and same-version
         // grouping fall out of the sort.
-        let mut candidates: Vec<&DuckLakeTableFile> = self
-            .files()
+        let table_files = self.files()?;
+        let mut candidates: Vec<&DuckLakeTableFile> = table_files
             .iter()
             .filter(|f| {
                 f.delete_file_id.is_none()
@@ -386,7 +386,8 @@ impl DuckLakeTable {
         let mut files_processed = 0usize;
         let mut rows_written = 0i64;
 
-        for tf in self.files() {
+        let table_files = self.files()?;
+        for tf in &table_files {
             let record_count = tf.max_row_count.unwrap_or(0);
             let delete_count = tf.delete_count.unwrap_or(0);
             // Only files with a live delete file masking >= threshold of the rows.

--- a/src/delete_exec.rs
+++ b/src/delete_exec.rs
@@ -259,12 +259,15 @@ async fn run_delete(
     base_snapshot: i64,
 ) -> DataFusionResult<u64> {
     let state: &dyn Session = session_state;
+    let table_files = table
+        .files()
+        .map_err(|error| DataFusionError::External(Box::new(error)))?;
 
     // Delete-all (no WHERE): metadata-only truncate — end every live data file in
     // one snapshot. Skip the empty table entirely (no-op, no snapshot).
     let predicate = match predicate {
         None => {
-            if table.files().is_empty() {
+            if table_files.is_empty() {
                 return Ok(0);
             }
             return writer
@@ -285,7 +288,7 @@ async fn run_delete(
     let mut entries: Vec<DeleteFileEntry> = Vec::new();
     let mut total_deleted: u64 = 0;
 
-    for tf in table.files() {
+    for tf in &table_files {
         // v1 refuses files rewritten by an UPDATE/compaction: their surviving
         // rows carry embedded rowids whose physical order need not match the
         // DuckLake `pos` space, so positional resolution could mis-delete. Clean

--- a/src/metadata_provider.rs
+++ b/src/metadata_provider.rs
@@ -1,4 +1,5 @@
 use crate::Result;
+use std::collections::HashMap;
 
 // SQL queries for DuckLake catalog tables
 // These queries are database-agnostic and work with DuckDB, SQLite, PostgreSQL, MySQL
@@ -596,6 +597,19 @@ pub struct DuckLakeFileColumnStatistics {
     pub max_value: Option<String>,
 }
 
+/// One visible data file and its catalog column statistics.
+///
+/// Table scans consume these records in bounded pages so selective predicates
+/// can discard files without first materializing the table's full file set.
+#[derive(Debug, Clone)]
+pub struct DuckLakeFileMetadata {
+    pub file: DuckLakeTableFile,
+    pub column_statistics: Vec<DuckLakeFileColumnStatistics>,
+}
+
+/// Maximum number of file metadata records retained by the planning iterator.
+pub const FILE_METADATA_BATCH_SIZE: usize = 64;
+
 impl DuckLakeTableFile {
     pub fn new(file: DuckLakeFileData) -> Self {
         Self {
@@ -714,6 +728,55 @@ pub trait MetadataProvider: Send + Sync + std::fmt::Debug {
         _snapshot_id: i64,
     ) -> Result<DuckLakeStatistics> {
         Ok(DuckLakeStatistics::default())
+    }
+
+    /// Load only table- and table-column statistics.
+    ///
+    /// Built-in providers override this to avoid touching per-file statistics
+    /// while constructing a [`crate::DuckLakeTable`]. The default preserves
+    /// compatibility for external providers.
+    fn get_table_summary_statistics(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+    ) -> Result<DuckLakeStatistics> {
+        let mut statistics = self.get_table_statistics(table_id, snapshot_id)?;
+        statistics.files.clear();
+        Ok(statistics)
+    }
+
+    /// Load one keyset-paginated batch of visible files and their statistics.
+    ///
+    /// `after_data_file_id` is exclusive. Implementations must return records
+    /// ordered by `data_file_id` and no more than `limit` records. Built-in SQL
+    /// providers override this with bounded catalog queries; the default keeps
+    /// external providers source-compatible, although it is not memory-bounded.
+    fn get_table_file_metadata_page(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+        after_data_file_id: Option<i64>,
+        limit: usize,
+    ) -> Result<Vec<DuckLakeFileMetadata>> {
+        let mut files = self.get_table_files_for_select(table_id, snapshot_id)?;
+        files.sort_by_key(|file| file.data_file_id);
+        let statistics = self.get_table_statistics(table_id, snapshot_id)?.files;
+        let mut by_file: HashMap<i64, Vec<DuckLakeFileColumnStatistics>> = HashMap::new();
+        for statistic in statistics {
+            by_file
+                .entry(statistic.data_file_id)
+                .or_default()
+                .push(statistic);
+        }
+        Ok(files
+            .into_iter()
+            .filter(|file| after_data_file_id.map_or(true, |after| file.data_file_id > after))
+            .take(limit)
+            .map(|file| DuckLakeFileMetadata {
+                column_statistics: by_file.remove(&file.data_file_id).unwrap_or_default(),
+                file,
+            })
+            .collect())
     }
 
     /// Read rows that DuckDB's *data-inlining* optimization stored directly in

--- a/src/metadata_provider.rs
+++ b/src/metadata_provider.rs
@@ -582,6 +582,13 @@ pub struct DuckLakeTableColumnStatistics {
     pub contains_null: Option<bool>,
     pub min_value: Option<String>,
     pub max_value: Option<String>,
+    /// Sum of compressed bytes reported by every visible file for this column.
+    pub column_size_bytes: Option<i64>,
+    /// Whether the table-wide bounds are exact for the requested snapshot.
+    ///
+    /// DuckLake's rollup is complete for live data files, but positional
+    /// deletes can remove an extremal value without tightening the rollup.
+    pub bounds_are_exact: bool,
 }
 
 /// A row from `ducklake_file_column_stats` containing the fields DataFusion

--- a/src/metadata_provider.rs
+++ b/src/metadata_provider.rs
@@ -615,7 +615,10 @@ pub struct DuckLakeFileMetadata {
 }
 
 /// Maximum number of file metadata records retained by the planning iterator.
-pub const FILE_METADATA_BATCH_SIZE: usize = 64;
+///
+/// This keeps planning memory bounded while avoiding tens of thousands of
+/// catalog round trips for million-file tables.
+pub const FILE_METADATA_BATCH_SIZE: usize = 4_096;
 
 impl DuckLakeTableFile {
     pub fn new(file: DuckLakeFileData) -> Self {

--- a/src/metadata_provider.rs
+++ b/src/metadata_provider.rs
@@ -770,7 +770,7 @@ pub trait MetadataProvider: Send + Sync + std::fmt::Debug {
         }
         Ok(files
             .into_iter()
-            .filter(|file| after_data_file_id.map_or(true, |after| file.data_file_id > after))
+            .filter(|file| after_data_file_id.is_none_or(|after| file.data_file_id > after))
             .take(limit)
             .map(|file| DuckLakeFileMetadata {
                 column_statistics: by_file.remove(&file.data_file_id).unwrap_or_default(),

--- a/src/metadata_provider_duckdb.rs
+++ b/src/metadata_provider_duckdb.rs
@@ -13,6 +13,7 @@ use crate::metadata_provider::{
 };
 use duckdb::AccessMode::ReadOnly;
 use duckdb::{Config, Connection, params};
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex, MutexGuard};
 
 fn is_missing_statistics_table(error: &duckdb::Error) -> bool {
@@ -241,6 +242,96 @@ impl MetadataProvider for DuckdbMetadataProvider {
         Ok(files)
     }
 
+    fn get_table_summary_statistics(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+    ) -> crate::Result<DuckLakeStatistics> {
+        let conn = self.connection();
+        let table = match conn.prepare(SQL_GET_TABLE_STATS) {
+            Ok(mut stmt) => {
+                let mut rows = stmt.query([table_id])?;
+                rows.next()?
+                    .map(|row| {
+                        Ok::<_, duckdb::Error>(DuckLakeTableStatistics {
+                            record_count: row.get(0)?,
+                            file_size_bytes: row.get(1)?,
+                        })
+                    })
+                    .transpose()?
+            },
+            Err(error) if is_missing_statistics_table(&error) => None,
+            Err(error) => return Err(error.into()),
+        };
+        let column_sizes: HashMap<i64, i64> = match conn.prepare(
+            "SELECT stats.column_id,
+                    CASE
+                      WHEN COUNT(*) = COUNT(stats.column_size_bytes)
+                       AND COUNT(*) = (
+                         SELECT COUNT(*) FROM ducklake_data_file visible
+                         WHERE visible.table_id = ?
+                           AND ? >= visible.begin_snapshot
+                           AND (? < visible.end_snapshot OR visible.end_snapshot IS NULL)
+                       )
+                      THEN SUM(stats.column_size_bytes)
+                    END
+             FROM ducklake_file_column_stats stats
+             INNER JOIN ducklake_data_file data
+               ON data.data_file_id = stats.data_file_id
+              AND data.table_id = stats.table_id
+             WHERE stats.table_id = ?
+               AND ? >= data.begin_snapshot
+               AND (? < data.end_snapshot OR data.end_snapshot IS NULL)
+             GROUP BY stats.column_id",
+        ) {
+            Ok(mut stmt) => stmt
+                .query_map(
+                    params![table_id, snapshot_id, snapshot_id, table_id, snapshot_id, snapshot_id],
+                    |row| Ok((row.get::<_, i64>(0)?, row.get::<_, Option<i64>>(1)?)),
+                )?
+                .filter_map(|row| match row {
+                    Ok((column_id, Some(size))) => Some(Ok((column_id, size))),
+                    Ok((_, None)) => None,
+                    Err(error) => Some(Err(error)),
+                })
+                .collect::<Result<_, _>>()?,
+            Err(error) if is_missing_statistics_table(&error) => HashMap::new(),
+            Err(error) => return Err(error.into()),
+        };
+        let bounds_are_exact: bool = conn.query_row(
+            "SELECT NOT EXISTS (
+                 SELECT 1 FROM ducklake_delete_file
+                 WHERE table_id = ?
+                   AND ? >= begin_snapshot
+                   AND (? < end_snapshot OR end_snapshot IS NULL)
+             )",
+            params![table_id, snapshot_id, snapshot_id],
+            |row| row.get(0),
+        )?;
+        let columns = match conn.prepare(SQL_GET_TABLE_COLUMN_STATS) {
+            Ok(mut stmt) => stmt
+                .query_map([table_id], |row| {
+                    let column_id = row.get(0)?;
+                    Ok(DuckLakeTableColumnStatistics {
+                        column_id,
+                        contains_null: row.get(1)?,
+                        min_value: row.get(2)?,
+                        max_value: row.get(3)?,
+                        column_size_bytes: column_sizes.get(&column_id).copied(),
+                        bounds_are_exact,
+                    })
+                })?
+                .collect::<Result<Vec<_>, _>>()?,
+            Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+            Err(error) => return Err(error.into()),
+        };
+        Ok(DuckLakeStatistics {
+            table,
+            columns,
+            files: Vec::new(),
+        })
+    }
+
     fn get_table_statistics(
         &self,
         table_id: i64,
@@ -272,6 +363,8 @@ impl MetadataProvider for DuckdbMetadataProvider {
                         contains_null: row.get(1)?,
                         min_value: row.get(2)?,
                         max_value: row.get(3)?,
+                        column_size_bytes: None,
+                        bounds_are_exact: false,
                     })
                 })?
                 .collect::<Result<Vec<_>, _>>()?,

--- a/src/metadata_provider_duckdb.rs
+++ b/src/metadata_provider_duckdb.rs
@@ -1,10 +1,10 @@
 use crate::DuckLakeError;
 use crate::metadata_provider::{
     ColumnWithTable, DataFileChange, DeleteFileChange, DuckLakeFileColumnStatistics,
-    DuckLakeFileData, DuckLakeStatistics, DuckLakeTableColumn, DuckLakeTableColumnStatistics,
-    DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable, MetadataProvider,
-    SQL_GET_DATA_FILES, SQL_GET_DATA_FILES_ADDED_BETWEEN_SNAPSHOTS, SQL_GET_DATA_PATH,
-    SQL_GET_DELETE_FILES_ADDED_BETWEEN_SNAPSHOTS, SQL_GET_FILE_COLUMN_STATS,
+    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeStatistics, DuckLakeTableColumn,
+    DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable,
+    MetadataProvider, SQL_GET_DATA_FILES, SQL_GET_DATA_FILES_ADDED_BETWEEN_SNAPSHOTS,
+    SQL_GET_DATA_PATH, SQL_GET_DELETE_FILES_ADDED_BETWEEN_SNAPSHOTS, SQL_GET_FILE_COLUMN_STATS,
     SQL_GET_LATEST_SNAPSHOT, SQL_GET_SCHEMA_BY_NAME, SQL_GET_TABLE_BY_NAME,
     SQL_GET_TABLE_COLUMN_STATS, SQL_GET_TABLE_COLUMNS, SQL_GET_TABLE_STATS, SQL_LIST_ALL_COLUMNS,
     SQL_LIST_ALL_FILES, SQL_LIST_ALL_TABLES, SQL_LIST_SCHEMAS, SQL_LIST_SNAPSHOTS, SQL_LIST_TABLES,
@@ -273,7 +273,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
                            AND ? >= visible.begin_snapshot
                            AND (? < visible.end_snapshot OR visible.end_snapshot IS NULL)
                        )
-                      THEN SUM(stats.column_size_bytes)
+                      THEN CAST(SUM(stats.column_size_bytes) AS BIGINT)
                     END
              FROM ducklake_file_column_stats stats
              INNER JOIN ducklake_data_file data
@@ -330,6 +330,138 @@ impl MetadataProvider for DuckdbMetadataProvider {
             columns,
             files: Vec::new(),
         })
+    }
+
+    fn get_table_file_metadata_page(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+        after_data_file_id: Option<i64>,
+        limit: usize,
+    ) -> crate::Result<Vec<DuckLakeFileMetadata>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).map_err(|_| {
+            crate::DuckLakeError::InvalidConfig("file metadata page limit exceeds i64".to_string())
+        })?;
+        let conn = self.connection();
+        let sql = format!(
+            "{SQL_GET_DATA_FILES}
+             AND data.data_file_id > ?
+             ORDER BY data.data_file_id
+             LIMIT ?"
+        );
+        let mut statement = conn.prepare(&sql)?;
+        let files = statement
+            .query_map(
+                params![
+                    table_id,
+                    snapshot_id,
+                    snapshot_id,
+                    table_id,
+                    snapshot_id,
+                    snapshot_id,
+                    after_data_file_id.unwrap_or(i64::MIN),
+                    limit
+                ],
+                |row| {
+                    let delete_file_id: Option<i64> = row.get(8)?;
+                    let (delete_file, delete_count) = if delete_file_id.is_some() {
+                        (
+                            Some(DuckLakeFileData {
+                                path: row.get(9)?,
+                                path_is_relative: row.get(10)?,
+                                file_size_bytes: row.get(11)?,
+                                footer_size: row.get(12)?,
+                                encryption_key: row.get(13)?,
+                            }),
+                            row.get(14)?,
+                        )
+                    } else {
+                        (None, None)
+                    };
+                    Ok(DuckLakeTableFile {
+                        data_file_id: row.get(0)?,
+                        file: DuckLakeFileData {
+                            path: row.get(1)?,
+                            path_is_relative: row.get(2)?,
+                            file_size_bytes: row.get(3)?,
+                            footer_size: row.get(4)?,
+                            encryption_key: row.get(5)?,
+                        },
+                        delete_file_id,
+                        delete_file,
+                        row_id_start: row.get(6)?,
+                        snapshot_id: Some(snapshot_id),
+                        begin_snapshot: None,
+                        schema_version: None,
+                        partial_max: None,
+                        max_row_count: row.get(7)?,
+                        delete_count,
+                    })
+                },
+            )?
+            .collect::<Result<Vec<_>, _>>()?;
+        let Some(last_data_file_id) = files.last().map(|file| file.data_file_id) else {
+            return Ok(Vec::new());
+        };
+        let statistics = match conn.prepare(
+            "SELECT stats.data_file_id, stats.column_id,
+                    stats.column_size_bytes, stats.value_count, stats.null_count,
+                    stats.min_value, stats.max_value
+             FROM ducklake_file_column_stats AS stats
+             INNER JOIN ducklake_data_file AS data
+               ON data.data_file_id = stats.data_file_id
+              AND data.table_id = stats.table_id
+             WHERE stats.table_id = ?
+               AND ? >= data.begin_snapshot
+               AND (? < data.end_snapshot OR data.end_snapshot IS NULL)
+               AND stats.data_file_id > ?
+               AND stats.data_file_id <= ?
+             ORDER BY stats.data_file_id, stats.column_id",
+        ) {
+            Ok(mut statement) => statement
+                .query_map(
+                    params![
+                        table_id,
+                        snapshot_id,
+                        snapshot_id,
+                        after_data_file_id.unwrap_or(i64::MIN),
+                        last_data_file_id
+                    ],
+                    |row| {
+                        Ok(DuckLakeFileColumnStatistics {
+                            data_file_id: row.get(0)?,
+                            column_id: row.get(1)?,
+                            column_size_bytes: row.get(2)?,
+                            value_count: row.get(3)?,
+                            null_count: row.get(4)?,
+                            min_value: row.get(5)?,
+                            max_value: row.get(6)?,
+                        })
+                    },
+                )?
+                .collect::<Result<Vec<_>, _>>()?,
+            Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+            Err(error) => return Err(error.into()),
+        };
+        let mut statistics_by_file: HashMap<i64, Vec<_>> = HashMap::new();
+        for statistic in statistics {
+            statistics_by_file
+                .entry(statistic.data_file_id)
+                .or_default()
+                .push(statistic);
+        }
+        Ok(files
+            .into_iter()
+            .map(|file| DuckLakeFileMetadata {
+                column_statistics: statistics_by_file
+                    .remove(&file.data_file_id)
+                    .unwrap_or_default(),
+                file,
+            })
+            .collect())
     }
 
     fn get_table_statistics(

--- a/src/metadata_provider_mysql.rs
+++ b/src/metadata_provider_mysql.rs
@@ -3,20 +3,58 @@
 use crate::Result;
 use crate::metadata_provider::{
     ColumnWithTable, DataFileChange, DeleteFileChange, DuckLakeFileColumnStatistics,
-    DuckLakeFileData, DuckLakeStatistics, DuckLakeTableColumn, DuckLakeTableColumnStatistics,
-    DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable, MetadataProvider, SchemaMetadata,
-    SnapshotMetadata, TableMetadata, TableWithSchema, block_on, reconstruct_list_columns,
-    reconstruct_list_columns_with_table,
+    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeStatistics, DuckLakeTableColumn,
+    DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable,
+    MetadataProvider, SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, block_on,
+    reconstruct_list_columns, reconstruct_list_columns_with_table,
 };
 use sqlx::Row;
-use sqlx::mysql::{MySqlPool, MySqlPoolOptions};
+use sqlx::mysql::{MySqlPool, MySqlPoolOptions, MySqlRow};
 use sqlx::types::chrono::NaiveDateTime;
+use std::collections::HashMap;
 
 fn is_missing_statistics_table(error: &sqlx::Error) -> bool {
     let message = error.to_string().to_ascii_lowercase();
     message.contains("doesn't exist")
         || message.contains("does not exist")
         || message.contains("unknown table")
+}
+
+fn decode_table_file(row: &MySqlRow, snapshot_id: i64) -> Result<DuckLakeTableFile> {
+    let delete_file_id: Option<i64> = row.try_get(8)?;
+    let (delete_file, delete_count) = if delete_file_id.is_some() {
+        (
+            Some(DuckLakeFileData {
+                path: row.try_get(9)?,
+                path_is_relative: row.try_get(10)?,
+                file_size_bytes: row.try_get(11)?,
+                footer_size: row.try_get(12)?,
+                encryption_key: row.try_get(13)?,
+            }),
+            row.try_get(14)?,
+        )
+    } else {
+        (None, None)
+    };
+    Ok(DuckLakeTableFile {
+        data_file_id: row.try_get(0)?,
+        file: DuckLakeFileData {
+            path: row.try_get(1)?,
+            path_is_relative: row.try_get(2)?,
+            file_size_bytes: row.try_get(3)?,
+            footer_size: row.try_get(4)?,
+            encryption_key: row.try_get(5)?,
+        },
+        delete_file_id,
+        delete_file,
+        row_id_start: row.try_get(6)?,
+        snapshot_id: Some(snapshot_id),
+        begin_snapshot: None,
+        schema_version: None,
+        partial_max: None,
+        max_row_count: row.try_get(7)?,
+        delete_count,
+    })
 }
 
 /// MySQL-based metadata provider for DuckLake catalogs.
@@ -227,49 +265,231 @@ impl MetadataProvider for MySqlMetadataProvider {
             .fetch_all(&self.pool)
             .await?;
 
-            rows.into_iter()
-                .map(|row| {
-                    let data_file = DuckLakeFileData {
-                        path: row.try_get(1)?,
-                        path_is_relative: row.try_get(2)?,
-                        file_size_bytes: row.try_get(3)?,
-                        footer_size: row.try_get(4)?,
-                        encryption_key: row.try_get(5)?,
-                    };
-                    let row_id_start: Option<i64> = row.try_get(6)?;
-                    let record_count: Option<i64> = row.try_get(7)?;
-
-                    let (delete_file, delete_count) = if row.try_get::<Option<i64>, _>(8)?.is_some()
-                    {
-                        (
-                            Some(DuckLakeFileData {
-                                path: row.try_get(9)?,
-                                path_is_relative: row.try_get(10)?,
-                                file_size_bytes: row.try_get(11)?,
-                                footer_size: row.try_get(12)?,
-                                encryption_key: row.try_get(13)?,
-                            }),
-                            row.try_get(14)?,
-                        )
-                    } else {
-                        (None, None)
-                    };
-
-                    Ok(DuckLakeTableFile {
-                        data_file_id: row.try_get(0)?,
-                        file: data_file,
-                        delete_file_id: row.try_get(8)?,
-                        delete_file,
-                        row_id_start,
-                        snapshot_id: Some(snapshot_id),
-                        begin_snapshot: None,
-                        schema_version: None,
-                        partial_max: None,
-                        max_row_count: record_count,
-                        delete_count,
-                    })
-                })
+            rows.iter()
+                .map(|row| decode_table_file(row, snapshot_id))
                 .collect()
+        })
+    }
+
+    fn get_table_file_metadata_page(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+        after_data_file_id: Option<i64>,
+        limit: usize,
+    ) -> Result<Vec<DuckLakeFileMetadata>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).map_err(|_| {
+            crate::DuckLakeError::InvalidConfig("file metadata page limit exceeds i64".to_string())
+        })?;
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT data.data_file_id, data.path, data.path_is_relative,
+                        data.file_size_bytes, data.footer_size, data.encryption_key,
+                        data.row_id_start, data.record_count,
+                        del.delete_file_id, del.path, del.path_is_relative,
+                        del.file_size_bytes, del.footer_size, del.encryption_key,
+                        del.delete_count
+                 FROM ducklake_data_file AS data
+                 LEFT JOIN ducklake_delete_file AS del
+                   ON data.data_file_id = del.data_file_id
+                  AND del.table_id = ?
+                  AND ? >= del.begin_snapshot
+                  AND (? < del.end_snapshot OR del.end_snapshot IS NULL)
+                 WHERE data.table_id = ?
+                   AND ? >= data.begin_snapshot
+                   AND (? < data.end_snapshot OR data.end_snapshot IS NULL)
+                   AND data.data_file_id > ?
+                 ORDER BY data.data_file_id
+                 LIMIT ?",
+            )
+            .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .bind(after_data_file_id.unwrap_or(i64::MIN))
+            .bind(limit)
+            .fetch_all(&self.pool)
+            .await?;
+            let files = rows
+                .iter()
+                .map(|row| decode_table_file(row, snapshot_id))
+                .collect::<Result<Vec<_>>>()?;
+            let Some(last_data_file_id) = files.last().map(|file| file.data_file_id) else {
+                return Ok(Vec::new());
+            };
+            let statistics = match sqlx::query(
+                "SELECT stats.data_file_id, stats.column_id,
+                        stats.column_size_bytes, stats.value_count, stats.null_count,
+                        stats.min_value, stats.max_value
+                 FROM ducklake_file_column_stats AS stats
+                 INNER JOIN ducklake_data_file AS data
+                   ON data.data_file_id = stats.data_file_id
+                  AND data.table_id = stats.table_id
+                 WHERE stats.table_id = ?
+                   AND ? >= data.begin_snapshot
+                   AND (? < data.end_snapshot OR data.end_snapshot IS NULL)
+                   AND stats.data_file_id > ?
+                   AND stats.data_file_id <= ?
+                 ORDER BY stats.data_file_id, stats.column_id",
+            )
+            .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .bind(after_data_file_id.unwrap_or(i64::MIN))
+            .bind(last_data_file_id)
+            .fetch_all(&self.pool)
+            .await
+            {
+                Ok(rows) => rows
+                    .into_iter()
+                    .map(|row| {
+                        Ok(DuckLakeFileColumnStatistics {
+                            data_file_id: row.try_get(0)?,
+                            column_id: row.try_get(1)?,
+                            column_size_bytes: row.try_get(2)?,
+                            value_count: row.try_get(3)?,
+                            null_count: row.try_get(4)?,
+                            min_value: row.try_get(5)?,
+                            max_value: row.try_get(6)?,
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?,
+                Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+                Err(error) => return Err(error.into()),
+            };
+            let mut statistics_by_file: HashMap<i64, Vec<_>> = HashMap::new();
+            for statistic in statistics {
+                statistics_by_file
+                    .entry(statistic.data_file_id)
+                    .or_default()
+                    .push(statistic);
+            }
+            Ok(files
+                .into_iter()
+                .map(|file| DuckLakeFileMetadata {
+                    column_statistics: statistics_by_file
+                        .remove(&file.data_file_id)
+                        .unwrap_or_default(),
+                    file,
+                })
+                .collect())
+        })
+    }
+
+    fn get_table_summary_statistics(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+    ) -> Result<DuckLakeStatistics> {
+        block_on(async {
+            let table = match sqlx::query(
+                "SELECT record_count, file_size_bytes
+                 FROM ducklake_table_stats WHERE table_id = ?",
+            )
+            .bind(table_id)
+            .fetch_optional(&self.pool)
+            .await
+            {
+                Ok(row) => row
+                    .map(|row| {
+                        Ok::<_, sqlx::Error>(DuckLakeTableStatistics {
+                            record_count: row.try_get(0)?,
+                            file_size_bytes: row.try_get(1)?,
+                        })
+                    })
+                    .transpose()?,
+                Err(error) if is_missing_statistics_table(&error) => None,
+                Err(error) => return Err(error.into()),
+            };
+            let column_sizes = match sqlx::query(
+                "SELECT stats.column_id,
+                        CASE
+                          WHEN COUNT(*) = COUNT(stats.column_size_bytes)
+                           AND COUNT(*) = (
+                             SELECT COUNT(*) FROM ducklake_data_file visible
+                             WHERE visible.table_id = ?
+                               AND ? >= visible.begin_snapshot
+                               AND (? < visible.end_snapshot OR visible.end_snapshot IS NULL)
+                           )
+                          THEN CAST(SUM(stats.column_size_bytes) AS SIGNED)
+                        END
+                 FROM ducklake_file_column_stats stats
+                 INNER JOIN ducklake_data_file data
+                   ON data.data_file_id = stats.data_file_id
+                  AND data.table_id = stats.table_id
+                 WHERE stats.table_id = ?
+                   AND ? >= data.begin_snapshot
+                   AND (? < data.end_snapshot OR data.end_snapshot IS NULL)
+                 GROUP BY stats.column_id",
+            )
+            .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_all(&self.pool)
+            .await
+            {
+                Ok(rows) => rows
+                    .into_iter()
+                    .filter_map(|row| match row.try_get::<Option<i64>, _>(1) {
+                        Ok(Some(size)) => Some(row.try_get(0).map(|column_id| (column_id, size))),
+                        Ok(None) => None,
+                        Err(error) => Some(Err(error)),
+                    })
+                    .collect::<std::result::Result<HashMap<i64, i64>, _>>()?,
+                Err(error) if is_missing_statistics_table(&error) => HashMap::new(),
+                Err(error) => return Err(error.into()),
+            };
+            let bounds_are_exact: bool = sqlx::query_scalar(
+                "SELECT NOT EXISTS (
+                     SELECT 1 FROM ducklake_delete_file
+                     WHERE table_id = ?
+                       AND ? >= begin_snapshot
+                       AND (? < end_snapshot OR end_snapshot IS NULL)
+                 )",
+            )
+            .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_one(&self.pool)
+            .await?;
+            let columns = match sqlx::query(
+                "SELECT column_id, contains_null, min_value, max_value
+                 FROM ducklake_table_column_stats WHERE table_id = ?",
+            )
+            .bind(table_id)
+            .fetch_all(&self.pool)
+            .await
+            {
+                Ok(rows) => rows
+                    .into_iter()
+                    .map(|row| {
+                        let column_id = row.try_get(0)?;
+                        Ok(DuckLakeTableColumnStatistics {
+                            column_id,
+                            contains_null: row.try_get(1)?,
+                            min_value: row.try_get(2)?,
+                            max_value: row.try_get(3)?,
+                            column_size_bytes: column_sizes.get(&column_id).copied(),
+                            bounds_are_exact,
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?,
+                Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+                Err(error) => return Err(error.into()),
+            };
+            Ok(DuckLakeStatistics {
+                table,
+                columns,
+                files: Vec::new(),
+            })
         })
     }
 

--- a/src/metadata_provider_mysql.rs
+++ b/src/metadata_provider_mysql.rs
@@ -311,6 +311,8 @@ impl MetadataProvider for MySqlMetadataProvider {
                             contains_null: row.try_get(1)?,
                             min_value: row.try_get(2)?,
                             max_value: row.try_get(3)?,
+                            column_size_bytes: None,
+                            bounds_are_exact: false,
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,

--- a/src/metadata_provider_postgres.rs
+++ b/src/metadata_provider_postgres.rs
@@ -3,18 +3,56 @@
 use crate::Result;
 use crate::metadata_provider::{
     ColumnWithTable, DataFileChange, DeleteFileChange, DuckLakeFileColumnStatistics,
-    DuckLakeFileData, DuckLakeStatistics, DuckLakeTableColumn, DuckLakeTableColumnStatistics,
-    DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable, MetadataProvider, SchemaMetadata,
-    SnapshotMetadata, TableMetadata, TableWithSchema, block_on, reconstruct_list_columns,
-    reconstruct_list_columns_with_table,
+    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeStatistics, DuckLakeTableColumn,
+    DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable,
+    MetadataProvider, SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, block_on,
+    reconstruct_list_columns, reconstruct_list_columns_with_table,
 };
 use sqlx::Row;
-use sqlx::postgres::{PgPool, PgPoolOptions};
+use sqlx::postgres::{PgPool, PgPoolOptions, PgRow};
 use sqlx::types::chrono::NaiveDateTime;
+use std::collections::HashMap;
 
 fn is_missing_statistics_table(error: &sqlx::Error) -> bool {
     let message = error.to_string().to_ascii_lowercase();
     message.contains("does not exist") || message.contains("undefined table")
+}
+
+fn decode_table_file(row: &PgRow, snapshot_id: i64) -> Result<DuckLakeTableFile> {
+    let delete_file_id: Option<i64> = row.try_get(8)?;
+    let (delete_file, delete_count) = if delete_file_id.is_some() {
+        (
+            Some(DuckLakeFileData {
+                path: row.try_get(9)?,
+                path_is_relative: row.try_get(10)?,
+                file_size_bytes: row.try_get(11)?,
+                footer_size: row.try_get(12)?,
+                encryption_key: row.try_get(13)?,
+            }),
+            row.try_get(14)?,
+        )
+    } else {
+        (None, None)
+    };
+    Ok(DuckLakeTableFile {
+        data_file_id: row.try_get(0)?,
+        file: DuckLakeFileData {
+            path: row.try_get(1)?,
+            path_is_relative: row.try_get(2)?,
+            file_size_bytes: row.try_get(3)?,
+            footer_size: row.try_get(4)?,
+            encryption_key: row.try_get(5)?,
+        },
+        delete_file_id,
+        delete_file,
+        row_id_start: row.try_get(6)?,
+        snapshot_id: Some(snapshot_id),
+        begin_snapshot: row.try_get(15)?,
+        schema_version: row.try_get(17)?,
+        partial_max: row.try_get(16)?,
+        max_row_count: row.try_get(7)?,
+        delete_count,
+    })
 }
 
 macro_rules! bind_repeat {
@@ -294,49 +332,200 @@ impl MetadataProvider for PostgresMetadataProvider {
                 .fetch_all(&self.pool)
                 .await?;
 
-            rows.into_iter()
-                .map(|row| {
-                    let data_file = DuckLakeFileData {
-                        path: row.try_get(1)?,
-                        path_is_relative: row.try_get(2)?,
-                        file_size_bytes: row.try_get(3)?,
-                        footer_size: row.try_get(4)?,
-                        encryption_key: row.try_get(5)?,
-                    };
-                    let row_id_start: Option<i64> = row.try_get(6)?;
-                    let record_count: Option<i64> = row.try_get(7)?;
-
-                    let (delete_file, delete_count) = if row.try_get::<Option<i64>, _>(8)?.is_some()
-                    {
-                        (
-                            Some(DuckLakeFileData {
-                                path: row.try_get(9)?,
-                                path_is_relative: row.try_get(10)?,
-                                file_size_bytes: row.try_get(11)?,
-                                footer_size: row.try_get(12)?,
-                                encryption_key: row.try_get(13)?,
-                            }),
-                            row.try_get(14)?,
-                        )
-                    } else {
-                        (None, None)
-                    };
-
-                    Ok(DuckLakeTableFile {
-                        data_file_id: row.try_get(0)?,
-                        file: data_file,
-                        delete_file_id: row.try_get(8)?,
-                        delete_file,
-                        row_id_start,
-                        snapshot_id: Some(snapshot_id),
-                        begin_snapshot: row.try_get(15)?,
-                        schema_version: row.try_get(17)?,
-                        partial_max: row.try_get(16)?,
-                        max_row_count: record_count,
-                        delete_count,
-                    })
-                })
+            rows.iter()
+                .map(|row| decode_table_file(row, snapshot_id))
                 .collect()
+        })
+    }
+
+    fn get_table_file_metadata_page(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+        after_data_file_id: Option<i64>,
+        limit: usize,
+    ) -> Result<Vec<DuckLakeFileMetadata>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).map_err(|_| {
+            crate::DuckLakeError::InvalidConfig("file metadata page limit exceeds i64".to_string())
+        })?;
+        block_on(async {
+            let has_partial_max: bool = sqlx::query_scalar(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.columns
+                 WHERE table_name = 'ducklake_data_file' AND column_name = 'partial_max')",
+            )
+            .fetch_one(&self.pool)
+            .await?;
+            let has_schema_versions: bool =
+                sqlx::query_scalar("SELECT to_regclass('ducklake_schema_versions') IS NOT NULL")
+                    .fetch_one(&self.pool)
+                    .await?;
+            let partial_max_expr = if has_partial_max {
+                "data.partial_max::bigint"
+            } else {
+                "NULL::bigint"
+            };
+            let schema_version_expr = if has_schema_versions {
+                "(SELECT sv.schema_version::bigint
+                  FROM ducklake_schema_versions sv
+                  WHERE sv.table_id = data.table_id
+                    AND sv.begin_snapshot <= data.begin_snapshot
+                  ORDER BY sv.begin_snapshot DESC LIMIT 1)"
+            } else {
+                "NULL::bigint"
+            };
+            let sql = format!(
+                "SELECT data.data_file_id, data.path, data.path_is_relative,
+                        data.file_size_bytes, data.footer_size, data.encryption_key,
+                        data.row_id_start, data.record_count,
+                        del.delete_file_id, del.path, del.path_is_relative,
+                        del.file_size_bytes, del.footer_size, del.encryption_key,
+                        del.delete_count, data.begin_snapshot::bigint,
+                        {partial_max_expr}, {schema_version_expr}
+                 FROM ducklake_data_file AS data
+                 LEFT JOIN ducklake_delete_file AS del
+                   ON data.data_file_id = del.data_file_id
+                  AND del.table_id = $1
+                  AND $2 >= del.begin_snapshot
+                  AND ($3 < del.end_snapshot OR del.end_snapshot IS NULL)
+                 WHERE data.table_id = $4
+                   AND $5 >= data.begin_snapshot
+                   AND ($6 < data.end_snapshot OR data.end_snapshot IS NULL)
+                   AND data.data_file_id > $7
+                 ORDER BY data.data_file_id
+                 LIMIT $8"
+            );
+            let rows = sqlx::query(&sql)
+                .bind(table_id)
+                .bind(snapshot_id)
+                .bind(snapshot_id)
+                .bind(table_id)
+                .bind(snapshot_id)
+                .bind(snapshot_id)
+                .bind(after_data_file_id.unwrap_or(i64::MIN))
+                .bind(limit)
+                .fetch_all(&self.pool)
+                .await?;
+            let files = rows
+                .iter()
+                .map(|row| decode_table_file(row, snapshot_id))
+                .collect::<Result<Vec<_>>>()?;
+            let Some(last_data_file_id) = files.last().map(|file| file.data_file_id) else {
+                return Ok(Vec::new());
+            };
+            let statistics = match sqlx::query(
+                "SELECT stats.data_file_id, stats.column_id,
+                        stats.column_size_bytes, stats.value_count, stats.null_count,
+                        stats.min_value, stats.max_value
+                 FROM ducklake_file_column_stats AS stats
+                 INNER JOIN ducklake_data_file AS data
+                   ON data.data_file_id = stats.data_file_id
+                  AND data.table_id = stats.table_id
+                 WHERE stats.table_id = $1
+                   AND $2 >= data.begin_snapshot
+                   AND ($3 < data.end_snapshot OR data.end_snapshot IS NULL)
+                   AND stats.data_file_id > $4
+                   AND stats.data_file_id <= $5
+                 ORDER BY stats.data_file_id, stats.column_id",
+            )
+            .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .bind(after_data_file_id.unwrap_or(i64::MIN))
+            .bind(last_data_file_id)
+            .fetch_all(&self.pool)
+            .await
+            {
+                Ok(rows) => rows
+                    .into_iter()
+                    .map(|row| {
+                        Ok(DuckLakeFileColumnStatistics {
+                            data_file_id: row.try_get(0)?,
+                            column_id: row.try_get(1)?,
+                            column_size_bytes: row.try_get(2)?,
+                            value_count: row.try_get(3)?,
+                            null_count: row.try_get(4)?,
+                            min_value: row.try_get(5)?,
+                            max_value: row.try_get(6)?,
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?,
+                Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+                Err(error) => return Err(error.into()),
+            };
+            let mut statistics_by_file: HashMap<i64, Vec<_>> = HashMap::new();
+            for statistic in statistics {
+                statistics_by_file
+                    .entry(statistic.data_file_id)
+                    .or_default()
+                    .push(statistic);
+            }
+            Ok(files
+                .into_iter()
+                .map(|file| DuckLakeFileMetadata {
+                    column_statistics: statistics_by_file
+                        .remove(&file.data_file_id)
+                        .unwrap_or_default(),
+                    file,
+                })
+                .collect())
+        })
+    }
+
+    fn get_table_summary_statistics(
+        &self,
+        table_id: i64,
+        _snapshot_id: i64,
+    ) -> Result<DuckLakeStatistics> {
+        block_on(async {
+            let table = match sqlx::query(
+                "SELECT record_count, file_size_bytes
+                 FROM ducklake_table_stats WHERE table_id = $1",
+            )
+            .bind(table_id)
+            .fetch_optional(&self.pool)
+            .await
+            {
+                Ok(row) => row
+                    .map(|row| {
+                        Ok::<_, sqlx::Error>(DuckLakeTableStatistics {
+                            record_count: row.try_get(0)?,
+                            file_size_bytes: row.try_get(1)?,
+                        })
+                    })
+                    .transpose()?,
+                Err(error) if is_missing_statistics_table(&error) => None,
+                Err(error) => return Err(error.into()),
+            };
+            let columns = match sqlx::query(
+                "SELECT column_id, contains_null, min_value, max_value
+                 FROM ducklake_table_column_stats WHERE table_id = $1",
+            )
+            .bind(table_id)
+            .fetch_all(&self.pool)
+            .await
+            {
+                Ok(rows) => rows
+                    .into_iter()
+                    .map(|row| {
+                        Ok(DuckLakeTableColumnStatistics {
+                            column_id: row.try_get(0)?,
+                            contains_null: row.try_get(1)?,
+                            min_value: row.try_get(2)?,
+                            max_value: row.try_get(3)?,
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?,
+                Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+                Err(error) => return Err(error.into()),
+            };
+            Ok(DuckLakeStatistics {
+                table,
+                columns,
+                files: Vec::new(),
+            })
         })
     }
 

--- a/src/metadata_provider_postgres.rs
+++ b/src/metadata_provider_postgres.rs
@@ -509,7 +509,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                                AND $2 >= visible.begin_snapshot
                                AND ($3 < visible.end_snapshot OR visible.end_snapshot IS NULL)
                            )
-                          THEN SUM(stats.column_size_bytes)
+                          THEN CAST(SUM(stats.column_size_bytes) AS BIGINT)
                         END
                  FROM ducklake_file_column_stats stats
                  INNER JOIN ducklake_data_file data

--- a/src/metadata_provider_postgres.rs
+++ b/src/metadata_provider_postgres.rs
@@ -477,7 +477,7 @@ impl MetadataProvider for PostgresMetadataProvider {
     fn get_table_summary_statistics(
         &self,
         table_id: i64,
-        _snapshot_id: i64,
+        snapshot_id: i64,
     ) -> Result<DuckLakeStatistics> {
         block_on(async {
             let table = match sqlx::query(
@@ -499,6 +499,60 @@ impl MetadataProvider for PostgresMetadataProvider {
                 Err(error) if is_missing_statistics_table(&error) => None,
                 Err(error) => return Err(error.into()),
             };
+            let column_sizes = match sqlx::query(
+                "SELECT stats.column_id,
+                        CASE
+                          WHEN COUNT(*) = COUNT(stats.column_size_bytes)
+                           AND COUNT(*) = (
+                             SELECT COUNT(*) FROM ducklake_data_file visible
+                             WHERE visible.table_id = $1
+                               AND $2 >= visible.begin_snapshot
+                               AND ($3 < visible.end_snapshot OR visible.end_snapshot IS NULL)
+                           )
+                          THEN SUM(stats.column_size_bytes)
+                        END
+                 FROM ducklake_file_column_stats stats
+                 INNER JOIN ducklake_data_file data
+                   ON data.data_file_id = stats.data_file_id
+                  AND data.table_id = stats.table_id
+                 WHERE stats.table_id = $4
+                   AND $5 >= data.begin_snapshot
+                   AND ($6 < data.end_snapshot OR data.end_snapshot IS NULL)
+                 GROUP BY stats.column_id",
+            )
+            .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_all(&self.pool)
+            .await
+            {
+                Ok(rows) => rows
+                    .into_iter()
+                    .filter_map(|row| match row.try_get::<Option<i64>, _>(1) {
+                        Ok(Some(size)) => Some(row.try_get(0).map(|column_id| (column_id, size))),
+                        Ok(None) => None,
+                        Err(error) => Some(Err(error)),
+                    })
+                    .collect::<std::result::Result<HashMap<i64, i64>, _>>()?,
+                Err(error) if is_missing_statistics_table(&error) => HashMap::new(),
+                Err(error) => return Err(error.into()),
+            };
+            let bounds_are_exact: bool = sqlx::query_scalar(
+                "SELECT NOT EXISTS (
+                     SELECT 1 FROM ducklake_delete_file
+                     WHERE table_id = $1
+                       AND $2 >= begin_snapshot
+                       AND ($3 < end_snapshot OR end_snapshot IS NULL)
+                 )",
+            )
+            .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_one(&self.pool)
+            .await?;
             let columns = match sqlx::query(
                 "SELECT column_id, contains_null, min_value, max_value
                  FROM ducklake_table_column_stats WHERE table_id = $1",
@@ -510,11 +564,14 @@ impl MetadataProvider for PostgresMetadataProvider {
                 Ok(rows) => rows
                     .into_iter()
                     .map(|row| {
+                        let column_id = row.try_get(0)?;
                         Ok(DuckLakeTableColumnStatistics {
-                            column_id: row.try_get(0)?,
+                            column_id,
                             contains_null: row.try_get(1)?,
                             min_value: row.try_get(2)?,
                             max_value: row.try_get(3)?,
+                            column_size_bytes: column_sizes.get(&column_id).copied(),
+                            bounds_are_exact,
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,
@@ -567,6 +624,8 @@ impl MetadataProvider for PostgresMetadataProvider {
                             contains_null: row.try_get(1)?,
                             min_value: row.try_get(2)?,
                             max_value: row.try_get(3)?,
+                            column_size_bytes: None,
+                            bounds_are_exact: false,
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,

--- a/src/metadata_provider_sqlite.rs
+++ b/src/metadata_provider_sqlite.rs
@@ -552,7 +552,7 @@ impl MetadataProvider for SqliteMetadataProvider {
     fn get_table_summary_statistics(
         &self,
         table_id: i64,
-        _snapshot_id: i64,
+        snapshot_id: i64,
     ) -> Result<DuckLakeStatistics> {
         block_on(async {
             let table = match sqlx::query(
@@ -574,6 +574,60 @@ impl MetadataProvider for SqliteMetadataProvider {
                 Err(error) if is_missing_statistics_table(&error) => None,
                 Err(error) => return Err(error.into()),
             };
+            let column_sizes = match sqlx::query(
+                "SELECT stats.column_id,
+                        CASE
+                          WHEN COUNT(*) = COUNT(stats.column_size_bytes)
+                           AND COUNT(*) = (
+                             SELECT COUNT(*) FROM ducklake_data_file visible
+                             WHERE visible.table_id = ?
+                               AND ? >= visible.begin_snapshot
+                               AND (? < visible.end_snapshot OR visible.end_snapshot IS NULL)
+                           )
+                          THEN SUM(stats.column_size_bytes)
+                        END
+                 FROM ducklake_file_column_stats stats
+                 INNER JOIN ducklake_data_file data
+                   ON data.data_file_id = stats.data_file_id
+                  AND data.table_id = stats.table_id
+                 WHERE stats.table_id = ?
+                   AND ? >= data.begin_snapshot
+                   AND (? < data.end_snapshot OR data.end_snapshot IS NULL)
+                 GROUP BY stats.column_id",
+            )
+            .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_all(&self.pool)
+            .await
+            {
+                Ok(rows) => rows
+                    .into_iter()
+                    .filter_map(|row| match row.try_get::<Option<i64>, _>(1) {
+                        Ok(Some(size)) => Some(row.try_get(0).map(|column_id| (column_id, size))),
+                        Ok(None) => None,
+                        Err(error) => Some(Err(error)),
+                    })
+                    .collect::<std::result::Result<HashMap<i64, i64>, _>>()?,
+                Err(error) if is_missing_statistics_table(&error) => HashMap::new(),
+                Err(error) => return Err(error.into()),
+            };
+            let bounds_are_exact: bool = sqlx::query_scalar(
+                "SELECT NOT EXISTS (
+                     SELECT 1 FROM ducklake_delete_file
+                     WHERE table_id = ?
+                       AND ? >= begin_snapshot
+                       AND (? < end_snapshot OR end_snapshot IS NULL)
+                 )",
+            )
+            .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_one(&self.pool)
+            .await?;
             let columns = match sqlx::query(
                 "SELECT column_id, contains_null, min_value, max_value
                  FROM ducklake_table_column_stats WHERE table_id = ?",
@@ -585,11 +639,14 @@ impl MetadataProvider for SqliteMetadataProvider {
                 Ok(rows) => rows
                     .into_iter()
                     .map(|row| {
+                        let column_id = row.try_get(0)?;
                         Ok(DuckLakeTableColumnStatistics {
-                            column_id: row.try_get(0)?,
+                            column_id,
                             contains_null: row.try_get(1)?,
                             min_value: row.try_get(2)?,
                             max_value: row.try_get(3)?,
+                            column_size_bytes: column_sizes.get(&column_id).copied(),
+                            bounds_are_exact,
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,
@@ -642,6 +699,8 @@ impl MetadataProvider for SqliteMetadataProvider {
                             contains_null: row.try_get(1)?,
                             min_value: row.try_get(2)?,
                             max_value: row.try_get(3)?,
+                            column_size_bytes: None,
+                            bounds_are_exact: false,
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,

--- a/src/metadata_provider_sqlite.rs
+++ b/src/metadata_provider_sqlite.rs
@@ -584,7 +584,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                                AND ? >= visible.begin_snapshot
                                AND (? < visible.end_snapshot OR visible.end_snapshot IS NULL)
                            )
-                          THEN SUM(stats.column_size_bytes)
+                          THEN CAST(SUM(stats.column_size_bytes) AS INTEGER)
                         END
                  FROM ducklake_file_column_stats stats
                  INNER JOIN ducklake_data_file data

--- a/src/metadata_provider_sqlite.rs
+++ b/src/metadata_provider_sqlite.rs
@@ -3,10 +3,10 @@
 use crate::Result;
 use crate::metadata_provider::{
     ColumnWithTable, DataFileChange, DeleteFileChange, DuckLakeFileColumnStatistics,
-    DuckLakeFileData, DuckLakeStatistics, DuckLakeTableColumn, DuckLakeTableColumnStatistics,
-    DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable, MetadataProvider, SchemaMetadata,
-    SnapshotMetadata, TableMetadata, TableWithSchema, block_on, reconstruct_list_columns,
-    reconstruct_list_columns_with_table,
+    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeStatistics, DuckLakeTableColumn,
+    DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable,
+    MetadataProvider, SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, block_on,
+    reconstruct_list_columns, reconstruct_list_columns_with_table,
 };
 use arrow::array::{
     ArrayRef, BinaryArray, BooleanArray, Float32Array, Float64Array, Int8Array, Int16Array,
@@ -15,15 +15,52 @@ use arrow::array::{
 };
 use arrow::datatypes::{DataType, SchemaRef};
 use sqlx::Row;
-use sqlx::sqlite::{SqlitePool, SqlitePoolOptions};
+use sqlx::sqlite::{SqlitePool, SqlitePoolOptions, SqliteRow};
 use sqlx::types::chrono::NaiveDateTime;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 /// Quote a SQL identifier for SQLite (double-quote, doubling embedded quotes),
 /// so catalog-supplied inlined-table / column names can't break the query.
 fn quote_ident(name: &str) -> String {
     format!("\"{}\"", name.replace('"', "\"\""))
+}
+
+fn decode_table_file(row: &SqliteRow, snapshot_id: i64) -> Result<DuckLakeTableFile> {
+    let data_file = DuckLakeFileData {
+        path: row.try_get(1)?,
+        path_is_relative: row.try_get(2)?,
+        file_size_bytes: row.try_get(3)?,
+        footer_size: row.try_get(4)?,
+        encryption_key: row.try_get(5)?,
+    };
+    let (delete_file, delete_count) = if row.try_get::<Option<i64>, _>(8)?.is_some() {
+        (
+            Some(DuckLakeFileData {
+                path: row.try_get(9)?,
+                path_is_relative: row.try_get(10)?,
+                file_size_bytes: row.try_get(11)?,
+                footer_size: row.try_get(12)?,
+                encryption_key: row.try_get(13)?,
+            }),
+            row.try_get(14)?,
+        )
+    } else {
+        (None, None)
+    };
+    Ok(DuckLakeTableFile {
+        data_file_id: row.try_get(0)?,
+        file: data_file,
+        delete_file_id: row.try_get(8)?,
+        delete_file,
+        row_id_start: row.try_get(6)?,
+        snapshot_id: Some(snapshot_id),
+        begin_snapshot: row.try_get(15)?,
+        schema_version: row.try_get(17)?,
+        partial_max: row.try_get(16)?,
+        max_row_count: row.try_get(7)?,
+        delete_count,
+    })
 }
 
 /// Build one Arrow [`RecordBatch`] (in `schema`, the table's physical schema)
@@ -366,49 +403,204 @@ impl MetadataProvider for SqliteMetadataProvider {
                 .fetch_all(&self.pool)
                 .await?;
 
-            rows.into_iter()
-                .map(|row| {
-                    let data_file = DuckLakeFileData {
-                        path: row.try_get(1)?,
-                        path_is_relative: row.try_get(2)?,
-                        file_size_bytes: row.try_get(3)?,
-                        footer_size: row.try_get(4)?,
-                        encryption_key: row.try_get(5)?,
-                    };
-                    let row_id_start: Option<i64> = row.try_get(6)?;
-                    let record_count: Option<i64> = row.try_get(7)?;
-
-                    let (delete_file, delete_count) = if row.try_get::<Option<i64>, _>(8)?.is_some()
-                    {
-                        (
-                            Some(DuckLakeFileData {
-                                path: row.try_get(9)?,
-                                path_is_relative: row.try_get(10)?,
-                                file_size_bytes: row.try_get(11)?,
-                                footer_size: row.try_get(12)?,
-                                encryption_key: row.try_get(13)?,
-                            }),
-                            row.try_get(14)?,
-                        )
-                    } else {
-                        (None, None)
-                    };
-
-                    Ok(DuckLakeTableFile {
-                        data_file_id: row.try_get(0)?,
-                        file: data_file,
-                        delete_file_id: row.try_get(8)?,
-                        delete_file,
-                        row_id_start,
-                        snapshot_id: Some(snapshot_id),
-                        begin_snapshot: row.try_get(15)?,
-                        schema_version: row.try_get(17)?,
-                        partial_max: row.try_get(16)?,
-                        max_row_count: record_count,
-                        delete_count,
-                    })
-                })
+            rows.iter()
+                .map(|row| decode_table_file(row, snapshot_id))
                 .collect()
+        })
+    }
+
+    fn get_table_file_metadata_page(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+        after_data_file_id: Option<i64>,
+        limit: usize,
+    ) -> Result<Vec<DuckLakeFileMetadata>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).map_err(|_| {
+            crate::DuckLakeError::InvalidConfig("file metadata page limit exceeds i64".to_string())
+        })?;
+        block_on(async {
+            let has_partial_max: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM pragma_table_info('ducklake_data_file') WHERE name = 'partial_max'",
+            )
+            .fetch_one(&self.pool)
+            .await?;
+            let has_schema_versions: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM sqlite_master
+                 WHERE type = 'table' AND name = 'ducklake_schema_versions'",
+            )
+            .fetch_one(&self.pool)
+            .await?;
+            let partial_max_expr = if has_partial_max > 0 {
+                "data.partial_max"
+            } else {
+                "NULL"
+            };
+            let schema_version_expr = if has_schema_versions > 0 {
+                "(SELECT sv.schema_version
+                  FROM ducklake_schema_versions sv
+                  WHERE sv.table_id = data.table_id
+                    AND sv.begin_snapshot <= data.begin_snapshot
+                  ORDER BY sv.begin_snapshot DESC
+                  LIMIT 1)"
+            } else {
+                "NULL"
+            };
+            let sql = format!(
+                "SELECT
+                    data.data_file_id, data.path, data.path_is_relative,
+                    data.file_size_bytes, data.footer_size, data.encryption_key,
+                    data.row_id_start, data.record_count,
+                    del.delete_file_id, del.path, del.path_is_relative,
+                    del.file_size_bytes, del.footer_size, del.encryption_key,
+                    del.delete_count, data.begin_snapshot,
+                    {partial_max_expr}, {schema_version_expr}
+                 FROM ducklake_data_file AS data
+                 LEFT JOIN ducklake_delete_file AS del
+                   ON data.data_file_id = del.data_file_id
+                  AND del.table_id = ?
+                  AND ? >= del.begin_snapshot
+                  AND (? < del.end_snapshot OR del.end_snapshot IS NULL)
+                 WHERE data.table_id = ?
+                   AND ? >= data.begin_snapshot
+                   AND (? < data.end_snapshot OR data.end_snapshot IS NULL)
+                   AND data.data_file_id > ?
+                 ORDER BY data.data_file_id
+                 LIMIT ?"
+            );
+            let rows = sqlx::query(&sql)
+                .bind(table_id)
+                .bind(snapshot_id)
+                .bind(snapshot_id)
+                .bind(table_id)
+                .bind(snapshot_id)
+                .bind(snapshot_id)
+                .bind(after_data_file_id.unwrap_or(i64::MIN))
+                .bind(limit)
+                .fetch_all(&self.pool)
+                .await?;
+            let files = rows
+                .iter()
+                .map(|row| decode_table_file(row, snapshot_id))
+                .collect::<Result<Vec<_>>>()?;
+            let Some(last_data_file_id) = files.last().map(|file| file.data_file_id) else {
+                return Ok(Vec::new());
+            };
+
+            let statistics = match sqlx::query(
+                "SELECT stats.data_file_id, stats.column_id,
+                        stats.column_size_bytes, stats.value_count, stats.null_count,
+                        stats.min_value, stats.max_value
+                 FROM ducklake_file_column_stats AS stats
+                 INNER JOIN ducklake_data_file AS data
+                   ON data.data_file_id = stats.data_file_id
+                  AND data.table_id = stats.table_id
+                 WHERE stats.table_id = ?
+                   AND ? >= data.begin_snapshot
+                   AND (? < data.end_snapshot OR data.end_snapshot IS NULL)
+                   AND stats.data_file_id > ?
+                   AND stats.data_file_id <= ?
+                 ORDER BY stats.data_file_id, stats.column_id",
+            )
+            .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .bind(after_data_file_id.unwrap_or(i64::MIN))
+            .bind(last_data_file_id)
+            .fetch_all(&self.pool)
+            .await
+            {
+                Ok(rows) => rows
+                    .into_iter()
+                    .map(|row| {
+                        Ok(DuckLakeFileColumnStatistics {
+                            data_file_id: row.try_get(0)?,
+                            column_id: row.try_get(1)?,
+                            column_size_bytes: row.try_get(2)?,
+                            value_count: row.try_get(3)?,
+                            null_count: row.try_get(4)?,
+                            min_value: row.try_get(5)?,
+                            max_value: row.try_get(6)?,
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?,
+                Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+                Err(error) => return Err(error.into()),
+            };
+            let mut statistics_by_file: HashMap<i64, Vec<_>> = HashMap::new();
+            for statistic in statistics {
+                statistics_by_file
+                    .entry(statistic.data_file_id)
+                    .or_default()
+                    .push(statistic);
+            }
+            Ok(files
+                .into_iter()
+                .map(|file| DuckLakeFileMetadata {
+                    column_statistics: statistics_by_file
+                        .remove(&file.data_file_id)
+                        .unwrap_or_default(),
+                    file,
+                })
+                .collect())
+        })
+    }
+
+    fn get_table_summary_statistics(
+        &self,
+        table_id: i64,
+        _snapshot_id: i64,
+    ) -> Result<DuckLakeStatistics> {
+        block_on(async {
+            let table = match sqlx::query(
+                "SELECT record_count, file_size_bytes
+                 FROM ducklake_table_stats WHERE table_id = ?",
+            )
+            .bind(table_id)
+            .fetch_optional(&self.pool)
+            .await
+            {
+                Ok(row) => row
+                    .map(|row| {
+                        Ok::<_, sqlx::Error>(DuckLakeTableStatistics {
+                            record_count: row.try_get(0)?,
+                            file_size_bytes: row.try_get(1)?,
+                        })
+                    })
+                    .transpose()?,
+                Err(error) if is_missing_statistics_table(&error) => None,
+                Err(error) => return Err(error.into()),
+            };
+            let columns = match sqlx::query(
+                "SELECT column_id, contains_null, min_value, max_value
+                 FROM ducklake_table_column_stats WHERE table_id = ?",
+            )
+            .bind(table_id)
+            .fetch_all(&self.pool)
+            .await
+            {
+                Ok(rows) => rows
+                    .into_iter()
+                    .map(|row| {
+                        Ok(DuckLakeTableColumnStatistics {
+                            column_id: row.try_get(0)?,
+                            contains_null: row.try_get(1)?,
+                            min_value: row.try_get(2)?,
+                            max_value: row.try_get(3)?,
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?,
+                Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+                Err(error) => return Err(error.into()),
+            };
+            Ok(DuckLakeStatistics {
+                table,
+                columns,
+                files: Vec::new(),
+            })
         })
     }
 

--- a/src/multicatalog_provider.rs
+++ b/src/multicatalog_provider.rs
@@ -510,7 +510,7 @@ impl MetadataProvider for MulticatalogProvider {
     fn get_table_summary_statistics(
         &self,
         table_id: i64,
-        _snapshot_id: i64,
+        snapshot_id: i64,
     ) -> Result<DuckLakeStatistics> {
         block_on(async {
             let table = match sqlx::query(
@@ -532,6 +532,60 @@ impl MetadataProvider for MulticatalogProvider {
                 Err(error) if is_missing_statistics_table(&error) => None,
                 Err(error) => return Err(error.into()),
             };
+            let column_sizes = match sqlx::query(
+                "SELECT stats.column_id,
+                        CASE
+                          WHEN COUNT(*) = COUNT(stats.column_size_bytes)
+                           AND COUNT(*) = (
+                             SELECT COUNT(*) FROM ducklake_data_file visible
+                             WHERE visible.table_id = $1
+                               AND $2 >= visible.begin_snapshot
+                               AND ($3 < visible.end_snapshot OR visible.end_snapshot IS NULL)
+                           )
+                          THEN SUM(stats.column_size_bytes)
+                        END
+                 FROM ducklake_file_column_stats stats
+                 INNER JOIN ducklake_data_file data
+                   ON data.data_file_id = stats.data_file_id
+                  AND data.table_id = stats.table_id
+                 WHERE stats.table_id = $4
+                   AND $5 >= data.begin_snapshot
+                   AND ($6 < data.end_snapshot OR data.end_snapshot IS NULL)
+                 GROUP BY stats.column_id",
+            )
+            .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_all(&self.pool)
+            .await
+            {
+                Ok(rows) => rows
+                    .into_iter()
+                    .filter_map(|row| match row.try_get::<Option<i64>, _>(1) {
+                        Ok(Some(size)) => Some(row.try_get(0).map(|column_id| (column_id, size))),
+                        Ok(None) => None,
+                        Err(error) => Some(Err(error)),
+                    })
+                    .collect::<std::result::Result<HashMap<i64, i64>, _>>()?,
+                Err(error) if is_missing_statistics_table(&error) => HashMap::new(),
+                Err(error) => return Err(error.into()),
+            };
+            let bounds_are_exact: bool = sqlx::query_scalar(
+                "SELECT NOT EXISTS (
+                     SELECT 1 FROM ducklake_delete_file
+                     WHERE table_id = $1
+                       AND $2 >= begin_snapshot
+                       AND ($3 < end_snapshot OR end_snapshot IS NULL)
+                 )",
+            )
+            .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_one(&self.pool)
+            .await?;
             let columns = match sqlx::query(
                 "SELECT column_id, contains_null, min_value, max_value
                  FROM ducklake_table_column_stats WHERE table_id = $1",
@@ -543,11 +597,14 @@ impl MetadataProvider for MulticatalogProvider {
                 Ok(rows) => rows
                     .into_iter()
                     .map(|row| {
+                        let column_id = row.try_get(0)?;
                         Ok(DuckLakeTableColumnStatistics {
-                            column_id: row.try_get(0)?,
+                            column_id,
                             contains_null: row.try_get(1)?,
                             min_value: row.try_get(2)?,
                             max_value: row.try_get(3)?,
+                            column_size_bytes: column_sizes.get(&column_id).copied(),
+                            bounds_are_exact,
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,
@@ -600,6 +657,8 @@ impl MetadataProvider for MulticatalogProvider {
                             contains_null: row.try_get(1)?,
                             min_value: row.try_get(2)?,
                             max_value: row.try_get(3)?,
+                            column_size_bytes: None,
+                            bounds_are_exact: false,
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,

--- a/src/multicatalog_provider.rs
+++ b/src/multicatalog_provider.rs
@@ -14,18 +14,56 @@
 use crate::Result;
 use crate::metadata_provider::{
     ColumnWithTable, DataFileChange, DeleteFileChange, DuckLakeFileColumnStatistics,
-    DuckLakeFileData, DuckLakeStatistics, DuckLakeTableColumn, DuckLakeTableColumnStatistics,
-    DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable, MetadataProvider, SchemaMetadata,
-    SnapshotMetadata, TableMetadata, TableWithSchema, block_on, reconstruct_list_columns,
-    reconstruct_list_columns_with_table,
+    DuckLakeFileData, DuckLakeFileMetadata, DuckLakeStatistics, DuckLakeTableColumn,
+    DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable,
+    MetadataProvider, SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, block_on,
+    reconstruct_list_columns, reconstruct_list_columns_with_table,
 };
 use sqlx::Row;
-use sqlx::postgres::{PgPool, PgPoolOptions};
+use sqlx::postgres::{PgPool, PgPoolOptions, PgRow};
 use sqlx::types::chrono::NaiveDateTime;
+use std::collections::HashMap;
 
 fn is_missing_statistics_table(error: &sqlx::Error) -> bool {
     let message = error.to_string().to_ascii_lowercase();
     message.contains("does not exist") || message.contains("undefined table")
+}
+
+fn decode_table_file(row: &PgRow, snapshot_id: i64) -> Result<DuckLakeTableFile> {
+    let delete_file_id: Option<i64> = row.try_get(8)?;
+    let (delete_file, delete_count) = if delete_file_id.is_some() {
+        (
+            Some(DuckLakeFileData {
+                path: row.try_get(9)?,
+                path_is_relative: row.try_get(10)?,
+                file_size_bytes: row.try_get(11)?,
+                footer_size: row.try_get(12)?,
+                encryption_key: row.try_get(13)?,
+            }),
+            row.try_get(14)?,
+        )
+    } else {
+        (None, None)
+    };
+    Ok(DuckLakeTableFile {
+        data_file_id: row.try_get(0)?,
+        file: DuckLakeFileData {
+            path: row.try_get(1)?,
+            path_is_relative: row.try_get(2)?,
+            file_size_bytes: row.try_get(3)?,
+            footer_size: row.try_get(4)?,
+            encryption_key: row.try_get(5)?,
+        },
+        delete_file_id,
+        delete_file,
+        row_id_start: row.try_get(6)?,
+        snapshot_id: Some(snapshot_id),
+        begin_snapshot: row.try_get(15)?,
+        schema_version: row.try_get(17)?,
+        partial_max: row.try_get(16)?,
+        max_row_count: row.try_get(7)?,
+        delete_count,
+    })
 }
 
 const DEFAULT_MAX_CONNECTIONS: u32 = 5;
@@ -327,49 +365,200 @@ impl MetadataProvider for MulticatalogProvider {
                 .fetch_all(&self.pool)
                 .await?;
 
-            rows.into_iter()
-                .map(|row| {
-                    let data_file = DuckLakeFileData {
-                        path: row.try_get(1)?,
-                        path_is_relative: row.try_get(2)?,
-                        file_size_bytes: row.try_get(3)?,
-                        footer_size: row.try_get(4)?,
-                        encryption_key: row.try_get(5)?,
-                    };
-                    let row_id_start: Option<i64> = row.try_get(6)?;
-                    let record_count: Option<i64> = row.try_get(7)?;
-
-                    let (delete_file, delete_count) = if row.try_get::<Option<i64>, _>(8)?.is_some()
-                    {
-                        (
-                            Some(DuckLakeFileData {
-                                path: row.try_get(9)?,
-                                path_is_relative: row.try_get(10)?,
-                                file_size_bytes: row.try_get(11)?,
-                                footer_size: row.try_get(12)?,
-                                encryption_key: row.try_get(13)?,
-                            }),
-                            row.try_get(14)?,
-                        )
-                    } else {
-                        (None, None)
-                    };
-
-                    Ok(DuckLakeTableFile {
-                        data_file_id: row.try_get(0)?,
-                        file: data_file,
-                        delete_file_id: row.try_get(8)?,
-                        delete_file,
-                        row_id_start,
-                        snapshot_id: Some(snapshot_id),
-                        begin_snapshot: row.try_get(15)?,
-                        schema_version: row.try_get(17)?,
-                        partial_max: row.try_get(16)?,
-                        max_row_count: record_count,
-                        delete_count,
-                    })
-                })
+            rows.iter()
+                .map(|row| decode_table_file(row, snapshot_id))
                 .collect()
+        })
+    }
+
+    fn get_table_file_metadata_page(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+        after_data_file_id: Option<i64>,
+        limit: usize,
+    ) -> Result<Vec<DuckLakeFileMetadata>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit).map_err(|_| {
+            crate::DuckLakeError::InvalidConfig("file metadata page limit exceeds i64".to_string())
+        })?;
+        block_on(async {
+            let has_partial_max: bool = sqlx::query_scalar(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.columns
+                 WHERE table_name = 'ducklake_data_file' AND column_name = 'partial_max')",
+            )
+            .fetch_one(&self.pool)
+            .await?;
+            let has_schema_versions: bool =
+                sqlx::query_scalar("SELECT to_regclass('ducklake_schema_versions') IS NOT NULL")
+                    .fetch_one(&self.pool)
+                    .await?;
+            let partial_max_expr = if has_partial_max {
+                "data.partial_max::bigint"
+            } else {
+                "NULL::bigint"
+            };
+            let schema_version_expr = if has_schema_versions {
+                "(SELECT sv.schema_version::bigint
+                  FROM ducklake_schema_versions sv
+                  WHERE sv.table_id = data.table_id
+                    AND sv.begin_snapshot <= data.begin_snapshot
+                  ORDER BY sv.begin_snapshot DESC LIMIT 1)"
+            } else {
+                "NULL::bigint"
+            };
+            let sql = format!(
+                "SELECT data.data_file_id, data.path, data.path_is_relative,
+                        data.file_size_bytes, data.footer_size, data.encryption_key,
+                        data.row_id_start, data.record_count,
+                        del.delete_file_id, del.path, del.path_is_relative,
+                        del.file_size_bytes, del.footer_size, del.encryption_key,
+                        del.delete_count, data.begin_snapshot::bigint,
+                        {partial_max_expr}, {schema_version_expr}
+                 FROM ducklake_data_file AS data
+                 LEFT JOIN ducklake_delete_file AS del
+                   ON data.data_file_id = del.data_file_id
+                  AND del.table_id = $1
+                  AND $2 >= del.begin_snapshot
+                  AND ($3 < del.end_snapshot OR del.end_snapshot IS NULL)
+                 WHERE data.table_id = $4
+                   AND $5 >= data.begin_snapshot
+                   AND ($6 < data.end_snapshot OR data.end_snapshot IS NULL)
+                   AND data.data_file_id > $7
+                 ORDER BY data.data_file_id
+                 LIMIT $8"
+            );
+            let rows = sqlx::query(&sql)
+                .bind(table_id)
+                .bind(snapshot_id)
+                .bind(snapshot_id)
+                .bind(table_id)
+                .bind(snapshot_id)
+                .bind(snapshot_id)
+                .bind(after_data_file_id.unwrap_or(i64::MIN))
+                .bind(limit)
+                .fetch_all(&self.pool)
+                .await?;
+            let files = rows
+                .iter()
+                .map(|row| decode_table_file(row, snapshot_id))
+                .collect::<Result<Vec<_>>>()?;
+            let Some(last_data_file_id) = files.last().map(|file| file.data_file_id) else {
+                return Ok(Vec::new());
+            };
+            let statistics = match sqlx::query(
+                "SELECT stats.data_file_id, stats.column_id,
+                        stats.column_size_bytes, stats.value_count, stats.null_count,
+                        stats.min_value, stats.max_value
+                 FROM ducklake_file_column_stats AS stats
+                 INNER JOIN ducklake_data_file AS data
+                   ON data.data_file_id = stats.data_file_id
+                  AND data.table_id = stats.table_id
+                 WHERE stats.table_id = $1
+                   AND $2 >= data.begin_snapshot
+                   AND ($3 < data.end_snapshot OR data.end_snapshot IS NULL)
+                   AND stats.data_file_id > $4
+                   AND stats.data_file_id <= $5
+                 ORDER BY stats.data_file_id, stats.column_id",
+            )
+            .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .bind(after_data_file_id.unwrap_or(i64::MIN))
+            .bind(last_data_file_id)
+            .fetch_all(&self.pool)
+            .await
+            {
+                Ok(rows) => rows
+                    .into_iter()
+                    .map(|row| {
+                        Ok(DuckLakeFileColumnStatistics {
+                            data_file_id: row.try_get(0)?,
+                            column_id: row.try_get(1)?,
+                            column_size_bytes: row.try_get(2)?,
+                            value_count: row.try_get(3)?,
+                            null_count: row.try_get(4)?,
+                            min_value: row.try_get(5)?,
+                            max_value: row.try_get(6)?,
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?,
+                Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+                Err(error) => return Err(error.into()),
+            };
+            let mut statistics_by_file: HashMap<i64, Vec<_>> = HashMap::new();
+            for statistic in statistics {
+                statistics_by_file
+                    .entry(statistic.data_file_id)
+                    .or_default()
+                    .push(statistic);
+            }
+            Ok(files
+                .into_iter()
+                .map(|file| DuckLakeFileMetadata {
+                    column_statistics: statistics_by_file
+                        .remove(&file.data_file_id)
+                        .unwrap_or_default(),
+                    file,
+                })
+                .collect())
+        })
+    }
+
+    fn get_table_summary_statistics(
+        &self,
+        table_id: i64,
+        _snapshot_id: i64,
+    ) -> Result<DuckLakeStatistics> {
+        block_on(async {
+            let table = match sqlx::query(
+                "SELECT record_count, file_size_bytes
+                 FROM ducklake_table_stats WHERE table_id = $1",
+            )
+            .bind(table_id)
+            .fetch_optional(&self.pool)
+            .await
+            {
+                Ok(row) => row
+                    .map(|row| {
+                        Ok::<_, sqlx::Error>(DuckLakeTableStatistics {
+                            record_count: row.try_get(0)?,
+                            file_size_bytes: row.try_get(1)?,
+                        })
+                    })
+                    .transpose()?,
+                Err(error) if is_missing_statistics_table(&error) => None,
+                Err(error) => return Err(error.into()),
+            };
+            let columns = match sqlx::query(
+                "SELECT column_id, contains_null, min_value, max_value
+                 FROM ducklake_table_column_stats WHERE table_id = $1",
+            )
+            .bind(table_id)
+            .fetch_all(&self.pool)
+            .await
+            {
+                Ok(rows) => rows
+                    .into_iter()
+                    .map(|row| {
+                        Ok(DuckLakeTableColumnStatistics {
+                            column_id: row.try_get(0)?,
+                            contains_null: row.try_get(1)?,
+                            min_value: row.try_get(2)?,
+                            max_value: row.try_get(3)?,
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?,
+                Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+                Err(error) => return Err(error.into()),
+            };
+            Ok(DuckLakeStatistics {
+                table,
+                columns,
+                files: Vec::new(),
+            })
         })
     }
 

--- a/src/multicatalog_provider.rs
+++ b/src/multicatalog_provider.rs
@@ -542,7 +542,7 @@ impl MetadataProvider for MulticatalogProvider {
                                AND $2 >= visible.begin_snapshot
                                AND ($3 < visible.end_snapshot OR visible.end_snapshot IS NULL)
                            )
-                          THEN SUM(stats.column_size_bytes)
+                          THEN CAST(SUM(stats.column_size_bytes) AS BIGINT)
                         END
                  FROM ducklake_file_column_stats stats
                  INNER JOIN ducklake_data_file data

--- a/src/table.rs
+++ b/src/table.rs
@@ -7,8 +7,9 @@ use crate::Result;
 use crate::column_rename::ColumnRenameExec;
 use crate::delete_filter::DeleteFilterExec;
 use crate::metadata_provider::{
-    DuckLakeFileColumnStatistics, DuckLakeFileData, DuckLakeStatistics, DuckLakeTableColumn,
-    DuckLakeTableColumnStatistics, DuckLakeTableFile, MetadataProvider,
+    DuckLakeFileColumnStatistics, DuckLakeFileData, DuckLakeFileMetadata, DuckLakeStatistics,
+    DuckLakeTableColumn, DuckLakeTableColumnStatistics, DuckLakeTableFile,
+    FILE_METADATA_BATCH_SIZE, MetadataProvider,
 };
 use crate::path_resolver::resolve_path;
 use crate::positional_source::PositionalFileSource;
@@ -270,6 +271,7 @@ fn build_datafusion_statistics(
     table_files: &[DuckLakeTableFile],
     catalog: DuckLakeStatistics,
     use_current_table_statistics: bool,
+    file_metadata_complete: bool,
 ) -> (Statistics, HashMap<i64, Arc<Statistics>>) {
     let table_column_rows: HashMap<i64, DuckLakeTableColumnStatistics> = catalog
         .columns
@@ -340,7 +342,7 @@ fn build_datafusion_statistics(
             _ => None,
         };
     }
-    table_statistics.num_rows = if let Some(rows) = row_total {
+    table_statistics.num_rows = if file_metadata_complete && let Some(rows) = row_total {
         Precision::Exact(rows)
     } else if use_current_table_statistics {
         catalog
@@ -348,7 +350,7 @@ fn build_datafusion_statistics(
             .as_ref()
             .and_then(|stats| stats.record_count)
             .and_then(|value| statistic_usize(value, "table_stats.record_count"))
-            .map(Precision::Inexact)
+            .map(Precision::Exact)
             .unwrap_or(Precision::Absent)
     } else {
         Precision::Absent
@@ -385,6 +387,10 @@ fn build_datafusion_statistics(
                 scalar_precision(raw.min_value.as_deref(), column, field_type, false);
             output.max_value =
                 scalar_precision(raw.max_value.as_deref(), column, field_type, false);
+        }
+
+        if !file_metadata_complete {
+            continue;
         }
 
         if table_files.is_empty() {
@@ -623,21 +629,17 @@ pub struct DuckLakeTable {
     row_lineage: bool,
     /// Column metadata from DuckLake (needed for field_id mapping)
     columns: Vec<DuckLakeTableColumn>,
-    /// Table files with paths as stored in metadata (resolved on-the-fly when needed)
-    table_files: Vec<DuckLakeTableFile>,
     /// Table-level statistics for the physical schema.
     table_statistics: Statistics,
-    /// Per-data-file statistics keyed by `data_file_id`.
-    file_statistics: HashMap<i64, Arc<Statistics>>,
     /// Per-file row-lineage read config, populated lazily on the rowid scan
     /// path. Each file requires its own parquet metadata read to detect an
     /// embedded `_ducklake_internal_row_id` column; we memoize so repeated
     /// scans don't re-fetch. `Arc`-wrapped so a cloned table (see `delete_from`)
     /// shares the same memoized configs.
     file_read_config_cache: Arc<std::sync::Mutex<HashMap<String, Arc<FileReadConfig>>>>,
-    /// Encryption factory for decrypting encrypted Parquet files (when encryption feature is enabled)
+    /// Encryption factory for the metadata page currently being planned.
     #[cfg(feature = "encryption")]
-    encryption_factory: Option<Arc<dyn EncryptionFactory>>,
+    encryption_factory: Arc<std::sync::Mutex<Option<Arc<dyn EncryptionFactory>>>>,
     /// Schema name (needed for write operations)
     #[cfg(feature = "write")]
     schema_name: Option<String>,
@@ -654,7 +656,6 @@ impl std::fmt::Debug for DuckLakeTable {
             .field("table_path", &self.table_path)
             .field("schema", &self.schema)
             .field("columns", &self.columns)
-            .field("table_files", &self.table_files)
             .finish_non_exhaustive()
     }
 }
@@ -669,51 +670,28 @@ impl DuckLakeTable {
         object_store_url: Arc<ObjectStoreUrl>,
         table_path: String,
     ) -> Result<Self> {
-        // Load ALL metadata with this snapshot_id
+        // File metadata is deliberately deferred until scan(), where it can be
+        // consumed and pruned in bounded pages.
         let columns = provider.get_table_structure(table_id, snapshot_id)?;
         let physical_schema = Arc::new(build_arrow_schema(&columns)?);
         let schema = physical_schema.clone();
-        let table_files = provider.get_table_files_for_select(table_id, snapshot_id)?;
-        let catalog_statistics = provider.get_table_statistics(table_id, snapshot_id)?;
+        let catalog_statistics = provider.get_table_summary_statistics(table_id, snapshot_id)?;
         // `ducklake_table_stats` and `ducklake_table_column_stats` describe the
         // current table generation. They must not be applied to an older
         // snapshot if a newer commit landed after the catalog was opened.
         let use_current_table_statistics = provider.get_current_snapshot()? == snapshot_id;
-        let (table_statistics, file_statistics) = build_datafusion_statistics(
+        let (table_statistics, _) = build_datafusion_statistics(
             physical_schema.as_ref(),
             &columns,
-            &table_files,
+            &[],
             catalog_statistics,
             use_current_table_statistics,
+            false,
         );
 
         // Build encryption factory from file encryption keys (when encryption feature is enabled)
         #[cfg(feature = "encryption")]
-        let encryption_factory = {
-            let mut builder = EncryptionFactoryBuilder::new();
-            for table_file in &table_files {
-                // Resolve the file path for the mapping
-                let resolved_path = resolve_path(
-                    &table_path,
-                    &table_file.file.path,
-                    table_file.file.path_is_relative,
-                )?;
-                builder.add_file(&resolved_path, table_file.file.encryption_key.as_deref());
-
-                // Also add delete file encryption key if present
-                if let Some(ref delete_file) = table_file.delete_file {
-                    let resolved_delete_path =
-                        resolve_path(&table_path, &delete_file.path, delete_file.path_is_relative)?;
-                    builder.add_file(&resolved_delete_path, delete_file.encryption_key.as_deref());
-                }
-            }
-            let factory = builder.build();
-            if factory.has_encrypted_files() {
-                Some(Arc::new(factory) as Arc<dyn EncryptionFactory>)
-            } else {
-                None
-            }
-        };
+        let encryption_factory = Arc::new(std::sync::Mutex::new(None));
 
         Ok(Self {
             table_id,
@@ -726,9 +704,7 @@ impl DuckLakeTable {
             physical_schema,
             row_lineage: false,
             columns,
-            table_files,
             table_statistics,
-            file_statistics,
             #[cfg(feature = "encryption")]
             encryption_factory,
             file_read_config_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
@@ -767,8 +743,13 @@ impl DuckLakeTable {
     /// each, [`Self::resolve_positions`] finds the rows to delete,
     /// [`Self::read_delete_file_positions`] reads the already-deleted set, and
     /// the union is written back via `set_delete_file` (CAS on `delete_file_id`).
-    pub fn files(&self) -> &[DuckLakeTableFile] {
-        &self.table_files
+    pub fn files(&self) -> Result<Vec<DuckLakeTableFile>> {
+        let files = self
+            .provider
+            .get_table_files_for_select(self.table_id, self.snapshot_id)?;
+        #[cfg(feature = "encryption")]
+        self.configure_encryption_factory(&files)?;
+        Ok(files)
     }
 
     /// Resolve a file path (data or delete file) to its absolute path
@@ -784,6 +765,7 @@ impl DuckLakeTable {
         &self,
         table_file: &DuckLakeTableFile,
         include_rowid: bool,
+        file_statistics: &HashMap<i64, Arc<Statistics>>,
     ) -> DataFusionResult<PartitionedFile> {
         let resolved_path = self.resolve_file_path(&table_file.file)?;
         let mut file = PartitionedFile::new(
@@ -796,7 +778,7 @@ impl DuckLakeTable {
         {
             file = file.with_metadata_size_hint(hint);
         }
-        if let Some(statistics) = self.file_statistics.get(&table_file.data_file_id) {
+        if let Some(statistics) = file_statistics.get(&table_file.data_file_id) {
             let statistics = if include_rowid {
                 let mut statistics = statistics.as_ref().clone();
                 statistics
@@ -834,19 +816,18 @@ impl DuckLakeTable {
     /// one `Inexact` file suppresses pruning by that column for the whole scan.
     /// Pruning is therefore most effective on append-only / delete-free files.
     fn prune_table_files<'a>(
-        &'a self,
-        state: &dyn Session,
-        filters: &[Expr],
+        &self,
+        pruning: Option<&PruningPredicate>,
+        table_files: &'a [DuckLakeTableFile],
+        file_statistics: &HashMap<i64, Arc<Statistics>>,
     ) -> Vec<&'a DuckLakeTableFile> {
-        if filters.is_empty() || self.table_files.is_empty() {
-            return self.table_files.iter().collect();
-        }
-        match self.file_pruning_mask(state, filters) {
+        let Some(pruning) = pruning else {
+            return table_files.iter().collect();
+        };
+        match self.file_pruning_mask(pruning, table_files, file_statistics) {
             Ok(mask) => {
-                // The mask is 1:1 with `table_files` (DataFusion sizes it from
-                // `num_containers`); the zip below relies on that alignment.
-                debug_assert_eq!(mask.len(), self.table_files.len());
-                self.table_files
+                debug_assert_eq!(mask.len(), table_files.len());
+                table_files
                     .iter()
                     .zip(mask)
                     .filter_map(|(tf, keep)| keep.then_some(tf))
@@ -854,9 +835,24 @@ impl DuckLakeTable {
             },
             Err(e) => {
                 tracing::debug!(error = %e, "skipping plan-time file pruning");
-                self.table_files.iter().collect()
+                table_files.iter().collect()
             },
         }
+    }
+
+    fn file_pruning_predicate(
+        &self,
+        state: &dyn Session,
+        filters: &[Expr],
+    ) -> DataFusionResult<Option<PruningPredicate>> {
+        use datafusion::logical_expr::utils::conjunction;
+
+        let Some(expr) = conjunction(filters.iter().cloned()) else {
+            return Ok(None);
+        };
+        let df_schema = DFSchema::try_from(self.physical_schema.as_ref().clone())?;
+        let predicate = state.create_physical_expr(expr, &df_schema)?;
+        PruningPredicate::try_new(predicate, Arc::clone(&self.physical_schema)).map(Some)
     }
 
     /// Build a `PruningPredicate` from `filters` and evaluate it against every
@@ -866,31 +862,17 @@ impl DuckLakeTable {
     /// rowid), matching how `file_statistics` is indexed.
     fn file_pruning_mask(
         &self,
-        state: &dyn Session,
-        filters: &[Expr],
+        pruning: &PruningPredicate,
+        table_files: &[DuckLakeTableFile],
+        file_statistics: &HashMap<i64, Arc<Statistics>>,
     ) -> DataFusionResult<Vec<bool>> {
-        use datafusion::logical_expr::utils::conjunction;
-
-        // AND the filters into one predicate and plan it against the physical
-        // schema (no synthetic rowid), so column indices line up with the
-        // per-file statistics. A filter referencing a column absent from
-        // `physical_schema` (e.g. the synthetic rowid) fails here, and the
-        // caller falls back to keeping every file. Mirrors the DELETE path.
-        let Some(expr) = conjunction(filters.iter().cloned()) else {
-            return Ok(vec![true; self.table_files.len()]);
-        };
-        let df_schema = DFSchema::try_from(self.physical_schema.as_ref().clone())?;
-        let predicate = state.create_physical_expr(expr, &df_schema)?;
-        let pruning = PruningPredicate::try_new(predicate, Arc::clone(&self.physical_schema))?;
-
         // A file lacking recorded statistics (e.g. written before statistics
         // were produced) contributes `new_unknown`, which the predicate treats
         // as "cannot prune" — the file is kept.
-        let per_file: Vec<Arc<Statistics>> = self
-            .table_files
+        let per_file: Vec<Arc<Statistics>> = table_files
             .iter()
             .map(|tf| {
-                self.file_statistics
+                file_statistics
                     .get(&tf.data_file_id)
                     .map(Arc::clone)
                     .unwrap_or_else(|| Arc::new(Statistics::new_unknown(&self.physical_schema)))
@@ -903,10 +885,36 @@ impl DuckLakeTable {
     /// Create a ParquetSource with encryption support if enabled and needed
     fn create_parquet_source(&self, schema: SchemaRef) -> ParquetSource {
         #[cfg(feature = "encryption")]
-        if let Some(ref factory) = self.encryption_factory {
-            return ParquetSource::new(schema).with_encryption_factory(Arc::clone(factory));
+        if let Some(factory) = self.encryption_factory.lock().unwrap().as_ref().cloned() {
+            return ParquetSource::new(schema).with_encryption_factory(factory);
         }
         ParquetSource::new(schema)
+    }
+
+    #[cfg(feature = "encryption")]
+    fn configure_encryption_factory(&self, table_files: &[DuckLakeTableFile]) -> Result<()> {
+        let mut builder = EncryptionFactoryBuilder::new();
+        for table_file in table_files {
+            let resolved_path = resolve_path(
+                &self.table_path,
+                &table_file.file.path,
+                table_file.file.path_is_relative,
+            )?;
+            builder.add_file(&resolved_path, table_file.file.encryption_key.as_deref());
+            if let Some(delete_file) = &table_file.delete_file {
+                let path = resolve_path(
+                    &self.table_path,
+                    &delete_file.path,
+                    delete_file.path_is_relative,
+                )?;
+                builder.add_file(&path, delete_file.encryption_key.as_deref());
+            }
+        }
+        let factory = builder.build();
+        *self.encryption_factory.lock().unwrap() = factory
+            .has_encrypted_files()
+            .then(|| Arc::new(factory) as Arc<dyn EncryptionFactory>);
+        Ok(())
     }
 
     /// Compute the field_id -> physical-name read schema and rename mapping for a
@@ -1157,6 +1165,7 @@ impl DuckLakeTable {
         &self,
         state: &dyn Session,
         files: &[&DuckLakeTableFile],
+        file_statistics: &HashMap<i64, Arc<Statistics>>,
         projection: Option<&Vec<usize>>,
         limit: Option<usize>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
@@ -1170,7 +1179,7 @@ impl DuckLakeTable {
 
         for table_file in files {
             let mapping = self.file_schema_mapping(state, &table_file.file).await?;
-            let pf = self.partitioned_data_file(table_file, false)?;
+            let pf = self.partitioned_data_file(table_file, false, file_statistics)?;
 
             // Group key: physical field names + types, then the rename mapping.
             let (read_schema, name_mapping) = &mapping;
@@ -1259,6 +1268,7 @@ impl DuckLakeTable {
         &self,
         state: &dyn Session,
         table_file: &DuckLakeTableFile,
+        file_statistics: &HashMap<i64, Arc<Statistics>>,
         projection: Option<&Vec<usize>>,
         limit: Option<usize>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
@@ -1322,6 +1332,7 @@ impl DuckLakeTable {
             let pf = self.partitioned_data_file(
                 table_file,
                 file_cfg.embedded_rowid_parquet_name.is_some(),
+                file_statistics,
             )?;
             let mut builder = FileScanConfigBuilder::new(
                 self.object_store_url.as_ref().clone(),
@@ -1579,6 +1590,7 @@ impl DuckLakeTable {
         &self,
         state: &dyn Session,
         table_file: &DuckLakeTableFile,
+        file_statistics: &HashMap<i64, Arc<Statistics>>,
         user_proj: &[usize],
         rowid_idx: usize,
         limit: Option<usize>,
@@ -1672,7 +1684,7 @@ impl DuckLakeTable {
         } else {
             // Embedded rowid, no deletes: legacy plain scan (cardinality-
             // preserving). Keep scan-level limit and reader pruning.
-            let pf = self.partitioned_data_file(table_file, true)?;
+            let pf = self.partitioned_data_file(table_file, true, file_statistics)?;
             let mut builder = FileScanConfigBuilder::new(
                 self.object_store_url.as_ref().clone(),
                 Arc::new(self.create_parquet_source(file_cfg.read_schema.clone())),
@@ -1811,9 +1823,7 @@ impl DuckLakeTable {
             physical_schema: self.physical_schema.clone(),
             row_lineage: false,
             columns: self.columns.clone(),
-            table_files: self.table_files.clone(),
             table_statistics: self.table_statistics.clone(),
-            file_statistics: self.file_statistics.clone(),
             // `snapshot_id`/cache match the post-#163 struct (Arc-wrapped cache,
             // pinned snapshot). A read-only clone starts with an empty cache.
             file_read_config_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
@@ -2227,10 +2237,6 @@ impl TableProvider for DuckLakeTable {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
-        // Plan-time pruning: restrict the files considered below to those whose
-        // statistics admit a match. Empty filters / missing stats keep every file.
-        let table_files = self.prune_table_files(state, filters);
-
         // Row-lineage detour: when the synthetic `rowid` column is projected,
         // every file needs its own scan because each has a distinct
         // `row_id_start`. `projection == None` with row lineage on means "all
@@ -2242,83 +2248,152 @@ impl TableProvider for DuckLakeTable {
             (None, _) => false,
         };
 
-        if rowid_in_proj {
-            let rowid_idx = rowid_idx.unwrap();
-            let user_proj: Vec<usize> = projection
-                .cloned()
-                .unwrap_or_else(|| (0..self.schema.fields().len()).collect());
+        let mut execs: Vec<Arc<dyn ExecutionPlan>> = Vec::new();
+        let pruning = match self.file_pruning_predicate(state, filters) {
+            Ok(pruning) => pruning,
+            Err(error) => {
+                tracing::debug!(%error, "skipping plan-time file pruning");
+                None
+            },
+        };
+        let mut after_data_file_id = None;
+        loop {
+            let metadata = self.provider.get_table_file_metadata_page(
+                self.table_id,
+                self.snapshot_id,
+                after_data_file_id,
+                FILE_METADATA_BATCH_SIZE,
+            )?;
+            if metadata.is_empty() {
+                break;
+            }
+            if metadata.len() > FILE_METADATA_BATCH_SIZE {
+                return Err(DataFusionError::External(Box::new(
+                    crate::DuckLakeError::InvalidConfig(format!(
+                        "metadata provider returned {} files for a {}-file planning page",
+                        metadata.len(),
+                        FILE_METADATA_BATCH_SIZE
+                    )),
+                )));
+            }
+            let next_after = metadata.last().unwrap().file.data_file_id;
+            if after_data_file_id.map_or(false, |after| next_after <= after) {
+                return Err(DataFusionError::External(Box::new(
+                    crate::DuckLakeError::InvalidConfig(
+                        "metadata provider returned a non-advancing file page".to_string(),
+                    ),
+                )));
+            }
+            after_data_file_id = Some(next_after);
 
-            let mut execs: Vec<Arc<dyn ExecutionPlan>> = Vec::new();
-            for tf in table_files.iter().copied() {
-                // A merged partial file read below its partial_max needs per-row
-                // snapshot filtering; it always embeds its rowid, so the partial
-                // path serves the projected rowid directly.
-                let exec = if self.needs_snapshot_filter(tf) {
-                    let output_schema = self.output_schema_for_projection(&user_proj, rowid_idx);
-                    self.build_exec_for_partial_file(state, tf, output_schema)
+            let mut catalog_file_statistics = Vec::new();
+            let mut table_files = Vec::with_capacity(metadata.len());
+            for DuckLakeFileMetadata {
+                file,
+                column_statistics,
+            } in metadata
+            {
+                table_files.push(file);
+                catalog_file_statistics.extend(column_statistics);
+            }
+            let (_, file_statistics) = build_datafusion_statistics(
+                self.physical_schema.as_ref(),
+                &self.columns,
+                &table_files,
+                DuckLakeStatistics {
+                    files: catalog_file_statistics,
+                    ..Default::default()
+                },
+                false,
+                true,
+            );
+            #[cfg(feature = "encryption")]
+            self.configure_encryption_factory(&table_files)?;
+
+            let table_files =
+                self.prune_table_files(pruning.as_ref(), &table_files, &file_statistics);
+
+            if rowid_in_proj {
+                let rowid_idx = rowid_idx.unwrap();
+                let user_proj: Vec<usize> = projection
+                    .cloned()
+                    .unwrap_or_else(|| (0..self.schema.fields().len()).collect());
+                for table_file in table_files {
+                    let exec = if self.needs_snapshot_filter(table_file) {
+                        let output_schema =
+                            self.output_schema_for_projection(&user_proj, rowid_idx);
+                        self.build_exec_for_partial_file(state, table_file, output_schema)
+                            .await?
+                    } else {
+                        self.build_exec_for_file_with_rowid(
+                            state,
+                            table_file,
+                            &file_statistics,
+                            &user_proj,
+                            rowid_idx,
+                            limit,
+                        )
                         .await?
-                } else {
-                    self.build_exec_for_file_with_rowid(state, tf, &user_proj, rowid_idx, limit)
-                        .await?
-                };
-                execs.push(exec);
+                    };
+                    execs.push(exec);
+                }
+                continue;
             }
 
+            let (needs_filter, rest): (Vec<_>, Vec<_>) = table_files
+                .into_iter()
+                .partition(|table_file| self.needs_snapshot_filter(table_file));
+            let (files_with_deletes, files_without_deletes): (Vec<_>, Vec<_>) = rest
+                .into_iter()
+                .partition(|table_file| table_file.delete_file.is_some());
+
+            if !files_without_deletes.is_empty() {
+                execs.push(
+                    self.build_exec_for_files_without_deletes(
+                        state,
+                        &files_without_deletes,
+                        &file_statistics,
+                        projection,
+                        limit,
+                    )
+                    .await?,
+                );
+            }
+            for table_file in files_with_deletes {
+                execs.push(
+                    self.build_exec_for_file_with_deletes(
+                        state,
+                        table_file,
+                        &file_statistics,
+                        projection,
+                        limit,
+                    )
+                    .await?,
+                );
+            }
+            for table_file in needs_filter {
+                let output_schema = match projection {
+                    Some(indices) => Arc::new(self.schema.project(indices)?),
+                    None => self.schema.clone(),
+                };
+                execs.push(
+                    self.build_exec_for_partial_file(state, table_file, output_schema)
+                        .await?,
+                );
+            }
+        }
+
+        if rowid_in_proj {
             if execs.is_empty() {
                 use datafusion::physical_plan::empty::EmptyExec;
-                let projected_schema = self.output_schema_for_projection(&user_proj, rowid_idx);
-                return Ok(Arc::new(EmptyExec::new(projected_schema)));
+                let rowid_idx = rowid_idx.unwrap();
+                let user_proj: Vec<usize> = projection
+                    .cloned()
+                    .unwrap_or_else(|| (0..self.schema.fields().len()).collect());
+                let schema = self.output_schema_for_projection(&user_proj, rowid_idx);
+                return Ok(Arc::new(EmptyExec::new(schema)));
             }
-
             return combine_execution_plans(execs);
-        }
-
-        // Fast path: rowid not projected. All projection indices refer to
-        // physical columns, so the existing logic works untouched.
-        //
-        // First peel off merged partial files being read below their partial_max
-        // — they need per-row snapshot filtering and are handled per file. Every
-        // other file (ordinary, or a partial file at/after its partial_max) takes
-        // the existing grouped/with-deletes paths unchanged.
-        let (needs_filter, rest): (Vec<_>, Vec<_>) = table_files
-            .into_iter()
-            .partition(|tf| self.needs_snapshot_filter(tf));
-        let (files_with_deletes, files_without_deletes): (Vec<_>, Vec<_>) =
-            rest.into_iter().partition(|tf| tf.delete_file.is_some());
-
-        let mut execs: Vec<Arc<dyn ExecutionPlan>> = Vec::new();
-
-        // Create single exec for all files without deletes (more efficient)
-        if !files_without_deletes.is_empty() {
-            let exec = self
-                .build_exec_for_files_without_deletes(
-                    state,
-                    &files_without_deletes,
-                    projection,
-                    limit,
-                )
-                .await?;
-            execs.push(exec);
-        }
-
-        // Only create separate execs for files with deletes
-        for table_file in files_with_deletes {
-            let exec = self
-                .build_exec_for_file_with_deletes(state, table_file, projection, limit)
-                .await?;
-            execs.push(exec);
-        }
-
-        // Per-file snapshot-filtered execs for partial files read in the past.
-        for table_file in needs_filter {
-            let output_schema = match projection {
-                Some(indices) => Arc::new(self.schema.project(indices)?),
-                None => self.schema.clone(),
-            };
-            let exec = self
-                .build_exec_for_partial_file(state, table_file, output_schema)
-                .await?;
-            execs.push(exec);
         }
 
         // Inlined data: rows DuckDB's data-inlining optimization stored directly
@@ -2455,8 +2530,11 @@ impl TableProvider for DuckLakeTable {
         // `scan()` does — but no data scan and no mutation happen here; the exec
         // collects each scan and performs the rewrite + atomic commit at execute
         // time.
-        let mut scans = Vec::with_capacity(self.table_files.len());
-        for tf in &self.table_files {
+        let table_files = self
+            .files()
+            .map_err(|error| DataFusionError::External(Box::new(error)))?;
+        let mut scans = Vec::with_capacity(table_files.len());
+        for tf in &table_files {
             scans.push(self.build_update_scan(state, tf).await?);
         }
 
@@ -2617,6 +2695,228 @@ fn is_object_store_not_found(err: &DataFusionError) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::metadata_provider::{
+        ColumnWithTable, DataFileChange, DeleteFileChange, FileWithTable, SchemaMetadata,
+        SnapshotMetadata, TableMetadata, TableWithSchema,
+    };
+    use datafusion::prelude::{SessionContext, col, lit};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Debug, Default)]
+    struct LazyMillionFileProvider {
+        eager_file_reads: AtomicUsize,
+        max_page: AtomicUsize,
+    }
+
+    impl MetadataProvider for LazyMillionFileProvider {
+        fn get_current_snapshot(&self) -> Result<i64> {
+            Ok(1)
+        }
+
+        fn get_data_path(&self) -> Result<String> {
+            Ok("memory:///".to_string())
+        }
+
+        fn list_snapshots(&self) -> Result<Vec<SnapshotMetadata>> {
+            unimplemented!()
+        }
+
+        fn list_schemas(&self, _snapshot_id: i64) -> Result<Vec<SchemaMetadata>> {
+            unimplemented!()
+        }
+
+        fn list_tables(&self, _schema_id: i64, _snapshot_id: i64) -> Result<Vec<TableMetadata>> {
+            unimplemented!()
+        }
+
+        fn get_table_structure(
+            &self,
+            _table_id: i64,
+            _snapshot_id: i64,
+        ) -> Result<Vec<DuckLakeTableColumn>> {
+            Ok(vec![DuckLakeTableColumn::new(
+                1,
+                "id".to_string(),
+                "bigint".to_string(),
+                false,
+            )])
+        }
+
+        fn get_table_files_for_select(
+            &self,
+            _table_id: i64,
+            _snapshot_id: i64,
+        ) -> Result<Vec<DuckLakeTableFile>> {
+            self.eager_file_reads.fetch_add(1, Ordering::Relaxed);
+            panic!("the eager file API must not be used while planning a scan")
+        }
+
+        fn get_table_summary_statistics(
+            &self,
+            _table_id: i64,
+            _snapshot_id: i64,
+        ) -> Result<DuckLakeStatistics> {
+            Ok(DuckLakeStatistics {
+                table: Some(crate::metadata_provider::DuckLakeTableStatistics {
+                    record_count: Some(1_000_000),
+                    file_size_bytes: Some(1_000_000),
+                }),
+                ..Default::default()
+            })
+        }
+
+        fn get_table_file_metadata_page(
+            &self,
+            _table_id: i64,
+            snapshot_id: i64,
+            after_data_file_id: Option<i64>,
+            limit: usize,
+        ) -> Result<Vec<DuckLakeFileMetadata>> {
+            let start = after_data_file_id.unwrap_or(0) + 1;
+            let end = (start + i64::try_from(limit).unwrap()).min(1_000_001);
+            let page: Vec<_> = (start..end)
+                .map(|data_file_id| DuckLakeFileMetadata {
+                    file: DuckLakeTableFile {
+                        data_file_id,
+                        file: DuckLakeFileData::new(
+                            format!("file-{data_file_id}.parquet"),
+                            true,
+                            1,
+                        ),
+                        delete_file_id: None,
+                        delete_file: None,
+                        row_id_start: Some(data_file_id - 1),
+                        snapshot_id: Some(snapshot_id),
+                        begin_snapshot: Some(1),
+                        schema_version: Some(0),
+                        partial_max: None,
+                        max_row_count: Some(1),
+                        delete_count: None,
+                    },
+                    column_statistics: vec![DuckLakeFileColumnStatistics {
+                        data_file_id,
+                        column_id: 1,
+                        column_size_bytes: Some(1),
+                        value_count: Some(1),
+                        null_count: Some(0),
+                        min_value: Some(data_file_id.to_string()),
+                        max_value: Some(data_file_id.to_string()),
+                    }],
+                })
+                .collect();
+            self.max_page.fetch_max(page.len(), Ordering::Relaxed);
+            Ok(page)
+        }
+
+        fn get_schema_by_name(
+            &self,
+            _name: &str,
+            _snapshot_id: i64,
+        ) -> Result<Option<SchemaMetadata>> {
+            unimplemented!()
+        }
+
+        fn get_table_by_name(
+            &self,
+            _schema_id: i64,
+            _name: &str,
+            _snapshot_id: i64,
+        ) -> Result<Option<TableMetadata>> {
+            unimplemented!()
+        }
+
+        fn table_exists(&self, _schema_id: i64, _name: &str, _snapshot_id: i64) -> Result<bool> {
+            unimplemented!()
+        }
+
+        fn list_all_tables(&self, _snapshot_id: i64) -> Result<Vec<TableWithSchema>> {
+            unimplemented!()
+        }
+
+        fn list_all_columns(&self, _snapshot_id: i64) -> Result<Vec<ColumnWithTable>> {
+            unimplemented!()
+        }
+
+        fn list_all_files(&self, _snapshot_id: i64) -> Result<Vec<FileWithTable>> {
+            unimplemented!()
+        }
+
+        fn get_data_files_added_between_snapshots(
+            &self,
+            _table_id: i64,
+            _start_snapshot: i64,
+            _end_snapshot: i64,
+        ) -> Result<Vec<DataFileChange>> {
+            unimplemented!()
+        }
+
+        fn get_delete_files_added_between_snapshots(
+            &self,
+            _table_id: i64,
+            _start_snapshot: i64,
+            _end_snapshot: i64,
+        ) -> Result<Vec<DeleteFileChange>> {
+            unimplemented!()
+        }
+    }
+
+    #[test]
+    fn planning_prunes_a_lazy_million_file_fixture_in_bounded_pages() -> Result<()> {
+        let provider = Arc::new(LazyMillionFileProvider::default());
+        let table = DuckLakeTable::new(
+            1,
+            "events",
+            provider.clone(),
+            1,
+            Arc::new(ObjectStoreUrl::parse("memory://").unwrap()),
+            String::new(),
+        )?;
+        assert_eq!(provider.eager_file_reads.load(Ordering::Relaxed), 0);
+
+        let state = SessionContext::new().state();
+        let filters = [col("id").eq(lit(999_999_i64))];
+        let pruning = table
+            .file_pruning_predicate(&state, &filters)
+            .unwrap()
+            .unwrap();
+        let mut after = None;
+        let mut retained = Vec::new();
+        loop {
+            let metadata =
+                provider.get_table_file_metadata_page(1, 1, after, FILE_METADATA_BATCH_SIZE)?;
+            if metadata.is_empty() {
+                break;
+            }
+            after = metadata.last().map(|entry| entry.file.data_file_id);
+            let files: Vec<_> = metadata.iter().map(|entry| entry.file.clone()).collect();
+            let catalog_statistics = metadata
+                .into_iter()
+                .flat_map(|entry| entry.column_statistics)
+                .collect();
+            let (_, file_statistics) = build_datafusion_statistics(
+                table.physical_schema.as_ref(),
+                &table.columns,
+                &files,
+                DuckLakeStatistics {
+                    files: catalog_statistics,
+                    ..Default::default()
+                },
+                false,
+                true,
+            );
+            retained.extend(
+                table
+                    .prune_table_files(Some(&pruning), &files, &file_statistics)
+                    .into_iter()
+                    .map(|file| file.data_file_id),
+            );
+        }
+
+        assert_eq!(provider.max_page.load(Ordering::Relaxed), 64);
+        assert_eq!(retained, vec![999_999]);
+        assert_eq!(provider.eager_file_reads.load(Ordering::Relaxed), 0);
+        Ok(())
+    }
 
     #[test]
     fn test_validated_file_size_positive() {

--- a/src/table.rs
+++ b/src/table.rs
@@ -383,10 +383,23 @@ fn build_datafusion_statistics(
             if raw.contains_null == Some(false) {
                 output.null_count = Precision::Exact(0);
             }
-            output.min_value =
-                scalar_precision(raw.min_value.as_deref(), column, field_type, false);
-            output.max_value =
-                scalar_precision(raw.max_value.as_deref(), column, field_type, false);
+            output.min_value = scalar_precision(
+                raw.min_value.as_deref(),
+                column,
+                field_type,
+                raw.bounds_are_exact,
+            );
+            output.max_value = scalar_precision(
+                raw.max_value.as_deref(),
+                column,
+                field_type,
+                raw.bounds_are_exact,
+            );
+            output.byte_size = raw
+                .column_size_bytes
+                .and_then(|value| statistic_usize(value, "file_column_stats.column_size_bytes"))
+                .map(Precision::Inexact)
+                .unwrap_or(Precision::Absent);
         }
 
         if !file_metadata_complete {
@@ -2761,6 +2774,14 @@ mod tests {
                     record_count: Some(1_000_000),
                     file_size_bytes: Some(1_000_000),
                 }),
+                columns: vec![DuckLakeTableColumnStatistics {
+                    column_id: 1,
+                    contains_null: Some(false),
+                    min_value: Some("1".to_string()),
+                    max_value: Some("1000000".to_string()),
+                    column_size_bytes: Some(1_000_000),
+                    bounds_are_exact: true,
+                }],
                 ..Default::default()
             })
         }
@@ -2872,6 +2893,20 @@ mod tests {
             String::new(),
         )?;
         assert_eq!(provider.eager_file_reads.load(Ordering::Relaxed), 0);
+        let statistics = table.statistics().unwrap();
+        assert_eq!(statistics.num_rows, Precision::Exact(1_000_000));
+        assert_eq!(
+            statistics.column_statistics[0].min_value,
+            Precision::Exact(ScalarValue::Int64(Some(1)))
+        );
+        assert_eq!(
+            statistics.column_statistics[0].max_value,
+            Precision::Exact(ScalarValue::Int64(Some(1_000_000)))
+        );
+        assert_eq!(
+            statistics.column_statistics[0].byte_size,
+            Precision::Inexact(1_000_000)
+        );
 
         let state = SessionContext::new().state();
         let filters = [col("id").eq(lit(999_999_i64))];
@@ -2915,6 +2950,43 @@ mod tests {
         assert_eq!(provider.max_page.load(Ordering::Relaxed), 64);
         assert_eq!(retained, vec![999_999]);
         assert_eq!(provider.eager_file_reads.load(Ordering::Relaxed), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn summary_bounds_with_live_deletes_remain_inexact() -> Result<()> {
+        let columns =
+            vec![DuckLakeTableColumn::new(1, "id".to_string(), "integer".to_string(), false)];
+        let schema = build_arrow_schema(&columns)?;
+        let (statistics, _) = build_datafusion_statistics(
+            &schema,
+            &columns,
+            &[],
+            DuckLakeStatistics {
+                columns: vec![DuckLakeTableColumnStatistics {
+                    column_id: 1,
+                    contains_null: Some(false),
+                    min_value: Some("0".to_string()),
+                    max_value: Some("9".to_string()),
+                    column_size_bytes: Some(40),
+                    bounds_are_exact: false,
+                }],
+                ..Default::default()
+            },
+            true,
+            false,
+        );
+
+        let column = &statistics.column_statistics[0];
+        assert_eq!(
+            column.min_value,
+            Precision::Inexact(ScalarValue::Int32(Some(0)))
+        );
+        assert_eq!(
+            column.max_value,
+            Precision::Inexact(ScalarValue::Int32(Some(9)))
+        );
+        assert_eq!(column.byte_size, Precision::Inexact(40));
         Ok(())
     }
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -2277,7 +2277,7 @@ impl TableProvider for DuckLakeTable {
                 )));
             }
             let next_after = metadata.last().unwrap().file.data_file_id;
-            if after_data_file_id.map_or(false, |after| next_after <= after) {
+            if after_data_file_id.is_some_and(|after| next_after <= after) {
                 return Err(DataFusionError::External(Box::new(
                     crate::DuckLakeError::InvalidConfig(
                         "metadata provider returned a non-advancing file page".to_string(),

--- a/src/table.rs
+++ b/src/table.rs
@@ -2719,6 +2719,7 @@ mod tests {
     struct LazyMillionFileProvider {
         eager_file_reads: AtomicUsize,
         max_page: AtomicUsize,
+        page_calls: AtomicUsize,
     }
 
     impl MetadataProvider for LazyMillionFileProvider {
@@ -2793,6 +2794,7 @@ mod tests {
             after_data_file_id: Option<i64>,
             limit: usize,
         ) -> Result<Vec<DuckLakeFileMetadata>> {
+            self.page_calls.fetch_add(1, Ordering::Relaxed);
             let start = after_data_file_id.unwrap_or(0) + 1;
             let end = (start + i64::try_from(limit).unwrap()).min(1_000_001);
             let page: Vec<_> = (start..end)
@@ -2947,7 +2949,8 @@ mod tests {
             );
         }
 
-        assert_eq!(provider.max_page.load(Ordering::Relaxed), 64);
+        assert_eq!(provider.max_page.load(Ordering::Relaxed), 4_096);
+        assert_eq!(provider.page_calls.load(Ordering::Relaxed), 246);
         assert_eq!(retained, vec![999_999]);
         assert_eq!(provider.eager_file_reads.load(Ordering::Relaxed), 0);
         Ok(())


### PR DESCRIPTION
## Summary
- defer per-file metadata until `TableProvider::scan`
- page visible SQLite and PostgreSQL file metadata with a 64-file keyset cursor
- prune each page immediately and retain only files that may match
- keep full file loading explicit for mutation and compaction paths
- add a lazy million-file fixture covering zero eager reads, the 64-record bound, and one retained match

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- Cargo build/tests intentionally deferred while PolderDB's serialized Rust CI lane is active

Closes #21
