### PR TITLE
feat(cdc)!: official DuckLake semantics — inclusive bounds, leading CDC columns, pure deletes (#179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   metadata columns `(snapshot_id, rowid, change_type)` lead, followed by the table
   columns. Previously they trailed. Queries selecting columns by name are unaffected;
   `SELECT *` consumers and positional readers must adjust (#179).
+- **BREAKING**: `ducklake_table_changes` now emits pure deletes as
+  `change_type='delete'` rows carrying the deleted rows' old values, matching official
+  DuckLake. Previously they were omitted (available only via `ducklake_table_deletions`,
+  which is unchanged). Consumers reading both feeds should de-duplicate deletions or
+  switch to a single feed (#179).
 
 ### Added
 - Differential CDC conformance suite: runs official DuckDB `ducklake_table_changes` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   changes committed in snapshots `start..=end`. Previously the start bound was exclusive.
   Migration: callers paging with `(last, now]` cursors should pass `last + 1` as the new
   start (#179).
+- **BREAKING**: the CDC feeds' column order now matches official DuckLake — the
+  metadata columns `(snapshot_id, rowid, change_type)` lead, followed by the table
+  columns. Previously they trailed. Queries selecting columns by name are unaffected;
+  `SELECT *` consumers and positional readers must adjust (#179).
 
 ### Added
 - Differential CDC conformance suite: runs official DuckDB `ducklake_table_changes` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING**: `ducklake_table_changes` / `ducklake_table_deletions` snapshot bounds
+  are now inclusive on both ends, matching official DuckLake: `(t, start, end)` returns
+  changes committed in snapshots `start..=end`. Previously the start bound was exclusive.
+  Migration: callers paging with `(last, now]` cursors should pass `last + 1` as the new
+  start (#179).
+
 ### Added
 - Differential CDC conformance suite: runs official DuckDB `ducklake_table_changes` /
   `ducklake_table_deletions` and this crate's feeds on identical catalogs and diffs
   the results, with explicit normalizers for the documented surface differences (#179).
 
 ### Fixed
-- DuckDB backend: `ducklake_table_deletions` treated the start snapshot as inclusive
-  (`BETWEEN`) while the insert feed treated it as exclusive, so deletions committed
-  exactly at a window's start snapshot were reported again in the next window.
-  Both positional and full-file delete lookups now follow the documented
-  `(start, end]` contract, matching the SQLite/PostgreSQL/MySQL backends (#179).
+- DuckDB backend: `ducklake_table_deletions` used a different start bound than the
+  insert feed, so deletions committed exactly at a window's start snapshot were
+  reported inconsistently between the two feeds. All backends and both feeds now
+  share a single window contract — the inclusive-on-both-ends semantics described
+  under **Changed** (#179).
 
 ## [0.5.0] - 2026-07-15
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -189,11 +189,15 @@ Known edges:
   with a conflict** (the compare-and-swap that also guards genuine concurrency — it is what
   prevents a stale rewrite from resurrecting superseded rows). Re-open the catalog (or create
   a fresh `SessionContext`) between mutating statements so it binds to the latest snapshot.
-- **`UPDATE` change-feed correlation is not available on encrypted (PME) catalogs.**
-  `ducklake_table_changes` still works on encrypted catalogs, but a range containing an
-  `UPDATE` surfaces its rewritten rows as plain `insert`s rather than being correlated into
-  `update_preimage`/`update_postimage` (the correlation reads parquet footers/rows the
-  change-feed path does not decrypt). Non-encrypted catalogs correlate normally.
+- **The change feed is degraded on encrypted (PME) catalogs.**
+  `ducklake_table_changes` still works on encrypted catalogs for inserted rows, but a
+  range containing an `UPDATE` surfaces its rewritten rows as plain `insert`s rather
+  than being correlated into `update_preimage`/`update_postimage`, and `delete` rows
+  are missing entirely (the correlated path reads parquet footers/rows the change-feed
+  path does not decrypt). A window whose only changes are deletes carries no data file
+  to detect encryption from, so it fails at read time on an encrypted catalog rather
+  than returning wrong results. Non-encrypted catalogs emit the full official
+  change-set (inserts, deletes, update pre/postimages).
 - **No partition-based file pruning** on read.
 - **Complex / nested types** have minimal support.
 - **DuckDB-encrypted (non-PME) Parquet files** are not supported (only PME).

--- a/src/metadata_provider.rs
+++ b/src/metadata_provider.rs
@@ -115,7 +115,7 @@ pub const SQL_GET_DATA_FILES_ADDED_BETWEEN_SNAPSHOTS: &str = "
         data.row_id_start
     FROM ducklake_data_file AS data
     WHERE data.table_id = ?
-      AND data.begin_snapshot > ?
+      AND data.begin_snapshot >= ?
       AND data.begin_snapshot <= ?
     ORDER BY data.begin_snapshot";
 
@@ -139,7 +139,7 @@ current_delete AS (
     FROM ducklake_delete_file df
     CROSS JOIN params p
     WHERE df.table_id = p.table_identifier
-      AND df.begin_snapshot > p.start_snapshot
+      AND df.begin_snapshot >= p.start_snapshot
       AND df.begin_snapshot <= p.finish_snapshot
 ),
 
@@ -224,7 +224,7 @@ LEFT JOIN LATERAL (
 ) pd ON true
 CROSS JOIN params p
 WHERE data.table_id = p.table_identifier
-  AND data.end_snapshot > p.start_snapshot
+  AND data.end_snapshot >= p.start_snapshot
   AND data.end_snapshot <= p.finish_snapshot;
 ";
 
@@ -870,8 +870,8 @@ pub trait MetadataProvider: Send + Sync + std::fmt::Debug {
 
     // Change tracking methods for table_changes (CDC) functionality
 
-    /// Get data files added between two snapshots (exclusive start, inclusive end)
-    /// Returns files where begin_snapshot > start_snapshot AND begin_snapshot <= end_snapshot
+    /// Get data files added between two snapshots (inclusive on both ends, matching official DuckLake)
+    /// Returns files where begin_snapshot >= start_snapshot AND begin_snapshot <= end_snapshot
     /// These represent INSERT changes - new rows added to the table
     fn get_data_files_added_between_snapshots(
         &self,
@@ -880,8 +880,8 @@ pub trait MetadataProvider: Send + Sync + std::fmt::Debug {
         end_snapshot: i64,
     ) -> Result<Vec<DataFileChange>>;
 
-    /// Get delete files added between two snapshots (exclusive start, inclusive end)
-    /// Returns delete files where begin_snapshot > start_snapshot AND begin_snapshot <= end_snapshot
+    /// Get delete files added between two snapshots (inclusive on both ends, matching official DuckLake)
+    /// Returns delete files where begin_snapshot >= start_snapshot AND begin_snapshot <= end_snapshot
     /// These represent DELETE changes - rows removed from the table
     fn get_delete_files_added_between_snapshots(
         &self,

--- a/src/metadata_provider_mysql.rs
+++ b/src/metadata_provider_mysql.rs
@@ -867,7 +867,7 @@ impl MetadataProvider for MySqlMetadataProvider {
                     data.row_id_start
                 FROM ducklake_data_file AS data
                 WHERE data.table_id = ?
-                  AND data.begin_snapshot > ?
+                  AND data.begin_snapshot >= ?
                   AND data.begin_snapshot <= ?
                 ORDER BY data.begin_snapshot",
             )
@@ -915,7 +915,7 @@ WITH current_delete AS (
         ddf.encryption_key
     FROM ducklake_delete_file ddf
     WHERE ddf.table_id = ?
-      AND ddf.begin_snapshot > ?
+      AND ddf.begin_snapshot >= ?
       AND ddf.begin_snapshot <= ?
 ),
 
@@ -994,7 +994,7 @@ LEFT JOIN LATERAL (
     LIMIT 1
 ) prev ON true
 WHERE data.table_id = ?
-  AND data.end_snapshot > ?
+  AND data.end_snapshot >= ?
   AND data.end_snapshot <= ?
 "#,
             )

--- a/src/metadata_provider_postgres.rs
+++ b/src/metadata_provider_postgres.rs
@@ -959,7 +959,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                     data.row_id_start
                 FROM ducklake_data_file AS data
                 WHERE data.table_id = $1
-                  AND data.begin_snapshot > $2
+                  AND data.begin_snapshot >= $2
                   AND data.begin_snapshot <= $3
                 ORDER BY data.begin_snapshot",
             )
@@ -1007,7 +1007,7 @@ WITH current_delete AS (
         ddf.encryption_key
     FROM ducklake_delete_file ddf
     WHERE ddf.table_id = $1
-      AND ddf.begin_snapshot > $2
+      AND ddf.begin_snapshot >= $2
       AND ddf.begin_snapshot <= $3
 ),
 
@@ -1086,7 +1086,7 @@ LEFT JOIN LATERAL (
     LIMIT 1
 ) prev ON true
 WHERE data.table_id = $1
-  AND data.end_snapshot > $2
+  AND data.end_snapshot >= $2
   AND data.end_snapshot <= $3
 "#,
             )

--- a/src/metadata_provider_sqlite.rs
+++ b/src/metadata_provider_sqlite.rs
@@ -1121,7 +1121,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                     data.row_id_start
                 FROM ducklake_data_file AS data
                 WHERE data.table_id = ?
-                  AND data.begin_snapshot > ?
+                  AND data.begin_snapshot >= ?
                   AND data.begin_snapshot <= ?
                 ORDER BY data.begin_snapshot",
             )
@@ -1201,7 +1201,7 @@ SELECT
 FROM ducklake_delete_file cd
 JOIN ducklake_data_file data ON data.data_file_id = cd.data_file_id
 WHERE cd.table_id = ?
-  AND cd.begin_snapshot > ?
+  AND cd.begin_snapshot >= ?
   AND cd.begin_snapshot <= ?
   AND data.table_id = ?
 
@@ -1247,7 +1247,7 @@ SELECT
     data.end_snapshot AS snapshot_id
 FROM ducklake_data_file data
 WHERE data.table_id = ?
-  AND data.end_snapshot > ?
+  AND data.end_snapshot >= ?
   AND data.end_snapshot <= ?
 "#,
             )

--- a/src/multicatalog_provider.rs
+++ b/src/multicatalog_provider.rs
@@ -1010,7 +1010,7 @@ impl MetadataProvider for MulticatalogProvider {
                     data.row_id_start
                 FROM ducklake_data_file AS data
                 WHERE data.table_id = $1
-                  AND data.begin_snapshot > $2
+                  AND data.begin_snapshot >= $2
                   AND data.begin_snapshot <= $3
                 ORDER BY data.begin_snapshot",
             )
@@ -1058,7 +1058,7 @@ WITH current_delete AS (
         ddf.encryption_key
     FROM ducklake_delete_file ddf
     WHERE ddf.table_id = $1
-      AND ddf.begin_snapshot > $2
+      AND ddf.begin_snapshot >= $2
       AND ddf.begin_snapshot <= $3
 ),
 data_files AS (
@@ -1102,7 +1102,7 @@ LEFT JOIN LATERAL (
     LIMIT 1
 ) prev ON true
 WHERE data.table_id = $1
-  AND data.end_snapshot > $2
+  AND data.end_snapshot >= $2
   AND data.end_snapshot <= $3
 "#,
             )

--- a/src/table_changes.rs
+++ b/src/table_changes.rs
@@ -85,7 +85,16 @@ impl fmt::Display for ChangeType {
     }
 }
 
-/// Custom execution plan that appends CDC columns (snapshot_id, change_type) to each batch
+/// Positions of the CDC metadata columns in the feed's output schema. They
+/// LEAD the table columns, matching official DuckLake's `ducklake_table_changes`
+/// projection (`SELECT snapshot_id, rowid, change_type, ...`).
+const SNAPSHOT_ID_IDX: usize = 0;
+const ROWID_IDX: usize = 1;
+const CHANGE_TYPE_IDX: usize = 2;
+/// Number of CDC metadata columns preceding the table columns.
+const CDC_COLS: usize = 3;
+
+/// Custom execution plan that prepends CDC columns (snapshot_id, rowid, change_type) to each batch
 ///
 /// This plan wraps a ParquetExec and appends CDC metadata columns to each output batch.
 /// It supports projection pushdown by:
@@ -93,7 +102,7 @@ impl fmt::Display for ChangeType {
 /// - Including only requested CDC columns in output
 /// - Optionally skipping input columns entirely when only CDC columns are needed
 #[derive(Debug)]
-pub struct AppendCDCColumnsExec {
+pub struct PrependCDCColumnsExec {
     /// The input execution plan (typically ParquetExec)
     input: Arc<dyn ExecutionPlan>,
     /// Snapshot ID for this file
@@ -116,7 +125,7 @@ pub struct AppendCDCColumnsExec {
     properties: Arc<PlanProperties>,
 }
 
-impl AppendCDCColumnsExec {
+impl PrependCDCColumnsExec {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         input: Arc<dyn ExecutionPlan>,
@@ -155,7 +164,7 @@ impl AppendCDCColumnsExec {
     }
 }
 
-impl DisplayAs for AppendCDCColumnsExec {
+impl DisplayAs for PrependCDCColumnsExec {
     fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match t {
             DisplayFormatType::Default
@@ -163,7 +172,7 @@ impl DisplayAs for AppendCDCColumnsExec {
             | DisplayFormatType::TreeRender => {
                 write!(
                     f,
-                    "AppendCDCColumnsExec: snapshot_id={}, change_type={}, \
+                    "PrependCDCColumnsExec: snapshot_id={}, change_type={}, \
                      include_snapshot={}, include_change={}, skip_input={}",
                     self.snapshot_id,
                     self.change_type,
@@ -176,9 +185,9 @@ impl DisplayAs for AppendCDCColumnsExec {
     }
 }
 
-impl ExecutionPlan for AppendCDCColumnsExec {
+impl ExecutionPlan for PrependCDCColumnsExec {
     fn name(&self) -> &str {
-        "AppendCDCColumnsExec"
+        "PrependCDCColumnsExec"
     }
 
     fn properties(&self) -> &Arc<PlanProperties> {
@@ -195,11 +204,11 @@ impl ExecutionPlan for AppendCDCColumnsExec {
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         if children.len() != 1 {
             return Err(DataFusionError::Internal(
-                "AppendCDCColumnsExec expects exactly one child".into(),
+                "PrependCDCColumnsExec expects exactly one child".into(),
             ));
         }
 
-        Ok(Arc::new(AppendCDCColumnsExec::new(
+        Ok(Arc::new(PrependCDCColumnsExec::new(
             children[0].clone(),
             self.snapshot_id,
             self.change_type,
@@ -222,7 +231,7 @@ impl ExecutionPlan for AppendCDCColumnsExec {
     ) -> DataFusionResult<SendableRecordBatchStream> {
         let input_stream = self.input.execute(partition, context)?;
 
-        Ok(Box::pin(AppendCDCColumnsStream {
+        Ok(Box::pin(PrependCDCColumnsStream {
             input: input_stream,
             snapshot_id: self.snapshot_id,
             change_type: self.change_type,
@@ -236,7 +245,7 @@ impl ExecutionPlan for AppendCDCColumnsExec {
 }
 
 /// Stream that appends CDC columns to input batches
-struct AppendCDCColumnsStream {
+struct PrependCDCColumnsStream {
     input: SendableRecordBatchStream,
     snapshot_id: i64,
     change_type: ChangeType,
@@ -247,7 +256,7 @@ struct AppendCDCColumnsStream {
     output_schema: SchemaRef,
 }
 
-impl Stream for AppendCDCColumnsStream {
+impl Stream for PrependCDCColumnsStream {
     type Item = DataFusionResult<RecordBatch>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -263,24 +272,19 @@ impl Stream for AppendCDCColumnsStream {
     }
 }
 
-impl AppendCDCColumnsStream {
+impl PrependCDCColumnsStream {
     fn transform_batch(&self, batch: &RecordBatch) -> DataFusionResult<RecordBatch> {
         let num_rows = batch.num_rows();
         let mut columns: Vec<ArrayRef> = Vec::new();
 
-        // Include input columns unless we're skipping them
-        if !self.skip_input_columns {
-            columns.extend(batch.columns().iter().cloned());
-        }
-
-        // Append requested CDC columns, in the order rowid, snapshot_id,
-        // change_type. rowid is all-NULL here: this insert-only path can't
-        // synthesize it (used for encrypted tables).
-        if self.include_rowid {
-            columns.push(Arc::new(Int64Array::from(vec![None::<i64>; num_rows])));
-        }
+        // Prepend requested CDC columns, in the order snapshot_id, rowid,
+        // change_type (official DuckLake order). rowid is all-NULL here: this
+        // insert-only path can't synthesize it (used for encrypted tables).
         if self.include_snapshot_id {
             columns.push(Arc::new(Int64Array::from(vec![self.snapshot_id; num_rows])));
+        }
+        if self.include_rowid {
+            columns.push(Arc::new(Int64Array::from(vec![None::<i64>; num_rows])));
         }
         if self.include_change_type {
             columns.push(Arc::new(StringArray::from(vec![
@@ -289,12 +293,17 @@ impl AppendCDCColumnsStream {
             ])));
         }
 
+        // Then the input columns, unless we're skipping them
+        if !self.skip_input_columns {
+            columns.extend(batch.columns().iter().cloned());
+        }
+
         RecordBatch::try_new(self.output_schema.clone(), columns)
             .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
     }
 }
 
-impl RecordBatchStream for AppendCDCColumnsStream {
+impl RecordBatchStream for PrependCDCColumnsStream {
     fn schema(&self) -> SchemaRef {
         self.output_schema.clone()
     }
@@ -340,18 +349,16 @@ impl TableChangesTable {
         table_path: String,
         table_schema: SchemaRef,
     ) -> Self {
-        // Build output schema: table columns + CDC metadata columns
-        // (rowid, snapshot_id, change_type), in that order.
-        let mut fields: Vec<Field> = table_schema
-            .fields()
-            .iter()
-            .map(|f| f.as_ref().clone())
-            .collect();
+        // Build output schema: CDC metadata columns leading — (snapshot_id,
+        // rowid, change_type), official DuckLake's ducklake_table_changes
+        // column order — then the table columns.
+        let mut fields: Vec<Field> = Vec::with_capacity(table_schema.fields().len() + CDC_COLS);
+        fields.push(Field::new("snapshot_id", DataType::Int64, false));
         // rowid is nullable: it is NULL on encrypted (PME) tables, where the
         // correlated feed cannot decrypt footers to resolve rowids.
         fields.push(Field::new("rowid", DataType::Int64, true));
-        fields.push(Field::new("snapshot_id", DataType::Int64, false));
         fields.push(Field::new("change_type", DataType::Utf8, false));
+        fields.extend(table_schema.fields().iter().map(|f| f.as_ref().clone()));
         let output_schema = Arc::new(Schema::new(fields));
 
         Self {
@@ -367,13 +374,10 @@ impl TableChangesTable {
     }
 
     /// Analyze projection and split into table columns and CDC columns.
-    /// CDC columns follow the table columns in the order `rowid`, `snapshot_id`,
-    /// `change_type`.
+    /// CDC columns lead the table columns in the order `snapshot_id`, `rowid`,
+    /// `change_type` (official DuckLake order).
     fn analyze_projection(&self, projection: Option<&Vec<usize>>) -> ProjectionInfo {
         let num_table_cols = self.table_schema.fields().len();
-        let rowid_idx = num_table_cols;
-        let snapshot_id_idx = num_table_cols + 1;
-        let change_type_idx = num_table_cols + 2;
 
         match projection {
             None => {
@@ -394,14 +398,14 @@ impl TableChangesTable {
                 let mut need_change_type = false;
 
                 for &idx in indices {
-                    if idx < num_table_cols {
-                        table_indices.push(idx);
-                    } else if idx == rowid_idx {
-                        need_rowid = true;
-                    } else if idx == snapshot_id_idx {
-                        need_snapshot_id = true;
-                    } else if idx == change_type_idx {
-                        need_change_type = true;
+                    match idx {
+                        SNAPSHOT_ID_IDX => need_snapshot_id = true,
+                        ROWID_IDX => need_rowid = true,
+                        CHANGE_TYPE_IDX => need_change_type = true,
+                        _ if idx < num_table_cols + CDC_COLS => {
+                            table_indices.push(idx - CDC_COLS);
+                        },
+                        _ => {},
                     }
                 }
 
@@ -423,7 +427,7 @@ impl TableChangesTable {
         }
     }
 
-    /// Build the schema that AppendCDCColumnsExec will output. On this
+    /// Build the schema that PrependCDCColumnsExec will output. On this
     /// (encryption-aware, insert-only) path rowid cannot be synthesized, so when
     /// requested it is emitted as a nullable, all-NULL column.
     fn build_cdc_exec_schema(
@@ -433,25 +437,27 @@ impl TableChangesTable {
         need_snapshot_id: bool,
         need_change_type: bool,
     ) -> SchemaRef {
-        let mut fields: Vec<Field> = table_indices
-            .iter()
-            .map(|&i| self.table_schema.field(i).clone())
-            .collect();
+        let mut fields: Vec<Field> = Vec::with_capacity(table_indices.len() + CDC_COLS);
 
-        if need_rowid {
-            fields.push(Field::new("rowid", DataType::Int64, true));
-        }
         if need_snapshot_id {
             fields.push(Field::new("snapshot_id", DataType::Int64, false));
+        }
+        if need_rowid {
+            fields.push(Field::new("rowid", DataType::Int64, true));
         }
         if need_change_type {
             fields.push(Field::new("change_type", DataType::Utf8, false));
         }
+        fields.extend(
+            table_indices
+                .iter()
+                .map(|&i| self.table_schema.field(i).clone()),
+        );
 
         Arc::new(Schema::new(fields))
     }
 
-    /// Build a ParquetExec wrapped with AppendCDCColumnsExec for a single file
+    /// Build a ParquetExec wrapped with PrependCDCColumnsExec for a single file
     #[cfg(feature = "encryption")]
     async fn build_exec_for_file(
         &self,
@@ -470,7 +476,7 @@ impl TableChangesTable {
             .await
     }
 
-    /// Build a ParquetExec wrapped with AppendCDCColumnsExec for a single file
+    /// Build a ParquetExec wrapped with PrependCDCColumnsExec for a single file
     #[cfg(not(feature = "encryption"))]
     async fn build_exec_for_file(
         &self,
@@ -487,7 +493,7 @@ impl TableChangesTable {
         .await
     }
 
-    /// Internal implementation for building a ParquetExec wrapped with AppendCDCColumnsExec
+    /// Internal implementation for building a ParquetExec wrapped with PrependCDCColumnsExec
     async fn build_exec_for_file_impl(
         &self,
         _state: &dyn Session,
@@ -543,15 +549,15 @@ impl TableChangesTable {
         // Determine if we should skip input columns (only CDC columns requested)
         let skip_input_columns = proj_info.table_indices.is_empty();
 
-        // Build output schema for AppendCDCColumnsExec
+        // Build output schema for PrependCDCColumnsExec
         let cdc_exec_schema = if skip_input_columns {
             // Only CDC columns - build schema with just those
             let mut fields = Vec::new();
-            if proj_info.need_rowid {
-                fields.push(Field::new("rowid", DataType::Int64, true));
-            }
             if proj_info.need_snapshot_id {
                 fields.push(Field::new("snapshot_id", DataType::Int64, false));
+            }
+            if proj_info.need_rowid {
+                fields.push(Field::new("rowid", DataType::Int64, true));
             }
             if proj_info.need_change_type {
                 fields.push(Field::new("change_type", DataType::Utf8, false));
@@ -566,7 +572,7 @@ impl TableChangesTable {
             )
         };
 
-        Ok(Arc::new(AppendCDCColumnsExec::new(
+        Ok(Arc::new(PrependCDCColumnsExec::new(
             parquet_exec,
             data_file.begin_snapshot,
             ChangeType::Insert,
@@ -743,10 +749,10 @@ impl TableChangesTable {
         projection: Option<&Vec<usize>>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         let table_len = self.table_schema.fields().len();
-        // Whether the caller wants the rowid column (it follows the table cols in
-        // the output schema). When it does not, plain inserts skip the positional
-        // scan and rowid synthesis entirely.
-        let need_rowid = projection.is_none_or(|idx| idx.contains(&table_len));
+        // Whether the caller wants the rowid column (at ROWID_IDX among the
+        // leading CDC columns). When it does not, plain inserts skip the
+        // positional scan and rowid synthesis entirely.
+        let need_rowid = projection.is_none_or(|idx| idx.contains(&ROWID_IDX));
 
         let mut insert_units = Vec::with_capacity(data_files.len());
         for (df, name) in data_files.iter().zip(embedded_names.iter()) {
@@ -849,8 +855,9 @@ impl TableChangesTable {
             need_rowid,
         ));
 
-        // The exec emits the full `[table columns, snapshot_id, change_type]`
-        // schema; honor the requested projection with a ProjectionExec on top.
+        // The exec emits the full `[snapshot_id, rowid, change_type, table
+        // columns]` schema; honor the requested projection with a
+        // ProjectionExec on top.
         match projection {
             None => Ok(full),
             Some(indices) => {
@@ -1442,7 +1449,7 @@ async fn correlate_changes(
     let mut out: Vec<RecordBatch> = Vec::new();
     // Plain inserts are always `insert` (they never pair with a delete).
     for k in &plain_inserts {
-        out.push(append_cdc_columns(
+        out.push(prepend_cdc_columns(
             &k.table_batch,
             k.rowid.clone(),
             k.snapshot_id,
@@ -1515,9 +1522,10 @@ async fn collect_delete_positions(
     Ok(Some(set))
 }
 
-/// Append the CDC `rowid` + `snapshot_id` + `change_type` columns to a
-/// table-column batch. `rowid` must have the same length as `table_batch`.
-fn append_cdc_columns(
+/// Prepend the CDC `snapshot_id` + `rowid` + `change_type` columns to a
+/// table-column batch (official DuckLake column order). `rowid` must have the
+/// same length as `table_batch`.
+fn prepend_cdc_columns(
     table_batch: &RecordBatch,
     rowid: Int64Array,
     snapshot_id: i64,
@@ -1525,10 +1533,11 @@ fn append_cdc_columns(
     output_schema: &SchemaRef,
 ) -> DataFusionResult<RecordBatch> {
     let n = table_batch.num_rows();
-    let mut cols: Vec<ArrayRef> = table_batch.columns().to_vec();
-    cols.push(Arc::new(rowid));
+    let mut cols: Vec<ArrayRef> = Vec::with_capacity(table_batch.num_columns() + CDC_COLS);
     cols.push(Arc::new(Int64Array::from(vec![snapshot_id; n])));
+    cols.push(Arc::new(rowid));
     cols.push(Arc::new(StringArray::from(vec![change.as_str(); n])));
+    cols.extend(table_batch.columns().iter().cloned());
     RecordBatch::try_new(output_schema.clone(), cols)
         .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
 }
@@ -1577,7 +1586,7 @@ fn filter_and_tag(
         .downcast_ref::<Int64Array>()
         .ok_or_else(|| DataFusionError::Internal("filtered rowid is not Int64".to_string()))?
         .clone();
-    Ok(Some(append_cdc_columns(
+    Ok(Some(prepend_cdc_columns(
         &filtered,
         rowid,
         keyed.snapshot_id,

--- a/src/table_changes.rs
+++ b/src/table_changes.rs
@@ -1,7 +1,9 @@
 //! Table changes (CDC) functionality for DuckLake
 //!
 //! This module provides the `ducklake_table_changes()` table function that returns
-//! actual row data from Parquet files with additional CDC metadata columns.
+//! actual row data from Parquet files with additional CDC metadata columns —
+//! inserts, deletes (with the deleted rows' old values), and UPDATEs correlated
+//! into `update_preimage`/`update_postimage` pairs, matching official DuckLake.
 //!
 //! Note: Ordering across files is undefined unless explicitly requested via ORDER BY.
 
@@ -737,14 +739,14 @@ impl TableChangesTable {
 
     /// Build the correlated change feed: pair a same-snapshot delete + insert
     /// that share a rowid into `update_preimage` (old) + `update_postimage`
-    /// (new); surface unmatched inserts as `insert`; and DROP unmatched deletes
-    /// (pure deletes stay out of `ducklake_table_changes`, matching its historical
-    /// insert-oriented behaviour — they remain available via
-    /// `ducklake_table_deletions`).
+    /// (new); surface unmatched inserts as `insert` and unmatched deletes as
+    /// `delete` (carrying the deleted rows' old values), matching official
+    /// DuckLake's `ducklake_table_changes`.
     async fn build_correlated_changes(
         &self,
         state: &dyn Session,
         data_files: &[DataFileChange],
+        delete_files: &[crate::metadata_provider::DeleteFileChange],
         embedded_names: &[Option<String>],
         projection: Option<&Vec<usize>>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
@@ -773,26 +775,12 @@ impl TableChangesTable {
             });
         }
 
-        // Deletes only matter here as the delete half of an UPDATE, paired with a
-        // postimage — which requires an added file carrying an embedded rowid.
-        // With no embedded file there are no postimages, so every delete in range
-        // is a pure delete (dropped from ducklake_table_changes). Skip fetching
-        // and scanning the delete side entirely: it is cheaper, and it avoids
-        // failing on a delete source (encrypted, NULL row_id_start, unreadable)
-        // whose rows can't affect this insert-only output.
-        let any_embedded = embedded_names.iter().any(|n| n.is_some());
-        let delete_units = if any_embedded {
-            let delete_files = self
-                .provider
-                .get_delete_files_added_between_snapshots(
-                    self.table_id,
-                    self.start_snapshot,
-                    self.end_snapshot,
-                )
-                .map_err(|e| DataFusionError::External(Box::new(e)))?;
-
+        // Every delete in range is read: unmatched ones surface as `delete`
+        // rows, and those sharing a (snapshot_id, rowid) with an embedded-rowid
+        // insert pair into update preimages.
+        let delete_units = {
             let mut delete_units = Vec::with_capacity(delete_files.len());
-            for dfc in &delete_files {
+            for dfc in delete_files {
                 validated_record_count(dfc.data_record_count, &dfc.data_file_path)?;
                 let resolved = resolve_path(
                     &self.table_path,
@@ -842,8 +830,6 @@ impl TableChangesTable {
                 });
             }
             delete_units
-        } else {
-            Vec::new()
         };
 
         let full: Arc<dyn ExecutionPlan> = Arc::new(TableChangesExec::new(
@@ -907,30 +893,41 @@ impl TableProvider for TableChangesTable {
             )
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
+        // Deletes applied in the window surface as `delete` rows (and pair into
+        // update preimages), so they participate in both the empty check and
+        // the path decision — a delete-only window is NOT empty.
+        let delete_files = self
+            .provider
+            .get_delete_files_added_between_snapshots(
+                self.table_id,
+                self.start_snapshot,
+                self.end_snapshot,
+            )
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
         // Handle empty case
-        if data_files.is_empty() {
+        if data_files.is_empty() && delete_files.is_empty() {
             use datafusion::physical_plan::empty::EmptyExec;
             return Ok(Arc::new(EmptyExec::new(proj_info.output_schema)));
         }
 
-        // Decide whether to take the correlated path (pairing an UPDATE's
-        // delete+insert into preimage/postimage). Two guards, BOTH cheap and
-        // metadata-only, keep the common cases off the expensive/unsafe footer
-        // probing that the correlated path needs:
+        // Decide whether to take the correlated path (reading delete sources to
+        // emit `delete` rows and pair an UPDATE's delete+insert into
+        // preimage/postimage). Guards, all cheap and metadata-only:
         //
-        //  1. Deletes-present: an UPDATE (or compaction) ALWAYS adds a positional
-        //     delete, so a range with no added delete files cannot contain an
-        //     UPDATE — there is nothing to correlate. Skipping detection here
-        //     means a plain-INSERT catalog does ZERO per-file parquet footer
-        //     reads at plan time (previously it probed every added file).
+        //  1. Deletes-present OR rowid-requested: with neither, the window is
+        //     plain inserts and needs no correlation — a plain-INSERT catalog
+        //     does ZERO per-file parquet footer reads at plan time.
         //  2. Not encrypted: the correlated path reads parquet footers (to detect
         //     the embedded-rowid postimage) and the source rows of deletes, none
         //     of which it can decrypt (the delete-side change record carries no
-        //     key). On a PME catalog we therefore stay on the historical
-        //     insert-only path below — which IS encryption-aware — so CDC never
-        //     fails; the tradeoff is that UPDATEs are not correlated into
-        //     preimage/postimage there (they surface as plain inserts). See
-        //     COMPATIBILITY.md.
+        //     key). On a PME catalog we therefore stay on the insert-only path
+        //     below — which IS encryption-aware — so CDC over inserts never
+        //     fails; the tradeoff is that UPDATEs surface as plain inserts and
+        //     pure deletes are missing there. See COMPATIBILITY.md. (A
+        //     delete-only window carries no data file to detect encryption
+        //     from, so on an encrypted catalog it fails at read rather than
+        //     returning wrong results.)
         let any_encrypted = {
             #[cfg(feature = "encryption")]
             {
@@ -942,13 +939,7 @@ impl TableProvider for TableChangesTable {
             }
         };
 
-        // rowid output requires the correlated (collect-based) path: it derives a
-        // stable per-row rowid — the embedded ROW_ID for UPDATE / compaction
-        // postimages, else `row_id_start + physical position` for plain inserts.
-        // That path reads parquet footers and cannot decrypt, so on encrypted
-        // (PME) catalogs we fall through to the encryption-aware insert-only path
-        // below, which emits rowid as NULL rather than failing the read.
-        if proj_info.need_rowid && !any_encrypted {
+        if (proj_info.need_rowid || !delete_files.is_empty()) && !any_encrypted {
             let mut embedded_names: Vec<Option<String>> = Vec::with_capacity(data_files.len());
             for data_file in &data_files {
                 embedded_names.push(
@@ -961,38 +952,14 @@ impl TableProvider for TableChangesTable {
                 );
             }
             return self
-                .build_correlated_changes(state, &data_files, &embedded_names, projection)
+                .build_correlated_changes(
+                    state,
+                    &data_files,
+                    &delete_files,
+                    &embedded_names,
+                    projection,
+                )
                 .await;
-        }
-
-        let range_has_deletes = !self
-            .provider
-            .get_delete_files_added_between_snapshots(
-                self.table_id,
-                self.start_snapshot,
-                self.end_snapshot,
-            )
-            .map_err(|e| DataFusionError::External(Box::new(e)))?
-            .is_empty();
-
-        if range_has_deletes && !any_encrypted {
-            // Detect which added data files carry an embedded rowid column (the
-            // postimages of an UPDATE / compaction). Only probe footers now that
-            // we know a delete exists and the files are readable un-decrypted.
-            let mut embedded_names: Vec<Option<String>> = Vec::with_capacity(data_files.len());
-            let mut any_embedded = false;
-            for data_file in &data_files {
-                let name = self
-                    .detect_embedded_rowid_name(state, &data_file.path, data_file.path_is_relative)
-                    .await?;
-                any_embedded |= name.is_some();
-                embedded_names.push(name);
-            }
-            if any_embedded {
-                return self
-                    .build_correlated_changes(state, &data_files, &embedded_names, projection)
-                    .await;
-            }
         }
 
         // Build encryption factory from file encryption keys (when encryption feature is enabled)
@@ -1336,7 +1303,14 @@ async fn correlate_changes(
 
     // Deleted rows: the positions newly masked at this snapshot, with each row's
     // rowid (embedded column when the source file has one, else row_id_start +
-    // physical position).
+    // physical position). The rowid is required only when it is output
+    // (`need_rowid`) or when an update pair is possible (some postimage exists
+    // to correlate against); with neither, every delete is a pure delete and
+    // its rowid a placeholder — so a non-rowid projection over a delete-only
+    // window never fails on a source file whose rowid cannot be synthesized
+    // (no embedded rowid and a NULL row_id_start), mirroring
+    // `ducklake_table_deletions`.
+    let preimage_rowids_required = need_rowid || !postimages.is_empty();
     let mut preimages: Vec<KeyedRows> = Vec::new();
     for unit in &delete_units {
         let current = collect_delete_positions(&unit.current_delete_scan, context.clone()).await?;
@@ -1379,8 +1353,9 @@ async fn correlate_changes(
             };
 
             // With no embedded rowid, deleted rowids are row_id_start + position;
-            // require row_id_start in that case rather than emitting wrong ids.
-            let synth_start: Option<i64> = if embedded.is_none() {
+            // require row_id_start in that case rather than emitting wrong ids —
+            // but only when the rowid is actually consumed (output or pairing).
+            let synth_start: Option<i64> = if embedded.is_none() && preimage_rowids_required {
                 Some(unit.row_id_start.ok_or_else(|| {
                     DataFusionError::Internal(
                         "cannot synthesize deleted rowid: source file has neither an embedded \
@@ -1401,8 +1376,9 @@ async fn correlate_changes(
                     rowids.push(match (embedded, synth_start) {
                         (Some(arr), _) => arr.value(i),
                         (None, Some(start)) => start + p,
-                        // synth_start is Some whenever embedded is None (above).
-                        (None, None) => unreachable!("row_id_start resolved above"),
+                        // Unneeded rowid (not output, nothing to pair with):
+                        // a placeholder that update_keys can never contain.
+                        (None, None) => 0,
                     });
                 }
             }
@@ -1478,12 +1454,21 @@ async fn correlate_changes(
         }
     }
     for k in &preimages {
-        // Only rows paired with an insert are surfaced (as preimages); pure
-        // deletes stay out of the changes feed.
+        // Rows paired with an insert surface as update preimages; the rest are
+        // pure deletes, emitted as `delete` rows carrying the old values
+        // (matching official DuckLake's table_changes).
         if let Some(b) = filter_and_tag(
             k,
             &key_mask(k, &update_keys, true),
             ChangeType::UpdatePreimage,
+            &output_schema,
+        )? {
+            out.push(b);
+        }
+        if let Some(b) = filter_and_tag(
+            k,
+            &key_mask(k, &update_keys, false),
+            ChangeType::Delete,
             &output_schema,
         )? {
             out.push(b);

--- a/src/table_deletions.rs
+++ b/src/table_deletions.rs
@@ -71,7 +71,7 @@ pub struct TableDeletionsTable {
     table_path: String,
     /// Original table schema (without CDC columns)
     table_schema: SchemaRef,
-    /// Combined schema: table columns + rowid + snapshot_id + change_type
+    /// Combined schema: snapshot_id + rowid + change_type + table columns
     output_schema: SchemaRef,
 }
 
@@ -85,19 +85,17 @@ impl TableDeletionsTable {
         table_path: String,
         table_schema: SchemaRef,
     ) -> Self {
-        // Build output schema: table columns + CDC metadata columns
-        // (rowid, snapshot_id, change_type), in that order.
-        let mut fields: Vec<Field> = table_schema
-            .fields()
-            .iter()
-            .map(|f| f.as_ref().clone())
-            .collect();
+        // Build output schema: CDC metadata columns leading — (snapshot_id,
+        // rowid, change_type), matching ducklake_table_changes and official
+        // DuckLake's column order — then the table columns.
+        let mut fields: Vec<Field> = Vec::with_capacity(table_schema.fields().len() + 3);
+        fields.push(Field::new("snapshot_id", DataType::Int64, false));
         // rowid is nullable for symmetry with ducklake_table_changes (where it is
         // NULL on encrypted tables); the deletions path always synthesizes a
         // non-null value for the cases it supports.
         fields.push(Field::new("rowid", DataType::Int64, true));
-        fields.push(Field::new("snapshot_id", DataType::Int64, false));
         fields.push(Field::new("change_type", DataType::Utf8, false));
+        fields.extend(table_schema.fields().iter().map(|f| f.as_ref().clone()));
         let output_schema = Arc::new(Schema::new(fields));
 
         Self {
@@ -338,13 +336,12 @@ impl TableProvider for TableDeletionsTable {
             return Ok(Arc::new(EmptyExec::new(output_schema)));
         }
 
-        // Does the caller actually want `rowid`? It follows the table columns in
-        // the output schema. When it is projected away we skip resolving it (no
+        // Does the caller actually want `rowid`? It sits at index 1 among the
+        // leading CDC columns. When it is projected away we skip resolving it (no
         // footer probe, no synthesis), so a query like `SELECT id, change_type
         // FROM ducklake_table_deletions(...)` never fails on a file whose rowid
         // cannot be synthesized (no embedded rowid and a NULL row_id_start).
-        let rowid_idx = self.table_schema.fields().len();
-        let need_rowid = projection.is_none_or(|indices| indices.contains(&rowid_idx));
+        let need_rowid = projection.is_none_or(|indices| indices.contains(&1));
 
         // Build execution plan for each delete entry
         let mut execs: Vec<Arc<dyn ExecutionPlan>> = Vec::with_capacity(delete_files.len());
@@ -362,7 +359,7 @@ impl TableProvider for TableDeletionsTable {
             UnionExec::try_new(execs)?
         };
 
-        // The exec emits the full `[table cols, rowid, snapshot_id, change_type]`
+        // The exec emits the full `[snapshot_id, rowid, change_type, table cols]`
         // schema; honor the requested projection with a ProjectionExec on top.
         match projection {
             None => Ok(full),
@@ -416,7 +413,7 @@ pub struct DeletedRowsExec {
     /// emitted as a placeholder (dropped by the projection above) and neither an
     /// embedded rowid nor a row_id_start is required.
     need_rowid: bool,
-    /// Output schema (table columns + rowid + snapshot_id + change_type)
+    /// Output schema (snapshot_id + rowid + change_type + table columns)
     output_schema: SchemaRef,
     /// Cached plan properties
     properties: Arc<PlanProperties>,
@@ -776,24 +773,24 @@ impl DeletedRowsStream {
             return Ok(None);
         }
 
-        // Select the deleted rows' TABLE columns (excluding the embedded rowid
-        // helper column, if the scan read one), then append the CDC columns.
+        // Emit the CDC columns first — snapshot_id, rowid, change_type, the
+        // official order — then the deleted rows' TABLE columns (excluding the
+        // embedded rowid helper column, if the scan read one).
         let indices = UInt32Array::from(keep_indices.clone());
+        let num_output_rows = keep_indices.len();
         let mut columns: Vec<ArrayRef> = Vec::with_capacity(self.table_len + 3);
+        columns.push(Arc::new(Int64Array::from(vec![
+            self.snapshot_id;
+            num_output_rows
+        ])));
+        columns.push(Arc::new(Int64Array::from(rowids)));
+        columns.push(Arc::new(StringArray::from(vec!["delete"; num_output_rows])));
+
         for col in batch.columns().iter().take(self.table_len) {
             let filtered = take(col.as_ref(), &indices, None)
                 .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
             columns.push(filtered);
         }
-
-        // Append CDC columns: rowid, snapshot_id, change_type.
-        let num_output_rows = keep_indices.len();
-        columns.push(Arc::new(Int64Array::from(rowids)));
-        columns.push(Arc::new(Int64Array::from(vec![
-            self.snapshot_id;
-            num_output_rows
-        ])));
-        columns.push(Arc::new(StringArray::from(vec!["delete"; num_output_rows])));
 
         RecordBatch::try_new(self.output_schema.clone(), columns)
             .map(Some)

--- a/tests/cdc_differential_tests.rs
+++ b/tests/cdc_differential_tests.rs
@@ -11,12 +11,6 @@
 //! ratchet: when the crate converges on the official behavior, delete the
 //! normalizer and the diff tightens automatically.
 //!
-//! * NORMALIZER-DELETE-ROUTING — official `table_changes` emits pure deletes
-//!   as `change_type='delete'`; the crate routes them to
-//!   `ducklake_table_deletions`. We therefore assert the full change-set in
-//!   two halves: crate `table_changes` == official `table_changes` minus its
-//!   'delete' rows, and crate `table_deletions` == official
-//!   `ducklake_table_deletions` (all deleted rows, update preimages included).
 //! * NORMALIZER-DELETIONS-CHANGE-TYPE — the crate's `ducklake_table_deletions`
 //!   materializes a constant `change_type='delete'` column that official's
 //!   function does not have (official also exposes rowid/snapshot_id as
@@ -444,21 +438,11 @@ async fn assert_cdc_conformance(table: &str, statements: &[&str]) -> DataFusionR
             );
         }
 
-        // NORMALIZER-DELETE-ROUTING (half 1): the crate's table_changes must
-        // match official's minus its pure-delete rows.
-        let official_nondelete = CanonFeed::new(
-            official_changes.all_columns.clone(),
-            official_changes.table_columns.clone(),
-            official_changes
-                .rows
-                .iter()
-                .filter(|r| r.change_type.as_deref() != Some("delete"))
-                .cloned()
-                .collect(),
-        );
+        // The crate's table_changes must match official's VERBATIM — inserts,
+        // update pre/postimages, and pure deletes included.
         assert_feeds_match(
             &format!("table_changes window [{a},{b}]"),
-            &official_nondelete,
+            &official_changes,
             &crate_changes,
         );
 

--- a/tests/cdc_differential_tests.rs
+++ b/tests/cdc_differential_tests.rs
@@ -11,9 +11,6 @@
 //! ratchet: when the crate converges on the official behavior, delete the
 //! normalizer and the diff tightens automatically.
 //!
-//! * NORMALIZER-BOUNDS — official snapshot bounds are inclusive on both ends;
-//!   the crate's are exclusive-start / inclusive-end. Official `[a, b]` is
-//!   queried on the crate as `(a-1, b]`.
 //! * NORMALIZER-DELETE-ROUTING — official `table_changes` emits pure deletes
 //!   as `change_type='delete'`; the crate routes them to
 //!   `ducklake_table_deletions`. We therefore assert the full change-set in
@@ -412,17 +409,16 @@ async fn assert_cdc_conformance(table: &str, statements: &[&str]) -> DataFusionR
 
     let ctx = crate_context(&path).await?;
     for ((a, b), official_changes, official_deletions) in official {
-        // NORMALIZER-BOUNDS: official [a, b] == crate (a-1, b].
-        let (ca, cb) = (a - 1, b);
+        // Bounds are inclusive on both ends, matching official DuckLake.
         let crate_changes = crate_feed(
             &ctx,
-            &format!("SELECT * FROM ducklake_table_changes('main.{table}', {ca}, {cb})"),
+            &format!("SELECT * FROM ducklake_table_changes('main.{table}', {a}, {b})"),
             true,
         )
         .await?;
         let crate_deletions = crate_feed(
             &ctx,
-            &format!("SELECT * FROM ducklake_table_deletions('main.{table}', {ca}, {cb})"),
+            &format!("SELECT * FROM ducklake_table_deletions('main.{table}', {a}, {b})"),
             true,
         )
         .await?;

--- a/tests/cdc_differential_tests.rs
+++ b/tests/cdc_differential_tests.rs
@@ -17,11 +17,14 @@
 //!   two halves: crate `table_changes` == official `table_changes` minus its
 //!   'delete' rows, and crate `table_deletions` == official
 //!   `ducklake_table_deletions` (all deleted rows, update preimages included).
-//! * NORMALIZER-COLUMN-PLACEMENT — official leads with
-//!   `(snapshot_id, rowid, change_type)`; the crate appends
-//!   `(rowid, snapshot_id, change_type)` after the table columns. Rows are
-//!   canonicalized by column NAME; the residual table-column name order is
-//!   still asserted equal.
+//! * NORMALIZER-DELETIONS-CHANGE-TYPE — the crate's `ducklake_table_deletions`
+//!   materializes a constant `change_type='delete'` column that official's
+//!   function does not have (official also exposes rowid/snapshot_id as
+//!   virtual columns rather than in `SELECT *` — inherent to DataFusion's
+//!   lack of virtual columns, documented in COMPATIBILITY.md). The
+//!   `table_changes` column list is asserted positionally identical to
+//!   official's; the deletions list must be official's with `change_type`
+//!   inserted after `(snapshot_id, rowid)`.
 //!
 //! Not yet covered (tracked in #179): TIMESTAMPTZ bounds, encrypted (PME)
 //! catalogs, compaction rewrites, schema evolution between snapshots.
@@ -77,18 +80,20 @@ struct CanonRow {
     cells: Vec<String>,
 }
 
-/// One engine's canonicalized feed output: sorted rows + the residual
-/// (non-CDC) column names in their original order.
+/// One engine's canonicalized feed output: sorted rows, the full column-name
+/// list in output order, and the residual (non-CDC) column names.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct CanonFeed {
+    all_columns: Vec<String>,
     table_columns: Vec<String>,
     rows: Vec<CanonRow>,
 }
 
 impl CanonFeed {
-    fn new(table_columns: Vec<String>, mut rows: Vec<CanonRow>) -> Self {
+    fn new(all_columns: Vec<String>, table_columns: Vec<String>, mut rows: Vec<CanonRow>) -> Self {
         rows.sort();
         Self {
+            all_columns,
             table_columns,
             rows,
         }
@@ -267,10 +272,11 @@ fn official_feed(
     }
     if rows.is_empty() {
         // No rows to derive residual names from; leave empty (callers skip the
-        // name assertion for empty feeds).
+        // name assertions for empty feeds).
         table_columns.clear();
+        return Ok(CanonFeed::new(Vec::new(), table_columns, rows));
     }
-    Ok(CanonFeed::new(table_columns, rows))
+    Ok(CanonFeed::new(names, table_columns, rows))
 }
 
 /// Run `sql` through the crate (DataFusion) and canonicalize.
@@ -282,6 +288,7 @@ async fn crate_feed(
     let batches = ctx.sql(sql).await?.collect().await?;
     let mut rows = Vec::new();
     let mut table_columns = Vec::new();
+    let mut all_columns = Vec::new();
     for batch in &batches {
         let names: Vec<String> = batch
             .schema()
@@ -297,8 +304,12 @@ async fn crate_feed(
             table_columns = cols;
             rows.push(row);
         }
+        all_columns = names;
     }
-    Ok(CanonFeed::new(table_columns, rows))
+    if rows.is_empty() {
+        all_columns.clear();
+    }
+    Ok(CanonFeed::new(all_columns, table_columns, rows))
 }
 
 async fn crate_context(path: &Path) -> DataFusionResult<SessionContext> {
@@ -423,9 +434,20 @@ async fn assert_cdc_conformance(table: &str, statements: &[&str]) -> DataFusionR
         )
         .await?;
 
+        // Column placement is converged for table_changes: the crate's
+        // `SELECT *` column list must be positionally IDENTICAL to official's
+        // (snapshot_id, rowid, change_type, table columns).
+        if !official_changes.all_columns.is_empty() && !crate_changes.all_columns.is_empty() {
+            assert_eq!(
+                official_changes.all_columns, crate_changes.all_columns,
+                "table_changes window [{a},{b}]: full column list diverges from official"
+            );
+        }
+
         // NORMALIZER-DELETE-ROUTING (half 1): the crate's table_changes must
         // match official's minus its pure-delete rows.
         let official_nondelete = CanonFeed::new(
+            official_changes.all_columns.clone(),
             official_changes.table_columns.clone(),
             official_changes
                 .rows
@@ -440,6 +462,18 @@ async fn assert_cdc_conformance(table: &str, statements: &[&str]) -> DataFusionR
             &crate_changes,
         );
 
+        // NORMALIZER-DELETIONS-CHANGE-TYPE: the crate's deletions column list
+        // must be official's `(snapshot_id, rowid, <table cols>)` with the
+        // crate's constant change_type column inserted after rowid.
+        if !official_deletions.all_columns.is_empty() && !crate_deletions.all_columns.is_empty() {
+            let mut expected = official_deletions.all_columns.clone();
+            expected.insert(2, "change_type".to_string());
+            assert_eq!(
+                expected, crate_deletions.all_columns,
+                "table_deletions window [{a},{b}]: column list diverges from official + change_type"
+            );
+        }
+
         // NORMALIZER-DELETE-ROUTING (half 2): the crate's table_deletions must
         // match official's ducklake_table_deletions (all deleted rows, update
         // preimages included). The crate adds a constant change_type='delete'
@@ -452,6 +486,7 @@ async fn assert_cdc_conformance(table: &str, statements: &[&str]) -> DataFusionR
             );
         }
         let crate_deletions_stripped = CanonFeed::new(
+            official_deletions.all_columns.clone(),
             crate_deletions.table_columns.clone(),
             crate_deletions
                 .rows

--- a/tests/cdc_rowid_tests.rs
+++ b/tests/cdc_rowid_tests.rs
@@ -358,8 +358,8 @@ async fn changes_without_rowid_projection_still_correlates() -> DataFusionResult
 
 /// With rowid projected over a range that has plain inserts AND a pure delete
 /// (no UPDATE / embedded rowid), the changes feed returns the inserts with
-/// correct rowids and drops the pure delete — no postimage exists, so the delete
-/// side is skipped entirely rather than scanned.
+/// correct rowids and the pure delete as a `delete` row that preserves the
+/// rowid the row was inserted with (matching official DuckLake).
 #[tokio::test]
 async fn changes_with_rowid_plain_inserts_and_pure_delete() -> DataFusionResult<()> {
     let tmp = TempDir::new().unwrap();
@@ -375,14 +375,72 @@ async fn changes_with_rowid_plain_inserts_and_pure_delete() -> DataFusionResult<
     let ctx = ctx_for(path.to_str().unwrap()).await?;
     let mut r = rows(
         &ctx,
-        "SELECT id, rowid, change_type FROM ducklake_table_changes('main.t', 0, 1000) ORDER BY rowid",
+        "SELECT id, rowid, change_type FROM ducklake_table_changes('main.t', 0, 1000) \
+         ORDER BY rowid, change_type",
     )
     .await?;
-    r.sort_by_key(|x| x.1);
-    // The three inserted rows with rowids 0,1,2; the pure delete is dropped.
+    r.sort();
+    // The three inserted rows with rowids 0,1,2; the pure delete surfaces with
+    // the same rowid (1) its row was inserted with.
     assert_eq!(
         r,
-        vec![(10, 0, "insert".into()), (20, 1, "insert".into()), (30, 2, "insert".into()),]
+        vec![
+            (10, 0, "insert".into()),
+            (20, 1, "delete".into()),
+            (20, 1, "insert".into()),
+            (30, 2, "insert".into()),
+        ]
+    );
+    Ok(())
+}
+
+/// A non-rowid projection over a delete-only window must succeed even when the
+/// delete's source file has a NULL `row_id_start` (older/foreign catalogs):
+/// with rowid neither output nor pairable (no postimage in range), no rowid is
+/// synthesized — mirroring `ducklake_table_deletions`. Projecting rowid over
+/// the same window still fails, since a real value would be required.
+#[tokio::test]
+async fn pure_delete_without_row_id_start_non_rowid_projection() -> DataFusionResult<()> {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("chg_norowidstart.ducklake");
+    write_catalog(
+        &path,
+        &[
+            "CREATE TABLE c.t(id INTEGER, name VARCHAR);",
+            "INSERT INTO c.t VALUES (10,'a'),(20,'b');",
+            "DELETE FROM c.t WHERE id = 20;",
+        ],
+    )?;
+    // Simulate an older/foreign catalog that never recorded row_id_start.
+    {
+        let conn = duckdb::Connection::open(&path).map_err(box_err)?;
+        conn.execute("UPDATE ducklake_data_file SET row_id_start = NULL;", [])
+            .map_err(box_err)?;
+    }
+    let ctx = ctx_for(path.to_str().unwrap()).await?;
+
+    // Without rowid: the delete surfaces, no synthesis needed.
+    let batches = ctx
+        .sql(
+            "SELECT id, change_type FROM ducklake_table_changes('main.t', 0, 1000) \
+             WHERE change_type = 'delete'",
+        )
+        .await?
+        .collect()
+        .await?;
+    let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total, 1, "the pure delete surfaces without rowid synthesis");
+
+    // With rowid projected: synthesis is required and must fail loudly rather
+    // than emitting wrong ids.
+    let err = ctx
+        .sql("SELECT rowid, change_type FROM ducklake_table_changes('main.t', 0, 1000)")
+        .await?
+        .collect()
+        .await;
+    assert!(
+        err.is_err(),
+        "rowid projection must error when it cannot be synthesized"
     );
     Ok(())
 }

--- a/tests/sql_update_tests.rs
+++ b/tests/sql_update_tests.rs
@@ -354,10 +354,12 @@ async fn update_change_feed_emits_preimage_and_postimage() {
 
     // The change feed over the update snapshot pairs the delete + insert that
     // share rowid 1 into update_preimage (old) + update_postimage (new).
+    // Bounds are inclusive: start at the first post-`before` snapshot.
+    let start = before + 1;
     let fctx = functions_ctx(&temp_dir).await;
     let sql = format!(
         "SELECT id, val, change_type \
-         FROM ducklake_table_changes('main.t', {before}, {after}) \
+         FROM ducklake_table_changes('main.t', {start}, {after}) \
          ORDER BY change_type, id"
     );
     let batches = fctx.sql(&sql).await.unwrap().collect().await.unwrap();
@@ -411,10 +413,12 @@ async fn update_change_feed_ignores_unrelated_inserts() {
 
     // Exactly one preimage + one postimage for the single updated row; no
     // spurious plain insert/delete rows.
+    // Bounds are inclusive: start at the first post-`before` snapshot.
+    let start = before + 1;
     let fctx = functions_ctx(&temp_dir).await;
     let sql = format!(
         "SELECT change_type, COUNT(*) AS n \
-         FROM ducklake_table_changes('main.t', {before}, {after}) \
+         FROM ducklake_table_changes('main.t', {start}, {after}) \
          GROUP BY change_type ORDER BY change_type"
     );
     let batches = fctx.sql(&sql).await.unwrap().collect().await.unwrap();
@@ -516,9 +520,11 @@ async fn update_change_feed_mixed_insert_and_update() {
     .await;
     let after = max_snapshot(&temp_dir).await;
 
+    // Bounds are inclusive: start at the first post-`before` snapshot.
+    let start = before + 1;
     let fctx = functions_ctx(&temp_dir).await;
     let sql = format!(
-        "SELECT id, val, change_type FROM ducklake_table_changes('main.t', {before}, {after}) \
+        "SELECT id, val, change_type FROM ducklake_table_changes('main.t', {start}, {after}) \
          ORDER BY change_type, id"
     );
     let batches = fctx.sql(&sql).await.unwrap().collect().await.unwrap();
@@ -567,9 +573,11 @@ async fn change_feed_insert_only_range_is_all_inserts() {
     .await;
     let after = max_snapshot(&temp_dir).await;
 
+    // Bounds are inclusive: start at the first post-`before` snapshot.
+    let start = before + 1;
     let fctx = functions_ctx(&temp_dir).await;
     let sql = format!(
-        "SELECT change_type, COUNT(*) AS n FROM ducklake_table_changes('main.t', {before}, {after}) \
+        "SELECT change_type, COUNT(*) AS n FROM ducklake_table_changes('main.t', {start}, {after}) \
          GROUP BY change_type ORDER BY change_type"
     );
     let batches = fctx.sql(&sql).await.unwrap().collect().await.unwrap();

--- a/tests/table_changes_tests.rs
+++ b/tests/table_changes_tests.rs
@@ -286,12 +286,13 @@ mod integration_tests {
             "Schema should contain 'change_type' CDC column"
         );
 
-        // Verify column order: table columns first, then CDC columns
+        // Verify column order: CDC columns leading (official DuckLake order),
+        // then table columns.
         assert_eq!(field_names.len(), 6, "Should have 6 columns total");
         assert_eq!(
             field_names,
-            vec!["id", "event_type", "value", "rowid", "snapshot_id", "change_type"],
-            "Columns should be in order: table columns, then CDC columns"
+            vec!["snapshot_id", "rowid", "change_type", "id", "event_type", "value"],
+            "Columns should be in order: CDC columns (official order), then table columns"
         );
 
         Ok(())

--- a/tests/table_changes_tests.rs
+++ b/tests/table_changes_tests.rs
@@ -146,10 +146,13 @@ mod integration_tests {
 
         let ctx = create_context_with_functions(catalog_path.to_str().unwrap()).await?;
 
-        // Query all columns including table data + CDC metadata
+        // Query all columns including table data + CDC metadata; the fixture's
+        // final snapshot also deletes id=2, so filter to the insert rows.
         let df = ctx
             .sql(
-                "SELECT id, event_type, value, snapshot_id, change_type FROM ducklake_table_changes('main.events', 0, 10) ORDER BY id",
+                "SELECT id, event_type, value, snapshot_id, change_type \
+                 FROM ducklake_table_changes('main.events', 0, 10) \
+                 WHERE change_type = 'insert' ORDER BY id",
             )
             .await?;
 
@@ -170,22 +173,17 @@ mod integration_tests {
         // All rows should have ids 1-5
         assert_eq!(all_ids, vec![1, 2, 3, 4, 5], "Should have ids 1-5");
 
-        // All changes should be inserts (Phase 2 INSERT-only)
         for change_type in all_change_types {
-            assert_eq!(
-                change_type, "insert",
-                "All changes should be 'insert' in Phase 2"
-            );
+            assert_eq!(change_type, "insert", "filtered to insert rows");
         }
 
         Ok(())
     }
 
-    /// Test that ducklake_table_changes returns delete changes (delete files added)
+    /// Test that ducklake_table_changes returns pure deletes as `delete` rows
+    /// carrying the deleted rows' old values, matching official DuckLake.
     ///
-    /// NOTE: DELETE changes are NOT supported in Phase 2 INSERT-only.
-    /// This test verifies that no delete changes are returned (expected behavior for this phase).
-    /// Future phases will add DELETE support.
+    /// The fixture deletes the row with id=2 ('view', 50) in its final snapshot.
     #[tokio::test]
     async fn test_table_changes_deletes() -> DataFusionResult<()> {
         let temp_dir = TempDir::new().unwrap();
@@ -196,20 +194,25 @@ mod integration_tests {
 
         let ctx = create_context_with_functions(catalog_path.to_str().unwrap()).await?;
 
-        // Query only delete changes - in Phase 2, there should be none
         let df = ctx
-            .sql("SELECT snapshot_id, change_type FROM ducklake_table_changes('main.events', 0, 100) WHERE change_type = 'delete'")
+            .sql(
+                "SELECT id, event_type, value FROM \
+                 ducklake_table_changes('main.events', 0, 100) \
+                 WHERE change_type = 'delete'",
+            )
             .await?;
 
         let batches: Vec<RecordBatch> = df.collect().await?;
         let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 1, "exactly the one deleted row surfaces");
 
-        // Phase 2 INSERT-only: no delete changes expected
-        assert_eq!(
-            total_rows, 0,
-            "Phase 2 INSERT-only: no delete changes expected, got {}",
-            total_rows
-        );
+        let b = batches.iter().find(|b| b.num_rows() > 0).unwrap();
+        let ids = b
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::Int32Array>()
+            .unwrap();
+        assert_eq!(ids.value(0), 2, "the delete carries the old row's values");
 
         Ok(())
     }


### PR DESCRIPTION
Items 2–4 of #179: the three CDC surface convergences, batched so downstream consumers migrate once. After this PR, `SELECT * FROM ducklake_table_changes(...)` is **verbatim-identical** to official DuckLake's — same windows, same rows, same rowids, same change types, same column order — and the differential harness enforces that with no normalizers left on the changes feed.

## Breaking changes (one 0.6 migration)

1. **Inclusive-inclusive snapshot bounds** (`0d5e92f`). Windows are now `[start, end]`, matching official (`GetTableInsertions`: `begin_snapshot >= start AND <= end`; official docs example `table_changes('t', 2, 2)` returns snapshot 2). Previously exclusive-start. All five query copies flipped (shared/DuckDB, SQLite, PostgreSQL, MySQL, multicatalog). *Migration: cursor pagination `(last, now]` → pass `last + 1`.*

2. **CDC columns lead** (`45e7e70`). Output is `(snapshot_id, rowid, change_type, <table columns>)`, official's order; previously the metadata columns trailed. By-name queries unaffected; `SELECT *`/positional consumers adjust.

3. **Pure deletes surface in `table_changes`** (`9ba8ea3`). Unmatched deletes now emit as `change_type='delete'` rows carrying the deleted rows' old values and preserved rowids, exactly like official. Delete-only windows are no longer empty. `ducklake_table_deletions` is unchanged — consumers reading both feeds should de-duplicate or pick one.

## Verification

- **Differential harness ratchet fully tightened for the changes feed**: each convergence deleted its normalizer; `table_changes` is now compared against official DuckDB **verbatim** (the deletions feed keeps one documented difference: a materialized constant `change_type` column, asserted explicitly). 9 scenarios × every snapshot window, all green.
- Full default + `write-sqlite` sweeps green; Docker backends green (Postgres 51, MySQL 14, multicatalog 13).
- Manual side-by-side via `examples/basic_query` against the official extension: identical output cell-for-cell, including the pure delete and update pair, at identical window numbers.
- External review finding addressed: the unconditional delete path no longer requires `row_id_start` when rowid is neither projected nor pairable (mirrors `ducklake_table_deletions`), so non-rowid projections over delete-only windows work on older/foreign catalogs that never recorded `row_id_start` — with a regression test (`pure_delete_without_row_id_start_non_rowid_projection`).

## Notes

- Encrypted (PME) catalogs keep the insert-only fallback (updates surface as inserts, deletes missing; a delete-only window now fails at read rather than silently returning nothing) — documented in COMPATIBILITY.md, to be removed by the CDC-decryption item of #179.
- Discovered during item 2 and tracked separately in #179: official also includes compaction-merged files via `partial_max >= start`, which our CDC queries don't yet honor; and the multicatalog CDC path has no test coverage (its own SQL copy is flipped here, exercised only by the shared feed-layer tests).
