### PR TITLE
fix(cdc): read compaction-merged partial files — partial_max windows, per-row origin snapshots (#179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- CDC feeds missed changes inside compaction-merged files. Windows starting past a
+  merged file's `begin_snapshot` now include it via `partial_max`, each merged row
+  is attributed to its origin snapshot (from the embedded
+  `_ducklake_internal_snapshot_id` column), out-of-window rows are filtered, and a
+  merge itself emits no change events — matching official DuckLake. Catalogs
+  written under the older spec (`partial_file_info`) are handled on the DuckDB
+  backend (#179).
+
 ### Changed
 - **BREAKING**: `ducklake_table_changes` / `ducklake_table_deletions` snapshot bounds
   are now inclusive on both ends, matching official DuckLake: `(t, start, end)` returns

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -196,8 +196,11 @@ Known edges:
   are missing entirely (the correlated path reads parquet footers/rows the change-feed
   path does not decrypt). A window whose only changes are deletes carries no data file
   to detect encryption from, so it fails at read time on an encrypted catalog rather
-  than returning wrong results. Non-encrypted catalogs emit the full official
-  change-set (inserts, deletes, update pre/postimages).
+  than returning wrong results. Compaction-merged (partial) files whose window overlap
+  comes only from `partial_max` are likewise dropped on encrypted catalogs (their
+  per-row snapshot column cannot be read). Non-encrypted catalogs emit the full
+  official change-set (inserts, deletes, update pre/postimages, merged-file rows at
+  their origin snapshots).
 - **No partition-based file pruning** on read.
 - **Complex / nested types** have minimal support.
 - **DuckDB-encrypted (non-PME) Parquet files** are not supported (only PME).

--- a/src/metadata_provider.rs
+++ b/src/metadata_provider.rs
@@ -112,11 +112,13 @@ pub const SQL_GET_DATA_FILES_ADDED_BETWEEN_SNAPSHOTS: &str = "
         data.file_size_bytes,
         data.footer_size,
         data.encryption_key,
-        data.row_id_start
+        data.row_id_start,
+        data.partial_max
     FROM ducklake_data_file AS data
-    WHERE data.table_id = ?
-      AND data.begin_snapshot >= ?
-      AND data.begin_snapshot <= ?
+    WHERE data.table_id = $1
+      AND data.begin_snapshot <= $3
+      AND (data.begin_snapshot >= $2
+           OR (data.partial_max IS NOT NULL AND data.partial_max >= $2))
     ORDER BY data.begin_snapshot";
 
 pub const SQL_GET_DELETE_FILES_ADDED_BETWEEN_SNAPSHOTS: &str = "
@@ -659,6 +661,13 @@ pub struct DataFileChange {
     /// synthesize a plain insert's rowid (`row_id_start + physical_position`);
     /// files with an embedded rowid do not need it.
     pub row_id_start: Option<i64>,
+    /// For a compaction-merged partial file: the maximum origin snapshot id of
+    /// its rows (`partial_max` in the catalog). `Some` means the file spans
+    /// snapshots `begin_snapshot..=partial_max` and each row's snapshot must be
+    /// read from the embedded `_ducklake_internal_snapshot_id` column, with
+    /// rows outside the query window filtered out. `None` for ordinary files
+    /// (all rows belong to `begin_snapshot`).
+    pub partial_max: Option<i64>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/metadata_provider_duckdb.rs
+++ b/src/metadata_provider_duckdb.rs
@@ -738,10 +738,59 @@ impl MetadataProvider for DuckdbMetadataProvider {
         end_snapshot: i64,
     ) -> crate::Result<Vec<DataFileChange>> {
         let conn = self.connection();
-        let mut stmt = conn.prepare(SQL_GET_DATA_FILES_ADDED_BETWEEN_SNAPSHOTS)?;
 
+        // DuckLake's catalog schema renamed the merged-partial-file marker:
+        // older catalogs (spec 0.2, written by earlier ducklake extensions)
+        // carry `partial_file_info` (a cumulative `snapshot:rowcount|...`
+        // string); current ones carry `partial_max` (BIGINT). Detect which
+        // column this catalog has and query accordingly.
+        let has_partial_max: bool = conn.query_row(
+            "SELECT COUNT(*) > 0 FROM pragma_table_info('ducklake_data_file') \
+             WHERE name = 'partial_max'",
+            [],
+            |row| row.get(0),
+        )?;
+
+        if has_partial_max {
+            let mut stmt = conn.prepare(SQL_GET_DATA_FILES_ADDED_BETWEEN_SNAPSHOTS)?;
+            let files = stmt
+                .query_map(params![table_id, start_snapshot, end_snapshot], |row| {
+                    Ok(DataFileChange {
+                        begin_snapshot: row.get(0)?,
+                        path: row.get(1)?,
+                        path_is_relative: row.get(2)?,
+                        file_size_bytes: row.get(3)?,
+                        footer_size: row.get(4)?,
+                        encryption_key: row.get(5)?,
+                        row_id_start: row.get(6)?,
+                        partial_max: row.get(7)?,
+                    })
+                })?
+                .collect::<Result<Vec<_>, _>>()?;
+            return Ok(files);
+        }
+
+        // Old-spec catalog: fetch candidate partial files broadly and apply the
+        // `partial_max >= start` bound in Rust after parsing the info string.
+        let mut stmt = conn.prepare(
+            "SELECT
+                data.begin_snapshot,
+                data.path,
+                data.path_is_relative,
+                data.file_size_bytes,
+                data.footer_size,
+                data.encryption_key,
+                data.row_id_start,
+                data.partial_file_info
+            FROM ducklake_data_file AS data
+            WHERE data.table_id = $1
+              AND data.begin_snapshot <= $3
+              AND (data.begin_snapshot >= $2 OR data.partial_file_info IS NOT NULL)
+            ORDER BY data.begin_snapshot",
+        )?;
         let files = stmt
             .query_map(params![table_id, start_snapshot, end_snapshot], |row| {
+                let info: Option<String> = row.get(7)?;
                 Ok(DataFileChange {
                     begin_snapshot: row.get(0)?,
                     path: row.get(1)?,
@@ -750,9 +799,16 @@ impl MetadataProvider for DuckdbMetadataProvider {
                     footer_size: row.get(4)?,
                     encryption_key: row.get(5)?,
                     row_id_start: row.get(6)?,
+                    partial_max: info.as_deref().and_then(parse_partial_file_info_max),
                 })
             })?
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .filter(|f: &DataFileChange| {
+                f.begin_snapshot >= start_snapshot
+                    || f.partial_max.is_some_and(|max| max >= start_snapshot)
+            })
+            .collect();
 
         Ok(files)
     }
@@ -797,5 +853,36 @@ impl MetadataProvider for DuckdbMetadataProvider {
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(files)
+    }
+}
+
+/// Parse the maximum origin snapshot id out of an old-spec `partial_file_info`
+/// string — a `|`-separated list of cumulative `snapshot:rowcount` pairs (e.g.
+/// `"2:1|3:2|4:3"`), whose last pair carries the file's maximum snapshot.
+fn parse_partial_file_info_max(info: &str) -> Option<i64> {
+    info.rsplit('|')
+        .next()
+        .and_then(|pair| pair.split(':').next())
+        .and_then(|snap| snap.trim().parse::<i64>().ok())
+}
+
+#[cfg(test)]
+mod partial_file_info_tests {
+    use super::parse_partial_file_info_max;
+
+    #[test]
+    fn parses_multi_pair_info() {
+        assert_eq!(parse_partial_file_info_max("2:1|3:2|4:3"), Some(4));
+    }
+
+    #[test]
+    fn parses_single_pair_info() {
+        assert_eq!(parse_partial_file_info_max("7:100"), Some(7));
+    }
+
+    #[test]
+    fn malformed_info_is_none() {
+        assert_eq!(parse_partial_file_info_max(""), None);
+        assert_eq!(parse_partial_file_info_max("nonsense"), None);
     }
 }

--- a/src/metadata_provider_mysql.rs
+++ b/src/metadata_provider_mysql.rs
@@ -856,7 +856,22 @@ impl MetadataProvider for MySqlMetadataProvider {
         end_snapshot: i64,
     ) -> Result<Vec<DataFileChange>> {
         block_on(async {
-            let rows = sqlx::query(
+            // Older catalogs predate `partial_max`; degrade it to NULL there
+            // (they cannot contain partial files).
+            let has_partial_max: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM information_schema.columns
+                 WHERE table_schema = DATABASE()
+                   AND table_name = 'ducklake_data_file'
+                   AND column_name = 'partial_max'",
+            )
+            .fetch_one(&self.pool)
+            .await?;
+            let pm = if has_partial_max > 0 {
+                "data.partial_max"
+            } else {
+                "NULL"
+            };
+            let rows = sqlx::query(&format!(
                 "SELECT
                     data.begin_snapshot,
                     data.path,
@@ -864,16 +879,19 @@ impl MetadataProvider for MySqlMetadataProvider {
                     data.file_size_bytes,
                     data.footer_size,
                     data.encryption_key,
-                    data.row_id_start
+                    data.row_id_start,
+                    {pm}
                 FROM ducklake_data_file AS data
                 WHERE data.table_id = ?
-                  AND data.begin_snapshot >= ?
                   AND data.begin_snapshot <= ?
-                ORDER BY data.begin_snapshot",
-            )
+                  AND (data.begin_snapshot >= ?
+                       OR ({pm} IS NOT NULL AND {pm} >= ?))
+                ORDER BY data.begin_snapshot"
+            ))
             .bind(table_id)
-            .bind(start_snapshot)
             .bind(end_snapshot)
+            .bind(start_snapshot)
+            .bind(start_snapshot)
             .fetch_all(&self.pool)
             .await?;
 
@@ -887,6 +905,7 @@ impl MetadataProvider for MySqlMetadataProvider {
                         footer_size: row.try_get(4)?,
                         encryption_key: row.try_get(5)?,
                         row_id_start: row.try_get(6)?,
+                        partial_max: row.try_get(7)?,
                     })
                 })
                 .collect()

--- a/src/metadata_provider_postgres.rs
+++ b/src/metadata_provider_postgres.rs
@@ -948,7 +948,21 @@ impl MetadataProvider for PostgresMetadataProvider {
         end_snapshot: i64,
     ) -> Result<Vec<DataFileChange>> {
         block_on(async {
-            let rows = sqlx::query(
+            // Older catalogs predate `partial_max`; degrade it to NULL there
+            // (they cannot contain partial files), matching the probe pattern
+            // used by the scan queries above.
+            let has_partial_max: bool = sqlx::query_scalar(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.columns
+                 WHERE table_name = 'ducklake_data_file' AND column_name = 'partial_max')",
+            )
+            .fetch_one(&self.pool)
+            .await?;
+            let pm = if has_partial_max {
+                "data.partial_max::bigint"
+            } else {
+                "NULL::bigint"
+            };
+            let rows = sqlx::query(&format!(
                 "SELECT
                     data.begin_snapshot,
                     data.path,
@@ -956,13 +970,15 @@ impl MetadataProvider for PostgresMetadataProvider {
                     data.file_size_bytes,
                     data.footer_size,
                     data.encryption_key,
-                    data.row_id_start
+                    data.row_id_start,
+                    {pm}
                 FROM ducklake_data_file AS data
                 WHERE data.table_id = $1
-                  AND data.begin_snapshot >= $2
                   AND data.begin_snapshot <= $3
-                ORDER BY data.begin_snapshot",
-            )
+                  AND (data.begin_snapshot >= $2
+                       OR ({pm} IS NOT NULL AND {pm} >= $2))
+                ORDER BY data.begin_snapshot"
+            ))
             .bind(table_id)
             .bind(start_snapshot)
             .bind(end_snapshot)
@@ -979,6 +995,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                         footer_size: row.try_get(4)?,
                         encryption_key: row.try_get(5)?,
                         row_id_start: row.try_get(6)?,
+                        partial_max: row.try_get(7)?,
                     })
                 })
                 .collect()

--- a/src/metadata_provider_sqlite.rs
+++ b/src/metadata_provider_sqlite.rs
@@ -1110,7 +1110,20 @@ impl MetadataProvider for SqliteMetadataProvider {
         end_snapshot: i64,
     ) -> Result<Vec<DataFileChange>> {
         block_on(async {
-            let rows = sqlx::query(
+            // Older catalogs predate `partial_max`; degrade it to NULL there
+            // (they cannot contain partial files), matching the probe pattern
+            // used by the scan queries above.
+            let has_partial_max: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM pragma_table_info('ducklake_data_file') WHERE name = 'partial_max'",
+            )
+            .fetch_one(&self.pool)
+            .await?;
+            let pm = if has_partial_max > 0 {
+                "data.partial_max"
+            } else {
+                "NULL"
+            };
+            let rows = sqlx::query(&format!(
                 "SELECT
                     data.begin_snapshot,
                     data.path,
@@ -1118,13 +1131,15 @@ impl MetadataProvider for SqliteMetadataProvider {
                     data.file_size_bytes,
                     data.footer_size,
                     data.encryption_key,
-                    data.row_id_start
+                    data.row_id_start,
+                    {pm}
                 FROM ducklake_data_file AS data
-                WHERE data.table_id = ?
-                  AND data.begin_snapshot >= ?
-                  AND data.begin_snapshot <= ?
-                ORDER BY data.begin_snapshot",
-            )
+                WHERE data.table_id = ?1
+                  AND data.begin_snapshot <= ?3
+                  AND (data.begin_snapshot >= ?2
+                       OR ({pm} IS NOT NULL AND {pm} >= ?2))
+                ORDER BY data.begin_snapshot"
+            ))
             .bind(table_id)
             .bind(start_snapshot)
             .bind(end_snapshot)
@@ -1141,6 +1156,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                         footer_size: row.try_get(4)?,
                         encryption_key: row.try_get(5)?,
                         row_id_start: row.try_get(6)?,
+                        partial_max: row.try_get(7)?,
                     })
                 })
                 .collect()

--- a/src/multicatalog_provider.rs
+++ b/src/multicatalog_provider.rs
@@ -999,7 +999,21 @@ impl MetadataProvider for MulticatalogProvider {
     ) -> Result<Vec<DataFileChange>> {
         // CDC inherits catalog via table_id. No additional scoping.
         block_on(async {
-            let rows = sqlx::query(
+            // Older catalogs predate `partial_max`; degrade it to NULL there
+            // (they cannot contain partial files), matching the probe pattern
+            // used by the scan queries above.
+            let has_partial_max: bool = sqlx::query_scalar(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.columns
+                 WHERE table_name = 'ducklake_data_file' AND column_name = 'partial_max')",
+            )
+            .fetch_one(&self.pool)
+            .await?;
+            let pm = if has_partial_max {
+                "data.partial_max::bigint"
+            } else {
+                "NULL::bigint"
+            };
+            let rows = sqlx::query(&format!(
                 "SELECT
                     data.begin_snapshot,
                     data.path,
@@ -1007,13 +1021,15 @@ impl MetadataProvider for MulticatalogProvider {
                     data.file_size_bytes,
                     data.footer_size,
                     data.encryption_key,
-                    data.row_id_start
+                    data.row_id_start,
+                    {pm}
                 FROM ducklake_data_file AS data
                 WHERE data.table_id = $1
-                  AND data.begin_snapshot >= $2
                   AND data.begin_snapshot <= $3
-                ORDER BY data.begin_snapshot",
-            )
+                  AND (data.begin_snapshot >= $2
+                       OR ({pm} IS NOT NULL AND {pm} >= $2))
+                ORDER BY data.begin_snapshot"
+            ))
             .bind(table_id)
             .bind(start_snapshot)
             .bind(end_snapshot)
@@ -1030,6 +1046,7 @@ impl MetadataProvider for MulticatalogProvider {
                         footer_size: row.try_get(4)?,
                         encryption_key: row.try_get(5)?,
                         row_id_start: row.try_get(6)?,
+                        partial_max: row.try_get(7)?,
                     })
                 })
                 .collect()

--- a/src/table_changes.rs
+++ b/src/table_changes.rs
@@ -42,7 +42,9 @@ use parquet::arrow::async_reader::ParquetObjectReader;
 use crate::metadata_provider::{DataFileChange, MetadataProvider};
 use crate::path_resolver::resolve_path;
 use crate::positional_source::PositionalFileSource;
-use crate::row_id::{FileRowNumberExec, ROW_ID_PARQUET_FIELD_ID, ROW_POS_COLUMN_NAME};
+use crate::row_id::{
+    FileRowNumberExec, ROW_ID_PARQUET_FIELD_ID, ROW_POS_COLUMN_NAME, SNAPSHOT_ID_PARQUET_FIELD_ID,
+};
 use crate::table::{delete_file_schema, validated_file_size, validated_record_count};
 use crate::types::extract_parquet_field_ids;
 
@@ -85,6 +87,17 @@ impl fmt::Display for ChangeType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.as_str())
     }
+}
+
+/// Physical names of a data file's embedded CDC columns, when present.
+#[derive(Debug, Clone, Default)]
+struct EmbeddedCdcNames {
+    /// `_ducklake_internal_row_id` under its physical name (field id
+    /// [`ROW_ID_PARQUET_FIELD_ID`]).
+    rowid: Option<String>,
+    /// `_ducklake_internal_snapshot_id` under its physical name (field id
+    /// [`SNAPSHOT_ID_PARQUET_FIELD_ID`]).
+    snapshot: Option<String>,
 }
 
 /// Positions of the CDC metadata columns in the feed's output schema. They
@@ -586,15 +599,17 @@ impl TableChangesTable {
         )))
     }
 
-    /// Read a file's parquet footer and return the physical name of its embedded
-    /// row-id column ([`ROW_ID_PARQUET_FIELD_ID`]) when present. A file that
-    /// carries one is the postimage side of an `UPDATE` / compaction.
-    async fn detect_embedded_rowid_name(
+    /// Read a file's parquet footer and return the physical names of its
+    /// embedded CDC columns: the row-id column ([`ROW_ID_PARQUET_FIELD_ID`],
+    /// present on UPDATE / non-adjacent-compaction outputs) and the per-row
+    /// snapshot-id column ([`SNAPSHOT_ID_PARQUET_FIELD_ID`], present on
+    /// compaction-merged partial files).
+    async fn detect_embedded_cdc_names(
         &self,
         state: &dyn Session,
         path: &str,
         is_relative: bool,
-    ) -> DataFusionResult<Option<String>> {
+    ) -> DataFusionResult<EmbeddedCdcNames> {
         let resolved = resolve_path(&self.table_path, path, is_relative)
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
         let object_store = state
@@ -605,24 +620,37 @@ impl TableChangesTable {
             .await
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
         let field_ids = extract_parquet_field_ids(builder.metadata());
-        Ok(field_ids.get(&ROW_ID_PARQUET_FIELD_ID).cloned())
+        Ok(EmbeddedCdcNames {
+            rowid: field_ids.get(&ROW_ID_PARQUET_FIELD_ID).cloned(),
+            snapshot: field_ids.get(&SNAPSHOT_ID_PARQUET_FIELD_ID).cloned(),
+        })
     }
 
     /// The read schema for a data file: the table columns, plus the embedded
-    /// rowid column (under its physical name) when `embedded_name` is `Some`.
-    fn read_schema_with_optional_rowid(&self, embedded_name: &Option<String>) -> SchemaRef {
-        match embedded_name {
-            Some(name) => {
+    /// rowid / per-row snapshot columns (under their physical names) when
+    /// present, in that order.
+    fn read_schema_with_embedded(
+        &self,
+        rowid_name: &Option<String>,
+        snapshot_name: &Option<String>,
+    ) -> SchemaRef {
+        match (rowid_name, snapshot_name) {
+            (None, None) => self.table_schema.clone(),
+            (rowid, snapshot) => {
                 let mut fields: Vec<Field> = self
                     .table_schema
                     .fields()
                     .iter()
                     .map(|f| f.as_ref().clone())
                     .collect();
-                fields.push(Field::new(name, DataType::Int64, true));
+                if let Some(name) = rowid {
+                    fields.push(Field::new(name, DataType::Int64, true));
+                }
+                if let Some(name) = snapshot {
+                    fields.push(Field::new(name, DataType::Int64, true));
+                }
                 Arc::new(Schema::new(fields))
             },
-            None => self.table_schema.clone(),
         }
     }
 
@@ -635,8 +663,8 @@ impl TableChangesTable {
     fn build_insert_scan(
         &self,
         data_file: &DataFileChange,
-        embedded_name: &Option<String>,
-        need_rowid: bool,
+        embedded: &EmbeddedCdcNames,
+        need_rowid_resolution: bool,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         let resolved = resolve_path(
             &self.table_path,
@@ -654,7 +682,13 @@ impl TableChangesTable {
         {
             pf = pf.with_metadata_size_hint(hint);
         }
-        let read_schema = self.read_schema_with_optional_rowid(embedded_name);
+        // The per-row snapshot column is read only for partial (merged) files.
+        let snapshot_name = if data_file.partial_max.is_some() {
+            embedded.snapshot.clone()
+        } else {
+            None
+        };
+        let read_schema = self.read_schema_with_embedded(&embedded.rowid, &snapshot_name);
         let plain_scan = |pf: PartitionedFile, schema: SchemaRef| {
             let builder = FileScanConfigBuilder::new(
                 self.object_store_url.as_ref().clone(),
@@ -663,12 +697,14 @@ impl TableChangesTable {
             .with_file_group(FileGroup::new(vec![pf]));
             DataSourceExec::from_data_source(builder.build())
         };
-        match embedded_name {
-            // Postimage / rewrite: rowid IS the embedded column — a plain scan.
+        match &embedded.rowid {
+            // Postimage / rewrite / non-adjacent merge: rowid IS the embedded
+            // column — a plain scan.
             Some(_) => Ok(plain_scan(pf, read_schema)),
-            // Plain insert, rowid requested: scan positionally to synthesize
-            // rowid = row_id_start + physical position.
-            None if need_rowid => {
+            // No embedded rowid but resolution required (rowid projected, or a
+            // partial file whose real rowids feed the update correlation): scan
+            // positionally to synthesize rowid = row_id_start + position.
+            None if need_rowid_resolution => {
                 let source = PositionalFileSource::wrap(Arc::new(ParquetSource::new(read_schema)));
                 let builder =
                     FileScanConfigBuilder::new(self.object_store_url.as_ref().clone(), source)
@@ -677,7 +713,7 @@ impl TableChangesTable {
                 let scan = DataSourceExec::from_data_source(builder.build());
                 Ok(Arc::new(FileRowNumberExec::new(scan, vec![0])))
             },
-            // Plain insert, rowid not requested: a plain scan, no positions.
+            // Plain insert, rowid not needed: a plain scan, no positions.
             None => Ok(plain_scan(pf, read_schema)),
         }
     }
@@ -703,7 +739,7 @@ impl TableChangesTable {
         {
             pf = pf.with_metadata_size_hint(hint);
         }
-        let read_schema = self.read_schema_with_optional_rowid(embedded_name);
+        let read_schema = self.read_schema_with_embedded(embedded_name, &None);
         let source = PositionalFileSource::wrap(Arc::new(ParquetSource::new(read_schema)));
         let builder = FileScanConfigBuilder::new(self.object_store_url.as_ref().clone(), source)
             .with_file_group(FileGroup::new(vec![pf]))
@@ -747,7 +783,7 @@ impl TableChangesTable {
         state: &dyn Session,
         data_files: &[DataFileChange],
         delete_files: &[crate::metadata_provider::DeleteFileChange],
-        embedded_names: &[Option<String>],
+        embedded_names: &[EmbeddedCdcNames],
         projection: Option<&Vec<usize>>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         let table_len = self.table_schema.fields().len();
@@ -757,20 +793,45 @@ impl TableChangesTable {
         let need_rowid = projection.is_none_or(|idx| idx.contains(&ROWID_IDX));
 
         let mut insert_units = Vec::with_capacity(data_files.len());
-        for (df, name) in data_files.iter().zip(embedded_names.iter()) {
-            // Embedded file: rowid is the trailing embedded column (at `table_len`).
-            // Plain insert (rowid requested): `build_insert_scan` appends a
-            // physical-position column (at `table_len`); rowid = row_id_start + pos.
-            let embedded = name.is_some();
+        for (df, names) in data_files.iter().zip(embedded_names.iter()) {
+            // Column layout of the scan batch after the `table_len` table
+            // columns: [embedded rowid?][embedded snapshot? (partial files
+            // only)][position? (appended by FileRowNumberExec)].
+            let is_partial = df.partial_max.is_some();
+            if is_partial && names.snapshot.is_none() {
+                return Err(DataFusionError::External(
+                    format!(
+                        "data file {} is a merged partial file (partial_max set) but carries \
+                         no embedded per-row snapshot column; cannot attribute its rows to \
+                         snapshots",
+                        df.path
+                    )
+                    .into(),
+                ));
+            }
+            // A partial file's rows carry REAL rowids into the update
+            // correlation (a placeholder could false-pair), so rowid is
+            // resolved for them even when it is not projected.
+            let resolve_rowid = need_rowid || is_partial;
+            let has_embedded_rowid = names.rowid.is_some();
+            let mut next_idx = table_len;
+            let embedded_col_idx = has_embedded_rowid.then(|| {
+                let i = next_idx;
+                next_idx += 1;
+                i
+            });
+            let snapshot_col_idx = (is_partial && names.snapshot.is_some()).then(|| {
+                let i = next_idx;
+                next_idx += 1;
+                i
+            });
+            let pos_col_idx = (!has_embedded_rowid && resolve_rowid).then_some(next_idx);
             insert_units.push(InsertUnit {
                 snapshot_id: df.begin_snapshot,
-                scan: self.build_insert_scan(df, name, need_rowid)?,
-                embedded_col_idx: name.as_ref().map(|_| table_len),
-                pos_col_idx: if !embedded && need_rowid {
-                    Some(table_len)
-                } else {
-                    None
-                },
+                scan: self.build_insert_scan(df, names, resolve_rowid)?,
+                embedded_col_idx,
+                snapshot_col_idx,
+                pos_col_idx,
                 row_id_start: df.row_id_start,
             });
         }
@@ -789,12 +850,13 @@ impl TableChangesTable {
                 )
                 .map_err(|e| DataFusionError::External(Box::new(e)))?;
                 let old_embedded = self
-                    .detect_embedded_rowid_name(
+                    .detect_embedded_cdc_names(
                         state,
                         &dfc.data_file_path,
                         dfc.data_file_path_is_relative,
                     )
-                    .await?;
+                    .await?
+                    .rowid;
                 let data_scan = self.build_delete_data_scan(
                     &resolved,
                     dfc.data_file_size_bytes,
@@ -839,6 +901,7 @@ impl TableChangesTable {
             self.output_schema.clone(),
             table_len,
             need_rowid,
+            (self.start_snapshot, self.end_snapshot),
         ));
 
         // The exec emits the full `[snapshot_id, rowid, change_type, table
@@ -911,6 +974,8 @@ impl TableProvider for TableChangesTable {
             return Ok(Arc::new(EmptyExec::new(proj_info.output_schema)));
         }
 
+        let mut data_files = data_files;
+
         // Decide whether to take the correlated path (reading delete sources to
         // emit `delete` rows and pair an UPDATE's delete+insert into
         // preimage/postimage). Guards, all cheap and metadata-only:
@@ -939,11 +1004,28 @@ impl TableProvider for TableChangesTable {
             }
         };
 
-        if (proj_info.need_rowid || !delete_files.is_empty()) && !any_encrypted {
-            let mut embedded_names: Vec<Option<String>> = Vec::with_capacity(data_files.len());
+        // Merged partial files whose window overlap comes only from
+        // `partial_max` (begin_snapshot before the window) need per-row
+        // attribution, which the encrypted insert-only path below cannot do
+        // (it cannot read the embedded snapshot column). Drop them there —
+        // matching the pre-partial_max behavior — rather than emitting rows
+        // with wrong snapshots. See COMPATIBILITY.md. When that leaves no
+        // data files at all, the feed is empty (deletes are already
+        // documented-missing on encrypted catalogs), not a planning error.
+        if any_encrypted {
+            data_files.retain(|f| f.begin_snapshot >= self.start_snapshot);
+            if data_files.is_empty() {
+                use datafusion::physical_plan::empty::EmptyExec;
+                return Ok(Arc::new(EmptyExec::new(proj_info.output_schema)));
+            }
+        }
+        let any_partial = data_files.iter().any(|f| f.partial_max.is_some());
+
+        if (proj_info.need_rowid || !delete_files.is_empty() || any_partial) && !any_encrypted {
+            let mut embedded_names: Vec<EmbeddedCdcNames> = Vec::with_capacity(data_files.len());
             for data_file in &data_files {
                 embedded_names.push(
-                    self.detect_embedded_rowid_name(
+                    self.detect_embedded_cdc_names(
                         state,
                         &data_file.path,
                         data_file.path_is_relative,
@@ -1017,10 +1099,16 @@ impl TableProvider for TableChangesTable {
 /// column at `pos_col_idx` and whose rowid is `row_id_start + position`.
 #[derive(Clone)]
 struct InsertUnit {
+    /// The file's `begin_snapshot`: every row's snapshot for an ordinary file;
+    /// for a merged partial file (`snapshot_col_idx` set) it is only the
+    /// minimum, and each row's actual snapshot comes from the embedded column.
     snapshot_id: i64,
     scan: Arc<dyn ExecutionPlan>,
     /// Column index of the embedded rowid, or `None` for a plain insert.
     embedded_col_idx: Option<usize>,
+    /// Column index of the embedded per-row snapshot (merged partial files
+    /// only). Rows outside the query window are filtered out on read.
+    snapshot_col_idx: Option<usize>,
     /// Column index of the physical row-position (plain inserts only).
     pos_col_idx: Option<usize>,
     /// First rowid of the file (`None` if the catalog carries none). Required
@@ -1074,6 +1162,9 @@ pub struct TableChangesExec {
     /// skip rowid synthesis (emitting a placeholder dropped by the projection),
     /// so a non-rowid projection never needs a plain insert's row_id_start.
     need_rowid: bool,
+    /// The query's `[start, end]` snapshot window (inclusive), used to filter
+    /// rows of merged partial files by their embedded per-row snapshot.
+    window: (i64, i64),
     properties: Arc<PlanProperties>,
 }
 
@@ -1096,6 +1187,7 @@ impl std::fmt::Debug for DeleteUnit {
 }
 
 impl TableChangesExec {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         insert_units: Vec<InsertUnit>,
         delete_units: Vec<DeleteUnit>,
@@ -1103,6 +1195,7 @@ impl TableChangesExec {
         output_schema: SchemaRef,
         table_len: usize,
         need_rowid: bool,
+        window: (i64, i64),
     ) -> Self {
         let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(output_schema.clone()),
@@ -1117,6 +1210,7 @@ impl TableChangesExec {
             output_schema,
             table_len,
             need_rowid,
+            window,
             properties,
         }
     }
@@ -1186,6 +1280,7 @@ impl ExecutionPlan for TableChangesExec {
         let output_schema = self.output_schema.clone();
         let table_len = self.table_len;
         let need_rowid = self.need_rowid;
+        let window = self.window;
 
         let fut = async move {
             correlate_changes(
@@ -1194,6 +1289,7 @@ impl ExecutionPlan for TableChangesExec {
                 output_schema,
                 table_len,
                 need_rowid,
+                window,
                 context,
             )
             .await
@@ -1214,13 +1310,17 @@ impl ExecutionPlan for TableChangesExec {
 }
 
 /// Collect the inserted and deleted rows, correlate update pairs by
-/// `(snapshot_id, rowid)`, and produce the tagged output batches.
+/// `(snapshot_id, rowid)`, and produce the tagged output batches. `window` is
+/// the query's inclusive `[start, end]` snapshot range, applied per row to
+/// merged partial files (whose rows span several snapshots).
+#[allow(clippy::too_many_arguments)]
 async fn correlate_changes(
     insert_units: Vec<InsertUnit>,
     delete_units: Vec<DeleteUnit>,
     output_schema: SchemaRef,
     table_len: usize,
     need_rowid: bool,
+    window: (i64, i64),
     context: Arc<TaskContext>,
 ) -> DataFusionResult<Vec<RecordBatch>> {
     // Inserted rows split into postimage candidates (embedded rowid — can pair
@@ -1239,63 +1339,94 @@ async fn correlate_changes(
                 continue;
             }
             let table_batch = b.project(&(0..table_len).collect::<Vec<_>>())?;
-            match unit.embedded_col_idx {
-                // UPDATE / compaction postimage: rowid IS the embedded column.
-                Some(idx) => {
-                    let rowid = b
-                        .column(idx)
-                        .as_any()
-                        .downcast_ref::<Int64Array>()
-                        .ok_or_else(|| {
-                            DataFusionError::Internal(
-                                "embedded rowid column is not Int64".to_string(),
-                            )
-                        })?
-                        .clone();
-                    postimages.push(KeyedRows {
-                        snapshot_id: unit.snapshot_id,
-                        table_batch,
-                        rowid,
-                    });
+
+            // Resolve each row's rowid: the embedded column when present, else
+            // row_id_start + physical position (only when actually needed).
+            let embedded_rowid = match unit.embedded_col_idx {
+                Some(idx) => Some(int64_column(&b, idx, "embedded rowid")?.clone()),
+                None => None,
+            };
+            let rowid: Int64Array = match (&embedded_rowid, unit.pos_col_idx) {
+                (Some(arr), _) => (*arr).clone(),
+                (None, Some(pos_idx)) => {
+                    let row_id_start = unit.row_id_start.ok_or_else(|| {
+                        DataFusionError::Internal(
+                            "cannot synthesize rowid: inserted file has neither an embedded \
+                             rowid nor a row_id_start"
+                                .to_string(),
+                        )
+                    })?;
+                    let pos = int64_column(&b, pos_idx, ROW_POS_COLUMN_NAME)?;
+                    Int64Array::from(
+                        (0..n)
+                            .map(|i| row_id_start + pos.value(i))
+                            .collect::<Vec<i64>>(),
+                    )
                 },
-                // Plain insert: rowid = row_id_start + physical position when
-                // requested, else a placeholder dropped by the projection.
-                None => {
-                    let rowid = if need_rowid {
-                        let pos_idx = unit.pos_col_idx.ok_or_else(|| {
-                            DataFusionError::Internal(
-                                "plain insert scan is missing its position column".to_string(),
-                            )
-                        })?;
-                        let row_id_start = unit.row_id_start.ok_or_else(|| {
-                            DataFusionError::Internal(
-                                "cannot synthesize rowid: inserted file has neither an embedded \
-                                 rowid nor a row_id_start"
-                                    .to_string(),
-                            )
-                        })?;
-                        let pos = b
-                            .column(pos_idx)
+                // Rowid neither embedded nor resolved (not requested): a
+                // placeholder dropped by the projection; never pairs.
+                (None, None) => Int64Array::from(vec![0i64; n]),
+            };
+
+            match unit.snapshot_col_idx {
+                // Merged partial file: each row belongs to its embedded origin
+                // snapshot. Filter rows to the query window and split the batch
+                // into one KeyedRows group per snapshot; their rowids are real,
+                // so they participate in update pairing like any insertion.
+                Some(snap_idx) => {
+                    let snaps = int64_column(&b, snap_idx, "embedded snapshot_id")?;
+                    let mut by_snapshot: std::collections::BTreeMap<i64, Vec<u32>> =
+                        std::collections::BTreeMap::new();
+                    for i in 0..n {
+                        if snaps.is_null(i) {
+                            return Err(DataFusionError::Internal(
+                                "embedded snapshot_id column contains NULL".to_string(),
+                            ));
+                        }
+                        let s = snaps.value(i);
+                        if s >= window.0 && s <= window.1 {
+                            by_snapshot.entry(s).or_default().push(i as u32);
+                        }
+                    }
+                    for (snapshot, row_indices) in by_snapshot {
+                        let indices = UInt32Array::from(row_indices);
+                        let cols: Vec<ArrayRef> = table_batch
+                            .columns()
+                            .iter()
+                            .map(|c| {
+                                take(c.as_ref(), &indices, None)
+                                    .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+                            })
+                            .collect::<DataFusionResult<_>>()?;
+                        let group_batch = RecordBatch::try_new(table_batch.schema(), cols)?;
+                        let group_rowid = take(&rowid, &indices, None)
+                            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?
                             .as_any()
                             .downcast_ref::<Int64Array>()
-                            .ok_or_else(|| {
-                                DataFusionError::Internal(format!(
-                                    "{ROW_POS_COLUMN_NAME} column is not Int64"
-                                ))
-                            })?;
-                        Int64Array::from(
-                            (0..n)
-                                .map(|i| row_id_start + pos.value(i))
-                                .collect::<Vec<i64>>(),
-                        )
-                    } else {
-                        Int64Array::from(vec![0i64; n])
-                    };
-                    plain_inserts.push(KeyedRows {
+                            .expect("take preserves Int64")
+                            .clone();
+                        postimages.push(KeyedRows {
+                            snapshot_id: snapshot,
+                            table_batch: group_batch,
+                            rowid: group_rowid,
+                        });
+                    }
+                },
+                // Ordinary file: all rows belong to begin_snapshot. Embedded
+                // rowids (UPDATE / rewrite outputs) can pair with deletes;
+                // plain inserts carry fresh (or placeholder) rowids and never
+                // pair.
+                None => {
+                    let keyed = KeyedRows {
                         snapshot_id: unit.snapshot_id,
                         table_batch,
                         rowid,
-                    });
+                    };
+                    if embedded_rowid.is_some() {
+                        postimages.push(keyed);
+                    } else {
+                        plain_inserts.push(keyed);
+                    }
                 },
             }
         }
@@ -1475,6 +1606,19 @@ async fn correlate_changes(
         }
     }
     Ok(out)
+}
+
+/// Downcast a batch column to `Int64Array` with a descriptive error.
+fn int64_column<'a>(
+    batch: &'a RecordBatch,
+    idx: usize,
+    what: &str,
+) -> DataFusionResult<&'a Int64Array> {
+    batch
+        .column(idx)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .ok_or_else(|| DataFusionError::Internal(format!("{what} column is not Int64")))
 }
 
 /// Collect the `pos` set from a delete-file scan (`None` scan => `None`).

--- a/tests/cdc_differential_tests.rs
+++ b/tests/cdc_differential_tests.rs
@@ -637,3 +637,109 @@ async fn diff_update_all_rows() -> DataFusionResult<()> {
     )
     .await
 }
+
+/// Compaction: several small inserts merged into one partial file, then a
+/// post-compaction insert. Official attributes each merged row to its ORIGIN
+/// snapshot in the change feed (via the embedded
+/// `_ducklake_internal_snapshot_id` column); windows starting after the
+/// merged file's begin_snapshot must still see the in-window origin rows, and
+/// the merge itself emits no CDC events.
+///
+/// The INSTALLED (1.4-era) extension has two since-fixed gaps here, so this
+/// scenario cannot live-diff everything against it:
+///  * windows starting past the merged file's begin_snapshot exclude the file
+///    entirely (its CDC predicate predates partial-file inclusion) — those
+///    windows are asserted against CURRENT official semantics (per
+///    `test/sql/compaction/small_insert_compaction.test` upstream);
+///  * deletes targeting a merged file are mis-attributed to origin snapshots
+///    (its delete files lack the per-row snapshot column) — not exercised
+///    here, tracked as a #179 follow-up.
+///
+/// Snapshots: 1 = CREATE TABLE, 2/3/4 = single-row inserts (rowids 0/1/2),
+/// 5 = merge (no CDC events), 6 = insert of (4,'d') (rowid 3).
+#[tokio::test]
+async fn diff_compacted_inserts() -> DataFusionResult<()> {
+    let tmp = TempDir::new().map_err(box_err)?;
+    let path = tmp.path().join("compact.ducklake");
+    write_catalog(
+        &path,
+        &[
+            "CREATE TABLE c.t(id INTEGER, name VARCHAR);",
+            "INSERT INTO c.t VALUES (1, 'a');",
+            "INSERT INTO c.t VALUES (2, 'b');",
+            "INSERT INTO c.t VALUES (3, 'c');",
+            "CALL ducklake_merge_adjacent_files('c');",
+            "INSERT INTO c.t VALUES (4, 'd');",
+        ],
+    )?;
+
+    // Windows whose start does not exceed the merged file's begin_snapshot
+    // (2): the installed extension includes the file and resolves per-row
+    // origin snapshots correctly, so these live-diff against it.
+    let live_windows = [(0, 6), (1, 6), (2, 6), (2, 2), (0, 2), (2, 4)];
+    let mut official: Vec<((i64, i64), CanonFeed)> = Vec::new();
+    {
+        let conn = official_connection(&path)?;
+        for (a, b) in live_windows {
+            let changes = official_feed(
+                &conn,
+                &format!("SELECT * FROM ducklake_table_changes('c', 'main', 't', {a}, {b})"),
+                true,
+            )?;
+            official.push(((a, b), changes));
+        }
+    }
+    let ctx = crate_context(&path).await?;
+    for ((a, b), official_changes) in official {
+        let crate_changes = crate_feed(
+            &ctx,
+            &format!("SELECT * FROM ducklake_table_changes('main.t', {a}, {b})"),
+            true,
+        )
+        .await?;
+        assert_feeds_match(
+            &format!("compacted table_changes window [{a},{b}]"),
+            &official_changes,
+            &crate_changes,
+        );
+    }
+
+    // Windows reachable only through partial_max: asserted against CURRENT
+    // official semantics (each row at its origin snapshot; the merge emits
+    // nothing).
+    let insert_row = |snapshot: i64, rowid: i64, id: &str, name: &str| CanonRow {
+        snapshot_id: snapshot,
+        rowid: Some(rowid),
+        change_type: Some("insert".to_string()),
+        cells: vec![id.to_string(), name.to_string()],
+    };
+    let expectations: [((i64, i64), Vec<CanonRow>); 5] = [
+        ((3, 3), vec![insert_row(3, 1, "2", "b")]),
+        ((4, 4), vec![insert_row(4, 2, "3", "c")]),
+        ((5, 5), vec![]),
+        (
+            (3, 6),
+            vec![
+                insert_row(3, 1, "2", "b"),
+                insert_row(4, 2, "3", "c"),
+                insert_row(6, 3, "4", "d"),
+            ],
+        ),
+        ((4, 5), vec![insert_row(4, 2, "3", "c")]),
+    ];
+    for ((a, b), expected) in expectations {
+        let got = crate_feed(
+            &ctx,
+            &format!("SELECT * FROM ducklake_table_changes('main.t', {a}, {b})"),
+            true,
+        )
+        .await?;
+        assert_eq!(
+            got.rows,
+            expected,
+            "partial-only window [{a},{b}] diverges from current official semantics\n{}",
+            pretty(&got)
+        );
+    }
+    Ok(())
+}

--- a/tests/compaction_sqlite_tests.rs
+++ b/tests/compaction_sqlite_tests.rs
@@ -831,3 +831,120 @@ async fn merge_partial_file_serves_time_travel_after_sources_are_deleted() {
     // The current snapshot still returns everything.
     assert_eq!(read_rows(&temp).await.len(), 6);
 }
+
+/// CDC over a crate-compacted catalog: `ducklake_table_changes` must attribute
+/// each merged row to its ORIGIN snapshot (via the embedded per-row snapshot
+/// column) and honor windows that reach the merged file only through
+/// `partial_max`, matching official DuckLake.
+#[tokio::test(flavor = "multi_thread")]
+async fn cdc_attributes_merged_rows_to_origin_snapshots() {
+    let temp = TempDir::new().unwrap();
+    seed(&temp, vec![1], vec![10]).await;
+    let p = pool(&temp).await;
+    let s1 = scalar_i64(&p, "SELECT MAX(snapshot_id) FROM ducklake_snapshot").await;
+    append(&temp, vec![2], vec![20]).await;
+    let s2 = scalar_i64(&p, "SELECT MAX(snapshot_id) FROM ducklake_snapshot").await;
+    append(&temp, vec![3], vec![30]).await;
+    let s3 = scalar_i64(&p, "SELECT MAX(snapshot_id) FROM ducklake_snapshot").await;
+    run_merge(&temp, MergeOptions::default()).await;
+
+    // The merge produced a single partial file spanning s1..=s3.
+    let live_files = scalar_i64(
+        &p,
+        "SELECT COUNT(*) FROM ducklake_data_file WHERE end_snapshot IS NULL",
+    )
+    .await;
+    assert_eq!(live_files, 1, "merge coalesced to one live file");
+    let partial_max = opt_i64(
+        &p,
+        "SELECT partial_max FROM ducklake_data_file WHERE end_snapshot IS NULL",
+    )
+    .await;
+    assert_eq!(partial_max, Some(s3), "merged file records partial_max");
+
+    // CDC through the sqlite provider.
+    let provider = Arc::new(SqliteMetadataProvider::new(&ro_url(&temp)).await.unwrap());
+    let catalog =
+        DuckLakeCatalog::new(SqliteMetadataProvider::new(&ro_url(&temp)).await.unwrap()).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog("ducklake", Arc::new(catalog));
+    datafusion_ducklake::register_ducklake_functions(&ctx, provider);
+
+    let changes = |a: i64, b: i64| {
+        let ctx = ctx.clone();
+        async move {
+            let batches = ctx
+                .sql(&format!(
+                    "SELECT snapshot_id, rowid, change_type, id, val \
+                     FROM ducklake_table_changes('main.t', {a}, {b}) \
+                     ORDER BY snapshot_id"
+                ))
+                .await
+                .unwrap()
+                .collect()
+                .await
+                .unwrap();
+            let mut rows: Vec<(i64, i64, String, i32)> = Vec::new();
+            for batch in &batches {
+                let snaps = batch
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .unwrap();
+                let rowids = batch
+                    .column(1)
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .unwrap();
+                let cts = batch
+                    .column(2)
+                    .as_any()
+                    .downcast_ref::<arrow::array::StringArray>()
+                    .unwrap();
+                let ids = batch
+                    .column(3)
+                    .as_any()
+                    .downcast_ref::<Int32Array>()
+                    .unwrap();
+                for r in 0..batch.num_rows() {
+                    rows.push((
+                        snaps.value(r),
+                        rowids.value(r),
+                        cts.value(r).to_string(),
+                        ids.value(r),
+                    ));
+                }
+            }
+            rows
+        }
+    };
+
+    // Full range: every row at its origin snapshot with its original rowid.
+    assert_eq!(
+        changes(0, 1000).await,
+        vec![
+            (s1, 0, "insert".to_string(), 1),
+            (s2, 1, "insert".to_string(), 2),
+            (s3, 2, "insert".to_string(), 3),
+        ],
+        "merged rows attributed to origin snapshots"
+    );
+    // Windows reachable only via partial_max (start past the merged file's
+    // begin_snapshot).
+    assert_eq!(
+        changes(s2, s2).await,
+        vec![(s2, 1, "insert".to_string(), 2)],
+        "single-snapshot window inside the merged file"
+    );
+    assert_eq!(
+        changes(s3, 1000).await,
+        vec![(s3, 2, "insert".to_string(), 3)],
+        "suffix window inside the merged file"
+    );
+    // The merge snapshot itself emits nothing.
+    assert_eq!(
+        changes(s3 + 1, s3 + 1).await,
+        vec![],
+        "merge emits no CDC events"
+    );
+}


### PR DESCRIPTION
Part of #179: the CDC feeds silently **missed changes inside compaction-merged files**. Discovered while reading official's `GetTableInsertions` — its window predicate has a `partial_max` branch ours lacked.

## The bug

A compaction-merged file spans several origin snapshots (`begin_snapshot..=partial_max`), with each row's origin recorded in an embedded `_ducklake_internal_snapshot_id` column (reserved field id `2147483539`). Our CDC window predicate only checked `begin_snapshot`, so:

- a window starting past the merged file's `begin_snapshot` excluded the file entirely — **rows silently missing** from the feed;
- when the file did qualify, **every** row was attributed to `begin_snapshot` instead of its origin snapshot.

This affects catalogs compacted by this crate's own `merge_adjacent_files` (which already writes `partial_max` + the embedded column) as well as officially-compacted ones.

## The fix (matching official DuckLake)

- **Window predicate** now includes partial files via `partial_max >= start`, in all five query copies (shared/DuckDB, SQLite, PostgreSQL, MySQL, multicatalog). Backends degrade gracefully on older catalog schemas: the sqlx providers reuse the existing `partial_max → NULL` probe pattern, and the DuckDB provider additionally parses the old-spec `partial_file_info` string (`"snapshot:rowcount|..."`) to recover the max origin snapshot.
- **Per-row attribution**: the correlated path reads the embedded snapshot column, attributes each row to its origin snapshot, filters rows outside the inclusive window, and lets merged rows participate in update pairing with their real rowids.
- **A merge emits no change events** (sources are hard-deleted from the catalog; the merged file predates the merge snapshot) — verified.
- **Encrypted catalogs** drop partial files reachable only via `partial_max` (their embedded column can't be read) and return an empty feed rather than wrong rows or a planning error; documented in COMPATIBILITY.md.

## Verification

- New differential-harness scenario `diff_compacted_inserts`: windows the installed (1.4-era) extension handles are **live-diffed** against it; windows it predates (partial-file inclusion in CDC was added upstream later) are asserted against current official semantics, matching upstream's own `small_insert_compaction.test` expectations.
- New sqlite test `cdc_attributes_merged_rows_to_origin_snapshots`: end-to-end over a crate-compacted catalog (write → merge → per-window CDC assertions through the sqlite provider).
- Old-spec parser unit tests; full differential suite (10 scenarios), full `write-sqlite` sweep, and Docker backends (Postgres 51 + compaction 2, MySQL 14, multicatalog 13) all green.
- Manual check via `examples/basic_query` on an old-spec compacted catalog: `[0,100]` shows all rows at origin snapshots; `[3,3]` (reachable only via partial_max) returns exactly the snapshot-3 row; the merge snapshot returns nothing.
- External review findings addressed: older-catalog compatibility for the four sqlx backends (probe pattern), and the encrypted post-filter empty case.

## Follow-ups (tracked in #179)

- Deletions-feed per-row snapshot windowing for current-official 3-column delete files, and CDC over deletes targeting merged files (the installed 1.4-era extension mis-attributes those to origin snapshots — since fixed upstream, so it can't serve as the live oracle there).
