### PR TITLE
fix(read): NaN-aware float pruning — catalog gate + parquet pushdown barrier

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub mod encryption;
 pub mod error;
 pub mod information_schema;
 pub mod metadata_provider;
+pub(crate) mod nan_pruning_barrier;
 pub mod partition;
 pub mod path_resolver;
 pub(crate) mod positional_source;

--- a/src/metadata_provider.rs
+++ b/src/metadata_provider.rs
@@ -81,7 +81,7 @@ pub const SQL_GET_TABLE_STATS: &str =
     "SELECT record_count, file_size_bytes FROM ducklake_table_stats WHERE table_id = ?";
 
 pub const SQL_GET_TABLE_COLUMN_STATS: &str = "
-    SELECT column_id, contains_null, min_value, max_value
+    SELECT column_id, contains_null, min_value, max_value, contains_nan
     FROM ducklake_table_column_stats
     WHERE table_id = ?";
 
@@ -93,7 +93,8 @@ pub const SQL_GET_FILE_COLUMN_STATS: &str = "
         stats.value_count,
         stats.null_count,
         stats.min_value,
-        stats.max_value
+        stats.max_value,
+        stats.contains_nan
     FROM ducklake_file_column_stats AS stats
     INNER JOIN ducklake_data_file AS data
         ON data.data_file_id = stats.data_file_id
@@ -623,6 +624,13 @@ pub struct DuckLakeTableColumnStatistics {
     pub contains_null: Option<bool>,
     pub min_value: Option<String>,
     pub max_value: Option<String>,
+    /// Tri-state NaN flag for float columns: `Some(false)` = known NaN-free,
+    /// `Some(true)` = contains NaN, `None` = unknown (e.g. register-by-reference
+    /// loads, where the parquet footer carries no NaN signal). Stored min/max
+    /// exclude NaN, and NaN sorts above every value in both DuckDB and
+    /// DataFusion — so a float `max_value` is only a true upper bound when this
+    /// is `Some(false)`. `min_value` is unaffected (NaN can never lower it).
+    pub contains_nan: Option<bool>,
     /// Sum of compressed bytes reported by every visible file for this column.
     pub column_size_bytes: Option<i64>,
     /// Whether the table-wide bounds are exact for the requested snapshot.
@@ -643,6 +651,8 @@ pub struct DuckLakeFileColumnStatistics {
     pub null_count: Option<i64>,
     pub min_value: Option<String>,
     pub max_value: Option<String>,
+    /// Tri-state NaN flag; see [`DuckLakeTableColumnStatistics::contains_nan`].
+    pub contains_nan: Option<bool>,
 }
 
 /// One visible data file and its catalog column statistics.

--- a/src/metadata_provider_duckdb.rs
+++ b/src/metadata_provider_duckdb.rs
@@ -424,6 +424,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
                         contains_null: row.get(1)?,
                         min_value: row.get(2)?,
                         max_value: row.get(3)?,
+                        contains_nan: row.get(4)?,
                         column_size_bytes: column_sizes.get(&column_id).copied(),
                         bounds_are_exact,
                     })
@@ -518,7 +519,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
         let statistics = match conn.prepare(
             "SELECT stats.data_file_id, stats.column_id,
                     stats.column_size_bytes, stats.value_count, stats.null_count,
-                    stats.min_value, stats.max_value
+                    stats.min_value, stats.max_value, stats.contains_nan
              FROM ducklake_file_column_stats AS stats
              INNER JOIN ducklake_data_file AS data
                ON data.data_file_id = stats.data_file_id
@@ -548,6 +549,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
                             null_count: row.get(4)?,
                             min_value: row.get(5)?,
                             max_value: row.get(6)?,
+                            contains_nan: row.get(7)?,
                         })
                     },
                 )?
@@ -638,6 +640,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
                         contains_null: row.get(1)?,
                         min_value: row.get(2)?,
                         max_value: row.get(3)?,
+                        contains_nan: row.get(4)?,
                         column_size_bytes: None,
                         bounds_are_exact: false,
                     })
@@ -658,6 +661,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
                         null_count: row.get(4)?,
                         min_value: row.get(5)?,
                         max_value: row.get(6)?,
+                        contains_nan: row.get(7)?,
                     })
                 })?
                 .collect::<Result<Vec<_>, _>>()?,

--- a/src/metadata_provider_mysql.rs
+++ b/src/metadata_provider_mysql.rs
@@ -449,7 +449,7 @@ impl MetadataProvider for MySqlMetadataProvider {
             let statistics = match sqlx::query(
                 "SELECT stats.data_file_id, stats.column_id,
                         stats.column_size_bytes, stats.value_count, stats.null_count,
-                        stats.min_value, stats.max_value
+                        stats.min_value, stats.max_value, stats.contains_nan
                  FROM ducklake_file_column_stats AS stats
                  INNER JOIN ducklake_data_file AS data
                    ON data.data_file_id = stats.data_file_id
@@ -480,6 +480,7 @@ impl MetadataProvider for MySqlMetadataProvider {
                             null_count: row.try_get(4)?,
                             min_value: row.try_get(5)?,
                             max_value: row.try_get(6)?,
+                            contains_nan: row.try_get(7)?,
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,
@@ -616,7 +617,7 @@ impl MetadataProvider for MySqlMetadataProvider {
             .fetch_one(&self.pool)
             .await?;
             let columns = match sqlx::query(
-                "SELECT column_id, contains_null, min_value, max_value
+                "SELECT column_id, contains_null, min_value, max_value, contains_nan
                  FROM ducklake_table_column_stats WHERE table_id = ?",
             )
             .bind(table_id)
@@ -632,6 +633,7 @@ impl MetadataProvider for MySqlMetadataProvider {
                             contains_null: row.try_get(1)?,
                             min_value: row.try_get(2)?,
                             max_value: row.try_get(3)?,
+                            contains_nan: row.try_get(4)?,
                             column_size_bytes: column_sizes.get(&column_id).copied(),
                             bounds_are_exact,
                         })
@@ -671,7 +673,7 @@ impl MetadataProvider for MySqlMetadataProvider {
             };
 
             let columns = match sqlx::query(
-                "SELECT column_id, contains_null, min_value, max_value
+                "SELECT column_id, contains_null, min_value, max_value, contains_nan
                  FROM ducklake_table_column_stats WHERE table_id = ?",
             )
             .bind(table_id)
@@ -686,6 +688,7 @@ impl MetadataProvider for MySqlMetadataProvider {
                             contains_null: row.try_get(1)?,
                             min_value: row.try_get(2)?,
                             max_value: row.try_get(3)?,
+                            contains_nan: row.try_get(4)?,
                             column_size_bytes: None,
                             bounds_are_exact: false,
                         })
@@ -703,7 +706,8 @@ impl MetadataProvider for MySqlMetadataProvider {
                     stats.value_count,
                     stats.null_count,
                     stats.min_value,
-                    stats.max_value
+                    stats.max_value,
+                    stats.contains_nan
                  FROM ducklake_file_column_stats AS stats
                  INNER JOIN ducklake_data_file AS data
                     ON data.data_file_id = stats.data_file_id
@@ -729,6 +733,7 @@ impl MetadataProvider for MySqlMetadataProvider {
                             null_count: row.try_get(4)?,
                             min_value: row.try_get(5)?,
                             max_value: row.try_get(6)?,
+                            contains_nan: row.try_get(7)?,
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,

--- a/src/metadata_provider_postgres.rs
+++ b/src/metadata_provider_postgres.rs
@@ -532,7 +532,7 @@ impl MetadataProvider for PostgresMetadataProvider {
             let statistics = match sqlx::query(
                 "SELECT stats.data_file_id, stats.column_id,
                         stats.column_size_bytes, stats.value_count, stats.null_count,
-                        stats.min_value, stats.max_value
+                        stats.min_value, stats.max_value, stats.contains_nan
                  FROM ducklake_file_column_stats AS stats
                  INNER JOIN ducklake_data_file AS data
                    ON data.data_file_id = stats.data_file_id
@@ -563,6 +563,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                             null_count: row.try_get(4)?,
                             min_value: row.try_get(5)?,
                             max_value: row.try_get(6)?,
+                            contains_nan: row.try_get(7)?,
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,
@@ -703,7 +704,7 @@ impl MetadataProvider for PostgresMetadataProvider {
             .fetch_one(&self.pool)
             .await?;
             let columns = match sqlx::query(
-                "SELECT column_id, contains_null, min_value, max_value
+                "SELECT column_id, contains_null, min_value, max_value, contains_nan
                  FROM ducklake_table_column_stats WHERE table_id = $1",
             )
             .bind(table_id)
@@ -719,6 +720,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                             contains_null: row.try_get(1)?,
                             min_value: row.try_get(2)?,
                             max_value: row.try_get(3)?,
+                            contains_nan: row.try_get(4)?,
                             column_size_bytes: column_sizes.get(&column_id).copied(),
                             bounds_are_exact,
                         })
@@ -758,7 +760,7 @@ impl MetadataProvider for PostgresMetadataProvider {
             };
 
             let columns = match sqlx::query(
-                "SELECT column_id, contains_null, min_value, max_value
+                "SELECT column_id, contains_null, min_value, max_value, contains_nan
                  FROM ducklake_table_column_stats WHERE table_id = $1",
             )
             .bind(table_id)
@@ -773,6 +775,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                             contains_null: row.try_get(1)?,
                             min_value: row.try_get(2)?,
                             max_value: row.try_get(3)?,
+                            contains_nan: row.try_get(4)?,
                             column_size_bytes: None,
                             bounds_are_exact: false,
                         })
@@ -790,7 +793,8 @@ impl MetadataProvider for PostgresMetadataProvider {
                     stats.value_count,
                     stats.null_count,
                     stats.min_value,
-                    stats.max_value
+                    stats.max_value,
+                    stats.contains_nan
                  FROM ducklake_file_column_stats AS stats
                  INNER JOIN ducklake_data_file AS data
                     ON data.data_file_id = stats.data_file_id
@@ -816,6 +820,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                             null_count: row.try_get(4)?,
                             min_value: row.try_get(5)?,
                             max_value: row.try_get(6)?,
+                            contains_nan: row.try_get(7)?,
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,

--- a/src/metadata_provider_sqlite.rs
+++ b/src/metadata_provider_sqlite.rs
@@ -624,7 +624,7 @@ impl MetadataProvider for SqliteMetadataProvider {
             let statistics = match sqlx::query(
                 "SELECT stats.data_file_id, stats.column_id,
                         stats.column_size_bytes, stats.value_count, stats.null_count,
-                        stats.min_value, stats.max_value
+                        stats.min_value, stats.max_value, stats.contains_nan
                  FROM ducklake_file_column_stats AS stats
                  INNER JOIN ducklake_data_file AS data
                    ON data.data_file_id = stats.data_file_id
@@ -655,6 +655,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                             null_count: row.try_get(4)?,
                             min_value: row.try_get(5)?,
                             max_value: row.try_get(6)?,
+                            contains_nan: row.try_get(7)?,
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,
@@ -791,7 +792,7 @@ impl MetadataProvider for SqliteMetadataProvider {
             .fetch_one(&self.pool)
             .await?;
             let columns = match sqlx::query(
-                "SELECT column_id, contains_null, min_value, max_value
+                "SELECT column_id, contains_null, min_value, max_value, contains_nan
                  FROM ducklake_table_column_stats WHERE table_id = ?",
             )
             .bind(table_id)
@@ -807,6 +808,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                             contains_null: row.try_get(1)?,
                             min_value: row.try_get(2)?,
                             max_value: row.try_get(3)?,
+                            contains_nan: row.try_get(4)?,
                             column_size_bytes: column_sizes.get(&column_id).copied(),
                             bounds_are_exact,
                         })
@@ -846,7 +848,7 @@ impl MetadataProvider for SqliteMetadataProvider {
             };
 
             let columns = match sqlx::query(
-                "SELECT column_id, contains_null, min_value, max_value
+                "SELECT column_id, contains_null, min_value, max_value, contains_nan
                  FROM ducklake_table_column_stats WHERE table_id = ?",
             )
             .bind(table_id)
@@ -861,6 +863,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                             contains_null: row.try_get(1)?,
                             min_value: row.try_get(2)?,
                             max_value: row.try_get(3)?,
+                            contains_nan: row.try_get(4)?,
                             column_size_bytes: None,
                             bounds_are_exact: false,
                         })
@@ -878,7 +881,8 @@ impl MetadataProvider for SqliteMetadataProvider {
                     stats.value_count,
                     stats.null_count,
                     stats.min_value,
-                    stats.max_value
+                    stats.max_value,
+                    stats.contains_nan
                  FROM ducklake_file_column_stats AS stats
                  INNER JOIN ducklake_data_file AS data
                     ON data.data_file_id = stats.data_file_id
@@ -904,6 +908,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                             null_count: row.try_get(4)?,
                             min_value: row.try_get(5)?,
                             max_value: row.try_get(6)?,
+                            contains_nan: row.try_get(7)?,
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -181,11 +181,14 @@ pub struct ColumnStat {
     /// Number of non-NULL values in this column across the file.
     pub value_count: Option<i64>,
     /// For `FLOAT`/`DOUBLE` columns: whether any NaN is present. `None` for
-    /// non-floating columns. When `true`, `min_value`/`max_value` are omitted
-    /// (matching DuckLake), so float pruning is only sound when this is `false`.
+    /// non-floating columns, and for float columns whose NaN state is unknown
+    /// (footer-only harvests — the parquet footer carries no NaN signal). When
+    /// `true`, `min_value`/`max_value` are omitted (matching DuckLake); readers
+    /// may only trust a float `max_value` as an upper bound when this is
+    /// `false`, since NaN sorts above every value.
     pub contains_nan: Option<bool>,
-    /// Total compressed size of the column in bytes. Currently always `None`
-    /// (deferred; not needed for pruning). See `[[column-size-bytes]]`.
+    /// Total compressed size of the column in bytes, summed over the file's
+    /// column chunks (parquet `total_compressed_size`).
     pub column_size_bytes: Option<i64>,
 }
 

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -1178,7 +1178,8 @@ async fn live_columns_for_stats(
 /// `end_snapshot IS NULL` set); a positional delete leaves the data file live
 /// with unchanged stats — so global bounds widen on insert and never tighten on
 /// delete, matching official DuckLake. Min/max widen with a type-aware compare
-/// ([`crate::stats_encode::stat_cmp`]); `contains_null`/`contains_nan` are OR-reduced.
+/// ([`crate::stats_encode::stat_cmp`]); `contains_null`/`contains_nan` are
+/// OR-reduced when every live file reported them, else NULL/unknown.
 async fn recompute_table_column_stats(
     tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
     table_id: i64,

--- a/src/multicatalog_provider.rs
+++ b/src/multicatalog_provider.rs
@@ -554,7 +554,7 @@ impl MetadataProvider for MulticatalogProvider {
             let statistics = match sqlx::query(
                 "SELECT stats.data_file_id, stats.column_id,
                         stats.column_size_bytes, stats.value_count, stats.null_count,
-                        stats.min_value, stats.max_value
+                        stats.min_value, stats.max_value, stats.contains_nan
                  FROM ducklake_file_column_stats AS stats
                  INNER JOIN ducklake_data_file AS data
                    ON data.data_file_id = stats.data_file_id
@@ -585,6 +585,7 @@ impl MetadataProvider for MulticatalogProvider {
                             null_count: row.try_get(4)?,
                             min_value: row.try_get(5)?,
                             max_value: row.try_get(6)?,
+                            contains_nan: row.try_get(7)?,
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,
@@ -726,7 +727,7 @@ impl MetadataProvider for MulticatalogProvider {
             .fetch_one(&self.pool)
             .await?;
             let columns = match sqlx::query(
-                "SELECT column_id, contains_null, min_value, max_value
+                "SELECT column_id, contains_null, min_value, max_value, contains_nan
                  FROM ducklake_table_column_stats WHERE table_id = $1",
             )
             .bind(table_id)
@@ -742,6 +743,7 @@ impl MetadataProvider for MulticatalogProvider {
                             contains_null: row.try_get(1)?,
                             min_value: row.try_get(2)?,
                             max_value: row.try_get(3)?,
+                            contains_nan: row.try_get(4)?,
                             column_size_bytes: column_sizes.get(&column_id).copied(),
                             bounds_are_exact,
                         })
@@ -781,7 +783,7 @@ impl MetadataProvider for MulticatalogProvider {
             };
 
             let columns = match sqlx::query(
-                "SELECT column_id, contains_null, min_value, max_value
+                "SELECT column_id, contains_null, min_value, max_value, contains_nan
                  FROM ducklake_table_column_stats WHERE table_id = $1",
             )
             .bind(table_id)
@@ -796,6 +798,7 @@ impl MetadataProvider for MulticatalogProvider {
                             contains_null: row.try_get(1)?,
                             min_value: row.try_get(2)?,
                             max_value: row.try_get(3)?,
+                            contains_nan: row.try_get(4)?,
                             column_size_bytes: None,
                             bounds_are_exact: false,
                         })
@@ -813,7 +816,8 @@ impl MetadataProvider for MulticatalogProvider {
                     stats.value_count,
                     stats.null_count,
                     stats.min_value,
-                    stats.max_value
+                    stats.max_value,
+                    stats.contains_nan
                  FROM ducklake_file_column_stats AS stats
                  INNER JOIN ducklake_data_file AS data
                     ON data.data_file_id = stats.data_file_id
@@ -839,6 +843,7 @@ impl MetadataProvider for MulticatalogProvider {
                             null_count: row.try_get(4)?,
                             min_value: row.try_get(5)?,
                             max_value: row.try_get(6)?,
+                            contains_nan: row.try_get(7)?,
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,

--- a/src/nan_pruning_barrier.rs
+++ b/src/nan_pruning_barrier.rs
@@ -1,0 +1,140 @@
+//! Filter-pushdown barrier for NaN-unsafe float columns
+//!
+//! Parquet footer min/max for float columns exclude NaN, and NaN sorts above
+//! every value in DataFusion (IEEE 754 totalOrder, matching DuckDB). When a
+//! file's NaN state is unknown or positive, a predicate like `x > C` pushed
+//! into the parquet scan can row-group-prune a group whose footer max is below
+//! `C` while it still holds matching NaN rows — silently dropping them. The
+//! catalog-level gate (see `float_max_is_bound` in `table.rs`) protects only
+//! plan-time file pruning; this node protects execution-time row-group/page/
+//! bloom pruning by refusing to push such predicates into the scan.
+//!
+//! Purely a pass-through at execution: it forwards batches unchanged and only
+//! participates in the filter-pushdown negotiation, rejecting predicates that
+//! reference a NaN-unsafe float column. Rejected predicates stay in the
+//! `FilterExec` above (all table filters are declared `Inexact`), so results
+//! remain correct — the scan just reads more row groups for those predicates.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use datafusion::common::config::ConfigOptions;
+use datafusion::error::{DataFusionError, Result as DataFusionResult};
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_plan::filter_pushdown::{
+    ChildFilterDescription, FilterDescription, FilterPushdownPhase,
+};
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, Statistics,
+};
+
+/// Pass-through node that blocks filter pushdown for predicates referencing
+/// float columns whose NaN state is not known to be false for every file
+/// beneath it.
+#[derive(Debug)]
+pub struct NanPruningBarrierExec {
+    input: Arc<dyn ExecutionPlan>,
+    /// Names (in this node's schema) of float columns whose NaN state is
+    /// unknown or positive for at least one file under this scan.
+    unsafe_columns: Arc<HashSet<String>>,
+    /// Child's properties, reused verbatim (the schema is unchanged).
+    properties: Arc<PlanProperties>,
+}
+
+impl NanPruningBarrierExec {
+    pub fn new(input: Arc<dyn ExecutionPlan>, unsafe_columns: Arc<HashSet<String>>) -> Self {
+        let properties = Arc::clone(input.properties());
+        Self {
+            input,
+            unsafe_columns,
+            properties,
+        }
+    }
+}
+
+impl DisplayAs for NanPruningBarrierExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let mut columns: Vec<&str> = self.unsafe_columns.iter().map(String::as_str).collect();
+        columns.sort_unstable();
+        write!(
+            f,
+            "NanPruningBarrierExec: unsafe_columns=[{}]",
+            columns.join(", ")
+        )
+    }
+}
+
+impl ExecutionPlan for NanPruningBarrierExec {
+    fn name(&self) -> &str {
+        "NanPruningBarrierExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn maintains_input_order(&self) -> Vec<bool> {
+        vec![true]
+    }
+
+    fn supports_limit_pushdown(&self) -> bool {
+        true
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        if children.len() != 1 {
+            return Err(DataFusionError::Internal(
+                "NanPruningBarrierExec expects exactly one child".into(),
+            ));
+        }
+        Ok(Arc::new(NanPruningBarrierExec::new(
+            Arc::clone(&children[0]),
+            Arc::clone(&self.unsafe_columns),
+        )))
+    }
+
+    fn gather_filters_for_pushdown(
+        &self,
+        _phase: FilterPushdownPhase,
+        parent_filters: Vec<Arc<dyn PhysicalExpr>>,
+        _config: &ConfigOptions,
+    ) -> DataFusionResult<FilterDescription> {
+        // Allow a predicate through only when every column it references is
+        // NaN-safe; the rest are reported unsupported and stay above us.
+        let allowed: HashSet<usize> = self
+            .input
+            .schema()
+            .fields()
+            .iter()
+            .enumerate()
+            .filter(|(_, field)| !self.unsafe_columns.contains(field.name()))
+            .map(|(index, _)| index)
+            .collect();
+        let child = ChildFilterDescription::from_child_with_allowed_indices(
+            &parent_filters,
+            allowed,
+            &self.input,
+        )?;
+        Ok(FilterDescription::new().with_child(child))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        self.input.execute(partition, context)
+    }
+
+    fn partition_statistics(&self, partition: Option<usize>) -> DataFusionResult<Arc<Statistics>> {
+        self.input.partition_statistics(partition)
+    }
+}

--- a/src/nan_pruning_barrier.rs
+++ b/src/nan_pruning_barrier.rs
@@ -19,12 +19,15 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use datafusion::common::config::ConfigOptions;
+use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
-use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_expr::expressions::Column;
+use datafusion::physical_expr::{PhysicalExpr, PhysicalSortExpr};
 use datafusion::physical_plan::filter_pushdown::{
     ChildFilterDescription, FilterDescription, FilterPushdownPhase,
 };
+use datafusion::physical_plan::sort_pushdown::SortOrderPushdownResult;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, Statistics,
 };
@@ -124,6 +127,39 @@ impl ExecutionPlan for NanPruningBarrierExec {
             &self.input,
         )?;
         Ok(FilterDescription::new().with_child(child))
+    }
+
+    fn try_pushdown_sort(
+        &self,
+        order: &[PhysicalSortExpr],
+    ) -> DataFusionResult<SortOrderPushdownResult<Arc<dyn ExecutionPlan>>> {
+        // Sort pushdown can reorder files/row groups from their statistics —
+        // the same NaN-blind stats the filter barrier exists for — so only
+        // delegate when no sort key touches an unsafe float column.
+        let references_unsafe = order.iter().any(|sort| {
+            let mut found = false;
+            sort.expr
+                .apply(|expr| {
+                    if let Some(column) = expr.downcast_ref::<Column>()
+                        && self.unsafe_columns.contains(column.name())
+                    {
+                        found = true;
+                        return Ok(TreeNodeRecursion::Stop);
+                    }
+                    Ok(TreeNodeRecursion::Continue)
+                })
+                .expect("column scan over a sort expression cannot fail");
+            found
+        });
+        if references_unsafe {
+            return Ok(SortOrderPushdownResult::Unsupported);
+        }
+        Ok(self.input.try_pushdown_sort(order)?.map(|inner| {
+            Arc::new(NanPruningBarrierExec::new(
+                inner,
+                Arc::clone(&self.unsafe_columns),
+            )) as Arc<dyn ExecutionPlan>
+        }))
     }
 
     fn execute(

--- a/src/stats_encode.rs
+++ b/src/stats_encode.rs
@@ -262,6 +262,7 @@ pub fn aggregate_global_column_stats(
         min_present: i64,
         max_present: i64,
         nullcount_present: i64,
+        nan_present: i64,
         has_null: bool,
         has_nan: bool,
         numeric: bool,
@@ -275,6 +276,7 @@ pub fn aggregate_global_column_stats(
             min_present: 0,
             max_present: 0,
             nullcount_present: 0,
+            nan_present: 0,
             has_null: false,
             has_nan: false,
             numeric: numeric(f.column_id),
@@ -299,8 +301,11 @@ pub fn aggregate_global_column_stats(
                 agg.has_null = true;
             }
         }
-        if f.contains_nan == Some(true) {
-            agg.has_nan = true;
+        if let Some(nan) = f.contains_nan {
+            agg.nan_present += 1;
+            if nan {
+                agg.has_nan = true;
+            }
         }
     }
 
@@ -315,10 +320,13 @@ pub fn aggregate_global_column_stats(
                 .then_some(a.max)
                 .flatten(),
             contains_null: (a.nullcount_present == live_file_count).then_some(a.has_null),
-            // Surface a table-level NaN flag only when NaN is actually present
-            // (Some(true)); otherwise leave it NULL/unknown — matching official
-            // DuckLake, which never records a definite table-level `false`.
-            contains_nan: a.has_nan.then_some(true),
+            // Tri-state, same coverage rule as the other fields and the same
+            // semantics as official DuckLake's MergeStats: known (OR-reduced)
+            // only when EVERY live file reported a NaN flag, else NULL/unknown.
+            // A definite `false` is what lets readers trust a float max as an
+            // upper bound (NaN would sort above it), so it must never be
+            // claimed while any file's NaN state is unknown.
+            contains_nan: (a.nan_present == live_file_count).then_some(a.has_nan),
         })
         .collect();
     out.sort_by_key(|g| g.column_id);
@@ -718,6 +726,40 @@ mod tests {
             null_count,
             contains_nan: None,
         }
+    }
+
+    fn fcs_nan(contains_nan: Option<bool>) -> FileColumnStat {
+        FileColumnStat {
+            contains_nan,
+            ..fcs(1, Some("1.0"), Some("2.0"), Some(0))
+        }
+    }
+
+    #[test]
+    fn global_rollup_contains_nan_tristate() {
+        // All live files known NaN-free ⇒ definite false (what lets readers
+        // trust the float max as an upper bound).
+        let out =
+            aggregate_global_column_stats(&[fcs_nan(Some(false)), fcs_nan(Some(false))], 2, |_| {
+                true
+            });
+        assert_eq!(out[0].contains_nan, Some(false));
+
+        // Full coverage with any NaN ⇒ definite true.
+        let out =
+            aggregate_global_column_stats(&[fcs_nan(Some(false)), fcs_nan(Some(true))], 2, |_| {
+                true
+            });
+        assert_eq!(out[0].contains_nan, Some(true));
+
+        // One file's NaN state unknown ⇒ unknown, even though the other file
+        // reported one — same coverage rule as official DuckLake's MergeStats.
+        let out = aggregate_global_column_stats(&[fcs_nan(Some(true)), fcs_nan(None)], 2, |_| true);
+        assert_eq!(out[0].contains_nan, None);
+
+        // A statless live file also degrades the flag to unknown.
+        let out = aggregate_global_column_stats(&[fcs_nan(Some(false))], 2, |_| true);
+        assert_eq!(out[0].contains_nan, None);
     }
 
     #[test]

--- a/src/table.rs
+++ b/src/table.rs
@@ -11,6 +11,7 @@ use crate::metadata_provider::{
     DuckLakeTableColumn, DuckLakeTableColumnStatistics, DuckLakeTableFile,
     FILE_METADATA_BATCH_SIZE, MetadataProvider,
 };
+use crate::nan_pruning_barrier::NanPruningBarrierExec;
 use crate::partition::PartitionSpec;
 use crate::path_resolver::resolve_path;
 use crate::positional_source::PositionalFileSource;
@@ -1140,8 +1141,10 @@ impl DuckLakeTable {
     /// [`crate::metadata_writer::MetadataWriter::set_delete_file`].
     ///
     /// Scans the whole file; pushing `predicate` down for row-group/bloom pruning
-    /// is a possible optimization. Only valid for insert-only files, where
-    /// `position = rowid - row_id_start`.
+    /// is a possible optimization — but any such pushdown must exclude float
+    /// predicates unless the file is known NaN-free (footer bounds exclude NaN;
+    /// see [`NanPruningBarrierExec`]), or a DELETE/UPDATE could miss NaN rows.
+    /// Only valid for insert-only files, where `position = rowid - row_id_start`.
     pub async fn resolve_positions(
         &self,
         state: &dyn Session,
@@ -1361,6 +1364,11 @@ impl DuckLakeTable {
             None => self.schema.clone(),
         };
 
+        // Float columns whose NaN state isn't known false for every scanned
+        // file: predicates on them must not reach the parquet reader's
+        // row-group/page pruning (footer bounds exclude NaN).
+        let nan_unsafe_columns = self.nan_unsafe_float_columns(files, file_statistics);
+
         // Build one scan per physical-schema group; ColumnRenameExec coerces each
         // group to the catalog schema (renamed columns or a differing Arrow type).
         let mut execs: Vec<Arc<dyn ExecutionPlan>> = Vec::with_capacity(groups.len());
@@ -1379,7 +1387,7 @@ impl DuckLakeTable {
             let parquet_exec: Arc<dyn ExecutionPlan> =
                 DataSourceExec::from_data_source(builder.build());
 
-            let exec = if !name_mapping.is_empty() || parquet_exec.schema() != output_schema {
+            let mut exec = if !name_mapping.is_empty() || parquet_exec.schema() != output_schema {
                 Arc::new(ColumnRenameExec::new(
                     parquet_exec,
                     output_schema.clone(),
@@ -1388,10 +1396,53 @@ impl DuckLakeTable {
             } else {
                 parquet_exec
             };
+            if !nan_unsafe_columns.is_empty() {
+                exec = Arc::new(NanPruningBarrierExec::new(
+                    exec,
+                    Arc::clone(&nan_unsafe_columns),
+                ));
+            }
             execs.push(exec);
         }
 
         combine_execution_plans(execs)
+    }
+
+    /// Float columns whose stored max is unusable for at least one of `files`
+    /// — the NaN state is unknown or positive, so parquet footer bounds (which
+    /// exclude NaN) must not drive row-group/page pruning for predicates on
+    /// them. Detected via the already-gated per-file statistics: a float
+    /// column with an `Absent` max is exactly one whose `contains_nan` isn't
+    /// known false (see `float_max_is_bound`); a file with no statistics entry
+    /// is unknown across the board.
+    fn nan_unsafe_float_columns(
+        &self,
+        files: &[&DuckLakeTableFile],
+        file_statistics: &HashMap<i64, Arc<Statistics>>,
+    ) -> Arc<HashSet<String>> {
+        let mut unsafe_columns = HashSet::new();
+        for (index, field) in self.physical_schema.fields().iter().enumerate() {
+            if !matches!(
+                field.data_type(),
+                DataType::Float16 | DataType::Float32 | DataType::Float64
+            ) {
+                continue;
+            }
+            let any_unsafe = files.iter().any(|file| {
+                file_statistics
+                    .get(&file.data_file_id)
+                    .is_none_or(|statistics| {
+                        matches!(
+                            statistics.column_statistics[index].max_value,
+                            Precision::Absent
+                        )
+                    })
+            });
+            if any_unsafe {
+                unsafe_columns.insert(field.name().clone());
+            }
+        }
+        Arc::new(unsafe_columns)
     }
 
     /// Configure this table for write operations.
@@ -1851,15 +1902,27 @@ impl DuckLakeTable {
         // FixedSizeList vs the catalog's List). Coerces each column to
         // `output_schema`.
         let output_schema = self.output_schema_for_projection(user_proj, rowid_idx);
-        if !file_cfg.name_mapping.is_empty() || after_deletes.schema() != output_schema {
-            Ok(Arc::new(ColumnRenameExec::new(
-                after_deletes,
-                output_schema,
-                file_cfg.name_mapping.clone(),
-            )))
-        } else {
-            Ok(after_deletes)
+        let mut exec =
+            if !file_cfg.name_mapping.is_empty() || after_deletes.schema() != output_schema {
+                Arc::new(ColumnRenameExec::new(
+                    after_deletes,
+                    output_schema,
+                    file_cfg.name_mapping.clone(),
+                )) as Arc<dyn ExecutionPlan>
+            } else {
+                after_deletes
+            };
+        // The positional path already refuses all filter pushdown
+        // (PositionalFileSource); only the legacy plain scan lets predicates
+        // reach the parquet reader's pruning, so only it needs the NaN barrier.
+        if !needs_position {
+            let nan_unsafe_columns =
+                self.nan_unsafe_float_columns(std::slice::from_ref(&table_file), file_statistics);
+            if !nan_unsafe_columns.is_empty() {
+                exec = Arc::new(NanPruningBarrierExec::new(exec, nan_unsafe_columns));
+            }
         }
+        Ok(exec)
     }
 
     /// Output schema for the rowid-projected per-file plan: physical fields

--- a/src/table.rs
+++ b/src/table.rs
@@ -3380,6 +3380,67 @@ mod tests {
     }
 
     #[test]
+    fn float_table_aggregate_max_needs_all_files_nan_free() -> Result<()> {
+        let columns =
+            vec![DuckLakeTableColumn::new(1, "x".to_string(), "double".to_string(), false)];
+        let schema = build_arrow_schema(&columns)?;
+        let mut file_a =
+            DuckLakeTableFile::new(DuckLakeFileData::new("a.parquet".to_string(), true, 1));
+        file_a.data_file_id = 1;
+        let mut file_b =
+            DuckLakeTableFile::new(DuckLakeFileData::new("b.parquet".to_string(), true, 1));
+        file_b.data_file_id = 2;
+        let table_files = vec![file_a, file_b];
+
+        let stat =
+            |data_file_id, min: &str, max: &str, contains_nan| DuckLakeFileColumnStatistics {
+                data_file_id,
+                column_id: 1,
+                column_size_bytes: Some(16),
+                value_count: Some(2),
+                null_count: Some(0),
+                min_value: Some(min.to_string()),
+                max_value: Some(max.to_string()),
+                contains_nan,
+            };
+        let build = |nan_b| {
+            build_datafusion_statistics(
+                &schema,
+                &columns,
+                &table_files,
+                DuckLakeStatistics {
+                    files: vec![stat(1, "1.0", "2.0", Some(false)), stat(2, "0.5", "3.0", nan_b)],
+                    ..Default::default()
+                },
+                false,
+                true,
+            )
+            .0
+        };
+
+        // Both files known NaN-free: bounds fold across the files.
+        let statistics = build(Some(false));
+        assert_eq!(
+            statistics.column_statistics[0].min_value,
+            Precision::Exact(ScalarValue::Float64(Some(0.5)))
+        );
+        assert_eq!(
+            statistics.column_statistics[0].max_value,
+            Precision::Exact(ScalarValue::Float64(Some(3.0)))
+        );
+
+        // One file NaN-unknown: its max is untrusted, so the aggregate max
+        // degrades to unknown; the min still folds from both files.
+        let statistics = build(None);
+        assert_eq!(
+            statistics.column_statistics[0].min_value,
+            Precision::Exact(ScalarValue::Float64(Some(0.5)))
+        );
+        assert_eq!(statistics.column_statistics[0].max_value, Precision::Absent);
+        Ok(())
+    }
+
+    #[test]
     fn test_validated_file_size_positive() {
         assert_eq!(validated_file_size(0, "test.parquet").unwrap(), 0);
         assert_eq!(validated_file_size(1024, "test.parquet").unwrap(), 1024);

--- a/src/table.rs
+++ b/src/table.rs
@@ -1143,7 +1143,7 @@ impl DuckLakeTable {
     /// Scans the whole file; pushing `predicate` down for row-group/bloom pruning
     /// is a possible optimization — but any such pushdown must exclude float
     /// predicates unless the file is known NaN-free (footer bounds exclude NaN;
-    /// see [`NanPruningBarrierExec`]), or a DELETE/UPDATE could miss NaN rows.
+    /// see `NanPruningBarrierExec`), or a DELETE/UPDATE could miss NaN rows.
     /// Only valid for insert-only files, where `position = rowid - row_id_start`.
     pub async fn resolve_positions(
         &self,

--- a/src/table.rs
+++ b/src/table.rs
@@ -226,6 +226,23 @@ fn parse_statistic_scalar(
     parsed
 }
 
+/// Whether a stored float `max_value` is a usable upper bound.
+///
+/// Catalog min/max exclude NaN, and NaN sorts above every value in both DuckDB
+/// and DataFusion (IEEE 754 totalOrder) — so a float column whose NaN state is
+/// unknown (`None`, e.g. register-by-reference loads) or positive (`Some(true)`,
+/// e.g. stats written by official DuckLake's INSERT) may hold values above its
+/// recorded max, and pruning `x > C` on that max would wrongly drop rows. The
+/// recorded min needs no such gate: NaN can never sit below it, so `min <= v`
+/// holds for every value including NaN. Mirrors official DuckLake, which ORs
+/// `contains_nan` into its greater-than filter SQL.
+fn float_max_is_bound(data_type: &DataType, contains_nan: Option<bool>) -> bool {
+    !matches!(
+        data_type,
+        DataType::Float16 | DataType::Float32 | DataType::Float64
+    ) || contains_nan == Some(false)
+}
+
 fn scalar_precision(
     value: Option<&str>,
     column: &DuckLakeTableColumn,
@@ -319,8 +336,11 @@ fn build_datafusion_statistics(
                 .unwrap_or(Precision::Absent);
             column_statistics.min_value =
                 scalar_precision(raw.min_value.as_deref(), column, field_type, exact);
-            column_statistics.max_value =
-                scalar_precision(raw.max_value.as_deref(), column, field_type, exact);
+            column_statistics.max_value = if float_max_is_bound(field_type, raw.contains_nan) {
+                scalar_precision(raw.max_value.as_deref(), column, field_type, exact)
+            } else {
+                Precision::Absent
+            };
             column_statistics.byte_size = raw
                 .column_size_bytes
                 .and_then(|value| statistic_usize(value, "file_column_stats.column_size_bytes"))
@@ -390,12 +410,16 @@ fn build_datafusion_statistics(
                 field_type,
                 raw.bounds_are_exact,
             );
-            output.max_value = scalar_precision(
-                raw.max_value.as_deref(),
-                column,
-                field_type,
-                raw.bounds_are_exact,
-            );
+            output.max_value = if float_max_is_bound(field_type, raw.contains_nan) {
+                scalar_precision(
+                    raw.max_value.as_deref(),
+                    column,
+                    field_type,
+                    raw.bounds_are_exact,
+                )
+            } else {
+                Precision::Absent
+            };
             output.byte_size = raw
                 .column_size_bytes
                 .and_then(|value| statistic_usize(value, "file_column_stats.column_size_bytes"))
@@ -473,11 +497,14 @@ fn build_datafusion_statistics(
                 None if all_null => {},
                 None => min_complete = false,
             }
-            match raw
+            // An unusable float max (NaN state unknown/positive) is treated as
+            // absent: with `all_null` it contributes nothing, otherwise it
+            // poisons `max_complete` so the aggregate max degrades to unknown.
+            let usable_max = raw
                 .max_value
                 .as_deref()
-                .and_then(|value| parse_statistic_scalar(value, column, field_type))
-            {
+                .filter(|_| float_max_is_bound(field_type, raw.contains_nan));
+            match usable_max.and_then(|value| parse_statistic_scalar(value, column, field_type)) {
                 Some(value) => {
                     max_value = match max_value {
                         Some(current) => current.partial_cmp(&value).map(|ordering| {
@@ -2960,6 +2987,7 @@ mod tests {
                     contains_null: Some(false),
                     min_value: Some("1".to_string()),
                     max_value: Some("1000000".to_string()),
+                    contains_nan: None,
                     column_size_bytes: Some(1_000_000),
                     bounds_are_exact: true,
                 }],
@@ -3006,6 +3034,7 @@ mod tests {
                         null_count: Some(0),
                         min_value: Some(data_file_id.to_string()),
                         max_value: Some(data_file_id.to_string()),
+                        contains_nan: None,
                     }],
                 })
                 .collect();
@@ -3153,6 +3182,7 @@ mod tests {
                     contains_null: Some(false),
                     min_value: Some("0".to_string()),
                     max_value: Some("9".to_string()),
+                    contains_nan: None,
                     column_size_bytes: Some(40),
                     bounds_are_exact: false,
                 }],
@@ -3172,6 +3202,117 @@ mod tests {
             Precision::Inexact(ScalarValue::Int32(Some(9)))
         );
         assert_eq!(column.byte_size, Precision::Inexact(40));
+        Ok(())
+    }
+
+    #[test]
+    fn float_file_max_gated_by_contains_nan() -> Result<()> {
+        let columns =
+            vec![DuckLakeTableColumn::new(1, "x".to_string(), "double".to_string(), false)];
+        let schema = build_arrow_schema(&columns)?;
+        let mut file =
+            DuckLakeTableFile::new(DuckLakeFileData::new("f.parquet".to_string(), true, 1));
+        file.data_file_id = 7;
+
+        for (contains_nan, max_usable) in [(None, false), (Some(true), false), (Some(false), true)]
+        {
+            let (table_stats, file_stats) = build_datafusion_statistics(
+                &schema,
+                &columns,
+                std::slice::from_ref(&file),
+                DuckLakeStatistics {
+                    files: vec![DuckLakeFileColumnStatistics {
+                        data_file_id: 7,
+                        column_id: 1,
+                        column_size_bytes: Some(16),
+                        value_count: Some(2),
+                        null_count: Some(0),
+                        min_value: Some("1.0".to_string()),
+                        max_value: Some("2.0".to_string()),
+                        contains_nan,
+                    }],
+                    ..Default::default()
+                },
+                false,
+                true,
+            );
+
+            // min is a valid lower bound regardless of NaN state — NaN sorts
+            // above every value, so it can never undercut the recorded min.
+            let per_file = &file_stats[&7].column_statistics[0];
+            let table_col = &table_stats.column_statistics[0];
+            assert_eq!(
+                per_file.min_value,
+                Precision::Exact(ScalarValue::Float64(Some(1.0))),
+                "contains_nan={contains_nan:?}"
+            );
+            assert_eq!(
+                table_col.min_value,
+                Precision::Exact(ScalarValue::Float64(Some(1.0))),
+                "contains_nan={contains_nan:?}"
+            );
+
+            let expected_max = if max_usable {
+                Precision::Exact(ScalarValue::Float64(Some(2.0)))
+            } else {
+                Precision::Absent
+            };
+            assert_eq!(
+                per_file.max_value, expected_max,
+                "contains_nan={contains_nan:?}"
+            );
+            assert_eq!(
+                table_col.max_value, expected_max,
+                "contains_nan={contains_nan:?}"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn float_rollup_max_gated_by_contains_nan() -> Result<()> {
+        let columns =
+            vec![DuckLakeTableColumn::new(1, "x".to_string(), "double".to_string(), false)];
+        let schema = build_arrow_schema(&columns)?;
+
+        for (contains_nan, max_usable) in [(None, false), (Some(true), false), (Some(false), true)]
+        {
+            let (statistics, _) = build_datafusion_statistics(
+                &schema,
+                &columns,
+                &[],
+                DuckLakeStatistics {
+                    columns: vec![DuckLakeTableColumnStatistics {
+                        column_id: 1,
+                        contains_null: Some(false),
+                        min_value: Some("1.0".to_string()),
+                        max_value: Some("2.0".to_string()),
+                        contains_nan,
+                        column_size_bytes: Some(16),
+                        bounds_are_exact: true,
+                    }],
+                    ..Default::default()
+                },
+                true,
+                false,
+            );
+
+            let column = &statistics.column_statistics[0];
+            assert_eq!(
+                column.min_value,
+                Precision::Exact(ScalarValue::Float64(Some(1.0))),
+                "contains_nan={contains_nan:?}"
+            );
+            let expected_max = if max_usable {
+                Precision::Exact(ScalarValue::Float64(Some(2.0)))
+            } else {
+                Precision::Absent
+            };
+            assert_eq!(
+                column.max_value, expected_max,
+                "contains_nan={contains_nan:?}"
+            );
+        }
         Ok(())
     }
 

--- a/tests/column_stats_tests.rs
+++ b/tests/column_stats_tests.rs
@@ -376,14 +376,25 @@ async fn float_with_nan_suppresses_minmax() {
     assert_eq!(vc, Some(3), "NaN counts as a non-null value");
 }
 
-/// NaN rows must survive a filtered scan end-to-end. Parquet footer float
-/// bounds exclude NaN while DataFusion evaluates `NaN > C` as true (IEEE
-/// totalOrder), so a float `>` predicate pushed into the parquet reader can
-/// row-group-prune the group holding the NaN row. `NanPruningBarrierExec`
-/// keeps such predicates out of the scan whenever the file's NaN state isn't
-/// known false — this asserts the query results, not just the plan shape.
-#[tokio::test(flavor = "multi_thread")]
-async fn nan_rows_survive_filtered_scan() {
+// ---------------------------------------------------------------------------
+// NaN pruning-safety scenarios
+//
+// Parquet footer float bounds exclude NaN while DataFusion evaluates `NaN > C`
+// as true (IEEE totalOrder), so any pruning that trusts a NaN-blind max can
+// silently drop NaN rows. Two guards exist: the catalog gate (`contains_nan`
+// must be false for a float max to drive plan-time file pruning) and
+// `NanPruningBarrierExec` (float predicates must not reach the parquet
+// reader's row-group pruning unless every scanned file is known NaN-free).
+// These tests pin the behavior for each writer/NaN combination end-to-end,
+// asserting query RESULTS first and plan shape second.
+// ---------------------------------------------------------------------------
+
+/// Write `t(id INT, x DOUBLE)` with one data file per `files` element (first
+/// is a Replace, the rest Append) and return the query context. The returned
+/// sqlite path allows tests to doctor catalog stats before querying.
+async fn setup_float_table(
+    files: &[(Vec<i32>, Vec<f64>)],
+) -> (TempDir, String, datafusion::prelude::SessionContext) {
     use datafusion::prelude::SessionContext;
     use datafusion_ducklake::{DuckLakeCatalog, SqliteMetadataProvider};
 
@@ -397,59 +408,255 @@ async fn nan_rows_survive_filtered_scan() {
         .unwrap();
     writer.set_data_path(data_path.to_str().unwrap()).unwrap();
 
-    let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Float64, true)]));
-    let batch = RecordBatch::try_new(
-        schema,
-        vec![Arc::new(Float64Array::from(vec![f64::NAN, 1.0, 2.0]))],
-    )
-    .unwrap();
-    DuckLakeTableWriter::new(Arc::new(writer), Arc::new(LocalFileSystem::new()))
-        .unwrap()
-        .write_table("main", "t", &[batch])
-        .await
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("x", DataType::Float64, true),
+    ]));
+    let table_writer =
+        DuckLakeTableWriter::new(Arc::new(writer), Arc::new(LocalFileSystem::new())).unwrap();
+    for (index, (ids, xs)) in files.iter().enumerate() {
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(ids.clone())), Arc::new(Float64Array::from(xs.clone()))],
+        )
         .unwrap();
+        if index == 0 {
+            table_writer
+                .write_table("main", "t", &[batch])
+                .await
+                .unwrap();
+        } else {
+            table_writer
+                .append_table("main", "t", &[batch])
+                .await
+                .unwrap();
+        }
+    }
 
-    let provider = SqliteMetadataProvider::new(&format!("sqlite:{}", db_path.display()))
-        .await
-        .unwrap();
+    let db_url = format!("sqlite:{}", db_path.display());
+    let provider = SqliteMetadataProvider::new(&db_url).await.unwrap();
     let catalog = DuckLakeCatalog::new(provider).unwrap();
     let ctx = SessionContext::new();
     ctx.register_catalog("test", Arc::new(catalog));
+    (temp, db_url, ctx)
+}
 
-    let count = |sql: &str| {
-        let ctx = ctx.clone();
-        let sql = sql.to_string();
-        async move {
-            let batches = ctx.sql(&sql).await.unwrap().collect().await.unwrap();
-            batches.iter().map(|b| b.num_rows()).sum::<usize>()
-        }
-    };
+async fn row_count(ctx: &datafusion::prelude::SessionContext, sql: &str) -> usize {
+    ctx.sql(sql)
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap()
+        .iter()
+        .map(|batch| batch.num_rows())
+        .sum()
+}
 
-    // NaN sorts above every value, so it matches any `>` bound the finite
-    // values fail; the footer max (2.0) must not prune it away.
-    assert_eq!(
-        count("SELECT x FROM test.main.t WHERE x > 100").await,
-        1,
-        "the NaN row must not be pruned by footer max"
-    );
-    assert_eq!(count("SELECT x FROM test.main.t WHERE x > 1.5").await, 2);
-    // `<` predicates never match NaN; finite semantics unchanged.
-    assert_eq!(count("SELECT x FROM test.main.t WHERE x < 1.5").await, 1);
-    assert_eq!(count("SELECT x FROM test.main.t").await, 3);
-
-    // The barrier must be present in the plan for the NaN-unsafe column.
-    let explain = ctx
-        .sql("EXPLAIN SELECT x FROM test.main.t WHERE x > 100")
+async fn physical_plan(ctx: &datafusion::prelude::SessionContext, sql: &str) -> String {
+    let batches = ctx
+        .sql(&format!("EXPLAIN {sql}"))
         .await
         .unwrap()
         .collect()
         .await
         .unwrap();
-    let plan = datafusion::arrow::util::pretty::pretty_format_batches(&explain)
+    datafusion::arrow::util::pretty::pretty_format_batches(&batches)
         .unwrap()
-        .to_string();
+        .to_string()
+}
+
+/// The original wrong-results repro: a write-through file containing NaN.
+/// NaN rows must survive filtered scans — the footer max must not row-group-
+/// prune them away.
+#[tokio::test(flavor = "multi_thread")]
+async fn nan_rows_survive_filtered_scan() {
+    let (_temp, _db, ctx) = setup_float_table(&[(vec![7, 8, 9], vec![f64::NAN, 1.0, 2.0])]).await;
+
+    // NaN sorts above every value, so it matches any `>` bound the finite
+    // values fail; the footer max (2.0) must not prune it away.
+    assert_eq!(
+        row_count(&ctx, "SELECT x FROM test.main.t WHERE x > 100").await,
+        1,
+        "the NaN row must not be pruned by footer max"
+    );
+    assert_eq!(
+        row_count(&ctx, "SELECT x FROM test.main.t WHERE x > 1.5").await,
+        2
+    );
+    // Equality probes for NaN itself: min <= NaN always holds, so the file
+    // must be kept and the row found.
+    assert_eq!(
+        row_count(
+            &ctx,
+            "SELECT x FROM test.main.t WHERE x = CAST('NaN' AS DOUBLE)"
+        )
+        .await,
+        1
+    );
+    // `<` predicates never match NaN; finite semantics unchanged.
+    assert_eq!(
+        row_count(&ctx, "SELECT x FROM test.main.t WHERE x < 1.5").await,
+        1
+    );
+    assert_eq!(row_count(&ctx, "SELECT x FROM test.main.t").await, 3);
+
+    // The barrier must be present in the plan for the NaN-unsafe column.
+    let plan = physical_plan(&ctx, "SELECT x FROM test.main.t WHERE x > 100").await;
     assert!(
         plan.contains("NanPruningBarrierExec: unsafe_columns=[x]"),
         "expected NaN pruning barrier in plan:\n{plan}"
+    );
+}
+
+/// NaN-free floats must keep BOTH pruning levels — the fix must not tax the
+/// common case. File-level: a `>` predicate above the max prunes the file
+/// outright. Row-group level: an in-range predicate is pushed into the
+/// parquet scan, with no barrier in the plan.
+#[tokio::test(flavor = "multi_thread")]
+async fn nan_free_floats_keep_full_pruning() {
+    let (_temp, _db, ctx) = setup_float_table(&[(vec![1, 2], vec![1.0, 2.0])]).await;
+
+    // contains_nan = false was recorded, so the catalog float max is trusted
+    // and the single file is pruned at plan time.
+    let plan = physical_plan(&ctx, "SELECT x FROM test.main.t WHERE x > 100").await;
+    assert!(
+        plan.contains("EmptyExec"),
+        "NaN-free file should be pruned via its float max:\n{plan}"
+    );
+    assert_eq!(
+        row_count(&ctx, "SELECT x FROM test.main.t WHERE x > 100").await,
+        0
+    );
+
+    // An in-range predicate keeps the file but reaches the parquet reader
+    // unimpeded: no barrier, predicate attached to the scan.
+    let plan = physical_plan(&ctx, "SELECT x FROM test.main.t WHERE x >= 1.5").await;
+    assert!(
+        !plan.contains("NanPruningBarrierExec"),
+        "no barrier expected for a NaN-free file:\n{plan}"
+    );
+    assert!(
+        plan.contains("predicate="),
+        "float predicate should be pushed into the parquet scan:\n{plan}"
+    );
+    assert_eq!(
+        row_count(&ctx, "SELECT x FROM test.main.t WHERE x >= 1.5").await,
+        1
+    );
+}
+
+/// The barrier is per-column: predicates on non-float columns keep full
+/// parquet pushdown even when a float column in the same file is NaN-unsafe.
+#[tokio::test(flavor = "multi_thread")]
+async fn barrier_blocks_only_float_predicates() {
+    let (_temp, _db, ctx) = setup_float_table(&[(vec![7, 8, 9], vec![f64::NAN, 1.0, 2.0])]).await;
+
+    // Integer predicate: barrier present (x is unsafe) but the predicate
+    // passes through it into the scan.
+    let plan = physical_plan(&ctx, "SELECT id FROM test.main.t WHERE id >= 8").await;
+    assert!(
+        plan.contains("NanPruningBarrierExec: unsafe_columns=[x]"),
+        "barrier expected while x is NaN-unsafe:\n{plan}"
+    );
+    assert!(
+        plan.contains("predicate="),
+        "integer predicate should pass the barrier into the scan:\n{plan}"
+    );
+    assert_eq!(
+        row_count(&ctx, "SELECT id FROM test.main.t WHERE id >= 8").await,
+        2
+    );
+
+    // Float predicate: rejected by the barrier — no predicate on the scan.
+    let plan = physical_plan(&ctx, "SELECT x FROM test.main.t WHERE x > 100").await;
+    assert!(
+        !plan.contains("predicate="),
+        "float predicate must not reach the parquet scan:\n{plan}"
+    );
+
+    // Mixed conjunction still finds the NaN row (id 7).
+    assert_eq!(
+        row_count(&ctx, "SELECT id FROM test.main.t WHERE id >= 0 AND x > 100").await,
+        1
+    );
+}
+
+/// Catalog rows shaped like official DuckLake's `ducklake_add_data_files`
+/// (register-by-reference): float min/max present, contains_nan NULL. The max
+/// must not be trusted at either pruning level, while the min still prunes —
+/// NaN can only hide above the max, never below the min.
+#[tokio::test(flavor = "multi_thread")]
+async fn nan_unknown_bounds_prune_only_below_min() {
+    let (_temp, db_url, ctx) =
+        setup_float_table(&[(vec![7, 8, 9], vec![f64::NAN, 1.0, 2.0])]).await;
+
+    // The crate's write path blanked the bounds and set contains_nan = true.
+    // Rewrite the row to the official add_data_files shape: footer bounds
+    // present (they exclude the NaN), NaN state unknown.
+    let pool = SqlitePool::connect(&db_url).await.unwrap();
+    sqlx::query(
+        "UPDATE ducklake_file_column_stats
+         SET min_value = '1.0', max_value = '2.0', contains_nan = NULL
+         WHERE column_id IN
+             (SELECT column_id FROM ducklake_column WHERE column_name = 'x')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // max present but NaN unknown: `x > 100` must keep the file AND keep the
+    // predicate away from the parquet reader — the NaN row survives.
+    assert_eq!(
+        row_count(&ctx, "SELECT x FROM test.main.t WHERE x > 100").await,
+        1,
+        "catalog max with unknown NaN state must not prune the NaN row"
+    );
+    let plan = physical_plan(&ctx, "SELECT x FROM test.main.t WHERE x > 100").await;
+    assert!(
+        plan.contains("NanPruningBarrierExec: unsafe_columns=[x]"),
+        "barrier expected while NaN state is unknown:\n{plan}"
+    );
+
+    // min stays trustworthy: a predicate strictly below it prunes the file
+    // outright (EmptyExec), NaN notwithstanding.
+    let plan = physical_plan(&ctx, "SELECT x FROM test.main.t WHERE x < 0.5").await;
+    assert!(
+        plan.contains("EmptyExec"),
+        "file should be pruned via its float min even with NaN unknown:\n{plan}"
+    );
+    assert_eq!(
+        row_count(&ctx, "SELECT x FROM test.main.t WHERE x < 0.5").await,
+        0
+    );
+}
+
+/// One NaN-unsafe file poisons float pushdown for the whole multi-file scan
+/// group (the unsafe set is a union), and NaN rows still surface from the
+/// unsafe file while finite rows come from both.
+#[tokio::test(flavor = "multi_thread")]
+async fn nan_multi_file_scan_blocks_float_pruning() {
+    let (_temp, _db, ctx) =
+        setup_float_table(&[(vec![1, 2], vec![1.0, 2.0]), (vec![3, 4], vec![f64::NAN, 5.0])]).await;
+
+    assert_eq!(row_count(&ctx, "SELECT x FROM test.main.t").await, 4);
+    assert_eq!(
+        row_count(&ctx, "SELECT x FROM test.main.t WHERE x > 100").await,
+        1,
+        "the NaN row in the second file must survive"
+    );
+    assert_eq!(
+        row_count(&ctx, "SELECT x FROM test.main.t WHERE x > 4").await,
+        2
+    );
+    assert_eq!(
+        row_count(&ctx, "SELECT x FROM test.main.t WHERE x < 1.5").await,
+        1
+    );
+
+    let plan = physical_plan(&ctx, "SELECT x FROM test.main.t WHERE x > 100").await;
+    assert!(
+        plan.contains("NanPruningBarrierExec: unsafe_columns=[x]"),
+        "one unsafe file must make x unsafe for the scan group:\n{plan}"
     );
 }

--- a/tests/column_stats_tests.rs
+++ b/tests/column_stats_tests.rs
@@ -375,3 +375,81 @@ async fn float_with_nan_suppresses_minmax() {
     assert_eq!(nan, Some(true), "contains_nan must be true");
     assert_eq!(vc, Some(3), "NaN counts as a non-null value");
 }
+
+/// NaN rows must survive a filtered scan end-to-end. Parquet footer float
+/// bounds exclude NaN while DataFusion evaluates `NaN > C` as true (IEEE
+/// totalOrder), so a float `>` predicate pushed into the parquet reader can
+/// row-group-prune the group holding the NaN row. `NanPruningBarrierExec`
+/// keeps such predicates out of the scan whenever the file's NaN state isn't
+/// known false — this asserts the query results, not just the plan shape.
+#[tokio::test(flavor = "multi_thread")]
+async fn nan_rows_survive_filtered_scan() {
+    use datafusion::prelude::SessionContext;
+    use datafusion_ducklake::{DuckLakeCatalog, SqliteMetadataProvider};
+
+    let temp = TempDir::new().unwrap();
+    let db_path = temp.path().join("stats.db");
+    let data_path = temp.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+    let conn_str = format!("sqlite:{}?mode=rwc", db_path.display());
+    let writer = SqliteMetadataWriter::new_with_init(&conn_str)
+        .await
+        .unwrap();
+    writer.set_data_path(data_path.to_str().unwrap()).unwrap();
+
+    let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Float64, true)]));
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![Arc::new(Float64Array::from(vec![f64::NAN, 1.0, 2.0]))],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(Arc::new(writer), Arc::new(LocalFileSystem::new()))
+        .unwrap()
+        .write_table("main", "t", &[batch])
+        .await
+        .unwrap();
+
+    let provider = SqliteMetadataProvider::new(&format!("sqlite:{}", db_path.display()))
+        .await
+        .unwrap();
+    let catalog = DuckLakeCatalog::new(provider).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog("test", Arc::new(catalog));
+
+    let count = |sql: &str| {
+        let ctx = ctx.clone();
+        let sql = sql.to_string();
+        async move {
+            let batches = ctx.sql(&sql).await.unwrap().collect().await.unwrap();
+            batches.iter().map(|b| b.num_rows()).sum::<usize>()
+        }
+    };
+
+    // NaN sorts above every value, so it matches any `>` bound the finite
+    // values fail; the footer max (2.0) must not prune it away.
+    assert_eq!(
+        count("SELECT x FROM test.main.t WHERE x > 100").await,
+        1,
+        "the NaN row must not be pruned by footer max"
+    );
+    assert_eq!(count("SELECT x FROM test.main.t WHERE x > 1.5").await, 2);
+    // `<` predicates never match NaN; finite semantics unchanged.
+    assert_eq!(count("SELECT x FROM test.main.t WHERE x < 1.5").await, 1);
+    assert_eq!(count("SELECT x FROM test.main.t").await, 3);
+
+    // The barrier must be present in the plan for the NaN-unsafe column.
+    let explain = ctx
+        .sql("EXPLAIN SELECT x FROM test.main.t WHERE x > 100")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let plan = datafusion::arrow::util::pretty::pretty_format_batches(&explain)
+        .unwrap()
+        .to_string();
+    assert!(
+        plan.contains("NanPruningBarrierExec: unsafe_columns=[x]"),
+        "expected NaN pruning barrier in plan:\n{plan}"
+    );
+}


### PR DESCRIPTION
## Problem

Catalog and parquet-footer float min/max exclude NaN, but DataFusion compares floats with IEEE 754 totalOrder (NaN above every value) — so `NaN > C` is true for any finite `C`. Any pruning that trusts a NaN-blind max can silently drop matching NaN rows. This fired at **two independent levels**:

1. **Plan-time file pruning** trusted catalog `max_value` unconditionally; `contains_nan` was not even selected by the read queries.
2. **Execution-time row-group pruning**: filters are pushed into `ParquetSource` by DataFusion's physical optimizer, and the reader prunes row groups from footer stats — same NaN blindness, no NaN flag in the format.

Reproducible end-to-end: write `[NaN, 1.0, 2.0]` through this crate's own writer, then

```sql
SELECT x, x > 100 FROM t ORDER BY x;   -- shows NaN row with true
SELECT count(*) FROM t WHERE x > 100;  -- returned 0 (row-group pruned); correct answer is 1
```

This also affects catalogs written by official DuckLake (INSERT stores float bounds alongside `contains_nan = true`; `ducklake_add_data_files` stores footer bounds with `contains_nan` NULL) — official's own reader handles both via NaN-aware pruning SQL; this crate's reader did not.

## Fix (mirrors official DuckLake's design, translated to DataFusion)

- **Catalog gate** (`float_max_is_bound`): select `contains_nan` in both stats queries across all five metadata providers; feed a float `max_value` to the pruner/optimizer only when `contains_nan = false`. **min is never gated** — NaN can only hide above the max, so `min <= v` holds for every value including NaN, and below-min file pruning keeps working even when NaN state is unknown. Applied at all three consumption points (per-file stats, table rollup, per-file→table aggregation).
- **`NanPruningBarrierExec`**: a pass-through node above plain parquet scans that participates only in pushdown negotiation. Predicates referencing a float column whose NaN state isn't known false for every file beneath it are reported unsupported and stay in the `FilterExec` above (all table filters are `Inexact`); NaN-safe predicates pass through untouched. Sort pushdown is delegated the same way — selectively, since it reorders row groups from the same NaN-blind stats. The positional/delete/snapshot-filter paths already refuse pushdown.
- **Rollup tri-state**: `aggregate_global_column_stats` now emits a definite `contains_nan = false` when every live file is known NaN-free, matching official `MergeStats` (previously it never emitted false, which would have left table-level float maxes permanently untrusted). Coverage-gated like the other rollup fields.

## Cost

Nothing for the common case: NaN-free write-through files keep full float pruning at both levels and get no barrier node. Only scans over files with unknown/positive NaN state lose parquet pushdown for float predicates specifically — which is exactly the pruning that returned wrong results.

## Testing

- End-to-end matrix (`tests/column_stats_tests.rs`): NaN row survives `>` and `= NaN` filters; NaN-free files keep file-level pruning (EmptyExec) and parquet pushdown with no barrier; barrier is per-column (int predicates pass, float predicates blocked, mixed conjunctions correct); official `add_data_files` catalog shape (bounds present, `contains_nan` NULL) keeps max untrusted while min still prunes; one unsafe file poisons float pushdown for a multi-file scan group.
- Unit: per-file/rollup max gating across `None`/`Some(true)`/`Some(false)`, aggregation degradation, rollup tri-state.
- Full `--all-features` suite: 606 passed / 0 failed (sqlite, duckdb, postgres, mysql, multicatalog).

Motivated by register-by-reference loads (footer-harvested stats carry `contains_nan` NULL, matching official `ducklake_add_data_files`), which this change makes safe to read.
