### PR TITLE
chore(release): 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,40 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-- **BREAKING**: `PostgresMetadataProvider`, `SqliteMetadataProvider`, and
-  `MySqlMetadataProvider` carry a new private field; construct them via `new()`
-  — or the new `from_pool()`, which adopts an existing connection pool —
-  instead of struct literals.
-- Per-call catalog capability probes (`partial_max` columns, the
-  `ducklake_schema_versions` ledger, SQLite's inlined-data registry) on the
-  scan and CDC paths run as one combined statement and are memoized
-  cache-positive-only per provider: a fully-migrated catalog probes once per
-  provider lifetime, while catalogs missing any capability keep re-probing
-  every call (so a mid-flight catalog upgrade is still picked up immediately).
-- **BREAKING**: CDC snapshot bounds are inclusive on both ends, matching official
-  DuckLake (was exclusive-start); cursor pagination should pass `last + 1` (#179).
-- **BREAKING**: CDC columns `(snapshot_id, rowid, change_type)` now lead the output,
-  matching official DuckLake (they trailed before) (#179).
-- **BREAKING**: `ducklake_table_changes` emits pure deletes as `change_type='delete'`
-  rows with the old values, matching official DuckLake (#179).
+## [0.6.0] - 2026-07-20
 
 ### Added
-- Differential CDC conformance suite: diffs both feeds live against the official
-  extension on identical catalogs (#179).
+- Table partitioning: `SET`/`RESET PARTITIONED BY` (`identity`/`year`/`month`/`day`/`hour`); per-partition files on write (SQLite), file pruning on read (all backends) (#191).
 - `ducklake_table_insertions()` — the official insertions feed (#179).
-- CDC snapshot bounds accept timestamp strings (official `AT (TIMESTAMP => ...)`
-  semantics) (#179).
-- The vendored sqllogictest suite binds (CDC UDTFs + dialect translation) and fails
-  the build on expected-pass regressions (#179).
+- CDC snapshot bounds accept timestamp strings (#179).
+- `retire_appends_since` to roll back a pure-append delta (#182).
+- `rowid` emitted by `ducklake_table_changes` / `ducklake_table_deletions` (#180).
+- Differential CDC conformance suite vs the official extension (#179).
+
+### Changed
+- **BREAKING**: CDC snapshot bounds are inclusive on both ends; paginate with `last + 1` (#179).
+- **BREAKING**: CDC output leads with `(snapshot_id, rowid, change_type)` (#179).
+- **BREAKING**: `ducklake_table_changes` emits pure deletes as `change_type='delete'` rows (#179).
+- **BREAKING**: metadata providers gained a private field — construct via `new()`/`from_pool()`, not struct literals (#192).
+- Filters push through pure column renames (#188).
+- Scan planning streams file metadata, memoizes capability probes, and stops at a short page (#181, #192).
 
 ### Fixed
-- DuckDB backend: delete-file window off-by-one double-reported boundary deletions (#179).
-- CDC missed changes inside compaction-merged files: `partial_max` windows + per-row
-  origin snapshots (#179).
-- Cumulative (3-column) delete files are windowed per row, each deletion at its own
-  delete snapshot (#179).
-- `SELECT COUNT(*)` over `ducklake_table_changes` errored on the insert-only path (#179).
+- DuckDB delete-file window off-by-one double-reported boundary deletions (#179).
+- CDC missed changes in compaction-merged files (`partial_max` windows) (#179).
+- Cumulative delete files windowed per row, each deletion at its own snapshot (#179).
+- `SELECT COUNT(*)` over `ducklake_table_changes` on the insert-only path (#179).
 
 ## [0.5.0] - 2026-07-15
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1847,7 +1847,7 @@ checksum = "cb9e7e5d11130c48c8bd4e80c79a9772dd28ce6dc330baca9246205d245b9e2e"
 
 [[package]]
 name = "datafusion-ducklake"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "arrow 58.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "benchmark"]
 
 [package]
 name = "datafusion-ducklake"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors = ["zac@hotdata.dev", "shefeek@hotdata.dev", "anoop@hotdata.dev"]
 description = "DuckLake query engine for rust, built with datafusion."

--- a/README.md
+++ b/README.md
@@ -158,6 +158,31 @@ writer options.
 
 ---
 
+## Partitioning
+
+Partition a table by one or more columns (optionally through a transform) so that queries
+filtering on a partition column skip whole files:
+
+```rust
+// Declare the partition scheme *before* loading data, then INSERT as usual.
+execute_ducklake_sql(
+    &ctx,
+    &catalog,
+    "ALTER TABLE ducklake.main.sales SET PARTITIONED BY (region, year(sale_date))",
+)
+.await?;
+```
+
+Writes split rows into one Parquet file per partition value; reads then prune non-matching
+files automatically. Supported transforms are `identity` (the raw value) and
+`year`/`month`/`day`/`hour`; pruning currently applies to `identity` and `year`
+(`month`/`day`/`hour` are recorded but not yet used to skip files). Partitioned **writes**
+are supported on **SQLite** today; **read + pruning** work on all backends. `RESET
+PARTITIONED BY` turns it off. See [COMPATIBILITY.md](COMPATIBILITY.md) and
+[`tests/partition_write_tests.rs`](tests/partition_write_tests.rs).
+
+---
+
 ## Multi-catalog (PostgreSQL, experimental)
 
 A single PostgreSQL metadata store can host **multiple independent DuckLake catalogs** —
@@ -220,7 +245,8 @@ A few highlights worth knowing up front:
 - Reads work on DuckDB, SQLite, PostgreSQL, and MySQL; **writes are SQLite/PostgreSQL only**.
 - Object stores: local filesystem and S3-compatible (S3, MinIO).
 - Snapshots can be selected programmatically (`DuckLakeCatalog::with_snapshot`), but there
-  is no SQL-level time travel (`AS OF`) yet, and no partition-based file pruning.
+  is no SQL-level time travel (`AS OF`) yet.
+- Table partitioning: read + file pruning on all backends; partitioned writes on SQLite.
 - Data inlined by DuckDB's ducklake extension is **not read** — see COMPATIBILITY.md for
   the `COUNT(*)` undercount caveat and how to avoid it.
 


### PR DESCRIPTION
## Release 0.6.0

Prepares the `0.6.0` release. No functional code changes — this branch sits directly on
`main` (`f88d718`, #192) and only bumps the version, promotes the changelog, and documents
partitioning:

- `Cargo.toml` **and** `Cargo.lock` → `0.6.0`
- `CHANGELOG.md`: `[Unreleased]` → `[0.6.0] - 2026-07-20` (backfilled the entries that
  merged without a changelog note — partitioning, filter push-through, `retire_appends_since`,
  CDC `rowid` — and tagged every entry with its PR); fresh empty `[Unreleased]` on top
- `README.md`: new **Partitioning** section; corrected the stale "no partition-based file
  pruning" note

### Highlights since 0.5.0

- **Table partitioning** (#191): partition by a column or transform (`identity`,
  `year`/`month`/`day`/`hour`) via `ALTER TABLE … SET/RESET PARTITIONED BY` or
  `set_partition_spec`; one Parquet file per partition on write (SQLite), file pruning on
  read (all backends). Fully opt-in — unpartitioned tables are unaffected.
- **CDC official semantics** (#179) — ⚠️ **BREAKING**: inclusive snapshot bounds on both
  ends, leading `(snapshot_id, rowid, change_type)` columns, pure deletes emitted as
  `delete` rows; plus `ducklake_table_insertions()`, timestamp bounds, and a differential
  conformance suite against the official extension.
- ⚠️ **BREAKING**: `PostgresMetadataProvider` / `SqliteMetadataProvider` /
  `MySqlMetadataProvider` gained a private field — construct via `new()` / `from_pool()`,
  not struct literals (#192).
- Filters push through pure column renames (#188); `retire_appends_since` (#182); `rowid`
  in the CDC feeds (#180); scan-planning perf — streaming file metadata, memoized
  capability probes, short-page paging stop (#181, #192).

See `CHANGELOG.md` for the complete list.

### Verification

- `cargo check --features write-sqlite` passes at `0.6.0`.
- CI runs the full gate set (fmt, clippy `--all-features -D warnings`, doc, tests incl. the
  Docker backends) on this branch.


After merge: tag `v0.6.0` and `cargo publish`.

