### PR TITLE
chore(deps): upgrade sqlx to 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.3.1",
  "http-body 1.0.1",
@@ -678,7 +678,7 @@ dependencies = [
  "crypto-bigint 0.5.5",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.3.1",
  "p256",
@@ -718,7 +718,7 @@ dependencies = [
  "http-body-util",
  "md-5 0.10.6",
  "pin-project-lite",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.9",
  "tracing",
 ]
@@ -900,6 +900,12 @@ name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base64"
@@ -1277,6 +1283,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1378,6 +1390,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1475,6 +1493,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "num-traits",
+ "rand_core 0.10.1",
+ "serdect",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1491,6 +1523,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "crypto-primes"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21f41f23de7d24cdbda7f0c4d9c0351f99a4ceb258ef30e5c1927af8987ffe5a"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "libm",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1512,6 +1555,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -2266,11 +2318,11 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.10"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
- "const-oid 0.9.6",
+ "const-oid 0.10.2",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -2292,7 +2344,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid 0.9.6",
  "crypto-common 0.1.6",
  "subtle",
 ]
@@ -2306,6 +2357,7 @@ dependencies = [
  "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -2346,7 +2398,7 @@ dependencies = [
  "cast",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.10.0",
  "libduckdb-sys",
  "num-integer",
  "rust_decimal",
@@ -2423,7 +2475,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
- "base16ct",
+ "base16ct 0.1.1",
  "crypto-bigint 0.4.9",
  "der 0.6.1",
  "digest 0.10.7",
@@ -2488,6 +2540,16 @@ dependencies = [
  "cfg-if",
  "home",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2576,9 +2638,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2650,9 +2712,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2660,15 +2722,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2688,15 +2750,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2705,21 +2767,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2729,7 +2791,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -2872,8 +2933,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -2909,6 +2968,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2922,11 +2990,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
- "hmac",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -2936,6 +3004,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3142,7 +3219,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -3399,15 +3476,6 @@ checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin 0.9.8",
 ]
 
 [[package]]
@@ -3683,22 +3751,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.5",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3941,9 +3993,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.7.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -4018,13 +4070,12 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
-version = "0.7.5"
+version = "0.8.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
 dependencies = [
- "der 0.7.10",
- "pkcs8 0.10.2",
- "spki 0.7.3",
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -4039,12 +4090,12 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
- "der 0.7.10",
- "spki 0.7.3",
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -4157,7 +4208,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror",
  "tokio",
  "tracing",
@@ -4194,7 +4245,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4453,7 +4504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
  "crypto-bigint 0.4.9",
- "hmac",
+ "hmac 0.12.1",
  "zeroize",
 ]
 
@@ -4502,21 +4553,19 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.10"
+version = "0.10.0-rc.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+checksum = "30b2aa4ba0d89f73d1e332df05be0eeab8840351c36ca5654341dfdb57bb3caf"
 dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
+ "const-oid 0.10.2",
+ "crypto-bigint 0.7.5",
+ "crypto-primes",
+ "digest 0.11.3",
  "pkcs1",
- "pkcs8 0.10.2",
- "rand_core 0.6.4",
- "signature 2.2.0",
- "spki 0.7.3",
- "subtle",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "signature 3.0.0",
+ "spki 0.8.0",
  "zeroize",
 ]
 
@@ -4726,7 +4775,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
- "base16ct",
+ "base16ct 0.1.1",
  "der 0.6.1",
  "generic-array",
  "pkcs8 0.9.0",
@@ -4867,6 +4916,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9af4a3e75ebd5599b30d4de5768e00b5095d518a79fefc3ecbaf77e665d1ec06"
+dependencies = [
+ "base16ct 1.0.0",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4875,6 +4934,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4926,12 +4996,12 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
+ "digest 0.11.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -5026,12 +5096,12 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
- "der 0.7.10",
+ "der 0.8.1",
 ]
 
 [[package]]
@@ -5082,9 +5152,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -5095,12 +5165,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "cfg-if",
  "chrono",
  "crc",
  "crossbeam-queue",
@@ -5110,12 +5181,11 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.15.5",
- "hashlink",
+ "hashbrown 0.16.1",
+ "hashlink 0.11.1",
  "indexmap 2.14.0",
  "log",
  "memchr",
- "once_cell",
  "percent-encoding",
  "rustls 0.23.37",
  "serde",
@@ -5127,14 +5197,14 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "webpki-roots 0.26.11",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5145,15 +5215,15 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
 dependencies = [
+ "cfg-if",
  "dotenvy",
  "either",
  "heck",
  "hex",
- "once_cell",
  "proc-macro2",
  "quote",
  "serde",
@@ -5164,58 +5234,45 @@ dependencies = [
  "sqlx-postgres",
  "sqlx-sqlite",
  "syn 2.0.117",
+ "thiserror",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "atoi",
- "base64 0.22.1",
  "bitflags 2.9.4",
  "byteorder",
  "bytes",
  "chrono",
  "crc",
- "digest 0.10.7",
+ "digest 0.11.3",
  "dotenvy",
  "either",
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "generic-array",
- "hex",
- "hkdf",
- "hmac",
- "itoa",
  "log",
- "md-5 0.10.6",
- "memchr",
- "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.10.1",
  "rsa",
  "serde",
- "sha1",
- "sha2 0.10.9",
- "smallvec",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "sqlx-core",
- "stringprep",
  "thiserror",
  "tracing",
- "whoami",
 ]
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64 0.22.1",
@@ -5224,23 +5281,21 @@ dependencies = [
  "chrono",
  "crc",
  "dotenvy",
- "etcetera",
+ "etcetera 0.11.0",
  "futures-channel",
  "futures-core",
  "futures-util",
  "hex",
  "hkdf",
- "hmac",
- "home",
+ "hmac 0.13.0",
  "itoa",
  "log",
- "md-5 0.10.6",
+ "md-5 0.11.0",
  "memchr",
- "once_cell",
- "rand 0.8.5",
+ "rand 0.10.1",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -5251,13 +5306,14 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
 dependencies = [
  "atoi",
  "chrono",
  "flume",
+ "form_urlencoded",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -5267,7 +5323,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
- "serde_urlencoded",
  "sqlx-core",
  "thiserror",
  "tracing",
@@ -5412,6 +5467,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5473,7 +5539,7 @@ dependencies = [
  "bytes",
  "docker_credential",
  "either",
- "etcetera",
+ "etcetera 0.8.0",
  "futures",
  "log",
  "memchr",
@@ -5501,22 +5567,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5965,12 +6031,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6111,15 +6171,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.7",
-]
-
-[[package]]
-name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
@@ -6129,13 +6180,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.6.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
-dependencies = [
- "libredox",
- "wasite",
-]
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ members = [".", "benchmark"]
 name = "datafusion-ducklake"
 version = "0.6.0"
 edition = "2024"
+# Floor set by sqlx 0.9, which requires 1.94.
+rust-version = "1.94.0"
 authors = ["zac@hotdata.dev", "shefeek@hotdata.dev", "anoop@hotdata.dev"]
 description = "DuckLake query engine for rust, built with datafusion."
 license = "Apache-2.0"
@@ -43,7 +45,7 @@ tempfile = { version = "3.14", optional = true }
 
 # Metadata providers (optional)
 duckdb = { version = "1.4.1", optional = true }
-sqlx = { version = "0.8", features = ["runtime-tokio"], optional = true }
+sqlx = { version = "0.9", features = ["runtime-tokio"], optional = true }
 
 [dev-dependencies]
 testcontainers = "0.23"
@@ -64,7 +66,10 @@ skip-tests-with-docker = []
 # Metadata provider backends
 metadata-duckdb = ["dep:duckdb"]
 metadata-postgres = ["dep:sqlx", "sqlx/postgres", "sqlx/chrono", "sqlx/tls-rustls-ring"]
-metadata-mysql = ["dep:sqlx", "sqlx/mysql", "sqlx/chrono"]
+# `mysql-rsa` keeps non-TLS `caching_sha2_password`/`sha256_password` auth working
+# (MySQL 8's default). sqlx bundled RSA unconditionally through 0.8; 0.9 split it
+# into an opt-in feature, and without it those connections fail at connect time.
+metadata-mysql = ["dep:sqlx", "sqlx/mysql", "sqlx/mysql-rsa", "sqlx/chrono"]
 metadata-sqlite = ["dep:sqlx", "sqlx/sqlite", "sqlx/chrono"]
 
 # Compile DuckDB C++ from source and statically bundle it. Enabled by default.

--- a/examples/compaction_demo.rs
+++ b/examples/compaction_demo.rs
@@ -219,7 +219,7 @@ async fn read_rows(
     Ok(rows)
 }
 
-async fn scalar(pool: &SqlitePool, sql: &str, table: &str) -> anyhow::Result<i64> {
+async fn scalar(pool: &SqlitePool, sql: &'static str, table: &str) -> anyhow::Result<i64> {
     Ok(sqlx::query(sql)
         .bind(table)
         .fetch_one(pool)

--- a/examples/multicatalog_write.rs
+++ b/examples/multicatalog_write.rs
@@ -308,7 +308,7 @@ fn build_orders_batch() -> RecordBatch {
 async fn dump_query(
     pool: &sqlx::PgPool,
     label: &str,
-    sql: &str,
+    sql: &'static str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     println!("\n  -- {} --", label);
     let rows = sqlx::query(sql).fetch_all(pool).await?;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.92.0"
+channel = "1.94.0"
 components = ["rustfmt", "clippy"]

--- a/src/metadata_provider_mysql.rs
+++ b/src/metadata_provider_mysql.rs
@@ -10,6 +10,7 @@ use crate::metadata_provider::{
     reconstruct_list_columns_with_table,
 };
 use crate::partition::PartitionSpec;
+use sqlx::AssertSqlSafe;
 use sqlx::Row;
 use sqlx::mysql::{MySqlPool, MySqlPoolOptions, MySqlRow};
 use sqlx::types::chrono::NaiveDateTime;
@@ -1025,7 +1026,7 @@ impl MetadataProvider for MySqlMetadataProvider {
             } else {
                 "NULL"
             };
-            let rows = sqlx::query(&format!(
+            let rows = sqlx::query(AssertSqlSafe(format!(
                 "SELECT
                     data.begin_snapshot,
                     data.path,
@@ -1041,7 +1042,7 @@ impl MetadataProvider for MySqlMetadataProvider {
                   AND (data.begin_snapshot >= ?
                        OR ({pm} IS NOT NULL AND {pm} >= ?))
                 ORDER BY data.begin_snapshot"
-            ))
+            )))
             .bind(table_id)
             .bind(end_snapshot)
             .bind(start_snapshot)
@@ -1085,7 +1086,7 @@ impl MetadataProvider for MySqlMetadataProvider {
             } else {
                 "NULL"
             };
-            let rows = sqlx::query(&format!(
+            let rows = sqlx::query(AssertSqlSafe(format!(
                 r#"
 WITH current_delete AS (
     SELECT
@@ -1181,7 +1182,7 @@ WHERE data.table_id = ?
   AND data.end_snapshot >= ?
   AND data.end_snapshot <= ?
 "#
-            ))
+            )))
             // Part 1 bindings: table_id (current_delete), end, start (window),
             // start (partial_max), table_id (data_files), table_id (prev lateral)
             .bind(table_id)

--- a/src/metadata_provider_postgres.rs
+++ b/src/metadata_provider_postgres.rs
@@ -9,6 +9,7 @@ use crate::metadata_provider::{
     reconstruct_list_columns, reconstruct_list_columns_with_table,
 };
 use crate::partition::PartitionSpec;
+use sqlx::AssertSqlSafe;
 use sqlx::Row;
 use sqlx::postgres::{PgPool, PgPoolOptions, PgRow};
 use sqlx::types::chrono::NaiveDateTime;
@@ -393,7 +394,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                   AND $5 >= data.begin_snapshot
                   AND ($6 < data.end_snapshot OR data.end_snapshot IS NULL)"
             );
-            let rows = sqlx::query(&sql)
+            let rows = sqlx::query(AssertSqlSafe(sql.as_str()))
                 .bind(table_id)
                 .bind(snapshot_id)
                 .bind(snapshot_id)
@@ -511,7 +512,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                  ORDER BY data.data_file_id
                  LIMIT $8"
             );
-            let rows = sqlx::query(&sql)
+            let rows = sqlx::query(AssertSqlSafe(sql.as_str()))
                 .bind(table_id)
                 .bind(snapshot_id)
                 .bind(snapshot_id)
@@ -1112,7 +1113,7 @@ impl MetadataProvider for PostgresMetadataProvider {
             } else {
                 "NULL::bigint"
             };
-            let rows = sqlx::query(&format!(
+            let rows = sqlx::query(AssertSqlSafe(format!(
                 "SELECT
                     data.begin_snapshot,
                     data.path,
@@ -1128,7 +1129,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                   AND (data.begin_snapshot >= $2
                        OR ({pm} IS NOT NULL AND {pm} >= $2))
                 ORDER BY data.begin_snapshot"
-            ))
+            )))
             .bind(table_id)
             .bind(start_snapshot)
             .bind(end_snapshot)
@@ -1170,7 +1171,7 @@ impl MetadataProvider for PostgresMetadataProvider {
             } else {
                 "NULL::bigint"
             };
-            let rows = sqlx::query(&format!(
+            let rows = sqlx::query(AssertSqlSafe(format!(
                 r#"
 WITH current_delete AS (
     SELECT
@@ -1266,7 +1267,7 @@ WHERE data.table_id = $1
   AND data.end_snapshot >= $2
   AND data.end_snapshot <= $3
 "#
-            ))
+            )))
             .bind(table_id)
             .bind(start_snapshot)
             .bind(end_snapshot)

--- a/src/metadata_provider_sqlite.rs
+++ b/src/metadata_provider_sqlite.rs
@@ -16,6 +16,7 @@ use arrow::array::{
     new_null_array,
 };
 use arrow::datatypes::{DataType, SchemaRef};
+use sqlx::AssertSqlSafe;
 use sqlx::Row;
 use sqlx::sqlite::{SqlitePool, SqlitePoolOptions, SqliteRow};
 use sqlx::types::chrono::NaiveDateTime;
@@ -480,7 +481,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                   AND ? >= data.begin_snapshot
                   AND (? < data.end_snapshot OR data.end_snapshot IS NULL)"
             );
-            let rows = sqlx::query(&sql)
+            let rows = sqlx::query(AssertSqlSafe(sql.as_str()))
                 .bind(table_id)
                 .bind(snapshot_id)
                 .bind(snapshot_id)
@@ -596,7 +597,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                  ORDER BY data.data_file_id
                  LIMIT ?"
             );
-            let rows = sqlx::query(&sql)
+            let rows = sqlx::query(AssertSqlSafe(sql.as_str()))
                 .bind(table_id)
                 .bind(snapshot_id)
                 .bind(snapshot_id)
@@ -961,11 +962,11 @@ impl MetadataProvider for SqliteMetadataProvider {
 
                 // Which of the table's columns this inline table physically has
                 // (its layout matches the schema version it was created for).
-                let info = sqlx::query(&format!(
+                let info = sqlx::query(AssertSqlSafe(format!(
                     "SELECT name FROM pragma_table_info({})",
                     // pragma wants a string literal; single-quote-escape the name.
                     format_args!("'{}'", phys.replace('\'', "''"))
-                ))
+                )))
                 .fetch_all(&self.pool)
                 .await?;
                 let present: HashSet<String> = info
@@ -992,7 +993,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                      ORDER BY row_id",
                     quote_ident(&phys)
                 );
-                let rows = sqlx::query(&sql)
+                let rows = sqlx::query(AssertSqlSafe(sql.as_str()))
                     .bind(snapshot_id)
                     .bind(snapshot_id)
                     .fetch_all(&self.pool)
@@ -1281,7 +1282,7 @@ impl MetadataProvider for SqliteMetadataProvider {
             } else {
                 "NULL"
             };
-            let rows = sqlx::query(&format!(
+            let rows = sqlx::query(AssertSqlSafe(format!(
                 "SELECT
                     data.begin_snapshot,
                     data.path,
@@ -1297,7 +1298,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                   AND (data.begin_snapshot >= ?2
                        OR ({pm} IS NOT NULL AND {pm} >= ?2))
                 ORDER BY data.begin_snapshot"
-            ))
+            )))
             .bind(table_id)
             .bind(start_snapshot)
             .bind(end_snapshot)
@@ -1343,7 +1344,7 @@ impl MetadataProvider for SqliteMetadataProvider {
             } else {
                 "NULL"
             };
-            let rows = sqlx::query(&format!(
+            let rows = sqlx::query(AssertSqlSafe(format!(
                 r#"
 -- Part 1: Incremental deletes (delete file added)
 SELECT
@@ -1436,7 +1437,7 @@ WHERE data.table_id = ?
   AND data.end_snapshot >= ?
   AND data.end_snapshot <= ?
 "#
-            ))
+            )))
             // Part 1 bindings: 4x table_id for prev subqueries, table_id for cd,
             // end, start (window), start (partial_max), table_id for data
             .bind(table_id)

--- a/src/metadata_writer_mysql.rs
+++ b/src/metadata_writer_mysql.rs
@@ -279,7 +279,7 @@ async fn reserve_ids(
 /// allocating without reuse. Done as check-then-insert (two statements) rather
 /// than `INSERT … SELECT … WHERE NOT EXISTS`, because that self-referential
 /// `INSERT … SELECT` against `ducklake_metadata` is rejected by MySQL (1093).
-async fn seed_counter(pool: &MySqlPool, key: &str, max_sql: &str) -> Result<()> {
+async fn seed_counter(pool: &MySqlPool, key: &str, max_sql: &'static str) -> Result<()> {
     let exists: i64 =
         sqlx::query("SELECT COUNT(*) FROM ducklake_metadata WHERE `key` = ? AND scope IS NULL")
             .bind(key)
@@ -1284,7 +1284,7 @@ impl MetadataWriter for MySqlMetadataWriter {
             // sqlx runs each query() as a single prepared statement on MySQL, so
             // create each table separately (see SQL_CREATE_TABLES).
             for ddl in SQL_CREATE_TABLES {
-                sqlx::query(ddl).execute(&self.pool).await?;
+                sqlx::query(*ddl).execute(&self.pool).await?;
             }
             // Upgrade a pre-existing catalog to carry ducklake_data_file.partition_id.
             // MySQL has no `ADD COLUMN IF NOT EXISTS`, so probe information_schema first

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -18,6 +18,7 @@ use crate::metadata_writer::{
     validate_name,
 };
 use crate::partition::PartitionTransform;
+use sqlx::AssertSqlSafe;
 use sqlx::Row;
 use sqlx::postgres::{PgPool, PgPoolOptions};
 
@@ -257,9 +258,12 @@ pub(crate) const SQL_CREATE_MULTICATALOG_TABLES: &[&str] = &[
 ];
 
 /// Run a slice of DDL statements against the pool. Each statement executes independently.
-pub(crate) async fn execute_ddl_statements(pool: &PgPool, statements: &[&str]) -> Result<()> {
+pub(crate) async fn execute_ddl_statements(
+    pool: &PgPool,
+    statements: &[&'static str],
+) -> Result<()> {
     for stmt in statements {
-        sqlx::query(stmt).execute(pool).await?;
+        sqlx::query(*stmt).execute(pool).await?;
     }
     Ok(())
 }
@@ -357,9 +361,12 @@ async fn lock_catalog(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
 ) -> Result<()> {
     if lock_timeout_ms > 0 {
-        sqlx::query(&format!("SET LOCAL lock_timeout = {}", lock_timeout_ms))
-            .execute(&mut **tx)
-            .await?;
+        sqlx::query(AssertSqlSafe(format!(
+            "SET LOCAL lock_timeout = {}",
+            lock_timeout_ms
+        )))
+        .execute(&mut **tx)
+        .await?;
     }
     let row =
         sqlx::query("SELECT catalog_id FROM ducklake_catalog WHERE catalog_id = $1 FOR UPDATE")
@@ -2494,27 +2501,27 @@ impl MetadataWriter for PostgresMetadataWriter {
                     // Merge: the partial output serves every snapshot the sources
                     // did, so schedule their physical files (resolving paths as the
                     // multicatalog expire path does) and REMOVE their catalog rows.
-                    let dead_data = sqlx::query(&format!(
+                    let dead_data = sqlx::query(AssertSqlSafe(format!(
                         "SELECT df.data_file_id, {COMPACTION_RESOLVED_PATH} AS resolved_path,
                                 {COMPACTION_REL_FLAG} AS rel
                          FROM ducklake_data_file df
                          JOIN ducklake_table t ON t.table_id = df.table_id
                          JOIN ducklake_schema s ON s.schema_id = t.schema_id
                          WHERE df.data_file_id = ANY($1)"
-                    ))
+                    )))
                     .bind(&source_data_ids)
                     .fetch_all(&mut *tx)
                     .await?;
                     schedule_compaction_files(&mut tx, self.catalog_id, dead_data).await?;
 
-                    let dead_del = sqlx::query(&format!(
+                    let dead_del = sqlx::query(AssertSqlSafe(format!(
                         "SELECT df.delete_file_id, {COMPACTION_RESOLVED_PATH} AS resolved_path,
                                 {COMPACTION_REL_FLAG} AS rel
                          FROM ducklake_delete_file df
                          JOIN ducklake_table t ON t.table_id = df.table_id
                          JOIN ducklake_schema s ON s.schema_id = t.schema_id
                          WHERE df.data_file_id = ANY($1)"
-                    ))
+                    )))
                     .bind(&source_data_ids)
                     .fetch_all(&mut *tx)
                     .await?;

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -14,6 +14,7 @@ use crate::metadata_writer::{
     validate_name,
 };
 use crate::partition::PartitionTransform;
+use sqlx::AssertSqlSafe;
 use sqlx::Row;
 use sqlx::sqlite::{SqlitePool, SqlitePoolOptions};
 
@@ -344,10 +345,10 @@ impl SqliteMetadataWriter {
             for child in
                 ["ducklake_table", "ducklake_column", "ducklake_data_file", "ducklake_delete_file"]
             {
-                sqlx::query(&format!(
+                sqlx::query(AssertSqlSafe(format!(
                     "UPDATE {child} SET end_snapshot = ?
                      WHERE table_id = ? AND end_snapshot IS NULL"
-                ))
+                )))
                 .bind(drop_snapshot)
                 .bind(table_id)
                 .execute(&mut *tx)
@@ -401,11 +402,11 @@ impl SqliteMetadataWriter {
                         tx.commit().await?;
                         return Ok(Vec::new());
                     }
-                    let rows = sqlx::query(&format!(
+                    let rows = sqlx::query(AssertSqlSafe(format!(
                         "SELECT snapshot_id, snapshot_time FROM ducklake_snapshot
                          WHERE snapshot_id IN ({}) ORDER BY snapshot_id",
                         id_list(&ids)
-                    ))
+                    )))
                     .fetch_all(&mut *tx)
                     .await?;
                     rows_to_snapshots(rows)?
@@ -429,10 +430,10 @@ impl SqliteMetadataWriter {
             let expire_ids: Vec<i64> = candidates.iter().map(|s| s.snapshot_id).collect();
 
             // 2. Delete the snapshot rows themselves.
-            sqlx::query(&format!(
+            sqlx::query(AssertSqlSafe(format!(
                 "DELETE FROM ducklake_snapshot WHERE snapshot_id IN ({})",
                 id_list(&expire_ids)
-            ))
+            )))
             .execute(&mut *tx)
             .await?;
 
@@ -464,7 +465,7 @@ impl SqliteMetadataWriter {
 
             // 4. Data files no longer referenced by any surviving snapshot (or belonging
             //    to a dead table): schedule their physical paths, then drop the rows.
-            let dead_data_files = sqlx::query(&format!(
+            let dead_data_files = sqlx::query(AssertSqlSafe(format!(
                 "SELECT df.data_file_id, {RESOLVED_PATH} AS resolved_path, {REL_FLAG} AS rel
                  FROM ducklake_data_file df
                  JOIN ducklake_table t ON t.table_id = df.table_id
@@ -472,15 +473,15 @@ impl SqliteMetadataWriter {
                  WHERE ({dead_table_filter}) OR (df.end_snapshot IS NOT NULL AND NOT EXISTS (
                      SELECT 1 FROM ducklake_snapshot
                      WHERE snapshot_id >= df.begin_snapshot AND snapshot_id < df.end_snapshot))"
-            ))
+            )))
             .fetch_all(&mut *tx)
             .await?;
             let data_file_ids = schedule_files(&mut tx, dead_data_files).await?;
             if !data_file_ids.is_empty() {
-                sqlx::query(&format!(
+                sqlx::query(AssertSqlSafe(format!(
                     "DELETE FROM ducklake_data_file WHERE data_file_id IN ({})",
                     id_list(&data_file_ids)
-                ))
+                )))
                 .execute(&mut *tx)
                 .await?;
             }
@@ -498,7 +499,7 @@ impl SqliteMetadataWriter {
             } else {
                 format!("df.table_id IN ({})", id_list(&dead_tables))
             };
-            let dead_delete_files = sqlx::query(&format!(
+            let dead_delete_files = sqlx::query(AssertSqlSafe(format!(
                 "SELECT df.delete_file_id, {RESOLVED_PATH} AS resolved_path, {REL_FLAG} AS rel
                  FROM ducklake_delete_file df
                  JOIN ducklake_table t ON t.table_id = df.table_id
@@ -507,15 +508,15 @@ impl SqliteMetadataWriter {
                     OR (df.end_snapshot IS NOT NULL AND NOT EXISTS (
                         SELECT 1 FROM ducklake_snapshot
                         WHERE snapshot_id >= df.begin_snapshot AND snapshot_id < df.end_snapshot))"
-            ))
+            )))
             .fetch_all(&mut *tx)
             .await?;
             let delete_file_ids = schedule_files(&mut tx, dead_delete_files).await?;
             if !delete_file_ids.is_empty() {
-                sqlx::query(&format!(
+                sqlx::query(AssertSqlSafe(format!(
                     "DELETE FROM ducklake_delete_file WHERE delete_file_id IN ({})",
                     id_list(&delete_file_ids)
-                ))
+                )))
                 .execute(&mut *tx)
                 .await?;
             }
@@ -535,9 +536,11 @@ impl SqliteMetadataWriter {
                     "ducklake_column",
                     "ducklake_schema_versions",
                 ] {
-                    sqlx::query(&format!("DELETE FROM {table} WHERE table_id IN ({dead})"))
-                        .execute(&mut *tx)
-                        .await?;
+                    sqlx::query(AssertSqlSafe(format!(
+                        "DELETE FROM {table} WHERE table_id IN ({dead})"
+                    )))
+                    .execute(&mut *tx)
+                    .await?;
                 }
             }
 
@@ -601,10 +604,10 @@ impl SqliteMetadataWriter {
             return Ok(());
         }
         block_on(async {
-            sqlx::query(&format!(
+            sqlx::query(AssertSqlSafe(format!(
                 "DELETE FROM ducklake_files_scheduled_for_deletion WHERE data_file_id IN ({})",
                 id_list(ids)
-            ))
+            )))
             .execute(&self.pool)
             .await?;
             Ok(())
@@ -636,7 +639,9 @@ impl SqliteMetadataWriter {
                  SELECT path AS p, CAST(path_is_relative AS INTEGER) AS rel
                  FROM ducklake_files_scheduled_for_deletion"
             );
-            let rows = sqlx::query(&q).fetch_all(&self.pool).await?;
+            let rows = sqlx::query(AssertSqlSafe(q.as_str()))
+                .fetch_all(&self.pool)
+                .await?;
             rows.into_iter()
                 .map(|r| {
                     let p: String = r.try_get(0)?;
@@ -819,10 +824,10 @@ async fn migrate_ducklake_column_drop_pk(pool: &SqlitePool) -> Result<()> {
     )
     .execute(&mut *tx)
     .await?;
-    sqlx::query(&format!(
+    sqlx::query(AssertSqlSafe(format!(
         "INSERT INTO ducklake_column__migrate ({insert_list}) \
          SELECT {select_list} FROM ducklake_column"
-    ))
+    )))
     .execute(&mut *tx)
     .await?;
     sqlx::query("DROP TABLE ducklake_column")
@@ -2468,55 +2473,55 @@ impl MetadataWriter for SqliteMetadataWriter {
                     // does) and REMOVE their catalog rows, so no snapshot resolves
                     // to them (avoids double-counting with the partial file, and
                     // upholds the invariant that scheduled files are unreachable).
-                    let dead_data = sqlx::query(&format!(
+                    let dead_data = sqlx::query(AssertSqlSafe(format!(
                         "SELECT df.data_file_id, {RESOLVED_PATH} AS resolved_path, {REL_FLAG} AS rel
                          FROM ducklake_data_file df
                          JOIN ducklake_table t ON t.table_id = df.table_id
                          JOIN ducklake_schema s ON s.schema_id = t.schema_id
                          WHERE df.data_file_id IN ({})",
                         id_list(&source_data_ids)
-                    ))
+                    )))
                     .fetch_all(&mut *tx)
                     .await?;
                     schedule_files(&mut tx, dead_data).await?;
 
-                    let dead_del = sqlx::query(&format!(
+                    let dead_del = sqlx::query(AssertSqlSafe(format!(
                         "SELECT df.delete_file_id, {RESOLVED_PATH} AS resolved_path, {REL_FLAG} AS rel
                          FROM ducklake_delete_file df
                          JOIN ducklake_table t ON t.table_id = df.table_id
                          JOIN ducklake_schema s ON s.schema_id = t.schema_id
                          WHERE df.data_file_id IN ({})",
                         id_list(&source_data_ids)
-                    ))
+                    )))
                     .fetch_all(&mut *tx)
                     .await?;
                     schedule_files(&mut tx, dead_del).await?;
 
-                    sqlx::query(&format!(
+                    sqlx::query(AssertSqlSafe(format!(
                         "DELETE FROM ducklake_delete_file WHERE data_file_id IN ({})",
                         id_list(&source_data_ids)
-                    ))
+                    )))
                     .execute(&mut *tx)
                     .await?;
-                    sqlx::query(&format!(
+                    sqlx::query(AssertSqlSafe(format!(
                         "DELETE FROM ducklake_data_file WHERE data_file_id IN ({})",
                         id_list(&source_data_ids)
-                    ))
+                    )))
                     .execute(&mut *tx)
                     .await?;
                     // Hard-delete the removed sources' per-column stats too, as
                     // official DuckLake does on merge (otherwise they orphan).
-                    sqlx::query(&format!(
+                    sqlx::query(AssertSqlSafe(format!(
                         "DELETE FROM ducklake_file_column_stats WHERE data_file_id IN ({})",
                         id_list(&source_data_ids)
-                    ))
+                    )))
                     .execute(&mut *tx)
                     .await?;
                     // Likewise the removed sources' per-file partition values.
-                    sqlx::query(&format!(
+                    sqlx::query(AssertSqlSafe(format!(
                         "DELETE FROM ducklake_file_partition_value WHERE data_file_id IN ({})",
                         id_list(&source_data_ids)
-                    ))
+                    )))
                     .execute(&mut *tx)
                     .await?;
                 },
@@ -2526,19 +2531,19 @@ impl MetadataWriter for SqliteMetadataWriter {
                     // Retire them (end_snapshot) but do NOT schedule them — an
                     // expire_snapshots run schedules them once their snapshots are
                     // gone, so they are never deleted while still reachable.
-                    sqlx::query(&format!(
+                    sqlx::query(AssertSqlSafe(format!(
                         "UPDATE ducklake_data_file SET end_snapshot = ?
                          WHERE data_file_id IN ({}) AND end_snapshot IS NULL",
                         id_list(&source_data_ids)
-                    ))
+                    )))
                     .bind(snapshot_id)
                     .execute(&mut *tx)
                     .await?;
-                    sqlx::query(&format!(
+                    sqlx::query(AssertSqlSafe(format!(
                         "UPDATE ducklake_delete_file SET end_snapshot = ?
                          WHERE data_file_id IN ({}) AND end_snapshot IS NULL",
                         id_list(&source_data_ids)
-                    ))
+                    )))
                     .bind(snapshot_id)
                     .execute(&mut *tx)
                     .await?;

--- a/src/multicatalog.rs
+++ b/src/multicatalog.rs
@@ -8,6 +8,7 @@ use crate::maintenance::{
     CleanupCriteria, ExpireCriteria, ExpiredSnapshot, ScheduledFile, format_sql_timestamp,
 };
 use crate::metadata_writer_postgres::execute_ddl_statements;
+use sqlx::AssertSqlSafe;
 use sqlx::Row;
 use sqlx::postgres::{PgPool, PgRow};
 
@@ -204,14 +205,14 @@ impl MulticatalogManager {
             "ducklake_column",
             "ducklake_schema_versions",
         ] {
-            sqlx::query(&format!(
+            sqlx::query(AssertSqlSafe(format!(
                 "DELETE FROM {} WHERE table_id IN (
                     SELECT t.table_id FROM ducklake_table t
                     JOIN ducklake_catalog_schema_map m ON m.schema_id = t.schema_id
                     WHERE m.catalog_id = $1
                 )",
                 child_table
-            ))
+            )))
             .bind(catalog_id)
             .execute(&mut *tx)
             .await?;
@@ -445,11 +446,11 @@ impl MulticatalogManager {
         for child_table in
             ["ducklake_table", "ducklake_column", "ducklake_data_file", "ducklake_delete_file"]
         {
-            sqlx::query(&format!(
+            sqlx::query(AssertSqlSafe(format!(
                 "UPDATE {} SET end_snapshot = $1
                  WHERE table_id = $2 AND end_snapshot IS NULL",
                 child_table
-            ))
+            )))
             .bind(drop_snapshot)
             .bind(table_id)
             .execute(&mut *tx)
@@ -635,7 +636,7 @@ impl MulticatalogManager {
 
         // 4. Data files orphaned (in this catalog): schedule paths, then drop the rows.
         //    `= ANY($2)` with an empty array is simply false — no special-casing needed.
-        let dead_data_files = sqlx::query(&format!(
+        let dead_data_files = sqlx::query(AssertSqlSafe(format!(
             "SELECT df.data_file_id, {PG_RESOLVED_PATH} AS resolved_path, {PG_REL_FLAG} AS rel
              FROM ducklake_data_file df
              JOIN ducklake_table t ON t.table_id = df.table_id
@@ -647,7 +648,7 @@ impl MulticatalogManager {
                  JOIN ducklake_catalog_snapshot_map m
                    ON m.snapshot_id = ss.snapshot_id AND m.catalog_id = $1
                  WHERE ss.snapshot_id >= df.begin_snapshot AND ss.snapshot_id < df.end_snapshot))"
-        ))
+        )))
         .bind(catalog_id)
         .bind(&dead_tables)
         .fetch_all(&mut *tx)
@@ -660,7 +661,7 @@ impl MulticatalogManager {
 
         // 5. Delete files orphaned by the data files above, a dead table, or no surviving
         //    snapshot. (Our writer does not emit delete files yet — no-op for our catalogs.)
-        let dead_delete_files = sqlx::query(&format!(
+        let dead_delete_files = sqlx::query(AssertSqlSafe(format!(
             "SELECT df.delete_file_id, {PG_RESOLVED_PATH} AS resolved_path, {PG_REL_FLAG} AS rel
              FROM ducklake_delete_file df
              JOIN ducklake_table t ON t.table_id = df.table_id
@@ -673,7 +674,7 @@ impl MulticatalogManager {
                     JOIN ducklake_catalog_snapshot_map m
                       ON m.snapshot_id = ss.snapshot_id AND m.catalog_id = $1
                     WHERE ss.snapshot_id >= df.begin_snapshot AND ss.snapshot_id < df.end_snapshot))"
-        ))
+        )))
         .bind(catalog_id)
         .bind(&data_file_ids)
         .bind(&dead_tables)
@@ -688,10 +689,12 @@ impl MulticatalogManager {
         // 6. Reclaim per-table metadata for fully-expired tables. (No ducklake_table_stats
         //    on Postgres — that table is maintained only by the SQLite writer.)
         for table in ["ducklake_table", "ducklake_column", "ducklake_schema_versions"] {
-            sqlx::query(&format!("DELETE FROM {table} WHERE table_id = ANY($1)"))
-                .bind(&dead_tables)
-                .execute(&mut *tx)
-                .await?;
+            sqlx::query(AssertSqlSafe(format!(
+                "DELETE FROM {table} WHERE table_id = ANY($1)"
+            )))
+            .bind(&dead_tables)
+            .execute(&mut *tx)
+            .await?;
         }
 
         // 7. Reclaim schemas no longer covered by a surviving snapshot of this catalog,
@@ -819,7 +822,9 @@ impl MulticatalogManager {
              SELECT path AS p, path_is_relative AS rel
              FROM ducklake_files_scheduled_for_deletion"
         );
-        let rows = sqlx::query(&q).fetch_all(&self.pool).await?;
+        let rows = sqlx::query(AssertSqlSafe(q.as_str()))
+            .fetch_all(&self.pool)
+            .await?;
         rows.into_iter()
             .map(|r| Ok((r.try_get::<String, _>(0)?, r.try_get::<bool, _>(1)?)))
             .collect()

--- a/src/multicatalog_provider.rs
+++ b/src/multicatalog_provider.rs
@@ -20,6 +20,7 @@ use crate::metadata_provider::{
     reconstruct_list_columns, reconstruct_list_columns_with_table,
 };
 use crate::partition::PartitionSpec;
+use sqlx::AssertSqlSafe;
 use sqlx::Row;
 use sqlx::postgres::{PgPool, PgPoolOptions, PgRow};
 use sqlx::types::chrono::NaiveDateTime;
@@ -417,7 +418,7 @@ impl MetadataProvider for MulticatalogProvider {
                   AND $5 >= data.begin_snapshot
                   AND ($6 < data.end_snapshot OR data.end_snapshot IS NULL)"
             );
-            let rows = sqlx::query(&sql)
+            let rows = sqlx::query(AssertSqlSafe(sql.as_str()))
                 .bind(table_id)
                 .bind(snapshot_id)
                 .bind(snapshot_id)
@@ -533,7 +534,7 @@ impl MetadataProvider for MulticatalogProvider {
                  ORDER BY data.data_file_id
                  LIMIT $8"
             );
-            let rows = sqlx::query(&sql)
+            let rows = sqlx::query(AssertSqlSafe(sql.as_str()))
                 .bind(table_id)
                 .bind(snapshot_id)
                 .bind(snapshot_id)
@@ -1153,7 +1154,7 @@ impl MetadataProvider for MulticatalogProvider {
             } else {
                 "NULL::bigint"
             };
-            let rows = sqlx::query(&format!(
+            let rows = sqlx::query(AssertSqlSafe(format!(
                 "SELECT
                     data.begin_snapshot,
                     data.path,
@@ -1169,7 +1170,7 @@ impl MetadataProvider for MulticatalogProvider {
                   AND (data.begin_snapshot >= $2
                        OR ({pm} IS NOT NULL AND {pm} >= $2))
                 ORDER BY data.begin_snapshot"
-            ))
+            )))
             .bind(table_id)
             .bind(start_snapshot)
             .bind(end_snapshot)
@@ -1211,7 +1212,7 @@ impl MetadataProvider for MulticatalogProvider {
             } else {
                 "NULL::bigint"
             };
-            let rows = sqlx::query(&format!(
+            let rows = sqlx::query(AssertSqlSafe(format!(
                 r#"
 WITH current_delete AS (
     SELECT
@@ -1272,7 +1273,7 @@ WHERE data.table_id = $1
   AND data.end_snapshot >= $2
   AND data.end_snapshot <= $3
 "#
-            ))
+            )))
             .bind(table_id)
             .bind(start_snapshot)
             .bind(end_snapshot)

--- a/tests/compaction_postgres_tests.rs
+++ b/tests/compaction_postgres_tests.rs
@@ -22,6 +22,7 @@ use datafusion_ducklake::{
     PostgresMetadataWriter, RewriteOptions,
 };
 use object_store::local::LocalFileSystem;
+use sqlx::AssertSqlSafe;
 use sqlx::Row;
 use sqlx::postgres::{PgPool, PgPoolOptions};
 use tempfile::TempDir;
@@ -122,7 +123,7 @@ async fn live_files(pool: &PgPool, cat_name: &str) -> Vec<datafusion_ducklake::D
 }
 
 async fn scalar_i64(pool: &PgPool, sql: &str, cat: i64) -> i64 {
-    sqlx::query(sql)
+    sqlx::query(AssertSqlSafe(sql))
         .bind(cat)
         .fetch_one(pool)
         .await

--- a/tests/compaction_sqlite_tests.rs
+++ b/tests/compaction_sqlite_tests.rs
@@ -16,6 +16,7 @@ use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use datafusion::prelude::*;
 use object_store::local::LocalFileSystem;
+use sqlx::AssertSqlSafe;
 use sqlx::Row;
 use sqlx::sqlite::SqlitePool;
 use tempfile::TempDir;
@@ -92,7 +93,7 @@ async fn pool(temp: &TempDir) -> SqlitePool {
 }
 
 async fn scalar_i64(p: &SqlitePool, sql: &str) -> i64 {
-    sqlx::query(sql)
+    sqlx::query(AssertSqlSafe(sql))
         .fetch_one(p)
         .await
         .unwrap()
@@ -101,7 +102,7 @@ async fn scalar_i64(p: &SqlitePool, sql: &str) -> i64 {
 }
 
 async fn opt_i64(p: &SqlitePool, sql: &str) -> Option<i64> {
-    sqlx::query(sql)
+    sqlx::query(AssertSqlSafe(sql))
         .fetch_one(p)
         .await
         .unwrap()
@@ -365,9 +366,9 @@ async fn merge_coalesces_small_files_preserving_results_rowids_and_time_travel()
     assert_eq!(scheduled, 3, "three source files scheduled for deletion");
 
     // changes_made records the compaction.
-    let changes: String = sqlx::query(&format!(
+    let changes: String = sqlx::query(AssertSqlSafe(format!(
         "SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id = {new_snapshot}"
-    ))
+    )))
     .fetch_one(&p)
     .await
     .unwrap()
@@ -534,9 +535,9 @@ async fn rewrite_drops_deleted_rows_and_retires_data_and_delete_files() {
     );
 
     // changes_made records the compaction.
-    let changes: String = sqlx::query(&format!(
+    let changes: String = sqlx::query(AssertSqlSafe(format!(
         "SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id = {new_snapshot}"
-    ))
+    )))
     .fetch_one(&p)
     .await
     .unwrap()

--- a/tests/inlined_data_sqlite_tests.rs
+++ b/tests/inlined_data_sqlite_tests.rs
@@ -19,6 +19,7 @@ use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use datafusion::prelude::*;
 use object_store::local::LocalFileSystem;
+use sqlx::AssertSqlSafe;
 use sqlx::sqlite::SqlitePool;
 use tempfile::TempDir;
 
@@ -106,10 +107,10 @@ async fn seed_inlined(
     .await
     .unwrap();
     let phys = format!("ducklake_inlined_data_{table_id}_1");
-    sqlx::query(&format!(
+    sqlx::query(AssertSqlSafe(format!(
         "CREATE TABLE IF NOT EXISTS {phys}
              (row_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, id INTEGER, val INTEGER)"
-    ))
+    )))
     .execute(pool)
     .await
     .unwrap();
@@ -123,9 +124,9 @@ async fn seed_inlined(
     .await
     .unwrap();
     for (row_id, begin, end, id, val) in rows {
-        sqlx::query(&format!(
+        sqlx::query(AssertSqlSafe(format!(
             "INSERT INTO {phys} (row_id, begin_snapshot, end_snapshot, id, val) VALUES (?,?,?,?,?)"
-        ))
+        )))
         .bind(row_id)
         .bind(begin)
         .bind(*end)

--- a/tests/maintenance_sqlite_tests.rs
+++ b/tests/maintenance_sqlite_tests.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 
 use object_store::ObjectStore;
 use object_store::local::LocalFileSystem;
+use sqlx::AssertSqlSafe;
 use sqlx::Row;
 use sqlx::sqlite::SqlitePool;
 use tempfile::TempDir;
@@ -63,7 +64,7 @@ async fn pool(h: &Harness) -> SqlitePool {
 }
 
 async fn scalar_i64(pool: &SqlitePool, sql: &str) -> i64 {
-    sqlx::query(sql)
+    sqlx::query(AssertSqlSafe(sql))
         .fetch_one(pool)
         .await
         .unwrap()

--- a/tests/multicatalog_postgres_tests.rs
+++ b/tests/multicatalog_postgres_tests.rs
@@ -14,6 +14,7 @@ use datafusion_ducklake::{
     DuckLakeError, DuckLakeTableWriter, MulticatalogManager, PostgresMetadataWriter,
     TypeChangeOperation, TypeChangeWriteMode, initialize_multicatalog_schema,
 };
+use sqlx::AssertSqlSafe;
 use sqlx::Row;
 use sqlx::postgres::{PgPool, PgPoolOptions};
 use testcontainers::ContainerAsync;
@@ -1651,7 +1652,7 @@ async fn drop_catalog_removes_populated_catalog() {
         "ducklake_delete_file",
         "ducklake_schema_versions",
     ] {
-        let n: i64 = sqlx::query(&format!("SELECT COUNT(*) FROM {}", table))
+        let n: i64 = sqlx::query(AssertSqlSafe(format!("SELECT COUNT(*) FROM {}", table)))
             .fetch_one(&pool)
             .await
             .unwrap()
@@ -1938,10 +1939,10 @@ async fn drop_table_in_catalog_tombstones_table_and_children() {
 
     // All currently-live child rows for this table now carry the drop snapshot.
     for child_table in ["ducklake_column", "ducklake_data_file"] {
-        let live: i64 = sqlx::query(&format!(
+        let live: i64 = sqlx::query(AssertSqlSafe(format!(
             "SELECT COUNT(*) FROM {} WHERE table_id = $1 AND end_snapshot IS NULL",
             child_table
-        ))
+        )))
         .bind(s.table_id)
         .fetch_one(&pool)
         .await
@@ -1950,10 +1951,10 @@ async fn drop_table_in_catalog_tombstones_table_and_children() {
         .unwrap();
         assert_eq!(live, 0, "no live rows left in {} after drop", child_table);
 
-        let tombstoned: i64 = sqlx::query(&format!(
+        let tombstoned: i64 = sqlx::query(AssertSqlSafe(format!(
             "SELECT COUNT(*) FROM {} WHERE table_id = $1 AND end_snapshot = $2",
             child_table
-        ))
+        )))
         .bind(s.table_id)
         .bind(snap_after_drop)
         .fetch_one(&pool)
@@ -2948,13 +2949,15 @@ async fn expire_in_catalog_full_after_drop_removes_table_metadata() {
     for tbl in
         ["ducklake_table", "ducklake_column", "ducklake_data_file", "ducklake_schema_versions"]
     {
-        let cnt: i64 = sqlx::query(&format!("SELECT COUNT(*) FROM {tbl} WHERE table_id = $1"))
-            .bind(s.table_id)
-            .fetch_one(&pool)
-            .await
-            .unwrap()
-            .try_get(0)
-            .unwrap();
+        let cnt: i64 = sqlx::query(AssertSqlSafe(format!(
+            "SELECT COUNT(*) FROM {tbl} WHERE table_id = $1"
+        )))
+        .bind(s.table_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .try_get(0)
+        .unwrap();
         assert_eq!(cnt, 0, "{tbl} fully reclaimed after expire");
     }
     let scheduled: i64 = sqlx::query(

--- a/tests/mysql_metadata_provider_test.rs
+++ b/tests/mysql_metadata_provider_test.rs
@@ -1031,3 +1031,52 @@ async fn test_query_with_filter() {
     assert_eq!(name_col.value(0), "Charlie");
     assert_eq!(name_col.value(1), "Diana");
 }
+
+/// Connecting as a password-protected `caching_sha2_password` user over a
+/// non-TLS channel must succeed.
+///
+/// This is MySQL 8's default auth plugin. On the first connection for a user the
+/// server's fast-auth cache is cold, so it demands full authentication; over an
+/// insecure channel the client must fetch the server's RSA public key and send
+/// the password encrypted. sqlx bundled that RSA backend unconditionally through
+/// 0.8, but 0.9 moved it behind the `mysql-rsa` feature and substitutes a stub
+/// that fails at connect time with "RSA auth backend disabled". Nothing catches
+/// that at compile time, and the rest of this suite connects as passwordless
+/// `root` (an empty password skips the RSA exchange entirely), so this test is
+/// what pins `sqlx/mysql-rsa` into the `metadata-mysql` feature.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn test_connect_caching_sha2_password_without_tls() {
+    let container = Mysql::default()
+        .with_init_sql(
+            "CREATE USER 'rsauser'@'%' IDENTIFIED WITH caching_sha2_password BY 'secret-pw';
+             GRANT ALL PRIVILEGES ON test.* TO 'rsauser'@'%';"
+                .to_string()
+                .into_bytes(),
+        )
+        .start()
+        .await
+        .expect("Failed to start MySQL");
+
+    let port = container
+        .get_host_port_ipv4(3306)
+        .await
+        .expect("Failed to get port");
+    let conn_str = format!("mysql://rsauser:secret-pw@127.0.0.1:{}/test", port);
+
+    let provider = MySqlMetadataProvider::new(&conn_str)
+        .await
+        .expect("should connect as a caching_sha2_password user over a non-TLS channel");
+
+    // Prove the connection is actually usable, not merely constructed.
+    init_schema(&provider.pool)
+        .await
+        .expect("should run DDL over the authenticated connection");
+    let snapshots = provider
+        .list_snapshots()
+        .expect("should query over the authenticated connection");
+    assert!(
+        snapshots.is_empty(),
+        "freshly initialized catalog should have no snapshots"
+    );
+}


### PR DESCRIPTION
Upgrades sqlx from 0.8 to 0.9 (closes #204), which requires wrapping runtime-built SQL in `AssertSqlSafe` and raises the MSRV to 1.94. Also enables `sqlx/mysql-rsa`, which sqlx 0.9 split out of the default feature set — without it, non-TLS `caching_sha2_password` connections (MySQL 8's default) fail at connect time.

Crate version bump for the public API break will follow in a separate PR.