### PR TITLE
perf(metadata): memoize schema-capability probes; stop paging at a short page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **BREAKING**: `PostgresMetadataProvider`, `SqliteMetadataProvider`, and
+  `MySqlMetadataProvider` carry a new private field; construct them via `new()`
+  instead of struct literals.
+- Per-call catalog capability probes (`partial_max` columns, the
+  `ducklake_schema_versions` ledger, SQLite's inlined-data registry) on the
+  scan and CDC paths run as one combined statement and are memoized
+  cache-positive-only per provider: a fully-migrated catalog probes once per
+  provider lifetime, while catalogs missing any capability keep re-probing
+  every call (so a mid-flight catalog upgrade is still picked up immediately).
 - **BREAKING**: CDC snapshot bounds are inclusive on both ends, matching official
   DuckLake (was exclusive-start); cursor pagination should pass `last + 1` (#179).
 - **BREAKING**: CDC columns `(snapshot_id, rowid, change_type)` now lead the output,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **BREAKING**: `PostgresMetadataProvider`, `SqliteMetadataProvider`, and
   `MySqlMetadataProvider` carry a new private field; construct them via `new()`
+  — or the new `from_pool()`, which adopts an existing connection pool —
   instead of struct literals.
 - Per-call catalog capability probes (`partial_max` columns, the
   `ducklake_schema_versions` ledger, SQLite's inlined-data registry) on the

--- a/src/metadata_provider_duckdb.rs
+++ b/src/metadata_provider_duckdb.rs
@@ -16,11 +16,31 @@ use crate::partition::PartitionSpec;
 use duckdb::AccessMode::ReadOnly;
 use duckdb::{Config, Connection, params};
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 
 fn is_missing_statistics_table(error: &duckdb::Error) -> bool {
     let message = error.to_string().to_ascii_lowercase();
     message.contains("does not exist") || message.contains("not found")
+}
+
+/// Optional catalog-schema capabilities probed before CDC queries.
+///
+/// Older catalogs (spec 0.2) may lack the `partial_max` columns; the CDC
+/// queries fall back to the old-spec `partial_file_info` string (data files)
+/// or degrade the predicate to NULL (delete files) when a capability is
+/// absent.
+#[derive(Debug, Clone, Copy)]
+struct SchemaCapabilities {
+    /// `ducklake_data_file.partial_max` exists.
+    data_file_partial_max: bool,
+    /// `ducklake_delete_file.partial_max` exists.
+    delete_file_partial_max: bool,
+}
+
+impl SchemaCapabilities {
+    fn all(&self) -> bool {
+        self.data_file_partial_max && self.delete_file_partial_max
+    }
 }
 
 /// DuckDB metadata provider
@@ -34,6 +54,9 @@ pub struct DuckdbMetadataProvider {
     /// Path to the catalog database, retained for logging/debugging
     #[allow(dead_code)]
     catalog_path: String,
+    /// Positive-only memo of the optional-schema capability probes. `Arc` so
+    /// derived `Clone` shares the cache across provider clones.
+    schema_capabilities: Arc<OnceLock<SchemaCapabilities>>,
 }
 
 impl DuckdbMetadataProvider {
@@ -45,12 +68,54 @@ impl DuckdbMetadataProvider {
         Ok(Self {
             conn: Arc::new(Mutex::new(conn)),
             catalog_path,
+            schema_capabilities: Arc::new(OnceLock::new()),
         })
     }
 
     /// Get a reference to the shared connection
     fn connection(&self) -> MutexGuard<'_, Connection> {
         self.conn.lock().expect("DuckDB connection mutex poisoned")
+    }
+
+    /// Whether the schema-capability memo is populated. Exposed for tests.
+    #[doc(hidden)]
+    pub fn schema_capabilities_cached(&self) -> bool {
+        self.schema_capabilities.get().is_some()
+    }
+
+    /// Returns the catalog's optional-schema capabilities, probing at most
+    /// once per provider lifetime on a fully-migrated catalog. Takes the
+    /// caller's already-locked `&Connection` (the shared mutex is not
+    /// reentrant).
+    ///
+    /// Cache-positive-only: capability existence is monotonic (migrations only
+    /// add columns/tables, never drop them), so an all-`true` answer is an
+    /// immutable fact and safe to memoize. A `false` answer is never cached —
+    /// the next call re-probes, so a mid-flight catalog upgrade is picked up
+    /// on the next call exactly like the previous per-call probing. Concurrent
+    /// first calls may each probe once (one statement each) — harmless; a
+    /// raced `set` is ignored.
+    fn schema_capabilities(&self, conn: &Connection) -> crate::Result<SchemaCapabilities> {
+        if let Some(caps) = self.schema_capabilities.get() {
+            return Ok(*caps);
+        }
+        let (data_file_partial_max, delete_file_partial_max): (bool, bool) = conn.query_row(
+            "SELECT
+               (SELECT COUNT(*) FROM pragma_table_info('ducklake_data_file')
+                WHERE name = 'partial_max') > 0,
+               (SELECT COUNT(*) FROM pragma_table_info('ducklake_delete_file')
+                WHERE name = 'partial_max') > 0",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        let caps = SchemaCapabilities {
+            data_file_partial_max,
+            delete_file_partial_max,
+        };
+        if caps.all() {
+            let _ = self.schema_capabilities.set(caps);
+        }
+        Ok(caps)
     }
 
     /// Create a new read-only connection to the catalog database
@@ -824,14 +889,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
         // carry `partial_file_info` (a cumulative `snapshot:rowcount|...`
         // string); current ones carry `partial_max` (BIGINT). Detect which
         // column this catalog has and query accordingly.
-        let has_partial_max: bool = conn.query_row(
-            "SELECT COUNT(*) > 0 FROM pragma_table_info('ducklake_data_file') \
-             WHERE name = 'partial_max'",
-            [],
-            |row| row.get(0),
-        )?;
-
-        if has_partial_max {
+        if self.schema_capabilities(&conn)?.data_file_partial_max {
             let mut stmt = conn.prepare(SQL_GET_DATA_FILES_ADDED_BETWEEN_SNAPSHOTS)?;
             let files = stmt
                 .query_map(params![table_id, start_snapshot, end_snapshot], |row| {
@@ -907,13 +965,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
         // Older catalogs have no such column — and no cumulative delete files —
         // so the predicate degrades to NULL there, keeping the plain
         // begin-snapshot window.
-        let has_delete_partial_max: bool = conn.query_row(
-            "SELECT COUNT(*) > 0 FROM pragma_table_info('ducklake_delete_file') \
-             WHERE name = 'partial_max'",
-            [],
-            |row| row.get(0),
-        )?;
-        let sql = if has_delete_partial_max {
+        let sql = if self.schema_capabilities(&conn)?.delete_file_partial_max {
             SQL_GET_DELETE_FILES_ADDED_BETWEEN_SNAPSHOTS.to_string()
         } else {
             SQL_GET_DELETE_FILES_ADDED_BETWEEN_SNAPSHOTS.replace("df.partial_max", "NULL")

--- a/src/metadata_provider_mysql.rs
+++ b/src/metadata_provider_mysql.rs
@@ -14,6 +14,7 @@ use sqlx::Row;
 use sqlx::mysql::{MySqlPool, MySqlPoolOptions, MySqlRow};
 use sqlx::types::chrono::NaiveDateTime;
 use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
 
 fn is_missing_statistics_table(error: &sqlx::Error) -> bool {
     let message = error.to_string().to_ascii_lowercase();
@@ -61,10 +62,32 @@ fn decode_table_file(row: &MySqlRow, snapshot_id: i64) -> Result<DuckLakeTableFi
     })
 }
 
+/// Optional catalog-schema capabilities probed before CDC queries.
+///
+/// Older catalogs may lack the `partial_max` columns; the CDC queries degrade
+/// the corresponding projections/predicates to NULL when a capability is
+/// absent.
+#[derive(Debug, Clone, Copy)]
+struct SchemaCapabilities {
+    /// `ducklake_data_file.partial_max` exists.
+    data_file_partial_max: bool,
+    /// `ducklake_delete_file.partial_max` exists.
+    delete_file_partial_max: bool,
+}
+
+impl SchemaCapabilities {
+    fn all(&self) -> bool {
+        self.data_file_partial_max && self.delete_file_partial_max
+    }
+}
+
 /// MySQL-based metadata provider for DuckLake catalogs.
 #[derive(Debug, Clone)]
 pub struct MySqlMetadataProvider {
     pub pool: MySqlPool,
+    // Positive-only memo of the optional-schema capability probes. `Arc` so
+    // derived `Clone` shares the cache across provider clones.
+    schema_capabilities: Arc<OnceLock<SchemaCapabilities>>,
 }
 
 impl MySqlMetadataProvider {
@@ -77,7 +100,51 @@ impl MySqlMetadataProvider {
 
         Ok(Self {
             pool,
+            schema_capabilities: Arc::new(OnceLock::new()),
         })
+    }
+
+    /// Whether the schema-capability memo is populated. Exposed for tests.
+    #[doc(hidden)]
+    pub fn schema_capabilities_cached(&self) -> bool {
+        self.schema_capabilities.get().is_some()
+    }
+
+    /// Returns the catalog's optional-schema capabilities, probing at most
+    /// once per provider lifetime on a fully-migrated catalog.
+    ///
+    /// Cache-positive-only: capability existence is monotonic (migrations only
+    /// add columns/tables, never drop them), so an all-`true` answer is an
+    /// immutable fact and safe to memoize. A `false` answer is never cached —
+    /// the next call re-probes, so a mid-flight catalog upgrade is picked up
+    /// on the next call exactly like the previous per-call probing. Concurrent
+    /// first calls may each probe once (one statement each) — harmless; a
+    /// raced `set` is ignored.
+    async fn schema_capabilities(&self) -> Result<SchemaCapabilities> {
+        if let Some(caps) = self.schema_capabilities.get() {
+            return Ok(*caps);
+        }
+        let row: (i64, i64) = sqlx::query_as(
+            "SELECT
+               (SELECT COUNT(*) FROM information_schema.columns
+                WHERE table_schema = DATABASE()
+                  AND table_name = 'ducklake_data_file'
+                  AND column_name = 'partial_max'),
+               (SELECT COUNT(*) FROM information_schema.columns
+                WHERE table_schema = DATABASE()
+                  AND table_name = 'ducklake_delete_file'
+                  AND column_name = 'partial_max')",
+        )
+        .fetch_one(&self.pool)
+        .await?;
+        let caps = SchemaCapabilities {
+            data_file_partial_max: row.0 > 0,
+            delete_file_partial_max: row.1 > 0,
+        };
+        if caps.all() {
+            let _ = self.schema_capabilities.set(caps);
+        }
+        Ok(caps)
     }
 }
 
@@ -938,15 +1005,7 @@ impl MetadataProvider for MySqlMetadataProvider {
         block_on(async {
             // Older catalogs predate `partial_max`; degrade it to NULL there
             // (they cannot contain partial files).
-            let has_partial_max: i64 = sqlx::query_scalar(
-                "SELECT COUNT(*) FROM information_schema.columns
-                 WHERE table_schema = DATABASE()
-                   AND table_name = 'ducklake_data_file'
-                   AND column_name = 'partial_max'",
-            )
-            .fetch_one(&self.pool)
-            .await?;
-            let pm = if has_partial_max > 0 {
+            let pm = if self.schema_capabilities().await?.data_file_partial_max {
                 "data.partial_max"
             } else {
                 "NULL"
@@ -1006,15 +1065,7 @@ impl MetadataProvider for MySqlMetadataProvider {
             // even when their begin_snapshot predates the window; included via
             // `ducklake_delete_file.partial_max`. Older catalogs lack the column
             // (and cumulative delete files); degrade it to NULL there.
-            let has_delete_partial_max: i64 = sqlx::query_scalar(
-                "SELECT COUNT(*) FROM information_schema.columns
-                 WHERE table_schema = DATABASE()
-                   AND table_name = 'ducklake_delete_file'
-                   AND column_name = 'partial_max'",
-            )
-            .fetch_one(&self.pool)
-            .await?;
-            let pm = if has_delete_partial_max > 0 {
+            let pm = if self.schema_capabilities().await?.delete_file_partial_max {
                 "ddf.partial_max"
             } else {
                 "NULL"

--- a/src/metadata_provider_mysql.rs
+++ b/src/metadata_provider_mysql.rs
@@ -104,6 +104,16 @@ impl MySqlMetadataProvider {
         })
     }
 
+    /// Creates a provider over an existing connection pool. Replaces
+    /// struct-literal construction, which stopped compiling when the
+    /// schema-capability memo field was added.
+    pub fn from_pool(pool: MySqlPool) -> Self {
+        Self {
+            pool,
+            schema_capabilities: Arc::new(OnceLock::new()),
+        }
+    }
+
     /// Whether the schema-capability memo is populated. Exposed for tests.
     #[doc(hidden)]
     pub fn schema_capabilities_cached(&self) -> bool {

--- a/src/metadata_provider_postgres.rs
+++ b/src/metadata_provider_postgres.rs
@@ -13,6 +13,7 @@ use sqlx::Row;
 use sqlx::postgres::{PgPool, PgPoolOptions, PgRow};
 use sqlx::types::chrono::NaiveDateTime;
 use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
 
 fn is_missing_statistics_table(error: &sqlx::Error) -> bool {
     let message = error.to_string().to_ascii_lowercase();
@@ -93,10 +94,34 @@ macro_rules! bind_repeat {
     };
 }
 
+/// Optional catalog-schema capabilities probed before scan / CDC queries.
+///
+/// Minimal / pre-v1.0 catalogs may lack the `partial_max` columns and the
+/// `ducklake_schema_versions` ledger; the queries degrade the corresponding
+/// projections to NULL when a capability is absent.
+#[derive(Debug, Clone, Copy)]
+struct SchemaCapabilities {
+    /// `ducklake_data_file.partial_max` exists.
+    data_file_partial_max: bool,
+    /// `ducklake_delete_file.partial_max` exists.
+    delete_file_partial_max: bool,
+    /// The `ducklake_schema_versions` table exists.
+    schema_versions: bool,
+}
+
+impl SchemaCapabilities {
+    fn all(&self) -> bool {
+        self.data_file_partial_max && self.delete_file_partial_max && self.schema_versions
+    }
+}
+
 /// PostgreSQL-based metadata provider for DuckLake catalogs.
 #[derive(Debug, Clone)]
 pub struct PostgresMetadataProvider {
     pub pool: PgPool,
+    // Positive-only memo of the optional-schema capability probes. `Arc` so
+    // derived `Clone` shares the cache across provider clones.
+    schema_capabilities: Arc<OnceLock<SchemaCapabilities>>,
 }
 
 impl PostgresMetadataProvider {
@@ -109,7 +134,49 @@ impl PostgresMetadataProvider {
 
         Ok(Self {
             pool,
+            schema_capabilities: Arc::new(OnceLock::new()),
         })
+    }
+
+    /// Whether the schema-capability memo is populated. Exposed for tests.
+    #[doc(hidden)]
+    pub fn schema_capabilities_cached(&self) -> bool {
+        self.schema_capabilities.get().is_some()
+    }
+
+    /// Returns the catalog's optional-schema capabilities, probing at most
+    /// once per provider lifetime on a fully-migrated catalog.
+    ///
+    /// Cache-positive-only: capability existence is monotonic (migrations only
+    /// add columns/tables, never drop them), so an all-`true` answer is an
+    /// immutable fact and safe to memoize. A `false` answer is never cached —
+    /// the next call re-probes, so a mid-flight catalog upgrade is picked up
+    /// on the next call exactly like the previous per-call probing. Concurrent
+    /// first calls may each probe once (one statement each) — harmless; a
+    /// raced `set` is ignored.
+    async fn schema_capabilities(&self) -> Result<SchemaCapabilities> {
+        if let Some(caps) = self.schema_capabilities.get() {
+            return Ok(*caps);
+        }
+        let row: (bool, bool, bool) = sqlx::query_as(
+            "SELECT
+               EXISTS (SELECT 1 FROM information_schema.columns
+                       WHERE table_name = 'ducklake_data_file' AND column_name = 'partial_max'),
+               EXISTS (SELECT 1 FROM information_schema.columns
+                       WHERE table_name = 'ducklake_delete_file' AND column_name = 'partial_max'),
+               to_regclass('ducklake_schema_versions') IS NOT NULL",
+        )
+        .fetch_one(&self.pool)
+        .await?;
+        let caps = SchemaCapabilities {
+            data_file_partial_max: row.0,
+            delete_file_partial_max: row.1,
+            schema_versions: row.2,
+        };
+        if caps.all() {
+            let _ = self.schema_capabilities.set(caps);
+        }
+        Ok(caps)
     }
 }
 
@@ -270,22 +337,13 @@ impl MetadataProvider for PostgresMetadataProvider {
             // still work (both are consumed only by compaction; `partial_max`
             // also by time-travel reads of partial files, which such catalogs
             // never contain).
-            let has_partial_max: bool = sqlx::query_scalar(
-                "SELECT EXISTS (SELECT 1 FROM information_schema.columns
-                 WHERE table_name = 'ducklake_data_file' AND column_name = 'partial_max')",
-            )
-            .fetch_one(&self.pool)
-            .await?;
-            let has_schema_versions: bool =
-                sqlx::query_scalar("SELECT to_regclass('ducklake_schema_versions') IS NOT NULL")
-                    .fetch_one(&self.pool)
-                    .await?;
-            let partial_max_expr = if has_partial_max {
+            let caps = self.schema_capabilities().await?;
+            let partial_max_expr = if caps.data_file_partial_max {
                 "data.partial_max::bigint"
             } else {
                 "NULL::bigint"
             };
-            let schema_version_expr = if has_schema_versions {
+            let schema_version_expr = if caps.schema_versions {
                 "(SELECT sv.schema_version::bigint
                   FROM ducklake_schema_versions sv
                   WHERE sv.table_id = data.table_id
@@ -407,22 +465,13 @@ impl MetadataProvider for PostgresMetadataProvider {
             crate::DuckLakeError::InvalidConfig("file metadata page limit exceeds i64".to_string())
         })?;
         block_on(async {
-            let has_partial_max: bool = sqlx::query_scalar(
-                "SELECT EXISTS (SELECT 1 FROM information_schema.columns
-                 WHERE table_name = 'ducklake_data_file' AND column_name = 'partial_max')",
-            )
-            .fetch_one(&self.pool)
-            .await?;
-            let has_schema_versions: bool =
-                sqlx::query_scalar("SELECT to_regclass('ducklake_schema_versions') IS NOT NULL")
-                    .fetch_one(&self.pool)
-                    .await?;
-            let partial_max_expr = if has_partial_max {
+            let caps = self.schema_capabilities().await?;
+            let partial_max_expr = if caps.data_file_partial_max {
                 "data.partial_max::bigint"
             } else {
                 "NULL::bigint"
             };
-            let schema_version_expr = if has_schema_versions {
+            let schema_version_expr = if caps.schema_versions {
                 "(SELECT sv.schema_version::bigint
                   FROM ducklake_schema_versions sv
                   WHERE sv.table_id = data.table_id
@@ -1043,13 +1092,7 @@ impl MetadataProvider for PostgresMetadataProvider {
             // Older catalogs predate `partial_max`; degrade it to NULL there
             // (they cannot contain partial files), matching the probe pattern
             // used by the scan queries above.
-            let has_partial_max: bool = sqlx::query_scalar(
-                "SELECT EXISTS (SELECT 1 FROM information_schema.columns
-                 WHERE table_name = 'ducklake_data_file' AND column_name = 'partial_max')",
-            )
-            .fetch_one(&self.pool)
-            .await?;
-            let pm = if has_partial_max {
+            let pm = if self.schema_capabilities().await?.data_file_partial_max {
                 "data.partial_max::bigint"
             } else {
                 "NULL::bigint"
@@ -1107,13 +1150,7 @@ impl MetadataProvider for PostgresMetadataProvider {
             // even when their begin_snapshot predates the window; included via
             // `ducklake_delete_file.partial_max`. Older catalogs lack the column
             // (and cumulative delete files); degrade it to NULL there.
-            let has_delete_partial_max: bool = sqlx::query_scalar(
-                "SELECT EXISTS (SELECT 1 FROM information_schema.columns
-                 WHERE table_name = 'ducklake_delete_file' AND column_name = 'partial_max')",
-            )
-            .fetch_one(&self.pool)
-            .await?;
-            let pm = if has_delete_partial_max {
+            let pm = if self.schema_capabilities().await?.delete_file_partial_max {
                 "ddf.partial_max::bigint"
             } else {
                 "NULL::bigint"

--- a/src/metadata_provider_postgres.rs
+++ b/src/metadata_provider_postgres.rs
@@ -138,6 +138,16 @@ impl PostgresMetadataProvider {
         })
     }
 
+    /// Creates a provider over an existing connection pool. Replaces
+    /// struct-literal construction, which stopped compiling when the
+    /// schema-capability memo field was added.
+    pub fn from_pool(pool: PgPool) -> Self {
+        Self {
+            pool,
+            schema_capabilities: Arc::new(OnceLock::new()),
+        }
+    }
+
     /// Whether the schema-capability memo is populated. Exposed for tests.
     #[doc(hidden)]
     pub fn schema_capabilities_cached(&self) -> bool {

--- a/src/metadata_provider_sqlite.rs
+++ b/src/metadata_provider_sqlite.rs
@@ -218,6 +218,16 @@ impl SqliteMetadataProvider {
         })
     }
 
+    /// Creates a provider over an existing connection pool. Replaces
+    /// struct-literal construction, which stopped compiling when the
+    /// schema-capability memo field was added.
+    pub fn from_pool(pool: SqlitePool) -> Self {
+        Self {
+            pool,
+            schema_capabilities: Arc::new(OnceLock::new()),
+        }
+    }
+
     /// Whether the schema-capability memo is populated. Exposed for tests.
     #[doc(hidden)]
     pub fn schema_capabilities_cached(&self) -> bool {

--- a/src/metadata_provider_sqlite.rs
+++ b/src/metadata_provider_sqlite.rs
@@ -20,7 +20,7 @@ use sqlx::Row;
 use sqlx::sqlite::{SqlitePool, SqlitePoolOptions, SqliteRow};
 use sqlx::types::chrono::NaiveDateTime;
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 /// Quote a SQL identifier for SQLite (double-quote, doubling embedded quotes),
 /// so catalog-supplied inlined-table / column names can't break the query.
@@ -162,10 +162,44 @@ fn is_missing_statistics_table(error: &sqlx::Error) -> bool {
     message.contains("no such table") || message.contains("does not exist")
 }
 
+/// Optional catalog-schema capabilities probed before scan / CDC / inlined-data
+/// queries.
+///
+/// Minimal / pre-v1.0 catalogs may lack the `partial_max` / `partition_id`
+/// columns, the `ducklake_schema_versions` ledger, and the inlined-data
+/// registry; the queries degrade the corresponding projections to NULL (or
+/// skip inlined-data reads) when a capability is absent.
+#[derive(Debug, Clone, Copy)]
+struct SchemaCapabilities {
+    /// `ducklake_data_file.partial_max` exists.
+    data_file_partial_max: bool,
+    /// `ducklake_delete_file.partial_max` exists.
+    delete_file_partial_max: bool,
+    /// `ducklake_data_file.partition_id` exists.
+    data_file_partition_id: bool,
+    /// The `ducklake_schema_versions` table exists.
+    schema_versions: bool,
+    /// The `ducklake_inlined_data_tables` registry exists.
+    inlined_data_tables: bool,
+}
+
+impl SchemaCapabilities {
+    fn all(&self) -> bool {
+        self.data_file_partial_max
+            && self.delete_file_partial_max
+            && self.data_file_partition_id
+            && self.schema_versions
+            && self.inlined_data_tables
+    }
+}
+
 /// SQLite-based metadata provider for DuckLake catalogs.
 #[derive(Debug, Clone)]
 pub struct SqliteMetadataProvider {
     pub pool: SqlitePool,
+    // Positive-only memo of the optional-schema capability probes. `Arc` so
+    // derived `Clone` shares the cache across provider clones.
+    schema_capabilities: Arc<OnceLock<SchemaCapabilities>>,
 }
 
 impl SqliteMetadataProvider {
@@ -180,7 +214,56 @@ impl SqliteMetadataProvider {
 
         Ok(Self {
             pool,
+            schema_capabilities: Arc::new(OnceLock::new()),
         })
+    }
+
+    /// Whether the schema-capability memo is populated. Exposed for tests.
+    #[doc(hidden)]
+    pub fn schema_capabilities_cached(&self) -> bool {
+        self.schema_capabilities.get().is_some()
+    }
+
+    /// Returns the catalog's optional-schema capabilities, probing at most
+    /// once per provider lifetime on a fully-migrated catalog.
+    ///
+    /// Cache-positive-only: capability existence is monotonic (migrations only
+    /// add columns/tables, never drop them), so an all-`true` answer is an
+    /// immutable fact and safe to memoize. A `false` answer is never cached —
+    /// the next call re-probes, so a mid-flight catalog upgrade is picked up
+    /// on the next call exactly like the previous per-call probing. Concurrent
+    /// first calls may each probe once (one statement each) — harmless; a
+    /// raced `set` is ignored.
+    async fn schema_capabilities(&self) -> Result<SchemaCapabilities> {
+        if let Some(caps) = self.schema_capabilities.get() {
+            return Ok(*caps);
+        }
+        let row: (bool, bool, bool, bool, bool) = sqlx::query_as(
+            "SELECT
+               (SELECT COUNT(*) FROM pragma_table_info('ducklake_data_file')
+                WHERE name = 'partial_max') > 0,
+               (SELECT COUNT(*) FROM pragma_table_info('ducklake_delete_file')
+                WHERE name = 'partial_max') > 0,
+               (SELECT COUNT(*) FROM pragma_table_info('ducklake_data_file')
+                WHERE name = 'partition_id') > 0,
+               (SELECT COUNT(*) FROM sqlite_master
+                WHERE type = 'table' AND name = 'ducklake_schema_versions') > 0,
+               (SELECT COUNT(*) FROM sqlite_master
+                WHERE type = 'table' AND name = 'ducklake_inlined_data_tables') > 0",
+        )
+        .fetch_one(&self.pool)
+        .await?;
+        let caps = SchemaCapabilities {
+            data_file_partial_max: row.0,
+            delete_file_partial_max: row.1,
+            data_file_partition_id: row.2,
+            schema_versions: row.3,
+            inlined_data_tables: row.4,
+        };
+        if caps.all() {
+            let _ = self.schema_capabilities.set(caps);
+        }
+        Ok(caps)
     }
 }
 
@@ -341,23 +424,13 @@ impl MetadataProvider for SqliteMetadataProvider {
             // still work (both are consumed only by compaction; `partial_max`
             // also by time-travel reads of partial files, which such catalogs
             // never contain).
-            let has_partial_max: i64 = sqlx::query_scalar(
-                "SELECT COUNT(*) FROM pragma_table_info('ducklake_data_file') WHERE name = 'partial_max'",
-            )
-            .fetch_one(&self.pool)
-            .await?;
-            let has_schema_versions: i64 = sqlx::query_scalar(
-                "SELECT COUNT(*) FROM sqlite_master
-                 WHERE type = 'table' AND name = 'ducklake_schema_versions'",
-            )
-            .fetch_one(&self.pool)
-            .await?;
-            let partial_max_expr = if has_partial_max > 0 {
+            let caps = self.schema_capabilities().await?;
+            let partial_max_expr = if caps.data_file_partial_max {
                 "data.partial_max"
             } else {
                 "NULL"
             };
-            let schema_version_expr = if has_schema_versions > 0 {
+            let schema_version_expr = if caps.schema_versions {
                 "(SELECT sv.schema_version
                   FROM ducklake_schema_versions sv
                   WHERE sv.table_id = data.table_id
@@ -470,33 +543,18 @@ impl MetadataProvider for SqliteMetadataProvider {
             crate::DuckLakeError::InvalidConfig("file metadata page limit exceeds i64".to_string())
         })?;
         block_on(async {
-            let has_partial_max: i64 = sqlx::query_scalar(
-                "SELECT COUNT(*) FROM pragma_table_info('ducklake_data_file') WHERE name = 'partial_max'",
-            )
-            .fetch_one(&self.pool)
-            .await?;
-            let has_schema_versions: i64 = sqlx::query_scalar(
-                "SELECT COUNT(*) FROM sqlite_master
-                 WHERE type = 'table' AND name = 'ducklake_schema_versions'",
-            )
-            .fetch_one(&self.pool)
-            .await?;
-            let has_partition_id: i64 = sqlx::query_scalar(
-                "SELECT COUNT(*) FROM pragma_table_info('ducklake_data_file') WHERE name = 'partition_id'",
-            )
-            .fetch_one(&self.pool)
-            .await?;
-            let partial_max_expr = if has_partial_max > 0 {
+            let caps = self.schema_capabilities().await?;
+            let partial_max_expr = if caps.data_file_partial_max {
                 "data.partial_max"
             } else {
                 "NULL"
             };
-            let partition_id_expr = if has_partition_id > 0 {
+            let partition_id_expr = if caps.data_file_partition_id {
                 "data.partition_id"
             } else {
                 "NULL"
             };
-            let schema_version_expr = if has_schema_versions > 0 {
+            let schema_version_expr = if caps.schema_versions {
                 "(SELECT sv.schema_version
                   FROM ducklake_schema_versions sv
                   WHERE sv.table_id = data.table_id
@@ -860,13 +918,7 @@ impl MetadataProvider for SqliteMetadataProvider {
         block_on(async {
             // Most catalogs have no inlined data — the registry table is absent.
             // Detect and return empty so they (and older catalogs) are unaffected.
-            let has_registry: i64 = sqlx::query_scalar(
-                "SELECT COUNT(*) FROM sqlite_master
-                 WHERE type = 'table' AND name = 'ducklake_inlined_data_tables'",
-            )
-            .fetch_one(&self.pool)
-            .await?;
-            if has_registry == 0 {
+            if !self.schema_capabilities().await?.inlined_data_tables {
                 return Ok(Vec::new());
             }
 
@@ -1209,12 +1261,7 @@ impl MetadataProvider for SqliteMetadataProvider {
             // Older catalogs predate `partial_max`; degrade it to NULL there
             // (they cannot contain partial files), matching the probe pattern
             // used by the scan queries above.
-            let has_partial_max: i64 = sqlx::query_scalar(
-                "SELECT COUNT(*) FROM pragma_table_info('ducklake_data_file') WHERE name = 'partial_max'",
-            )
-            .fetch_one(&self.pool)
-            .await?;
-            let pm = if has_partial_max > 0 {
+            let pm = if self.schema_capabilities().await?.data_file_partial_max {
                 "data.partial_max"
             } else {
                 "NULL"
@@ -1276,12 +1323,7 @@ impl MetadataProvider for SqliteMetadataProvider {
             // included via `ducklake_delete_file.partial_max` (their max embedded
             // snapshot). Older catalogs lack the column — and cumulative delete
             // files — so it degrades to NULL there.
-            let has_delete_partial_max: i64 = sqlx::query_scalar(
-                "SELECT COUNT(*) FROM pragma_table_info('ducklake_delete_file') WHERE name = 'partial_max'",
-            )
-            .fetch_one(&self.pool)
-            .await?;
-            let pm = if has_delete_partial_max > 0 {
+            let pm = if self.schema_capabilities().await?.delete_file_partial_max {
                 "cd.partial_max"
             } else {
                 "NULL"

--- a/src/multicatalog_provider.rs
+++ b/src/multicatalog_provider.rs
@@ -24,6 +24,7 @@ use sqlx::Row;
 use sqlx::postgres::{PgPool, PgPoolOptions, PgRow};
 use sqlx::types::chrono::NaiveDateTime;
 use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
 
 fn is_missing_statistics_table(error: &sqlx::Error) -> bool {
     let message = error.to_string().to_ascii_lowercase();
@@ -71,6 +72,27 @@ fn decode_table_file(row: &PgRow, snapshot_id: i64) -> Result<DuckLakeTableFile>
 
 const DEFAULT_MAX_CONNECTIONS: u32 = 5;
 
+/// Optional catalog-schema capabilities probed before scan / CDC queries.
+///
+/// Minimal / pre-v1.0 catalogs may lack the `partial_max` columns and the
+/// `ducklake_schema_versions` ledger; the queries degrade the corresponding
+/// projections to NULL when a capability is absent.
+#[derive(Debug, Clone, Copy)]
+struct SchemaCapabilities {
+    /// `ducklake_data_file.partial_max` exists.
+    data_file_partial_max: bool,
+    /// `ducklake_delete_file.partial_max` exists.
+    delete_file_partial_max: bool,
+    /// The `ducklake_schema_versions` table exists.
+    schema_versions: bool,
+}
+
+impl SchemaCapabilities {
+    fn all(&self) -> bool {
+        self.data_file_partial_max && self.delete_file_partial_max && self.schema_versions
+    }
+}
+
 /// Catalog-scoped Postgres metadata reader.
 ///
 /// Construct with [`Self::with_pool`] (name-keyed; resolves to `catalog_id` once
@@ -79,6 +101,9 @@ const DEFAULT_MAX_CONNECTIONS: u32 = 5;
 pub struct MulticatalogProvider {
     pool: PgPool,
     catalog_id: i64,
+    // Positive-only memo of the optional-schema capability probes. `Arc` so
+    // derived `Clone` shares the cache across provider clones.
+    schema_capabilities: Arc<OnceLock<SchemaCapabilities>>,
 }
 
 impl MulticatalogProvider {
@@ -106,6 +131,7 @@ impl MulticatalogProvider {
         Ok(Self {
             pool,
             catalog_id,
+            schema_capabilities: Arc::new(OnceLock::new()),
         })
     }
 
@@ -115,11 +141,53 @@ impl MulticatalogProvider {
         Ok(Self {
             pool,
             catalog_id,
+            schema_capabilities: Arc::new(OnceLock::new()),
         })
     }
 
     pub fn catalog_id(&self) -> i64 {
         self.catalog_id
+    }
+
+    /// Whether the schema-capability memo is populated. Exposed for tests.
+    #[doc(hidden)]
+    pub fn schema_capabilities_cached(&self) -> bool {
+        self.schema_capabilities.get().is_some()
+    }
+
+    /// Returns the catalog's optional-schema capabilities, probing at most
+    /// once per provider lifetime on a fully-migrated catalog.
+    ///
+    /// Cache-positive-only: capability existence is monotonic (migrations only
+    /// add columns/tables, never drop them), so an all-`true` answer is an
+    /// immutable fact and safe to memoize. A `false` answer is never cached —
+    /// the next call re-probes, so a mid-flight catalog upgrade is picked up
+    /// on the next call exactly like the previous per-call probing. Concurrent
+    /// first calls may each probe once (one statement each) — harmless; a
+    /// raced `set` is ignored.
+    async fn schema_capabilities(&self) -> Result<SchemaCapabilities> {
+        if let Some(caps) = self.schema_capabilities.get() {
+            return Ok(*caps);
+        }
+        let row: (bool, bool, bool) = sqlx::query_as(
+            "SELECT
+               EXISTS (SELECT 1 FROM information_schema.columns
+                       WHERE table_name = 'ducklake_data_file' AND column_name = 'partial_max'),
+               EXISTS (SELECT 1 FROM information_schema.columns
+                       WHERE table_name = 'ducklake_delete_file' AND column_name = 'partial_max'),
+               to_regclass('ducklake_schema_versions') IS NOT NULL",
+        )
+        .fetch_one(&self.pool)
+        .await?;
+        let caps = SchemaCapabilities {
+            data_file_partial_max: row.0,
+            delete_file_partial_max: row.1,
+            schema_versions: row.2,
+        };
+        if caps.all() {
+            let _ = self.schema_capabilities.set(caps);
+        }
+        Ok(caps)
     }
 }
 
@@ -303,22 +371,13 @@ impl MetadataProvider for MulticatalogProvider {
             // `ducklake_schema_versions` ledger. Surfacing these lets compaction
             // (which pairs its writer with THIS reader) select merge candidates
             // and lets time-travel reads filter partial files per-row.
-            let has_partial_max: bool = sqlx::query_scalar(
-                "SELECT EXISTS (SELECT 1 FROM information_schema.columns
-                 WHERE table_name = 'ducklake_data_file' AND column_name = 'partial_max')",
-            )
-            .fetch_one(&self.pool)
-            .await?;
-            let has_schema_versions: bool =
-                sqlx::query_scalar("SELECT to_regclass('ducklake_schema_versions') IS NOT NULL")
-                    .fetch_one(&self.pool)
-                    .await?;
-            let partial_max_expr = if has_partial_max {
+            let caps = self.schema_capabilities().await?;
+            let partial_max_expr = if caps.data_file_partial_max {
                 "data.partial_max::bigint"
             } else {
                 "NULL::bigint"
             };
-            let schema_version_expr = if has_schema_versions {
+            let schema_version_expr = if caps.schema_versions {
                 "(SELECT sv.schema_version::bigint
                   FROM ducklake_schema_versions sv
                   WHERE sv.table_id = data.table_id
@@ -438,22 +497,13 @@ impl MetadataProvider for MulticatalogProvider {
             crate::DuckLakeError::InvalidConfig("file metadata page limit exceeds i64".to_string())
         })?;
         block_on(async {
-            let has_partial_max: bool = sqlx::query_scalar(
-                "SELECT EXISTS (SELECT 1 FROM information_schema.columns
-                 WHERE table_name = 'ducklake_data_file' AND column_name = 'partial_max')",
-            )
-            .fetch_one(&self.pool)
-            .await?;
-            let has_schema_versions: bool =
-                sqlx::query_scalar("SELECT to_regclass('ducklake_schema_versions') IS NOT NULL")
-                    .fetch_one(&self.pool)
-                    .await?;
-            let partial_max_expr = if has_partial_max {
+            let caps = self.schema_capabilities().await?;
+            let partial_max_expr = if caps.data_file_partial_max {
                 "data.partial_max::bigint"
             } else {
                 "NULL::bigint"
             };
-            let schema_version_expr = if has_schema_versions {
+            let schema_version_expr = if caps.schema_versions {
                 "(SELECT sv.schema_version::bigint
                   FROM ducklake_schema_versions sv
                   WHERE sv.table_id = data.table_id
@@ -1093,13 +1143,7 @@ impl MetadataProvider for MulticatalogProvider {
             // Older catalogs predate `partial_max`; degrade it to NULL there
             // (they cannot contain partial files), matching the probe pattern
             // used by the scan queries above.
-            let has_partial_max: bool = sqlx::query_scalar(
-                "SELECT EXISTS (SELECT 1 FROM information_schema.columns
-                 WHERE table_name = 'ducklake_data_file' AND column_name = 'partial_max')",
-            )
-            .fetch_one(&self.pool)
-            .await?;
-            let pm = if has_partial_max {
+            let pm = if self.schema_capabilities().await?.data_file_partial_max {
                 "data.partial_max::bigint"
             } else {
                 "NULL::bigint"
@@ -1157,13 +1201,7 @@ impl MetadataProvider for MulticatalogProvider {
             // even when their begin_snapshot predates the window; included via
             // `ducklake_delete_file.partial_max`. Older catalogs lack the column
             // (and cumulative delete files); degrade it to NULL there.
-            let has_delete_partial_max: bool = sqlx::query_scalar(
-                "SELECT EXISTS (SELECT 1 FROM information_schema.columns
-                 WHERE table_name = 'ducklake_delete_file' AND column_name = 'partial_max')",
-            )
-            .fetch_one(&self.pool)
-            .await?;
-            let pm = if has_delete_partial_max {
+            let pm = if self.schema_capabilities().await?.delete_file_partial_max {
                 "ddf.partial_max::bigint"
             } else {
                 "NULL::bigint"

--- a/src/table.rs
+++ b/src/table.rs
@@ -2398,6 +2398,13 @@ impl TableProvider for DuckLakeTable {
                     )),
                 )));
             }
+            // A short page proves the file list is exhausted (pages are keyed
+            // and ordered by data_file_id under a LIMIT), so stop after
+            // processing it rather than paying one more metadata round trip
+            // for the empty terminator page. For tables with fewer files than
+            // the batch size — the common case — this halves the planning
+            // metadata queries.
+            let last_page = metadata.len() < FILE_METADATA_BATCH_SIZE;
             let next_after = metadata.last().unwrap().file.data_file_id;
             if after_data_file_id.is_some_and(|after| next_after <= after) {
                 return Err(DataFusionError::External(Box::new(
@@ -2462,6 +2469,9 @@ impl TableProvider for DuckLakeTable {
                     };
                     execs.push(exec);
                 }
+                if last_page {
+                    break;
+                }
                 continue;
             }
 
@@ -2505,6 +2515,9 @@ impl TableProvider for DuckLakeTable {
                     self.build_exec_for_partial_file(state, table_file, output_schema)
                         .await?,
                 );
+            }
+            if last_page {
+                break;
             }
         }
 

--- a/tests/multicatalog_provider_tests.rs
+++ b/tests/multicatalog_provider_tests.rs
@@ -399,3 +399,35 @@ async fn get_table_files_for_select_returns_row_id_start_and_record_count() {
     );
     assert_eq!(f.snapshot_id, Some(sn), "snapshot_id is the query snapshot");
 }
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn schema_capability_probe_memoized_after_first_select() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let _ = seed_two_catalogs(&pool).await.unwrap();
+
+    let pa = MulticatalogProvider::with_pool(pool.clone(), "pg_prod")
+        .await
+        .unwrap();
+    let sn = pa.get_current_snapshot().unwrap();
+    let schema = pa.get_schema_by_name("public", sn).unwrap().unwrap();
+    let table = pa
+        .get_table_by_name(schema.schema_id, "users", sn)
+        .unwrap()
+        .unwrap();
+
+    // The multicatalog bootstrap schema is fully migrated, so the first scan
+    // probes once (all capabilities true) and memoizes; the second scan reuses
+    // the memo and must return identical results.
+    assert!(!pa.schema_capabilities_cached());
+    let first = pa.get_table_files_for_select(table.table_id, sn).unwrap();
+    assert!(
+        pa.schema_capabilities_cached(),
+        "an all-true probe result must be cached after the first call"
+    );
+    let second = pa.get_table_files_for_select(table.table_id, sn).unwrap();
+    assert_eq!(format!("{first:?}"), format!("{second:?}"));
+
+    // Clones share the memo (the cell is Arc-shared).
+    assert!(pa.clone().schema_capabilities_cached());
+}

--- a/tests/postgres_metadata_provider_test.rs
+++ b/tests/postgres_metadata_provider_test.rs
@@ -1065,3 +1065,71 @@ async fn test_query_with_filter() {
     assert_eq!(name_col.value(0), "Charlie");
     assert_eq!(name_col.value(1), "Diana");
 }
+
+/// Bring the minimal fixture schema up to a fully-migrated catalog: every
+/// optional capability the provider probes (`partial_max` columns, the
+/// `ducklake_schema_versions` ledger) plus the file columns the scan
+/// projection reads.
+async fn migrate_fixture_to_current_schema(pool: &PgPool) -> anyhow::Result<()> {
+    sqlx::query(
+        "ALTER TABLE ducklake_data_file
+             ADD COLUMN IF NOT EXISTS encryption_key VARCHAR,
+             ADD COLUMN IF NOT EXISTS record_count BIGINT,
+             ADD COLUMN IF NOT EXISTS row_id_start BIGINT,
+             ADD COLUMN IF NOT EXISTS begin_snapshot BIGINT NOT NULL DEFAULT 1,
+             ADD COLUMN IF NOT EXISTS end_snapshot BIGINT,
+             ADD COLUMN IF NOT EXISTS partial_max BIGINT",
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        "ALTER TABLE ducklake_delete_file
+             ADD COLUMN IF NOT EXISTS encryption_key VARCHAR,
+             ADD COLUMN IF NOT EXISTS partial_max BIGINT",
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS ducklake_schema_versions (
+             begin_snapshot BIGINT NOT NULL,
+             schema_version BIGINT NOT NULL,
+             table_id BIGINT NOT NULL
+         )",
+    )
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn test_schema_capability_probe_memoized_positive_only() {
+    let (provider, _container) = create_postgres_provider().await.unwrap();
+
+    populate_test_data(&provider)
+        .await
+        .expect("Failed to populate test data");
+    migrate_fixture_to_current_schema(&provider.pool)
+        .await
+        .expect("Failed to migrate fixture schema");
+
+    // Fully-migrated catalog: the first scan probes once (all capabilities
+    // true) and memoizes; the second scan reuses the memo and must return
+    // identical results.
+    assert!(!provider.schema_capabilities_cached());
+    let first = provider
+        .get_table_files_for_select(1, 1)
+        .expect("Should get table files");
+    assert!(
+        provider.schema_capabilities_cached(),
+        "an all-true probe result must be cached after the first call"
+    );
+    let second = provider
+        .get_table_files_for_select(1, 1)
+        .expect("Should get table files");
+    assert_eq!(first.len(), 2);
+    assert_eq!(format!("{first:?}"), format!("{second:?}"));
+
+    // Clones share the memo (the cell is Arc-shared).
+    assert!(provider.clone().schema_capabilities_cached());
+}

--- a/tests/sqlite_metadata_provider_test.rs
+++ b/tests/sqlite_metadata_provider_test.rs
@@ -996,3 +996,85 @@ async fn test_query_with_filter() {
     assert_eq!(name_col.value(0), "Charlie");
     assert_eq!(name_col.value(1), "Diana");
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_schema_capability_probe_memoized_positive_only() {
+    let provider = create_sqlite_provider().await.unwrap();
+
+    populate_test_data(&provider)
+        .await
+        .expect("Failed to populate test data");
+
+    // Minimal fixture: every optional capability is absent, so the
+    // positive-only memo must stay empty and repeated calls keep re-probing
+    // (the status quo for legacy catalogs) while returning identical results.
+    assert!(!provider.schema_capabilities_cached());
+    let first = provider
+        .get_table_files_for_select(1, 1)
+        .expect("Should get table files");
+    assert!(
+        !provider.schema_capabilities_cached(),
+        "a negative probe result must not be cached"
+    );
+    let second = provider
+        .get_table_files_for_select(1, 1)
+        .expect("Should get table files");
+    assert_eq!(first.len(), 2);
+    assert_eq!(format!("{first:?}"), format!("{second:?}"));
+
+    // Upgrade the catalog mid-flight: add every capability the provider
+    // probes. Because false was never cached, the very next call must see
+    // the upgrade and memoize the all-true answer.
+    let pool = &provider.pool;
+    sqlx::query("ALTER TABLE ducklake_data_file ADD COLUMN partial_max INTEGER")
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("ALTER TABLE ducklake_delete_file ADD COLUMN partial_max INTEGER")
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("ALTER TABLE ducklake_data_file ADD COLUMN partition_id INTEGER")
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "CREATE TABLE ducklake_schema_versions (
+            begin_snapshot INTEGER NOT NULL,
+            schema_version INTEGER NOT NULL,
+            table_id INTEGER NOT NULL
+        )",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "CREATE TABLE ducklake_inlined_data_tables (
+            table_id INTEGER NOT NULL,
+            table_name TEXT NOT NULL,
+            schema_snapshot INTEGER
+        )",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+
+    let migrated_first = provider
+        .get_table_files_for_select(1, 1)
+        .expect("Should get table files");
+    assert!(
+        provider.schema_capabilities_cached(),
+        "an all-true probe result must be cached after the first call"
+    );
+    let migrated_second = provider
+        .get_table_files_for_select(1, 1)
+        .expect("Should get table files");
+    assert_eq!(migrated_first.len(), 2);
+    assert_eq!(
+        format!("{migrated_first:?}"),
+        format!("{migrated_second:?}")
+    );
+
+    // Clones share the memo (the cell is Arc-shared).
+    assert!(provider.clone().schema_capabilities_cached());
+}


### PR DESCRIPTION
## Problem

Every scan/CDC call re-probes the catalog for optional-schema capabilities (`ducklake_data_file`/`ducklake_delete_file` `partial_max`, the `ducklake_schema_versions` ledger, sqlite's inlined-data registry, and — since #191 — `partition_id`) with separate SQL statements, and the scan-planning page loop always fetches one extra empty page to detect exhaustion. On a local metadata DB this is sub-ms noise; on a network metadata DB every statement is a round trip and the cost scales with tables touched per query.

Measured on TPC-H SF1 (19 queries, single stream, DataFusion consumer, catalog on ~1ms-RTT Postgres): **+18% end-to-end** from these probes alone, with multi-table queries +53–56%; one q2 execution issued **53 metadata statements vs 17** before the paging change. On a local catalog the same code measures +2% — which is why it went unnoticed.

## Fix

1. **Memoize the capability probes per provider, cache-positive-only.** All capabilities are probed in one combined statement; the result is stored (in an `Arc<OnceLock>`, shared across clones) **only when every flag is true**. Capability existence is monotonic — migrations only add columns/tables — so an all-true answer is an immutable fact, while a `false` is never cached: an under-migrated catalog keeps today's per-call probing bit-for-bit (including the NULL projection degradation and DuckDB's old-spec `partial_file_info` fallback), and a mid-flight catalog upgrade is picked up on the next call exactly as before.
2. **Stop paging at a short page.** A page with fewer rows than the requested LIMIT (keyed, ordered page query) proves exhaustion; process it and stop instead of fetching the empty terminator. Halves planning metadata queries for tables with fewer files than the batch size; exact-multiple file counts still terminate via the empty page.

With both: q2 is back to 17 metadata statements, and the fully-migrated fast path is one probe statement per provider lifetime.

## Validation

- Full suite green including testcontainers (postgres/multicatalog/mysql) and the #191 partition suites; new per-backend memoization tests cover: memoized-after-first-select, false-NOT-cached on minimal fixtures, and upgrade picked up next call.
- Deployed against a production-shaped stack (Neon metadata DB): recovers ~two-thirds of the measured regression; the remainder is consumer-side.

BREAKING: struct-literal construction of `PostgresMetadataProvider`/`SqliteMetadataProvider`/`MySqlMetadataProvider` no longer compiles (private memo field added) — use the constructors. CHANGELOG updated.