### PR TITLE
feat(write): roll back a committed append by retiring its data files

### DIFF
--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -747,6 +747,58 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
         ))
     }
 
+    /// Roll back a *pure-append* delta committed after `base_snapshot`: end
+    /// (retire) every live data file whose `begin_snapshot > base_snapshot` — the
+    /// files an append added on top of `base_snapshot` — in ONE new snapshot,
+    /// WITHOUT rewriting data, returning the table's live content to exactly what
+    /// it was at `base_snapshot`. This is the commit behind undoing an append that
+    /// committed its DuckLake snapshot but whose post-commit step (e.g. a search
+    /// index build) failed before the higher layer published it: the appended rows
+    /// sit at the catalog head, unreferenced by any published generation, and a
+    /// blind retry would stack a second copy on them. Retiring them here leaves a
+    /// clean base so the retry appends exactly once.
+    ///
+    /// Refuses with [`crate::DuckLakeError::Conflict`] if the delta since
+    /// `base_snapshot` is NOT a pure append — specifically if any of these exist
+    /// for the table: a delete file with `begin_snapshot > base_snapshot`, a data
+    /// file present at/before `base_snapshot` that was ended after it
+    /// (`begin_snapshot <= base_snapshot AND end_snapshot > base_snapshot`), or a
+    /// column version changed after it (`begin_snapshot > base_snapshot OR
+    /// end_snapshot > base_snapshot`). Forward-only file retirement cannot
+    /// faithfully revert a delete / replace / update / schema-promotion, so in
+    /// those cases the caller must keep its read freeze and surface the state
+    /// rather than expose a half-reverted table. The purity checks run BEFORE the
+    /// no-op return, so a delete-only orphan (no appended data file) still yields
+    /// `Conflict`, not a silent no-op.
+    ///
+    /// The guard covers every snapshot-visible change table this crate writes —
+    /// data files, delete files, and columns. This crate's write path produces no
+    /// inlined-data or partition-value rows (those DuckLake-spec tables are not part
+    /// of its schema), so there is nothing else to check. If inlined-data or
+    /// partition write support is ever added, extend the guard to reject a post-base
+    /// row there too, or this could silently treat such a delta as a pure append.
+    ///
+    /// Recomputes the visible stat totals (`record_count`, `file_size_bytes`, and
+    /// the per-column stats) from the surviving live files, and preserves
+    /// `next_row_id` (rowids stay monotonic — retired ranges are never reused).
+    /// Advances the catalog head LAST. Returns the new snapshot id, or `None` if no
+    /// appended files exist (a no-op — no snapshot is created).
+    ///
+    /// # Caller contract
+    /// `base_snapshot` MUST be a real `ducklake_snapshot.snapshot_id` — the table's
+    /// current published generation — because `begin_snapshot > base_snapshot` is
+    /// what distinguishes the orphaned append from published data. The caller MUST
+    /// serialize writes to the table (e.g. a per-table write lock) so no concurrent
+    /// legitimate append has a live file with `begin_snapshot > base_snapshot` that
+    /// this would wrongly retire.
+    ///
+    /// Default: unsupported; the SQLite and Postgres backends override it.
+    fn retire_appends_since(&self, _table_id: i64, _base_snapshot: i64) -> Result<Option<i64>> {
+        Err(DuckLakeError::InvalidConfig(
+            "retire_appends_since is not supported on this metadata backend".to_string(),
+        ))
+    }
+
     /// Register a data file that already carries DuckLake field-ids — e.g. a
     /// parquet copied verbatim from another catalog — adopting `column_ids` as
     /// the destination table's column ids so the file's embedded field-ids

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -628,6 +628,42 @@ async fn insert_file_column_stats(
     Ok(())
 }
 
+/// Read the table's live column generation as `(ColumnDef, column_id)`, ordered
+/// by `column_order`. Used to drive [`recompute_table_column_stats`]'s
+/// numeric-vs-not classification when the caller (e.g. `retire_appends_since`)
+/// doesn't already hold the column list the way a normal write does.
+async fn live_columns_for_stats(
+    table_id: i64,
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+) -> Result<(Vec<ColumnDef>, Vec<i64>)> {
+    let mut columns = Vec::new();
+    let mut column_ids = Vec::new();
+    for row in sqlx::query(
+        "SELECT column_id, column_name, column_type
+         FROM ducklake_column
+         WHERE table_id = $1 AND end_snapshot IS NULL
+         ORDER BY column_order",
+    )
+    .bind(table_id)
+    .fetch_all(&mut **tx)
+    .await?
+    {
+        let column_id: i64 = row.try_get(0)?;
+        let name: String = row.try_get(1)?;
+        let ducklake_type: String = row.try_get(2)?;
+        column_ids.push(column_id);
+        // Same-crate construction: the type string came from the catalog and is
+        // already valid, so skip ColumnDef::new's re-validation. `is_nullable` is
+        // irrelevant here — recompute_table_column_stats only reads the type.
+        columns.push(ColumnDef {
+            name,
+            ducklake_type,
+            is_nullable: true,
+        });
+    }
+    Ok((columns, column_ids))
+}
+
 /// Recompute `ducklake_table_column_stats` from the table's live files and
 /// replace the stored rows. See the SQLite writer's equivalent for the rationale
 /// (widen on insert, never tighten on delete; correct for every write mode).
@@ -2312,6 +2348,136 @@ impl MetadataWriter for PostgresMetadataWriter {
 
             tx.commit().await?;
             Ok(live_rows)
+        })
+    }
+
+    fn retire_appends_since(&self, table_id: i64, base_snapshot: i64) -> Result<Option<i64>> {
+        block_on(async {
+            // Metadata-only rollback of a pure-append delta, in one snapshot under
+            // the catalog lock: end every live data file added after base_snapshot,
+            // recompute the visible stats from the survivors, advance the head LAST.
+            // next_row_id is preserved (rowids never reused).
+            let mut tx = self.pool.begin().await?;
+            lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
+            assert_table_in_catalog(self.catalog_id, table_id, &mut tx).await?;
+
+            // Purity guard — the ONLY change since base may be appended data files.
+            // Checked before the no-op return so a delete-only / schema-only orphan
+            // surfaces as Conflict instead of a silent no-op. A post-base delete
+            // file, a base-era data file ended after base (replace/delete/update),
+            // or any post-base column version (schema promotion / add) all mean a
+            // non-append mutation we cannot faithfully revert with forward-only file
+            // retirement — refuse so the caller keeps its read freeze.
+            let impure_delete: Option<i64> = sqlx::query_scalar(
+                "SELECT 1::BIGINT FROM ducklake_delete_file
+                 WHERE table_id = $1 AND begin_snapshot > $2 LIMIT 1",
+            )
+            .bind(table_id)
+            .bind(base_snapshot)
+            .fetch_optional(&mut *tx)
+            .await?;
+            let impure_ended: Option<i64> = sqlx::query_scalar(
+                "SELECT 1::BIGINT FROM ducklake_data_file
+                 WHERE table_id = $1 AND begin_snapshot <= $2
+                   AND end_snapshot IS NOT NULL AND end_snapshot > $2 LIMIT 1",
+            )
+            .bind(table_id)
+            .bind(base_snapshot)
+            .fetch_optional(&mut *tx)
+            .await?;
+            let impure_column: Option<i64> = sqlx::query_scalar(
+                "SELECT 1::BIGINT FROM ducklake_column
+                 WHERE table_id = $1 AND (begin_snapshot > $2 OR end_snapshot > $2) LIMIT 1",
+            )
+            .bind(table_id)
+            .bind(base_snapshot)
+            .fetch_optional(&mut *tx)
+            .await?;
+            if impure_delete.is_some() || impure_ended.is_some() || impure_column.is_some() {
+                return Err(crate::DuckLakeError::Conflict(format!(
+                    "table {table_id}: changes since snapshot {base_snapshot} are not a pure \
+                     append (delete/replace/update or schema change present); refusing to retire"
+                )));
+            }
+
+            // Appended files to retire (live, begin_snapshot > base). No-op → None
+            // BEFORE allocating a snapshot, so repeated reconcile calls on a clean
+            // table never mint a content-free snapshot.
+            let has_appended: Option<i64> = sqlx::query_scalar(
+                "SELECT 1::BIGINT FROM ducklake_data_file
+                 WHERE table_id = $1 AND end_snapshot IS NULL AND begin_snapshot > $2 LIMIT 1",
+            )
+            .bind(table_id)
+            .bind(base_snapshot)
+            .fetch_optional(&mut *tx)
+            .await?;
+            if has_appended.is_none() {
+                return Ok(None);
+            }
+
+            let snapshot_id: i64 = sqlx::query(
+                "INSERT INTO ducklake_snapshot (snapshot_time, schema_version)
+                 VALUES (NOW(), 0) RETURNING snapshot_id",
+            )
+            .fetch_one(&mut *tx)
+            .await?
+            .try_get(0)?;
+            let prev_max: i64 = sqlx::query(
+                "SELECT COALESCE(MAX(s.schema_version), 0) FROM ducklake_snapshot s
+                 JOIN ducklake_catalog_snapshot_map m ON m.snapshot_id = s.snapshot_id
+                 WHERE m.catalog_id = $1",
+            )
+            .bind(self.catalog_id)
+            .fetch_one(&mut *tx)
+            .await?
+            .try_get(0)?;
+            sqlx::query("UPDATE ducklake_snapshot SET schema_version = $1 WHERE snapshot_id = $2")
+                .bind(prev_max.max(1))
+                .bind(snapshot_id)
+                .execute(&mut *tx)
+                .await?;
+
+            // Retire the appended files (append writes no delete files, so there are
+            // none to end — the purity guard above rejected any delete file > base).
+            sqlx::query(
+                "UPDATE ducklake_data_file SET end_snapshot = $1
+                 WHERE table_id = $2 AND end_snapshot IS NULL AND begin_snapshot > $3",
+            )
+            .bind(snapshot_id)
+            .bind(table_id)
+            .bind(base_snapshot)
+            .execute(&mut *tx)
+            .await?;
+
+            // Recompute the visible stat totals from the surviving live files
+            // (mirrors the compaction commit); next_row_id is deliberately not
+            // touched. With the pure-append guarantee, the survivors are exactly
+            // base_snapshot's files, so this restores base_snapshot's stats.
+            sqlx::query(
+                "UPDATE ducklake_table_stats SET
+                     record_count = (SELECT COALESCE(SUM(record_count), 0)
+                                     FROM ducklake_data_file
+                                     WHERE table_id = $1 AND end_snapshot IS NULL),
+                     file_size_bytes = (SELECT COALESCE(SUM(file_size_bytes), 0)
+                                        FROM ducklake_data_file
+                                        WHERE table_id = $1 AND end_snapshot IS NULL)
+                 WHERE table_id = $1",
+            )
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+
+            // Recompute per-column stats from the survivors too (register_data_file
+            // widened them when the appended file landed). Read the live column
+            // generation to drive the numeric-vs-not classification.
+            let (columns, column_ids) = live_columns_for_stats(table_id, &mut tx).await?;
+            recompute_table_column_stats(&mut tx, table_id, &columns, &column_ids).await?;
+
+            // advance_catalog_head MUST be the last write before commit.
+            advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
+
+            tx.commit().await?;
+            Ok(Some(snapshot_id))
         })
     }
 

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -1038,6 +1038,39 @@ async fn insert_file_column_stats(
     Ok(())
 }
 
+/// Read the table's live column generation as `(ColumnDef, column_id)`, ordered
+/// by `column_order`. Used to drive [`recompute_table_column_stats`] from
+/// `retire_appends_since`, which (unlike a normal write) doesn't already hold the
+/// column list. `is_nullable` is irrelevant — recompute only reads the type.
+async fn live_columns_for_stats(
+    table_id: i64,
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+) -> Result<(Vec<ColumnDef>, Vec<i64>)> {
+    let mut columns = Vec::new();
+    let mut column_ids = Vec::new();
+    for row in sqlx::query(
+        "SELECT column_id, column_name, column_type
+         FROM ducklake_column
+         WHERE table_id = ? AND end_snapshot IS NULL
+         ORDER BY column_order",
+    )
+    .bind(table_id)
+    .fetch_all(&mut **tx)
+    .await?
+    {
+        let column_id: i64 = row.try_get(0)?;
+        let name: String = row.try_get(1)?;
+        let ducklake_type: String = row.try_get(2)?;
+        column_ids.push(column_id);
+        columns.push(ColumnDef {
+            name,
+            ducklake_type,
+            is_nullable: true,
+        });
+    }
+    Ok((columns, column_ids))
+}
+
 /// Recompute the table-wide `ducklake_table_column_stats` roll-up (optimizer
 /// stats) from the table's currently-live files, and replace the stored rows.
 ///
@@ -2250,6 +2283,108 @@ impl MetadataWriter for SqliteMetadataWriter {
                 schema_id,
                 table_id,
             })
+        })
+    }
+
+    fn retire_appends_since(&self, table_id: i64, base_snapshot: i64) -> Result<Option<i64>> {
+        block_on(async {
+            // Metadata-only rollback of a pure-append delta in one snapshot: end
+            // every live data file added after base_snapshot, recompute the visible
+            // stats from the survivors. next_row_id is preserved (rowids never
+            // reused). SQLite is single-catalog — head is implicit MAX(snapshot_id),
+            // so there is no lock_catalog / advance_catalog_head (mirrors truncate).
+            let mut tx = self.pool.begin().await?;
+
+            // Write-lock-first (mirrors `commit_truncate`): allocate the snapshot up
+            // front so the purity proof and no-op check run under SQLite's write lock
+            // even if the caller hasn't externally serialized writes. On a Conflict or
+            // no-op we return WITHOUT committing, so the allocation rolls back — no
+            // snapshot row and no id gap. Non-DDL, so schema_version carries forward.
+            let (snapshot_id, _schema_version) = insert_snapshot(&mut tx).await?;
+
+            // Purity guard — see the trait doc. A post-base delete file, a base-era
+            // data file ended after base, or a post-base column version means a
+            // non-append mutation we cannot faithfully revert with forward-only
+            // retirement → Conflict.
+            let impure_delete: Option<i64> = sqlx::query_scalar(
+                "SELECT 1 FROM ducklake_delete_file
+                 WHERE table_id = ? AND begin_snapshot > ? LIMIT 1",
+            )
+            .bind(table_id)
+            .bind(base_snapshot)
+            .fetch_optional(&mut *tx)
+            .await?;
+            let impure_ended: Option<i64> = sqlx::query_scalar(
+                "SELECT 1 FROM ducklake_data_file
+                 WHERE table_id = ? AND begin_snapshot <= ?
+                   AND end_snapshot IS NOT NULL AND end_snapshot > ? LIMIT 1",
+            )
+            .bind(table_id)
+            .bind(base_snapshot)
+            .bind(base_snapshot)
+            .fetch_optional(&mut *tx)
+            .await?;
+            let impure_column: Option<i64> = sqlx::query_scalar(
+                "SELECT 1 FROM ducklake_column
+                 WHERE table_id = ? AND (begin_snapshot > ? OR end_snapshot > ?) LIMIT 1",
+            )
+            .bind(table_id)
+            .bind(base_snapshot)
+            .bind(base_snapshot)
+            .fetch_optional(&mut *tx)
+            .await?;
+            if impure_delete.is_some() || impure_ended.is_some() || impure_column.is_some() {
+                return Err(crate::DuckLakeError::Conflict(format!(
+                    "table {table_id}: changes since snapshot {base_snapshot} are not a pure \
+                     append (delete/replace/update or schema change present); refusing to retire"
+                )));
+            }
+
+            // No-op → None (no snapshot) if nothing was appended after base.
+            let has_appended: Option<i64> = sqlx::query_scalar(
+                "SELECT 1 FROM ducklake_data_file
+                 WHERE table_id = ? AND end_snapshot IS NULL AND begin_snapshot > ? LIMIT 1",
+            )
+            .bind(table_id)
+            .bind(base_snapshot)
+            .fetch_optional(&mut *tx)
+            .await?;
+            if has_appended.is_none() {
+                return Ok(None);
+            }
+
+            sqlx::query(
+                "UPDATE ducklake_data_file SET end_snapshot = ?
+                 WHERE table_id = ? AND end_snapshot IS NULL AND begin_snapshot > ?",
+            )
+            .bind(snapshot_id)
+            .bind(table_id)
+            .bind(base_snapshot)
+            .execute(&mut *tx)
+            .await?;
+
+            // Recompute visible totals from the survivors; next_row_id untouched.
+            sqlx::query(
+                "UPDATE ducklake_table_stats SET
+                     record_count = (SELECT COALESCE(SUM(record_count), 0)
+                                     FROM ducklake_data_file
+                                     WHERE table_id = ? AND end_snapshot IS NULL),
+                     file_size_bytes = (SELECT COALESCE(SUM(file_size_bytes), 0)
+                                        FROM ducklake_data_file
+                                        WHERE table_id = ? AND end_snapshot IS NULL)
+                 WHERE table_id = ?",
+            )
+            .bind(table_id)
+            .bind(table_id)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+
+            let (columns, column_ids) = live_columns_for_stats(table_id, &mut tx).await?;
+            recompute_table_column_stats(&mut tx, table_id, &columns, &column_ids).await?;
+
+            tx.commit().await?;
+            Ok(Some(snapshot_id))
         })
     }
 
@@ -3754,5 +3889,133 @@ mod tests {
         let result =
             writer.begin_write_transaction("main", "bad\ttable", &columns, WriteMode::Replace);
         assert!(result.is_err());
+    }
+
+    async fn read_end_snapshot(writer: &SqliteMetadataWriter, path: &str) -> Option<i64> {
+        sqlx::query("SELECT end_snapshot FROM ducklake_data_file WHERE path = ?")
+            .bind(path)
+            .fetch_one(&writer.pool)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap()
+    }
+
+    async fn max_snapshot(writer: &SqliteMetadataWriter) -> i64 {
+        sqlx::query_scalar("SELECT COALESCE(MAX(snapshot_id), 0) FROM ducklake_snapshot")
+            .fetch_one(&writer.pool)
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn retire_appends_since_rolls_back_pure_append() {
+        let (writer, _temp) = create_test_writer().await;
+        // Base generation: append file A -> commits the published snapshot.
+        let s0 = reserve_snapshot(&writer).await;
+        let (schema_id, _) = writer.get_or_create_schema("main", None, s0).unwrap();
+        let (table_id, _) = writer
+            .get_or_create_table(schema_id, "t", None, s0)
+            .unwrap();
+        let file_a = DataFileInfo::new("a.parquet", 1000, 100).with_footer_size(64);
+        let base = writer
+            .register_data_file(
+                table_id,
+                "main",
+                "t",
+                s0,
+                &file_a,
+                WriteMode::Append,
+                0,
+                &[],
+                &[],
+            )
+            .unwrap()
+            .snapshot_id;
+
+        // Append file B on top (the orphan): begin_snapshot > base.
+        let s1 = reserve_snapshot(&writer).await;
+        let file_b = DataFileInfo::new("b.parquet", 2000, 50).with_footer_size(64);
+        writer
+            .register_data_file(
+                table_id,
+                "main",
+                "t",
+                s1,
+                &file_b,
+                WriteMode::Append,
+                base,
+                &[],
+                &[],
+            )
+            .unwrap();
+
+        let (rc_before, nri_before, size_before) = read_table_stats(&writer, table_id).await;
+        assert_eq!((rc_before, nri_before, size_before), (150, 150, 3000));
+
+        // Roll back the append delta above base.
+        let new_snap = writer.retire_appends_since(table_id, base).unwrap();
+        assert!(new_snap.is_some(), "expected a compensating snapshot");
+
+        // File A stays live; file B retired.
+        assert!(read_end_snapshot(&writer, "a.parquet").await.is_none());
+        assert!(read_end_snapshot(&writer, "b.parquet").await.is_some());
+
+        // Stats restored to base; next_row_id preserved (rowids never reused).
+        let (rc_after, nri_after, size_after) = read_table_stats(&writer, table_id).await;
+        assert_eq!(rc_after, 100, "record_count back to base");
+        assert_eq!(size_after, 1000, "file_size_bytes back to base");
+        assert_eq!(nri_after, 150, "next_row_id preserved");
+
+        // Idempotent: nothing left above base -> no-op, no content-free snapshot.
+        let head = max_snapshot(&writer).await;
+        assert!(
+            writer
+                .retire_appends_since(table_id, base)
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(
+            max_snapshot(&writer).await,
+            head,
+            "no snapshot minted on no-op"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn retire_appends_since_refuses_non_append_delta() {
+        let (writer, _temp) = create_test_writer().await;
+        let s0 = reserve_snapshot(&writer).await;
+        let (schema_id, _) = writer.get_or_create_schema("main", None, s0).unwrap();
+        let (table_id, _) = writer
+            .get_or_create_table(schema_id, "t", None, s0)
+            .unwrap();
+        let file_a = DataFileInfo::new("a.parquet", 1000, 100).with_footer_size(64);
+        let base = writer
+            .register_data_file(
+                table_id,
+                "main",
+                "t",
+                s0,
+                &file_a,
+                WriteMode::Append,
+                0,
+                &[],
+                &[],
+            )
+            .unwrap()
+            .snapshot_id;
+
+        // A non-append mutation after base: truncate ends file A
+        // (begin_snapshot <= base, end_snapshot > base).
+        writer.commit_truncate(table_id, "main", "t", base).unwrap();
+
+        // The delta since base is no longer a pure append -> Conflict, so the
+        // caller keeps its read freeze rather than exposing a half-reverted table.
+        let err = writer.retire_appends_since(table_id, base).unwrap_err();
+        assert!(
+            matches!(err, crate::DuckLakeError::Conflict(_)),
+            "expected Conflict, got {err:?}"
+        );
     }
 }


### PR DESCRIPTION
## What

Add `MetadataWriter::retire_appends_since(table_id, base_snapshot)` — a spec-native way to
**roll back a pure-append delta** committed after a base snapshot. It ends (via `end_snapshot`,
in one new snapshot, without rewriting data) every live data file with `begin_snapshot > base_snapshot`,
returning the table's live content to exactly its base generation. Implemented for the Postgres and
SQLite backends; other backends get the default `unsupported` error.

## Why

A caller can commit a DuckLake append snapshot and only afterwards discover a downstream step failed
(e.g. building an external search index over the new snapshot). The appended rows then sit at the
catalog head, unreferenced by any published generation, and a blind retry stacks a second copy on them.

DuckLake forbids deleting the most-recent snapshot (`ducklake_expire_snapshots` always keeps
`MAX(snapshot_id)`), so "undo the last commit" cannot be a snapshot deletion. The spec-native lever is
**forward `end_snapshot` retirement** — the same mechanism behind `DELETE`/replace/compaction. This
primitive applies it, scoped to the files appended after the base.

## Safety / semantics

- **Purity guard.** Refuses with `Conflict` if the delta since `base_snapshot` is not a pure append:
  a delete file `begin_snapshot > base`, a base-era data file ended after base
  (`begin_snapshot <= base AND end_snapshot > base`), or a column change (`begin/end_snapshot > base`).
  Forward-only retirement cannot faithfully revert a delete/replace/update/schema-promotion, so those
  are surfaced rather than half-reverted. The guard runs *before* the no-op return, so a delete-only
  orphan yields `Conflict`, not a silent no-op. (This crate's write path produces no inlined-data or
  partition rows, so there is nothing else to check; the doc notes this must be extended if that
  changes.)
- **Stats.** Recomputes `record_count`/`file_size_bytes` and the per-column roll-up from the surviving
  live files (mirrors the compaction commit); preserves `next_row_id` (rowids stay monotonic).
- **Head/locking.** Postgres takes `lock_catalog` and advances the head last; SQLite is write-lock-first
  (allocates the snapshot up front so the purity proof runs under the write lock) and returns without
  committing on a `Conflict`/no-op so the allocation rolls back. Returns the new snapshot id, or `None`
  when nothing was appended after base.
- **Caller contract:** `base_snapshot` must be a real published `ducklake_snapshot.snapshot_id`, and the
  caller must serialize writes to the table.

## Tests

SQLite unit tests: a pure-append delta rolls back to base (data file retired, stats restored,
`next_row_id` preserved), the no-op path mints no snapshot, and a non-append delta (a post-base
truncate) is refused with `Conflict`.

## Note on base

Branched from `9d121eb` (the released `0.5.0` line) rather than the current `main` tip, to keep it in
lockstep with a downstream consumer that pins that rev; can be rebased onto `main` before merge (the
one intervening commit, #181, is an unrelated read-planning change).
