### PR TITLE
fix(write): preserve partition metadata in rewrites

### DIFF
--- a/src/compaction.rs
+++ b/src/compaction.rs
@@ -49,13 +49,14 @@ use crate::{DuckLakeError, Result};
 /// Options for [`DuckLakeTable::merge_adjacent_files`].
 #[derive(Debug, Clone)]
 pub struct MergeOptions {
-    /// Bin-pack adjacent small files (in `(schema_version, data_file_id)` order)
+    /// Bin-pack adjacent small files (in
+    /// `(schema_version, partition_id, partition_values, data_file_id)` order)
     /// until a bin reaches this many bytes, then emit it as one merged file.
     /// Files already at or above this size are left alone.
     pub target_file_size: u64,
     /// Cap on the number of source files considered in one call, to bound the
     /// memory and I/O of a single merge (candidates are taken in
-    /// `(schema_version, data_file_id)` order).
+    /// `(schema_version, partition_id, partition_values, data_file_id)` order).
     pub max_merged_files: usize,
     /// Skip files smaller than this many bytes. `0` makes every below-target file
     /// a candidate.
@@ -199,11 +200,11 @@ impl DuckLakeTable {
     ///
     /// Candidates are the table's live files that have no live delete file, whose
     /// size is in `[min_file_size, target_file_size)`, and whose origin snapshot
-    /// and schema version are known. They are grouped by schema version (so a DDL
-    /// boundary is never crossed) and, within a group, bin-packed in
-    /// `data_file_id` order until a bin reaches `target_file_size`; only bins of
-    /// two or more files are merged. Delete-bearing files are deliberately left
-    /// to [`rewrite_data_files`](Self::rewrite_data_files).
+    /// and schema version are known. They are grouped by schema version and
+    /// partition, so neither boundary is crossed, then bin-packed in
+    /// `data_file_id` order until a bin reaches `target_file_size`. Only bins
+    /// of two or more files are merged. Delete-bearing files are left to
+    /// [`rewrite_data_files`](Self::rewrite_data_files).
     ///
     /// Each source file's live rows are read with their original rowids
     /// preserved; a merged file that spans more than one origin snapshot is
@@ -229,10 +230,7 @@ impl DuckLakeTable {
             DuckLakeError::Internal("writable table has no schema name".to_string())
         })?;
 
-        // Candidates: live, delete-free, below-target files with a known origin
-        // snapshot + schema version, ordered so adjacency and same-version
-        // grouping fall out of the sort.
-        let table_files = self.files()?;
+        let table_files = self.files_with_partitions()?;
         let mut candidates: Vec<&DuckLakeTableFile> = table_files
             .iter()
             .filter(|f| {
@@ -249,17 +247,28 @@ impl DuckLakeTable {
                     && (f.file.file_size_bytes as u64) < opts.target_file_size
             })
             .collect();
-        candidates.sort_by_key(|f| (f.schema_version.unwrap_or(0), f.data_file_id));
+        candidates.sort_by(|a, b| {
+            a.schema_version
+                .cmp(&b.schema_version)
+                .then_with(|| a.partition_id.cmp(&b.partition_id))
+                .then_with(|| a.partition_values.cmp(&b.partition_values))
+                .then_with(|| a.data_file_id.cmp(&b.data_file_id))
+        });
         candidates.truncate(opts.max_merged_files);
 
-        // Bin-pack within each schema-version run; only bins of >= 2 files merge.
         let mut bins: Vec<Vec<&DuckLakeTableFile>> = Vec::new();
         let mut i = 0;
         while i < candidates.len() {
             let version = candidates[i].schema_version;
+            let partition_id = candidates[i].partition_id;
+            let partition_values = &candidates[i].partition_values;
             let mut running: u64 = 0;
             let mut bin: Vec<&DuckLakeTableFile> = Vec::new();
-            while i < candidates.len() && candidates[i].schema_version == version {
+            while i < candidates.len()
+                && candidates[i].schema_version == version
+                && candidates[i].partition_id == partition_id
+                && &candidates[i].partition_values == partition_values
+            {
                 bin.push(candidates[i]);
                 running += candidates[i].file.file_size_bytes as u64;
                 i += 1;
@@ -376,6 +385,7 @@ impl DuckLakeTable {
                     partial,
                 )
                 .await?;
+            let file = partitioned_output(file, bin[0]);
             outputs.push(CompactionOutputFile {
                 file,
                 partial_max,
@@ -449,7 +459,7 @@ impl DuckLakeTable {
         let mut files_processed = 0usize;
         let mut rows_written = 0i64;
 
-        let table_files = self.files()?;
+        let table_files = self.files_with_partitions()?;
         for tf in &table_files {
             let record_count = tf.max_row_count.unwrap_or(0);
             let delete_count = tf.delete_count.unwrap_or(0);
@@ -491,6 +501,7 @@ impl DuckLakeTable {
                         false,
                     )
                     .await?;
+                let file = partitioned_output(file, tf);
                 rows_written += live_rows as i64;
                 // A rewrite output holds only currently-live rows and begins at
                 // the compaction snapshot (begin_snapshot = None); its
@@ -520,5 +531,15 @@ impl DuckLakeTable {
             files_created: outputs.len(),
             rows_written,
         })
+    }
+}
+
+fn partitioned_output(
+    file: crate::metadata_writer::DataFileInfo,
+    source: &DuckLakeTableFile,
+) -> crate::metadata_writer::DataFileInfo {
+    match source.partition_id {
+        Some(partition_id) => file.with_partition(partition_id, source.partition_values.clone()),
+        None => file,
     }
 }

--- a/src/metadata_provider.rs
+++ b/src/metadata_provider.rs
@@ -1,5 +1,13 @@
-use crate::Result;
+use crate::{DuckLakeError, Result};
 use std::collections::HashMap;
+
+pub(crate) fn decode_key_index(value: i64, kind: &str) -> Result<i32> {
+    i32::try_from(value).map_err(|_| {
+        DuckLakeError::InvalidConfig(format!(
+            "{kind} key index {value} is outside the supported i32 range"
+        ))
+    })
+}
 
 // SQL queries for DuckLake catalog tables
 // These queries are database-agnostic and work with DuckDB, SQLite, PostgreSQL, MySQL
@@ -832,6 +840,20 @@ pub trait MetadataProvider: Send + Sync + std::fmt::Debug {
         Ok(None)
     }
 
+    /// Load partition values for a bounded set of data files.
+    ///
+    /// The default paged metadata implementation calls this when
+    /// [`Self::get_table_files_for_select`] omits partition values. External
+    /// providers can implement this smaller query instead of replacing paging.
+    fn get_file_partition_values(
+        &self,
+        _table_id: i64,
+        _snapshot_id: i64,
+        _data_file_ids: &[i64],
+    ) -> Result<HashMap<i64, Vec<(i32, Option<String>)>>> {
+        Ok(HashMap::new())
+    }
+
     /// Load table-, column-, and file-level statistics from the DuckLake
     /// catalog. Implementations should return unknown statistics when the
     /// optional statistics tables do not exist (for compatibility with older
@@ -882,13 +904,29 @@ pub trait MetadataProvider: Send + Sync + std::fmt::Debug {
                 .or_default()
                 .push(statistic);
         }
-        Ok(files
+        let mut files = files
             .into_iter()
             .filter(|file| after_data_file_id.is_none_or(|after| file.data_file_id > after))
             .take(limit)
-            .map(|file| DuckLakeFileMetadata {
-                column_statistics: by_file.remove(&file.data_file_id).unwrap_or_default(),
-                file,
+            .collect::<Vec<_>>();
+        let ids = files
+            .iter()
+            .filter(|file| file.partition_id.is_some() && file.partition_values.is_empty())
+            .map(|file| file.data_file_id)
+            .collect::<Vec<_>>();
+        let mut partition_values = self.get_file_partition_values(table_id, snapshot_id, &ids)?;
+        Ok(files
+            .drain(..)
+            .map(|mut file| {
+                if file.partition_values.is_empty()
+                    && let Some(values) = partition_values.remove(&file.data_file_id)
+                {
+                    file.partition_values = values;
+                }
+                DuckLakeFileMetadata {
+                    column_statistics: by_file.remove(&file.data_file_id).unwrap_or_default(),
+                    file,
+                }
             })
             .collect())
     }

--- a/src/metadata_provider_duckdb.rs
+++ b/src/metadata_provider_duckdb.rs
@@ -9,8 +9,8 @@ use crate::metadata_provider::{
     SQL_GET_SCHEMA_BY_NAME, SQL_GET_SORT_SPEC, SQL_GET_TABLE_BY_NAME, SQL_GET_TABLE_COLUMN_STATS,
     SQL_GET_TABLE_COLUMNS, SQL_GET_TABLE_STATS, SQL_LIST_ALL_COLUMNS, SQL_LIST_ALL_FILES,
     SQL_LIST_ALL_TABLES, SQL_LIST_SCHEMAS, SQL_LIST_SNAPSHOTS, SQL_LIST_TABLES, SQL_TABLE_EXISTS,
-    SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, reconstruct_list_columns,
-    reconstruct_list_columns_with_table,
+    SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, decode_key_index,
+    reconstruct_list_columns, reconstruct_list_columns_with_table,
 };
 use crate::partition::PartitionSpec;
 use crate::sort::SortSpec;
@@ -19,7 +19,7 @@ use duckdb::{Config, Connection, params};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 
-fn is_missing_statistics_table(error: &duckdb::Error) -> bool {
+fn is_missing_optional_table(error: &duckdb::Error) -> bool {
     let message = error.to_string().to_ascii_lowercase();
     message.contains("does not exist") || message.contains("not found")
 }
@@ -329,7 +329,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
             |row| row.get(0),
         ) {
             Ok(count) => count,
-            Err(error) if is_missing_statistics_table(&error) => return Ok(None),
+            Err(error) if is_missing_optional_table(&error) => return Ok(None),
             Err(error) => return Err(error.into()),
         };
         let prune_safe = generation_count == 1;
@@ -338,15 +338,26 @@ impl MetadataProvider for DuckdbMetadataProvider {
                 .query_map(params![table_id, snapshot_id, snapshot_id], |row| {
                     Ok((
                         row.get::<_, i64>(0)?,
-                        i32::try_from(row.get::<_, i64>(1)?).unwrap_or(0),
+                        row.get::<_, i64>(1)?,
                         row.get::<_, i64>(2)?,
                         row.get::<_, String>(3)?,
                     ))
                 })?
                 .collect::<Result<Vec<_>, _>>()?,
-            Err(error) if is_missing_statistics_table(&error) => return Ok(None),
+            Err(error) if is_missing_optional_table(&error) => return Ok(None),
             Err(error) => return Err(error.into()),
         };
+        let rows = rows
+            .into_iter()
+            .map(|(partition_id, key_index, column_id, transform)| {
+                Ok((
+                    partition_id,
+                    decode_key_index(key_index, "partition")?,
+                    column_id,
+                    transform,
+                ))
+            })
+            .collect::<crate::Result<Vec<_>>>()?;
         Ok(PartitionSpec::from_rows(rows, prune_safe))
     }
 
@@ -357,7 +368,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
                 .query_map(params![table_id, snapshot_id, snapshot_id], |row| {
                     Ok((
                         row.get::<_, i64>(0)?,
-                        i32::try_from(row.get::<_, i64>(1)?).unwrap_or(0),
+                        row.get::<_, i64>(1)?,
                         row.get::<_, String>(2)?,
                         row.get::<_, String>(3)?,
                         row.get::<_, String>(4)?,
@@ -365,9 +376,24 @@ impl MetadataProvider for DuckdbMetadataProvider {
                     ))
                 })?
                 .collect::<Result<Vec<_>, _>>()?,
-            Err(error) if is_missing_statistics_table(&error) => return Ok(None),
+            Err(error) if is_missing_optional_table(&error) => return Ok(None),
             Err(error) => return Err(error.into()),
         };
+        let rows = rows
+            .into_iter()
+            .map(
+                |(sort_id, key_index, expression, dialect, direction, null_order)| {
+                    Ok((
+                        sort_id,
+                        decode_key_index(key_index, "sort")?,
+                        expression,
+                        dialect,
+                        direction,
+                        null_order,
+                    ))
+                },
+            )
+            .collect::<crate::Result<Vec<_>>>()?;
         Ok(SortSpec::from_rows(rows))
     }
 
@@ -389,7 +415,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
                     })
                     .transpose()?
             },
-            Err(error) if is_missing_statistics_table(&error) => None,
+            Err(error) if is_missing_optional_table(&error) => None,
             Err(error) => return Err(error.into()),
         };
         let column_sizes: HashMap<i64, i64> = match conn.prepare(
@@ -424,7 +450,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
                     Err(error) => Some(Err(error)),
                 })
                 .collect::<Result<_, _>>()?,
-            Err(error) if is_missing_statistics_table(&error) => HashMap::new(),
+            Err(error) if is_missing_optional_table(&error) => HashMap::new(),
             Err(error) => return Err(error.into()),
         };
         let bounds_are_exact: bool = conn.query_row(
@@ -452,7 +478,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
                     })
                 })?
                 .collect::<Result<Vec<_>, _>>()?,
-            Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+            Err(error) if is_missing_optional_table(&error) => Vec::new(),
             Err(error) => return Err(error.into()),
         };
         Ok(DuckLakeStatistics {
@@ -576,7 +602,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
                     },
                 )?
                 .collect::<Result<Vec<_>, _>>()?,
-            Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+            Err(error) if is_missing_optional_table(&error) => Vec::new(),
             Err(error) => return Err(error.into()),
         };
         let mut statistics_by_file: HashMap<i64, Vec<_>> = HashMap::new();
@@ -598,20 +624,21 @@ impl MetadataProvider for DuckdbMetadataProvider {
                     |row| {
                         Ok((
                             row.get::<_, i64>(0)?,
-                            i32::try_from(row.get::<_, i64>(1)?).unwrap_or(0),
+                            row.get::<_, i64>(1)?,
                             row.get::<_, Option<String>>(2)?,
                         ))
                     },
                 )?;
                 for row in rows {
                     let (data_file_id, key_index, value) = row?;
+                    let key_index = decode_key_index(key_index, "partition")?;
                     values_by_file
                         .entry(data_file_id)
                         .or_default()
                         .push((key_index, value));
                 }
             },
-            Err(error) if is_missing_statistics_table(&error) => {},
+            Err(error) if is_missing_optional_table(&error) => {},
             Err(error) => return Err(error.into()),
         }
 
@@ -650,7 +677,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
                     })
                     .transpose()?
             },
-            Err(error) if is_missing_statistics_table(&error) => None,
+            Err(error) if is_missing_optional_table(&error) => None,
             Err(error) => return Err(error.into()),
         };
 
@@ -668,7 +695,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
                     })
                 })?
                 .collect::<Result<Vec<_>, _>>()?,
-            Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+            Err(error) if is_missing_optional_table(&error) => Vec::new(),
             Err(error) => return Err(error.into()),
         };
 
@@ -687,7 +714,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
                     })
                 })?
                 .collect::<Result<Vec<_>, _>>()?,
-            Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+            Err(error) if is_missing_optional_table(&error) => Vec::new(),
             Err(error) => return Err(error.into()),
         };
 

--- a/src/metadata_provider_mysql.rs
+++ b/src/metadata_provider_mysql.rs
@@ -6,7 +6,7 @@ use crate::metadata_provider::{
     DuckLakeFileData, DuckLakeFileMetadata, DuckLakeStatistics, DuckLakeTableColumn,
     DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable,
     MetadataProvider, SQL_GET_FILE_PARTITION_VALUES, SQL_GET_PARTITION_SPEC, SQL_GET_SORT_SPEC,
-    SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, block_on,
+    SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, block_on, decode_key_index,
     reconstruct_list_columns, reconstruct_list_columns_with_table,
 };
 use crate::partition::PartitionSpec;
@@ -17,7 +17,7 @@ use sqlx::types::chrono::NaiveDateTime;
 use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
 
-fn is_missing_statistics_table(error: &sqlx::Error) -> bool {
+fn is_missing_optional_table(error: &sqlx::Error) -> bool {
     let message = error.to_string().to_ascii_lowercase();
     message.contains("doesn't exist")
         || message.contains("does not exist")
@@ -366,7 +366,7 @@ impl MetadataProvider for MySqlMetadataProvider {
             .await
             {
                 Ok(count) => count,
-                Err(error) if is_missing_statistics_table(&error) => return Ok(None),
+                Err(error) if is_missing_optional_table(&error) => return Ok(None),
                 Err(error) => return Err(error.into()),
             };
             let prune_safe = generation_count == 1;
@@ -378,7 +378,7 @@ impl MetadataProvider for MySqlMetadataProvider {
                 .await
             {
                 Ok(rows) => rows,
-                Err(error) if is_missing_statistics_table(&error) => return Ok(None),
+                Err(error) if is_missing_optional_table(&error) => return Ok(None),
                 Err(error) => return Err(error.into()),
             };
             let parsed = rows
@@ -386,7 +386,7 @@ impl MetadataProvider for MySqlMetadataProvider {
                 .map(|row| {
                     Ok::<_, crate::DuckLakeError>((
                         row.try_get::<i64, _>(0)?,
-                        i32::try_from(row.try_get::<i64, _>(1)?).unwrap_or(0),
+                        decode_key_index(row.try_get(1)?, "partition")?,
                         row.try_get::<i64, _>(2)?,
                         row.try_get::<String, _>(3)?,
                     ))
@@ -406,7 +406,7 @@ impl MetadataProvider for MySqlMetadataProvider {
                 .await
             {
                 Ok(rows) => rows,
-                Err(error) if is_missing_statistics_table(&error) => return Ok(None),
+                Err(error) if is_missing_optional_table(&error) => return Ok(None),
                 Err(error) => return Err(error.into()),
             };
             let parsed = rows
@@ -414,7 +414,7 @@ impl MetadataProvider for MySqlMetadataProvider {
                 .map(|row| {
                     Ok::<_, crate::DuckLakeError>((
                         row.try_get::<i64, _>(0)?,
-                        i32::try_from(row.try_get::<i64, _>(1)?).unwrap_or(0),
+                        decode_key_index(row.try_get(1)?, "sort")?,
                         row.try_get::<String, _>(2)?,
                         row.try_get::<String, _>(3)?,
                         row.try_get::<String, _>(4)?,
@@ -515,7 +515,7 @@ impl MetadataProvider for MySqlMetadataProvider {
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,
-                Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+                Err(error) if is_missing_optional_table(&error) => Vec::new(),
                 Err(error) => return Err(error.into()),
             };
             let mut statistics_by_file: HashMap<i64, Vec<_>> = HashMap::new();
@@ -539,7 +539,7 @@ impl MetadataProvider for MySqlMetadataProvider {
                 Ok(rows) => {
                     for row in rows {
                         let data_file_id: i64 = row.try_get(0)?;
-                        let key_index: i32 = i32::try_from(row.try_get::<i64, _>(1)?).unwrap_or(0);
+                        let key_index = decode_key_index(row.try_get(1)?, "partition")?;
                         let value: Option<String> = row.try_get(2)?;
                         values_by_file
                             .entry(data_file_id)
@@ -547,7 +547,7 @@ impl MetadataProvider for MySqlMetadataProvider {
                             .push((key_index, value));
                     }
                 },
-                Err(error) if is_missing_statistics_table(&error) => {},
+                Err(error) if is_missing_optional_table(&error) => {},
                 Err(error) => return Err(error.into()),
             }
 
@@ -590,7 +590,7 @@ impl MetadataProvider for MySqlMetadataProvider {
                         })
                     })
                     .transpose()?,
-                Err(error) if is_missing_statistics_table(&error) => None,
+                Err(error) if is_missing_optional_table(&error) => None,
                 Err(error) => return Err(error.into()),
             };
             let column_sizes = match sqlx::query(
@@ -631,7 +631,7 @@ impl MetadataProvider for MySqlMetadataProvider {
                         Err(error) => Some(Err(error)),
                     })
                     .collect::<std::result::Result<HashMap<i64, i64>, _>>()?,
-                Err(error) if is_missing_statistics_table(&error) => HashMap::new(),
+                Err(error) if is_missing_optional_table(&error) => HashMap::new(),
                 Err(error) => return Err(error.into()),
             };
             let bounds_are_exact: bool = sqlx::query_scalar(
@@ -670,7 +670,7 @@ impl MetadataProvider for MySqlMetadataProvider {
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,
-                Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+                Err(error) if is_missing_optional_table(&error) => Vec::new(),
                 Err(error) => return Err(error.into()),
             };
             Ok(DuckLakeStatistics {
@@ -699,7 +699,7 @@ impl MetadataProvider for MySqlMetadataProvider {
                         })
                     })
                     .transpose()?,
-                Err(error) if is_missing_statistics_table(&error) => None,
+                Err(error) if is_missing_optional_table(&error) => None,
                 Err(error) => return Err(error.into()),
             };
 
@@ -725,7 +725,7 @@ impl MetadataProvider for MySqlMetadataProvider {
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,
-                Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+                Err(error) if is_missing_optional_table(&error) => Vec::new(),
                 Err(error) => return Err(error.into()),
             };
 
@@ -768,7 +768,7 @@ impl MetadataProvider for MySqlMetadataProvider {
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,
-                Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+                Err(error) if is_missing_optional_table(&error) => Vec::new(),
                 Err(error) => return Err(error.into()),
             };
 

--- a/src/metadata_provider_postgres.rs
+++ b/src/metadata_provider_postgres.rs
@@ -6,7 +6,7 @@ use crate::metadata_provider::{
     DuckLakeFileData, DuckLakeFileMetadata, DuckLakeStatistics, DuckLakeTableColumn,
     DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable,
     MetadataProvider, SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, block_on,
-    reconstruct_list_columns, reconstruct_list_columns_with_table,
+    decode_key_index, reconstruct_list_columns, reconstruct_list_columns_with_table,
 };
 use crate::partition::PartitionSpec;
 use crate::sort::SortSpec;
@@ -16,9 +16,54 @@ use sqlx::types::chrono::NaiveDateTime;
 use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
 
-fn is_missing_statistics_table(error: &sqlx::Error) -> bool {
+fn is_missing_optional_table(error: &sqlx::Error) -> bool {
     let message = error.to_string().to_ascii_lowercase();
     message.contains("does not exist") || message.contains("undefined table")
+}
+
+pub(crate) async fn load_file_partition_values(
+    pool: &PgPool,
+    table_id: i64,
+    snapshot_id: i64,
+    data_file_ids: &[i64],
+) -> Result<HashMap<i64, Vec<(i32, Option<String>)>>> {
+    if data_file_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let rows = match sqlx::query(
+        "SELECT value.data_file_id, value.partition_key_index, value.partition_value
+         FROM ducklake_file_partition_value AS value
+         INNER JOIN ducklake_data_file AS data
+           ON data.data_file_id = value.data_file_id
+          AND data.table_id = value.table_id
+         WHERE data.table_id = $1
+           AND $2 >= data.begin_snapshot
+           AND ($3 < data.end_snapshot OR data.end_snapshot IS NULL)
+           AND value.data_file_id = ANY($4)
+         ORDER BY value.data_file_id, value.partition_key_index",
+    )
+    .bind(table_id)
+    .bind(snapshot_id)
+    .bind(snapshot_id)
+    .bind(data_file_ids)
+    .fetch_all(pool)
+    .await
+    {
+        Ok(rows) => rows,
+        Err(error) if is_missing_optional_table(&error) => return Ok(HashMap::new()),
+        Err(error) => return Err(error.into()),
+    };
+    let mut values = HashMap::new();
+    for row in rows {
+        let data_file_id: i64 = row.try_get(0)?;
+        let key_index = decode_key_index(row.try_get(1)?, "partition")?;
+        let value: Option<String> = row.try_get(2)?;
+        values
+            .entry(data_file_id)
+            .or_insert_with(Vec::new)
+            .push((key_index, value));
+    }
+    Ok(values)
 }
 
 fn decode_table_file(row: &PgRow, snapshot_id: i64) -> Result<DuckLakeTableFile> {
@@ -104,6 +149,8 @@ macro_rules! bind_repeat {
 struct SchemaCapabilities {
     /// `ducklake_data_file.partial_max` exists.
     data_file_partial_max: bool,
+    /// `ducklake_data_file.partition_id` exists.
+    data_file_partition_id: bool,
     /// `ducklake_delete_file.partial_max` exists.
     delete_file_partial_max: bool,
     /// The `ducklake_schema_versions` table exists.
@@ -112,7 +159,10 @@ struct SchemaCapabilities {
 
 impl SchemaCapabilities {
     fn all(&self) -> bool {
-        self.data_file_partial_max && self.delete_file_partial_max && self.schema_versions
+        self.data_file_partial_max
+            && self.data_file_partition_id
+            && self.delete_file_partial_max
+            && self.schema_versions
     }
 }
 
@@ -169,10 +219,12 @@ impl PostgresMetadataProvider {
         if let Some(caps) = self.schema_capabilities.get() {
             return Ok(*caps);
         }
-        let row: (bool, bool, bool) = sqlx::query_as(
+        let row: (bool, bool, bool, bool) = sqlx::query_as(
             "SELECT
                EXISTS (SELECT 1 FROM information_schema.columns
                        WHERE table_name = 'ducklake_data_file' AND column_name = 'partial_max'),
+               EXISTS (SELECT 1 FROM information_schema.columns
+                       WHERE table_name = 'ducklake_data_file' AND column_name = 'partition_id'),
                EXISTS (SELECT 1 FROM information_schema.columns
                        WHERE table_name = 'ducklake_delete_file' AND column_name = 'partial_max'),
                to_regclass('ducklake_schema_versions') IS NOT NULL",
@@ -181,8 +233,9 @@ impl PostgresMetadataProvider {
         .await?;
         let caps = SchemaCapabilities {
             data_file_partial_max: row.0,
-            delete_file_partial_max: row.1,
-            schema_versions: row.2,
+            data_file_partition_id: row.1,
+            delete_file_partial_max: row.2,
+            schema_versions: row.3,
         };
         if caps.all() {
             let _ = self.schema_capabilities.set(caps);
@@ -354,6 +407,11 @@ impl MetadataProvider for PostgresMetadataProvider {
             } else {
                 "NULL::bigint"
             };
+            let partition_id_expr = if caps.data_file_partition_id {
+                "data.partition_id::bigint"
+            } else {
+                "NULL::bigint"
+            };
             let schema_version_expr = if caps.schema_versions {
                 "(SELECT sv.schema_version::bigint
                   FROM ducklake_schema_versions sv
@@ -383,7 +441,8 @@ impl MetadataProvider for PostgresMetadataProvider {
                     del.delete_count,
                     data.begin_snapshot::bigint AS data_begin_snapshot,
                     {partial_max_expr} AS data_partial_max,
-                    {schema_version_expr} AS data_schema_version
+                    {schema_version_expr} AS data_schema_version,
+                    {partition_id_expr} AS data_partition_id
                 FROM ducklake_data_file AS data
                 LEFT JOIN ducklake_delete_file AS del
                     ON data.data_file_id = del.data_file_id
@@ -405,7 +464,11 @@ impl MetadataProvider for PostgresMetadataProvider {
                 .await?;
 
             rows.iter()
-                .map(|row| decode_table_file(row, snapshot_id))
+                .map(|row| {
+                    let mut file = decode_table_file(row, snapshot_id)?;
+                    file.partition_id = row.try_get(18)?;
+                    Ok(file)
+                })
                 .collect()
         })
     }
@@ -423,7 +486,7 @@ impl MetadataProvider for PostgresMetadataProvider {
             .await
             {
                 Ok(count) => count,
-                Err(error) if is_missing_statistics_table(&error) => return Ok(None),
+                Err(error) if is_missing_optional_table(&error) => return Ok(None),
                 Err(error) => return Err(error.into()),
             };
             let prune_safe = generation_count == 1;
@@ -444,7 +507,7 @@ impl MetadataProvider for PostgresMetadataProvider {
             .await
             {
                 Ok(rows) => rows,
-                Err(error) if is_missing_statistics_table(&error) => return Ok(None),
+                Err(error) if is_missing_optional_table(&error) => return Ok(None),
                 Err(error) => return Err(error.into()),
             };
             let parsed = rows
@@ -452,7 +515,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                 .map(|row| {
                     Ok::<_, crate::DuckLakeError>((
                         row.try_get::<i64, _>(0)?,
-                        i32::try_from(row.try_get::<i64, _>(1)?).unwrap_or(0),
+                        decode_key_index(row.try_get(1)?, "partition")?,
                         row.try_get::<i64, _>(2)?,
                         row.try_get::<String, _>(3)?,
                     ))
@@ -482,7 +545,7 @@ impl MetadataProvider for PostgresMetadataProvider {
             .await
             {
                 Ok(rows) => rows,
-                Err(error) if is_missing_statistics_table(&error) => return Ok(None),
+                Err(error) if is_missing_optional_table(&error) => return Ok(None),
                 Err(error) => return Err(error.into()),
             };
             let parsed = rows
@@ -490,7 +553,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                 .map(|row| {
                     Ok::<_, crate::DuckLakeError>((
                         row.try_get::<i64, _>(0)?,
-                        i32::try_from(row.try_get::<i64, _>(1)?).unwrap_or(0),
+                        decode_key_index(row.try_get(1)?, "sort")?,
                         row.try_get::<String, _>(2)?,
                         row.try_get::<String, _>(3)?,
                         row.try_get::<String, _>(4)?,
@@ -500,6 +563,20 @@ impl MetadataProvider for PostgresMetadataProvider {
                 .collect::<Result<Vec<_>>>()?;
             Ok(SortSpec::from_rows(parsed))
         })
+    }
+
+    fn get_file_partition_values(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+        data_file_ids: &[i64],
+    ) -> Result<HashMap<i64, Vec<(i32, Option<String>)>>> {
+        block_on(load_file_partition_values(
+            &self.pool,
+            table_id,
+            snapshot_id,
+            data_file_ids,
+        ))
     }
 
     fn get_table_file_metadata_page(
@@ -522,6 +599,11 @@ impl MetadataProvider for PostgresMetadataProvider {
             } else {
                 "NULL::bigint"
             };
+            let partition_id_expr = if caps.data_file_partition_id {
+                "data.partition_id::bigint"
+            } else {
+                "NULL::bigint"
+            };
             let schema_version_expr = if caps.schema_versions {
                 "(SELECT sv.schema_version::bigint
                   FROM ducklake_schema_versions sv
@@ -538,7 +620,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                         del.delete_file_id, del.path, del.path_is_relative,
                         del.file_size_bytes, del.footer_size, del.encryption_key,
                         del.delete_count, data.begin_snapshot::bigint,
-                        {partial_max_expr}, {schema_version_expr}
+                        {partial_max_expr}, {schema_version_expr}, {partition_id_expr}
                  FROM ducklake_data_file AS data
                  LEFT JOIN ducklake_delete_file AS del
                    ON data.data_file_id = del.data_file_id
@@ -565,7 +647,11 @@ impl MetadataProvider for PostgresMetadataProvider {
                 .await?;
             let files = rows
                 .iter()
-                .map(|row| decode_table_file(row, snapshot_id))
+                .map(|row| {
+                    let mut file = decode_table_file(row, snapshot_id)?;
+                    file.partition_id = row.try_get(18)?;
+                    Ok(file)
+                })
                 .collect::<Result<Vec<_>>>()?;
             let Some(last_data_file_id) = files.last().map(|file| file.data_file_id) else {
                 return Ok(Vec::new());
@@ -608,7 +694,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,
-                Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+                Err(error) if is_missing_optional_table(&error) => Vec::new(),
                 Err(error) => return Err(error.into()),
             };
             let mut statistics_by_file: HashMap<i64, Vec<_>> = HashMap::new();
@@ -619,34 +705,12 @@ impl MetadataProvider for PostgresMetadataProvider {
                     .push(statistic);
             }
 
-            // Enrich with per-file partition values (for pruning), scoped to the
-            // page's data_file_id range. Missing partition table => no enrichment.
-            let mut values_by_file: HashMap<i64, Vec<(i32, Option<String>)>> = HashMap::new();
-            match sqlx::query(
-                "SELECT data_file_id, partition_key_index, partition_value
-                 FROM ducklake_file_partition_value
-                 WHERE table_id = $1 AND data_file_id > $2 AND data_file_id <= $3",
-            )
-            .bind(table_id)
-            .bind(after_data_file_id.unwrap_or(i64::MIN))
-            .bind(last_data_file_id)
-            .fetch_all(&self.pool)
-            .await
-            {
-                Ok(rows) => {
-                    for row in rows {
-                        let data_file_id: i64 = row.try_get(0)?;
-                        let key_index: i32 = i32::try_from(row.try_get::<i64, _>(1)?).unwrap_or(0);
-                        let value: Option<String> = row.try_get(2)?;
-                        values_by_file
-                            .entry(data_file_id)
-                            .or_default()
-                            .push((key_index, value));
-                    }
-                },
-                Err(error) if is_missing_statistics_table(&error) => {},
-                Err(error) => return Err(error.into()),
-            }
+            let ids = files
+                .iter()
+                .map(|file| file.data_file_id)
+                .collect::<Vec<_>>();
+            let mut values_by_file =
+                load_file_partition_values(&self.pool, table_id, snapshot_id, &ids).await?;
 
             Ok(files
                 .into_iter()
@@ -687,7 +751,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                         })
                     })
                     .transpose()?,
-                Err(error) if is_missing_statistics_table(&error) => None,
+                Err(error) if is_missing_optional_table(&error) => None,
                 Err(error) => return Err(error.into()),
             };
             let column_sizes = match sqlx::query(
@@ -728,7 +792,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                         Err(error) => Some(Err(error)),
                     })
                     .collect::<std::result::Result<HashMap<i64, i64>, _>>()?,
-                Err(error) if is_missing_statistics_table(&error) => HashMap::new(),
+                Err(error) if is_missing_optional_table(&error) => HashMap::new(),
                 Err(error) => return Err(error.into()),
             };
             let bounds_are_exact: bool = sqlx::query_scalar(
@@ -767,7 +831,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,
-                Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+                Err(error) if is_missing_optional_table(&error) => Vec::new(),
                 Err(error) => return Err(error.into()),
             };
             Ok(DuckLakeStatistics {
@@ -796,7 +860,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                         })
                     })
                     .transpose()?,
-                Err(error) if is_missing_statistics_table(&error) => None,
+                Err(error) if is_missing_optional_table(&error) => None,
                 Err(error) => return Err(error.into()),
             };
 
@@ -822,7 +886,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,
-                Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+                Err(error) if is_missing_optional_table(&error) => Vec::new(),
                 Err(error) => return Err(error.into()),
             };
 
@@ -865,7 +929,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,
-                Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+                Err(error) if is_missing_optional_table(&error) => Vec::new(),
                 Err(error) => return Err(error.into()),
             };
 

--- a/src/metadata_provider_sqlite.rs
+++ b/src/metadata_provider_sqlite.rs
@@ -6,7 +6,7 @@ use crate::metadata_provider::{
     DuckLakeFileData, DuckLakeFileMetadata, DuckLakeStatistics, DuckLakeTableColumn,
     DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable,
     MetadataProvider, SQL_GET_FILE_PARTITION_VALUES, SQL_GET_PARTITION_SPEC, SQL_GET_SORT_SPEC,
-    SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, block_on,
+    SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, block_on, decode_key_index,
     reconstruct_list_columns, reconstruct_list_columns_with_table,
 };
 use crate::partition::PartitionSpec;
@@ -158,7 +158,7 @@ fn build_inlined_batch(
     Ok(RecordBatch::try_new(schema.clone(), arrays)?)
 }
 
-fn is_missing_statistics_table(error: &sqlx::Error) -> bool {
+fn is_missing_optional_table(error: &sqlx::Error) -> bool {
     let message = error.to_string().to_ascii_lowercase();
     message.contains("no such table") || message.contains("does not exist")
 }
@@ -510,7 +510,7 @@ impl MetadataProvider for SqliteMetadataProvider {
             .await
             {
                 Ok(count) => count,
-                Err(error) if is_missing_statistics_table(&error) => return Ok(None),
+                Err(error) if is_missing_optional_table(&error) => return Ok(None),
                 Err(error) => return Err(error.into()),
             };
             let prune_safe = generation_count == 1;
@@ -522,7 +522,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                 .await
             {
                 Ok(rows) => rows,
-                Err(error) if is_missing_statistics_table(&error) => return Ok(None),
+                Err(error) if is_missing_optional_table(&error) => return Ok(None),
                 Err(error) => return Err(error.into()),
             };
             let parsed = rows
@@ -530,7 +530,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                 .map(|row| {
                     Ok::<_, crate::DuckLakeError>((
                         row.try_get::<i64, _>(0)?,
-                        i32::try_from(row.try_get::<i64, _>(1)?).unwrap_or(0),
+                        decode_key_index(row.try_get(1)?, "partition")?,
                         row.try_get::<i64, _>(2)?,
                         row.try_get::<String, _>(3)?,
                     ))
@@ -550,7 +550,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                 .await
             {
                 Ok(rows) => rows,
-                Err(error) if is_missing_statistics_table(&error) => return Ok(None),
+                Err(error) if is_missing_optional_table(&error) => return Ok(None),
                 Err(error) => return Err(error.into()),
             };
             let parsed = rows
@@ -558,7 +558,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                 .map(|row| {
                     Ok::<_, crate::DuckLakeError>((
                         row.try_get::<i64, _>(0)?,
-                        i32::try_from(row.try_get::<i64, _>(1)?).unwrap_or(0),
+                        decode_key_index(row.try_get(1)?, "sort")?,
                         row.try_get::<String, _>(2)?,
                         row.try_get::<String, _>(3)?,
                         row.try_get::<String, _>(4)?,
@@ -690,7 +690,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,
-                Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+                Err(error) if is_missing_optional_table(&error) => Vec::new(),
                 Err(error) => return Err(error.into()),
             };
             let mut statistics_by_file: HashMap<i64, Vec<_>> = HashMap::new();
@@ -714,7 +714,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                 Ok(rows) => {
                     for row in rows {
                         let data_file_id: i64 = row.try_get(0)?;
-                        let key_index: i32 = i32::try_from(row.try_get::<i64, _>(1)?).unwrap_or(0);
+                        let key_index = decode_key_index(row.try_get(1)?, "partition")?;
                         let value: Option<String> = row.try_get(2)?;
                         values_by_file
                             .entry(data_file_id)
@@ -722,7 +722,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                             .push((key_index, value));
                     }
                 },
-                Err(error) if is_missing_statistics_table(&error) => {},
+                Err(error) if is_missing_optional_table(&error) => {},
                 Err(error) => return Err(error.into()),
             }
 
@@ -765,7 +765,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                         })
                     })
                     .transpose()?,
-                Err(error) if is_missing_statistics_table(&error) => None,
+                Err(error) if is_missing_optional_table(&error) => None,
                 Err(error) => return Err(error.into()),
             };
             let column_sizes = match sqlx::query(
@@ -806,7 +806,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                         Err(error) => Some(Err(error)),
                     })
                     .collect::<std::result::Result<HashMap<i64, i64>, _>>()?,
-                Err(error) if is_missing_statistics_table(&error) => HashMap::new(),
+                Err(error) if is_missing_optional_table(&error) => HashMap::new(),
                 Err(error) => return Err(error.into()),
             };
             let bounds_are_exact: bool = sqlx::query_scalar(
@@ -845,7 +845,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,
-                Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+                Err(error) if is_missing_optional_table(&error) => Vec::new(),
                 Err(error) => return Err(error.into()),
             };
             Ok(DuckLakeStatistics {
@@ -874,7 +874,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                         })
                     })
                     .transpose()?,
-                Err(error) if is_missing_statistics_table(&error) => None,
+                Err(error) if is_missing_optional_table(&error) => None,
                 Err(error) => return Err(error.into()),
             };
 
@@ -900,7 +900,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,
-                Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+                Err(error) if is_missing_optional_table(&error) => Vec::new(),
                 Err(error) => return Err(error.into()),
             };
 
@@ -943,7 +943,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,
-                Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+                Err(error) if is_missing_optional_table(&error) => Vec::new(),
                 Err(error) => return Err(error.into()),
             };
 

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -2313,6 +2313,15 @@ impl MetadataWriter for PostgresMetadataWriter {
             )
             .await?;
 
+            let live_partition_id: Option<i64> = sqlx::query_scalar(
+                "SELECT partition_id FROM ducklake_partition_info
+                 WHERE table_id = $1 AND end_snapshot IS NULL",
+            )
+            .bind(table_id)
+            .fetch_optional(&mut *tx)
+            .await?;
+            crate::metadata_writer::enforce_partition_fence(table_id, live_partition_id, file)?;
+
             // Register the new data file (the inserted row versions), exactly as
             // register_data_file: seed stats, draw the row-id range, insert, and
             // accumulate. Deletes are accounted at read time (delete_count), so the
@@ -2351,6 +2360,7 @@ impl MetadataWriter for PostgresMetadataWriter {
             .await?;
             let data_file_id: i64 = inserted.try_get(0)?;
             insert_file_column_stats(&mut tx, table_id, data_file_id, &file.column_stats).await?;
+            insert_partition_metadata(&mut tx, table_id, data_file_id, file).await?;
             recompute_table_column_stats(&mut tx, table_id, columns, column_ids).await?;
 
             sqlx::query(
@@ -2781,6 +2791,7 @@ impl MetadataWriter for PostgresMetadataWriter {
                 let data_file_id: i64 = inserted.try_get(0)?;
                 insert_file_column_stats(&mut tx, table_id, data_file_id, &out.file.column_stats)
                     .await?;
+                insert_partition_metadata(&mut tx, table_id, data_file_id, &out.file).await?;
             }
 
             // Recompute the visible stat totals from the surviving files (see the

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -2267,6 +2267,15 @@ impl MetadataWriter for SqliteMetadataWriter {
                 finalize_snapshot(&mut tx, table_id, columns, column_ids, mode, base_snapshot)
                     .await?;
 
+            let live_partition_id: Option<i64> = sqlx::query_scalar(
+                "SELECT partition_id FROM ducklake_partition_info
+                 WHERE table_id = ? AND end_snapshot IS NULL",
+            )
+            .bind(table_id)
+            .fetch_optional(&mut *tx)
+            .await?;
+            crate::metadata_writer::enforce_partition_fence(table_id, live_partition_id, file)?;
+
             // Register the new data file (inserted row versions), as in
             // register_data_file. Deletes are accounted at read time
             // (delete_count), so record_count stays gross — no adjustment for them.

--- a/src/multicatalog_provider.rs
+++ b/src/multicatalog_provider.rs
@@ -17,8 +17,9 @@ use crate::metadata_provider::{
     DuckLakeFileData, DuckLakeFileMetadata, DuckLakeStatistics, DuckLakeTableColumn,
     DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable,
     MetadataProvider, SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, block_on,
-    reconstruct_list_columns, reconstruct_list_columns_with_table,
+    decode_key_index, reconstruct_list_columns, reconstruct_list_columns_with_table,
 };
+use crate::metadata_provider_postgres::load_file_partition_values;
 use crate::partition::PartitionSpec;
 use sqlx::Row;
 use sqlx::postgres::{PgPool, PgPoolOptions, PgRow};
@@ -26,7 +27,7 @@ use sqlx::types::chrono::NaiveDateTime;
 use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
 
-fn is_missing_statistics_table(error: &sqlx::Error) -> bool {
+fn is_missing_optional_table(error: &sqlx::Error) -> bool {
     let message = error.to_string().to_ascii_lowercase();
     message.contains("does not exist") || message.contains("undefined table")
 }
@@ -81,6 +82,8 @@ const DEFAULT_MAX_CONNECTIONS: u32 = 5;
 struct SchemaCapabilities {
     /// `ducklake_data_file.partial_max` exists.
     data_file_partial_max: bool,
+    /// `ducklake_data_file.partition_id` exists.
+    data_file_partition_id: bool,
     /// `ducklake_delete_file.partial_max` exists.
     delete_file_partial_max: bool,
     /// The `ducklake_schema_versions` table exists.
@@ -89,7 +92,10 @@ struct SchemaCapabilities {
 
 impl SchemaCapabilities {
     fn all(&self) -> bool {
-        self.data_file_partial_max && self.delete_file_partial_max && self.schema_versions
+        self.data_file_partial_max
+            && self.data_file_partition_id
+            && self.delete_file_partial_max
+            && self.schema_versions
     }
 }
 
@@ -169,10 +175,12 @@ impl MulticatalogProvider {
         if let Some(caps) = self.schema_capabilities.get() {
             return Ok(*caps);
         }
-        let row: (bool, bool, bool) = sqlx::query_as(
+        let row: (bool, bool, bool, bool) = sqlx::query_as(
             "SELECT
                EXISTS (SELECT 1 FROM information_schema.columns
                        WHERE table_name = 'ducklake_data_file' AND column_name = 'partial_max'),
+               EXISTS (SELECT 1 FROM information_schema.columns
+                       WHERE table_name = 'ducklake_data_file' AND column_name = 'partition_id'),
                EXISTS (SELECT 1 FROM information_schema.columns
                        WHERE table_name = 'ducklake_delete_file' AND column_name = 'partial_max'),
                to_regclass('ducklake_schema_versions') IS NOT NULL",
@@ -181,8 +189,9 @@ impl MulticatalogProvider {
         .await?;
         let caps = SchemaCapabilities {
             data_file_partial_max: row.0,
-            delete_file_partial_max: row.1,
-            schema_versions: row.2,
+            data_file_partition_id: row.1,
+            delete_file_partial_max: row.2,
+            schema_versions: row.3,
         };
         if caps.all() {
             let _ = self.schema_capabilities.set(caps);
@@ -377,6 +386,11 @@ impl MetadataProvider for MulticatalogProvider {
             } else {
                 "NULL::bigint"
             };
+            let partition_id_expr = if caps.data_file_partition_id {
+                "data.partition_id::bigint"
+            } else {
+                "NULL::bigint"
+            };
             let schema_version_expr = if caps.schema_versions {
                 "(SELECT sv.schema_version::bigint
                   FROM ducklake_schema_versions sv
@@ -406,7 +420,8 @@ impl MetadataProvider for MulticatalogProvider {
                     del.delete_count,
                     data.begin_snapshot::bigint AS data_begin_snapshot,
                     {partial_max_expr} AS data_partial_max,
-                    {schema_version_expr} AS data_schema_version
+                    {schema_version_expr} AS data_schema_version,
+                    {partition_id_expr} AS data_partition_id
                 FROM ducklake_data_file AS data
                 LEFT JOIN ducklake_delete_file AS del
                     ON data.data_file_id = del.data_file_id
@@ -428,7 +443,11 @@ impl MetadataProvider for MulticatalogProvider {
                 .await?;
 
             rows.iter()
-                .map(|row| decode_table_file(row, snapshot_id))
+                .map(|row| {
+                    let mut file = decode_table_file(row, snapshot_id)?;
+                    file.partition_id = row.try_get(18)?;
+                    Ok(file)
+                })
                 .collect()
         })
     }
@@ -444,7 +463,7 @@ impl MetadataProvider for MulticatalogProvider {
             .await
             {
                 Ok(count) => count,
-                Err(error) if is_missing_statistics_table(&error) => return Ok(None),
+                Err(error) if is_missing_optional_table(&error) => return Ok(None),
                 Err(error) => return Err(error.into()),
             };
             let prune_safe = generation_count == 1;
@@ -465,7 +484,7 @@ impl MetadataProvider for MulticatalogProvider {
             .await
             {
                 Ok(rows) => rows,
-                Err(error) if is_missing_statistics_table(&error) => return Ok(None),
+                Err(error) if is_missing_optional_table(&error) => return Ok(None),
                 Err(error) => return Err(error.into()),
             };
             let parsed = rows
@@ -473,7 +492,7 @@ impl MetadataProvider for MulticatalogProvider {
                 .map(|row| {
                     Ok::<_, crate::DuckLakeError>((
                         row.try_get::<i64, _>(0)?,
-                        i32::try_from(row.try_get::<i64, _>(1)?).unwrap_or(0),
+                        decode_key_index(row.try_get(1)?, "partition")?,
                         row.try_get::<i64, _>(2)?,
                         row.try_get::<String, _>(3)?,
                     ))
@@ -483,6 +502,19 @@ impl MetadataProvider for MulticatalogProvider {
         })
     }
 
+    fn get_file_partition_values(
+        &self,
+        table_id: i64,
+        snapshot_id: i64,
+        data_file_ids: &[i64],
+    ) -> Result<HashMap<i64, Vec<(i32, Option<String>)>>> {
+        block_on(load_file_partition_values(
+            &self.pool,
+            table_id,
+            snapshot_id,
+            data_file_ids,
+        ))
+    }
     fn get_table_file_metadata_page(
         &self,
         table_id: i64,
@@ -503,6 +535,11 @@ impl MetadataProvider for MulticatalogProvider {
             } else {
                 "NULL::bigint"
             };
+            let partition_id_expr = if caps.data_file_partition_id {
+                "data.partition_id::bigint"
+            } else {
+                "NULL::bigint"
+            };
             let schema_version_expr = if caps.schema_versions {
                 "(SELECT sv.schema_version::bigint
                   FROM ducklake_schema_versions sv
@@ -519,7 +556,7 @@ impl MetadataProvider for MulticatalogProvider {
                         del.delete_file_id, del.path, del.path_is_relative,
                         del.file_size_bytes, del.footer_size, del.encryption_key,
                         del.delete_count, data.begin_snapshot::bigint,
-                        {partial_max_expr}, {schema_version_expr}
+                        {partial_max_expr}, {schema_version_expr}, {partition_id_expr}
                  FROM ducklake_data_file AS data
                  LEFT JOIN ducklake_delete_file AS del
                    ON data.data_file_id = del.data_file_id
@@ -546,7 +583,11 @@ impl MetadataProvider for MulticatalogProvider {
                 .await?;
             let files = rows
                 .iter()
-                .map(|row| decode_table_file(row, snapshot_id))
+                .map(|row| {
+                    let mut file = decode_table_file(row, snapshot_id)?;
+                    file.partition_id = row.try_get(18)?;
+                    Ok(file)
+                })
                 .collect::<Result<Vec<_>>>()?;
             let Some(last_data_file_id) = files.last().map(|file| file.data_file_id) else {
                 return Ok(Vec::new());
@@ -589,7 +630,7 @@ impl MetadataProvider for MulticatalogProvider {
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,
-                Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+                Err(error) if is_missing_optional_table(&error) => Vec::new(),
                 Err(error) => return Err(error.into()),
             };
             let mut statistics_by_file: HashMap<i64, Vec<_>> = HashMap::new();
@@ -600,35 +641,12 @@ impl MetadataProvider for MulticatalogProvider {
                     .push(statistic);
             }
 
-            // Enrich with per-file partition values (for pruning), scoped to the
-            // page's data_file_id range. Keyed by globally-unique ids; no catalog
-            // scoping. Missing partition table => no enrichment.
-            let mut values_by_file: HashMap<i64, Vec<(i32, Option<String>)>> = HashMap::new();
-            match sqlx::query(
-                "SELECT data_file_id, partition_key_index, partition_value
-                 FROM ducklake_file_partition_value
-                 WHERE table_id = $1 AND data_file_id > $2 AND data_file_id <= $3",
-            )
-            .bind(table_id)
-            .bind(after_data_file_id.unwrap_or(i64::MIN))
-            .bind(last_data_file_id)
-            .fetch_all(&self.pool)
-            .await
-            {
-                Ok(rows) => {
-                    for row in rows {
-                        let data_file_id: i64 = row.try_get(0)?;
-                        let key_index: i32 = i32::try_from(row.try_get::<i64, _>(1)?).unwrap_or(0);
-                        let value: Option<String> = row.try_get(2)?;
-                        values_by_file
-                            .entry(data_file_id)
-                            .or_default()
-                            .push((key_index, value));
-                    }
-                },
-                Err(error) if is_missing_statistics_table(&error) => {},
-                Err(error) => return Err(error.into()),
-            }
+            let ids = files
+                .iter()
+                .map(|file| file.data_file_id)
+                .collect::<Vec<_>>();
+            let mut values_by_file =
+                load_file_partition_values(&self.pool, table_id, snapshot_id, &ids).await?;
 
             Ok(files
                 .into_iter()
@@ -669,7 +687,7 @@ impl MetadataProvider for MulticatalogProvider {
                         })
                     })
                     .transpose()?,
-                Err(error) if is_missing_statistics_table(&error) => None,
+                Err(error) if is_missing_optional_table(&error) => None,
                 Err(error) => return Err(error.into()),
             };
             let column_sizes = match sqlx::query(
@@ -710,7 +728,7 @@ impl MetadataProvider for MulticatalogProvider {
                         Err(error) => Some(Err(error)),
                     })
                     .collect::<std::result::Result<HashMap<i64, i64>, _>>()?,
-                Err(error) if is_missing_statistics_table(&error) => HashMap::new(),
+                Err(error) if is_missing_optional_table(&error) => HashMap::new(),
                 Err(error) => return Err(error.into()),
             };
             let bounds_are_exact: bool = sqlx::query_scalar(
@@ -749,7 +767,7 @@ impl MetadataProvider for MulticatalogProvider {
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,
-                Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+                Err(error) if is_missing_optional_table(&error) => Vec::new(),
                 Err(error) => return Err(error.into()),
             };
             Ok(DuckLakeStatistics {
@@ -778,7 +796,7 @@ impl MetadataProvider for MulticatalogProvider {
                         })
                     })
                     .transpose()?,
-                Err(error) if is_missing_statistics_table(&error) => None,
+                Err(error) if is_missing_optional_table(&error) => None,
                 Err(error) => return Err(error.into()),
             };
 
@@ -804,7 +822,7 @@ impl MetadataProvider for MulticatalogProvider {
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,
-                Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+                Err(error) if is_missing_optional_table(&error) => Vec::new(),
                 Err(error) => return Err(error.into()),
             };
 
@@ -847,7 +865,7 @@ impl MetadataProvider for MulticatalogProvider {
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,
-                Err(error) if is_missing_statistics_table(&error) => Vec::new(),
+                Err(error) if is_missing_optional_table(&error) => Vec::new(),
                 Err(error) => return Err(error.into()),
             };
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -810,6 +810,30 @@ impl DuckLakeTable {
         Ok(files)
     }
 
+    pub(crate) fn files_with_partitions(&self) -> Result<Vec<DuckLakeTableFile>> {
+        let mut files = Vec::new();
+        let mut after_data_file_id = None;
+        while let Some(metadata) = self.next_file_metadata_page(&mut after_data_file_id)? {
+            let last_page = metadata.len() < FILE_METADATA_BATCH_SIZE;
+            for metadata in metadata {
+                if metadata.file.partition_id.is_some() && metadata.file.partition_values.is_empty()
+                {
+                    return Err(crate::DuckLakeError::InvalidConfig(format!(
+                        "metadata provider omitted partition values for partitioned data file {}",
+                        metadata.file.data_file_id,
+                    )));
+                }
+                files.push(metadata.file);
+            }
+            if last_page {
+                break;
+            }
+        }
+        #[cfg(feature = "encryption")]
+        self.configure_encryption_factory(&files)?;
+        Ok(files)
+    }
+
     /// Resolve a file path (data or delete file) to its absolute path
     fn resolve_file_path(&self, file: &DuckLakeFileData) -> DataFusionResult<String> {
         resolve_path(&self.table_path, &file.path, file.path_is_relative)
@@ -2231,6 +2255,8 @@ impl DuckLakeTable {
             data_file_id: table_file.data_file_id,
             delete_file_id: table_file.delete_file_id,
             source_path: table_file.file.path.clone(),
+            partition_id: table_file.partition_id,
+            partition_values: table_file.partition_values.clone(),
         })
     }
 
@@ -2413,6 +2439,10 @@ pub(crate) struct UpdateSourceScan {
     pub(crate) delete_file_id: Option<i64>,
     /// The source data file's catalog path (records the delete's provenance).
     pub(crate) source_path: String,
+    /// Partition generation of the source file, when the table is partitioned.
+    pub(crate) partition_id: Option<i64>,
+    /// Partition values of the source file in partition-key order.
+    pub(crate) partition_values: Vec<(i32, Option<String>)>,
 }
 
 /// The rewrite produced for one source data file by
@@ -2498,25 +2528,7 @@ impl TableProvider for DuckLakeTable {
             },
         };
         let mut after_data_file_id = None;
-        loop {
-            let metadata = self.provider.get_table_file_metadata_page(
-                self.table_id,
-                self.snapshot_id,
-                after_data_file_id,
-                FILE_METADATA_BATCH_SIZE,
-            )?;
-            if metadata.is_empty() {
-                break;
-            }
-            if metadata.len() > FILE_METADATA_BATCH_SIZE {
-                return Err(DataFusionError::External(Box::new(
-                    crate::DuckLakeError::InvalidConfig(format!(
-                        "metadata provider returned {} files for a {}-file planning page",
-                        metadata.len(),
-                        FILE_METADATA_BATCH_SIZE
-                    )),
-                )));
-            }
+        while let Some(metadata) = self.next_file_metadata_page(&mut after_data_file_id)? {
             // A short page proves the file list is exhausted (pages are keyed
             // and ordered by data_file_id under a LIMIT), so stop after
             // processing it rather than paying one more metadata round trip
@@ -2524,15 +2536,6 @@ impl TableProvider for DuckLakeTable {
             // the batch size — the common case — this halves the planning
             // metadata queries.
             let last_page = metadata.len() < FILE_METADATA_BATCH_SIZE;
-            let next_after = metadata.last().unwrap().file.data_file_id;
-            if after_data_file_id.is_some_and(|after| next_after <= after) {
-                return Err(DataFusionError::External(Box::new(
-                    crate::DuckLakeError::InvalidConfig(
-                        "metadata provider returned a non-advancing file page".to_string(),
-                    ),
-                )));
-            }
-            after_data_file_id = Some(next_after);
 
             let mut catalog_file_statistics = Vec::new();
             let mut table_files = Vec::with_capacity(metadata.len());
@@ -2834,6 +2837,40 @@ impl TableProvider for DuckLakeTable {
             ));
         }
 
+        let head_snapshot = self
+            .provider
+            .get_current_snapshot()
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        let live_partition_spec = self
+            .provider
+            .get_partition_spec(self.table_id, head_snapshot)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        if let Some(spec) = live_partition_spec {
+            let mut partition_columns = HashSet::with_capacity(spec.columns.len());
+            for partition_column in spec.columns {
+                let column = self
+                    .columns
+                    .iter()
+                    .find(|column| column.column_id == partition_column.column_id)
+                    .ok_or_else(|| {
+                        DataFusionError::Internal(format!(
+                            "partition column_id {} not found in table schema",
+                            partition_column.column_id
+                        ))
+                    })?;
+                partition_columns.insert(column.column_name.as_str());
+            }
+            if let Some((column_name, _)) = assignments
+                .iter()
+                .find(|(column_name, _)| partition_columns.contains(column_name.as_str()))
+            {
+                return Err(DataFusionError::NotImplemented(format!(
+                    "UPDATE of partition column '{column_name}' is not supported; \
+                     rewrite the table under a new partition spec instead"
+                )));
+            }
+        }
+
         // Assignment / filter expressions reference the table's DATA columns
         // (unqualified), never the synthetic `rowid`. Plan them against the
         // physical schema so column indices line up with the scanned batches.
@@ -2869,7 +2906,7 @@ impl TableProvider for DuckLakeTable {
         // collects each scan and performs the rewrite + atomic commit at execute
         // time.
         let table_files = self
-            .files()
+            .files_with_partitions()
             .map_err(|error| DataFusionError::External(Box::new(error)))?;
         let mut scans = Vec::with_capacity(table_files.len());
         for tf in &table_files {
@@ -2967,6 +3004,45 @@ impl TableProvider for DuckLakeTable {
             self.snapshot_id,
             self.object_store_url.clone(),
         )))
+    }
+}
+
+impl DuckLakeTable {
+    fn next_file_metadata_page(
+        &self,
+        after_data_file_id: &mut Option<i64>,
+    ) -> Result<Option<Vec<DuckLakeFileMetadata>>> {
+        let metadata = self.provider.get_table_file_metadata_page(
+            self.table_id,
+            self.snapshot_id,
+            *after_data_file_id,
+            FILE_METADATA_BATCH_SIZE,
+        )?;
+        if metadata.is_empty() {
+            return Ok(None);
+        }
+        if metadata.len() > FILE_METADATA_BATCH_SIZE {
+            return Err(crate::DuckLakeError::InvalidConfig(format!(
+                "metadata provider returned {} files for a {}-file page",
+                metadata.len(),
+                FILE_METADATA_BATCH_SIZE
+            )));
+        }
+        let next_after = metadata
+            .last()
+            .map(|entry| entry.file.data_file_id)
+            .ok_or_else(|| {
+                crate::DuckLakeError::Internal(
+                    "non-empty metadata page had no final file".to_string(),
+                )
+            })?;
+        if after_data_file_id.is_some_and(|after| next_after <= after) {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "metadata provider returned a non-advancing file page".to_string(),
+            ));
+        }
+        *after_data_file_id = Some(next_after);
+        Ok(Some(metadata))
     }
 }
 

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -352,6 +352,7 @@ impl DuckLakeTableWriter {
             temp: Some(temp),
             catalog_path,
             path_is_relative,
+            partition: None,
             mode,
             row_count: 0,
             nan_flags: Vec::new(),
@@ -970,6 +971,8 @@ pub struct TableWriteSession {
     catalog_path: String,
     /// Whether the catalog_path is relative to table path
     path_is_relative: bool,
+    /// Optional partition generation and per-key values registered with the file.
+    partition: Option<(i64, Vec<(i32, Option<String>)>)>,
     /// Replace vs Append; passed to `register_data_file` so the head advance and
     /// (for Replace) prior-generation retirement commit atomically with the file.
     mode: WriteMode,
@@ -981,6 +984,19 @@ pub struct TableWriteSession {
 }
 
 impl TableWriteSession {
+    /// Attaches partition values to the data file committed by this session.
+    ///
+    /// This supports combined append and positional-delete commits where the
+    /// appended file belongs to an existing partitioned table.
+    #[must_use]
+    pub fn with_partition_values(
+        mut self,
+        partition_id: i64,
+        values: Vec<(i32, Option<String>)>,
+    ) -> Self {
+        self.partition = Some((partition_id, values));
+        self
+    }
     pub fn write_batch(&mut self, batch: &RecordBatch) -> Result<()> {
         if self.writer.is_none() {
             return Err(crate::error::DuckLakeError::Internal(
@@ -1157,6 +1173,9 @@ impl TableWriteSession {
             .with_column_stats(column_stats);
         if !self.path_is_relative {
             file_info = file_info.with_absolute_path();
+        }
+        if let Some((partition_id, values)) = &self.partition {
+            file_info = file_info.with_partition(*partition_id, values.clone());
         }
         Ok(file_info)
     }

--- a/src/update_exec.rs
+++ b/src/update_exec.rs
@@ -20,6 +20,8 @@
 //!
 //! Limitations (shared with [`DuckLakeInsertExec`](crate::insert_exec)):
 //! collects matched rows into memory before writing; single partition only.
+//! Assignments to an active partition column are rejected during planning, before
+//! any object or metadata write, because rewritten rows would require repartitioning.
 //!
 //! # Session lifecycle (important)
 //!
@@ -223,6 +225,7 @@ impl ExecutionPlan for DuckLakeUpdateExec {
             let mut updated_batches: Vec<RecordBatch> = Vec::new();
             let mut delete_entries: Vec<DeleteFileEntry> = Vec::new();
             let mut total_updated: u64 = 0;
+            let mut output_partition: Option<(Option<i64>, Vec<(i32, Option<String>)>)> = None;
 
             for scan in &scans {
                 let batches =
@@ -236,6 +239,17 @@ impl ExecutionPlan for DuckLakeUpdateExec {
                 )?;
                 if out.matched_count == 0 {
                     continue;
+                }
+                let partition = (scan.partition_id, scan.partition_values.clone());
+                if let Some(existing) = &output_partition {
+                    if existing != &partition {
+                        return Err(DataFusionError::NotImplemented(
+                            "UPDATE cannot atomically write rows from more than one partition"
+                                .to_string(),
+                        ));
+                    }
+                } else {
+                    output_partition = Some(partition);
                 }
                 total_updated += out.matched_count as u64;
                 updated_batches.extend(out.updated_batches);
@@ -273,6 +287,19 @@ impl ExecutionPlan for DuckLakeUpdateExec {
                     WriteMode::Append,
                 )
                 .map_err(|e| DataFusionError::External(Box::new(e)))?;
+            if let Some((partition_id, partition_values)) = output_partition {
+                match partition_id {
+                    Some(partition_id) => {
+                        session = session.with_partition_values(partition_id, partition_values);
+                    },
+                    None if !partition_values.is_empty() => {
+                        return Err(DataFusionError::Internal(
+                            "unpartitioned UPDATE source has partition values".to_string(),
+                        ));
+                    },
+                    None => {},
+                }
+            }
             for batch in &updated_batches {
                 session
                     .write_batch(batch)

--- a/tests/compaction_postgres_tests.rs
+++ b/tests/compaction_postgres_tests.rs
@@ -17,9 +17,9 @@ use arrow::array::{Array, Int32Array, RecordBatch};
 use arrow::datatypes::{DataType, Field, Schema};
 use datafusion::prelude::*;
 use datafusion_ducklake::{
-    CompactionResult, DuckLakeCatalog, DuckLakeTable, DuckLakeTableWriter, MergeOptions,
+    ColumnDef, CompactionResult, DuckLakeCatalog, DuckLakeTable, DuckLakeTableWriter, MergeOptions,
     MetadataProvider, MetadataWriter, MulticatalogManager, MulticatalogProvider,
-    PostgresMetadataWriter, RewriteOptions,
+    PartitionTransform, PostgresMetadataWriter, RewriteOptions, WriteMode,
 };
 use object_store::local::LocalFileSystem;
 use sqlx::Row;
@@ -320,5 +320,106 @@ async fn rewrite_data_files_postgres() {
     assert_eq!(
         read_rows(&pool, cat_name, None).await,
         vec![(9, 90), (10, 100)]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn compaction_preserves_postgres_partition_values() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let tmp = TempDir::new().unwrap();
+    let data = tmp.path().join("data");
+    std::fs::create_dir_all(&data).unwrap();
+    let cat_name = "cat";
+    let cat = MulticatalogManager::new(pool.clone())
+        .create_catalog(cat_name)
+        .await
+        .unwrap();
+    let writer = writer_for(&pool, cat, &data).await;
+    let columns = schema()
+        .fields()
+        .iter()
+        .map(|field| ColumnDef::from_arrow(field.name(), field.data_type(), field.is_nullable()))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    let setup = writer
+        .begin_write_transaction("public", "t", &columns, WriteMode::Replace)
+        .unwrap();
+    writer
+        .publish_snapshot(
+            setup.table_id,
+            "public",
+            "t",
+            setup.snapshot_id,
+            WriteMode::Replace,
+            setup.base_snapshot_id,
+            &columns,
+            &setup.column_ids,
+        )
+        .unwrap();
+    writer
+        .set_partition_spec(
+            setup.table_id,
+            &[("id".to_string(), PartitionTransform::Identity)],
+        )
+        .unwrap();
+    let partition_id = scalar_i64(
+        &pool,
+        "SELECT partition_id FROM ducklake_partition_info
+         WHERE table_id = $1 AND end_snapshot IS NULL",
+        setup.table_id,
+    )
+    .await;
+
+    for (id, values) in [(1, vec![10, 20]), (1, vec![30, 40]), (2, vec![50])] {
+        let rows = vec![id; values.len()];
+        let mut session =
+            DuckLakeTableWriter::new(writer.clone(), Arc::new(LocalFileSystem::new()))
+                .unwrap()
+                .begin_write("public", "t", schema().as_ref(), WriteMode::Append)
+                .unwrap()
+                .with_partition_values(partition_id, vec![(0, Some(id.to_string()))]);
+        session.write_batch(&batch(rows, values)).unwrap();
+        session.finish().await.unwrap();
+    }
+
+    let result = with_writable_table(&pool, cat, cat_name, &data, |table, state| async move {
+        table
+            .merge_adjacent_files(&state, MergeOptions::default())
+            .await
+    })
+    .await;
+    assert_eq!(
+        result,
+        CompactionResult {
+            files_processed: 2,
+            files_created: 1,
+            rows_written: 4,
+        }
+    );
+
+    let provider = MulticatalogProvider::with_pool(pool.clone(), cat_name)
+        .await
+        .unwrap();
+    let snapshot = provider.get_current_snapshot().unwrap();
+    let page = provider
+        .get_table_file_metadata_page(setup.table_id, snapshot, None, 10)
+        .unwrap();
+    let mut partitions = page
+        .iter()
+        .map(|metadata| {
+            (
+                metadata.file.partition_id,
+                metadata.file.partition_values.clone(),
+            )
+        })
+        .collect::<Vec<_>>();
+    partitions.sort();
+    assert_eq!(
+        partitions,
+        vec![
+            (Some(partition_id), vec![(0, Some("1".to_string()))]),
+            (Some(partition_id), vec![(0, Some("2".to_string()))]),
+        ],
     );
 }

--- a/tests/compaction_sqlite_tests.rs
+++ b/tests/compaction_sqlite_tests.rs
@@ -21,9 +21,11 @@ use sqlx::sqlite::SqlitePool;
 use tempfile::TempDir;
 
 use datafusion_ducklake::maintenance::{CleanupCriteria, cleanup_old_files_sqlite};
+use datafusion_ducklake::partition::PartitionTransform;
 use datafusion_ducklake::{
-    CompactionResult, DuckLakeCatalog, DuckLakeTable, DuckLakeTableWriter, MergeOptions,
-    MetadataWriter, RewriteOptions, SqliteMetadataProvider, SqliteMetadataWriter,
+    ColumnDef, CompactionResult, DuckLakeCatalog, DuckLakeTable, DuckLakeTableWriter, MergeOptions,
+    MetadataProvider, MetadataWriter, RewriteOptions, SqliteMetadataProvider, SqliteMetadataWriter,
+    WriteMode,
 };
 
 fn two_col_schema() -> Arc<Schema> {
@@ -85,6 +87,63 @@ async fn append(temp: &TempDir, ids: Vec<i32>, vals: Vec<i32>) {
         .append_table("main", "t", &[b])
         .await
         .unwrap();
+}
+
+async fn setup_partitioned(temp: &TempDir) -> (Arc<SqliteMetadataWriter>, i64, i64) {
+    let writer = Arc::new(make_writer(temp).await);
+    let columns = two_col_schema()
+        .fields()
+        .iter()
+        .map(|field| ColumnDef::from_arrow(field.name(), field.data_type(), field.is_nullable()))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    let setup = writer
+        .begin_write_transaction("main", "t", &columns, WriteMode::Replace)
+        .unwrap();
+    writer
+        .publish_snapshot(
+            setup.table_id,
+            "main",
+            "t",
+            setup.snapshot_id,
+            WriteMode::Replace,
+            setup.base_snapshot_id,
+            &columns,
+            &setup.column_ids,
+        )
+        .unwrap();
+    writer
+        .set_partition_spec(
+            setup.table_id,
+            &[("id".to_string(), PartitionTransform::Identity)],
+        )
+        .unwrap();
+    let partition_id = scalar_i64(
+        &pool(temp).await,
+        "SELECT partition_id FROM ducklake_partition_info WHERE end_snapshot IS NULL",
+    )
+    .await;
+    (writer, setup.table_id, partition_id)
+}
+
+async fn append_partition(
+    writer: Arc<SqliteMetadataWriter>,
+    partition_id: i64,
+    id: i32,
+    vals: Vec<i32>,
+) {
+    let ids = vec![id; vals.len()];
+    let batch = batch(
+        two_col_schema(),
+        vec![Arc::new(Int32Array::from(ids)), Arc::new(Int32Array::from(vals))],
+    );
+    let mut session = DuckLakeTableWriter::new(writer, object_store())
+        .unwrap()
+        .begin_write("main", "t", two_col_schema().as_ref(), WriteMode::Append)
+        .unwrap()
+        .with_partition_values(partition_id, vec![(0, Some(id.to_string()))]);
+    session.write_batch(&batch).unwrap();
+    session.finish().await.unwrap();
 }
 
 async fn pool(temp: &TempDir) -> SqlitePool {
@@ -211,6 +270,90 @@ async fn run_rewrite(temp: &TempDir, opts: RewriteOptions) -> CompactionResult {
         table.rewrite_data_files(&state, opts).await.unwrap()
     })
     .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn compaction_preserves_partition_boundaries_and_values() {
+    let temp = TempDir::new().unwrap();
+    let (writer, table_id, partition_id) = setup_partitioned(&temp).await;
+    append_partition(Arc::clone(&writer), partition_id, 1, vec![10, 20]).await;
+    append_partition(Arc::clone(&writer), partition_id, 1, vec![30, 40]).await;
+    append_partition(Arc::clone(&writer), partition_id, 2, vec![50]).await;
+
+    assert_eq!(
+        run_merge(&temp, MergeOptions::default()).await,
+        CompactionResult {
+            files_processed: 2,
+            files_created: 1,
+            rows_written: 4,
+        }
+    );
+
+    let provider = SqliteMetadataProvider::new(&ro_url(&temp)).await.unwrap();
+    let snapshot = provider.get_current_snapshot().unwrap();
+    let page = provider
+        .get_table_file_metadata_page(table_id, snapshot, None, 10)
+        .unwrap();
+    let mut partitions = page
+        .iter()
+        .map(|metadata| {
+            (
+                metadata.file.partition_id,
+                metadata.file.partition_values.clone(),
+            )
+        })
+        .collect::<Vec<_>>();
+    partitions.sort();
+    assert_eq!(
+        partitions,
+        vec![
+            (Some(partition_id), vec![(0, Some("1".to_string()))]),
+            (Some(partition_id), vec![(0, Some("2".to_string()))]),
+        ]
+    );
+
+    let temp = TempDir::new().unwrap();
+    let (writer, table_id, partition_id) = setup_partitioned(&temp).await;
+    append_partition(writer, partition_id, 3, vec![60, 70, 80]).await;
+    let writer = SqliteMetadataWriter::new(&db_url(&temp)).await.unwrap();
+    let provider = SqliteMetadataProvider::new(&db_url(&temp)).await.unwrap();
+    let catalog = DuckLakeCatalog::with_writer(Arc::new(provider), Arc::new(writer)).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog("ducklake", Arc::new(catalog));
+    ctx.sql("DELETE FROM ducklake.main.t WHERE id = 3 AND val <= 70")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        run_rewrite(
+            &temp,
+            RewriteOptions {
+                delete_threshold: 0.0,
+            },
+        )
+        .await,
+        CompactionResult {
+            files_processed: 1,
+            files_created: 1,
+            rows_written: 1,
+        }
+    );
+    assert_eq!(read_rows(&temp).await, vec![(3, 80)]);
+
+    let provider = SqliteMetadataProvider::new(&ro_url(&temp)).await.unwrap();
+    let snapshot = provider.get_current_snapshot().unwrap();
+    let page = provider
+        .get_table_file_metadata_page(table_id, snapshot, None, 10)
+        .unwrap();
+    assert_eq!(page.len(), 1);
+    assert_eq!(page[0].file.partition_id, Some(partition_id));
+    assert_eq!(
+        page[0].file.partition_values,
+        vec![(0, Some("3".to_string()))],
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/sql_update_postgres_tests.rs
+++ b/tests/sql_update_postgres_tests.rs
@@ -16,8 +16,9 @@ use arrow::array::{Array, Int32Array, Int64Array, RecordBatch, UInt64Array};
 use arrow::datatypes::{DataType, Field, Schema};
 use datafusion::prelude::*;
 use datafusion_ducklake::{
-    DuckLakeCatalog, DuckLakeTableWriter, MetadataWriter, MulticatalogManager,
-    MulticatalogProvider, PostgresMetadataWriter,
+    ColumnDef, DuckLakeCatalog, DuckLakeTableWriter, MetadataProvider, MetadataWriter,
+    MulticatalogManager, MulticatalogProvider, PartitionTransform, PostgresMetadataWriter,
+    WriteMode,
 };
 use object_store::local::LocalFileSystem;
 use sqlx::postgres::{PgPool, PgPoolOptions};
@@ -171,4 +172,108 @@ async fn update_where_end_to_end_postgres() {
         vec![(0, 1, 10), (1, 2, 200), (2, 3, 30), (3, 4, 400)],
         "values updated in place; rowids 1 and 3 preserved across the rewrite"
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn update_preserves_postgres_partition_values() {
+    let (pool, _container) = spin_up_postgres().await.unwrap();
+    let temp = TempDir::new().unwrap();
+    let data = temp.path().join("data");
+    std::fs::create_dir_all(&data).unwrap();
+    let catalog_name = "cat";
+    let catalog_id = MulticatalogManager::new(pool.clone())
+        .create_catalog(catalog_name)
+        .await
+        .unwrap();
+    let writer = writer_for(&pool, catalog_id, &data).await;
+    let metadata: Arc<dyn MetadataWriter> = writer.clone();
+    let columns = schema()
+        .fields()
+        .iter()
+        .map(|field| ColumnDef::from_arrow(field.name(), field.data_type(), field.is_nullable()))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    let setup = writer
+        .begin_write_transaction("public", "t", &columns, WriteMode::Replace)
+        .unwrap();
+    writer
+        .publish_snapshot(
+            setup.table_id,
+            "public",
+            "t",
+            setup.snapshot_id,
+            WriteMode::Replace,
+            setup.base_snapshot_id,
+            &columns,
+            &setup.column_ids,
+        )
+        .unwrap();
+    writer
+        .set_partition_spec(
+            setup.table_id,
+            &[("id".to_string(), PartitionTransform::Identity)],
+        )
+        .unwrap();
+    let provider = MulticatalogProvider::with_pool(pool.clone(), catalog_name)
+        .await
+        .unwrap();
+    let snapshot = provider.get_current_snapshot().unwrap();
+    let partition_id = provider
+        .get_partition_spec(setup.table_id, snapshot)
+        .unwrap()
+        .unwrap()
+        .partition_id;
+    let batch = RecordBatch::try_new(
+        schema(),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 1, 1])),
+            Arc::new(Int32Array::from(vec![30, 10, 20])),
+        ],
+    )
+    .unwrap();
+    let mut session = DuckLakeTableWriter::new(metadata, Arc::new(LocalFileSystem::new()))
+        .unwrap()
+        .begin_write("public", "t", schema().as_ref(), WriteMode::Append)
+        .unwrap()
+        .with_partition_values(partition_id, vec![(0, Some("1".to_string()))]);
+    session.write_batch(&batch).unwrap();
+    session.finish().await.unwrap();
+
+    let ctx = writable_ctx(&pool, catalog_name, catalog_id, &data).await;
+    let batches = ctx
+        .sql(&format!(
+            "UPDATE {catalog_name}.public.t SET val = val + 1 WHERE id = 1"
+        ))
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let count = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .unwrap()
+        .value(0);
+    let provider = MulticatalogProvider::with_pool(pool.clone(), catalog_name)
+        .await
+        .unwrap();
+    let snapshot = provider.get_current_snapshot().unwrap();
+    let mut files = provider
+        .get_table_file_metadata_page(setup.table_id, snapshot, None, 16)
+        .unwrap();
+    files.sort_by_key(|metadata| metadata.file.data_file_id);
+    let output = files.last().unwrap();
+    let mut rows = read_rowid_rows(&pool, catalog_name).await;
+    rows.sort();
+
+    assert_eq!(count, 3);
+    assert_eq!(files.len(), 2);
+    assert_eq!(output.file.partition_id, Some(partition_id));
+    assert_eq!(
+        output.file.partition_values,
+        vec![(0, Some("1".to_string()))],
+    );
+    assert_eq!(rows, vec![(0, 1, 31), (1, 1, 11), (2, 1, 21)]);
 }

--- a/tests/sql_update_tests.rs
+++ b/tests/sql_update_tests.rs
@@ -18,9 +18,10 @@ use object_store::local::LocalFileSystem;
 use sqlx::sqlite::SqlitePool;
 use tempfile::TempDir;
 
+use datafusion_ducklake::partition::PartitionTransform;
 use datafusion_ducklake::{
-    DuckLakeCatalog, DuckLakeTableWriter, MetadataProvider, MetadataWriter, SqliteMetadataProvider,
-    SqliteMetadataWriter, register_ducklake_functions,
+    ColumnDef, DuckLakeCatalog, DuckLakeTableWriter, MetadataProvider, MetadataWriter,
+    SqliteMetadataProvider, SqliteMetadataWriter, WriteMode, register_ducklake_functions,
 };
 
 /// The `(id, val)` schema used throughout.
@@ -209,6 +210,134 @@ async fn live_data_file_count(temp_dir: &TempDir) -> i64 {
 }
 
 // ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_preserves_single_partition() {
+    let temp_dir = TempDir::new().unwrap();
+    let writer = Arc::new(make_writer(&temp_dir).await);
+    let columns = table_schema()
+        .fields()
+        .iter()
+        .map(|field| ColumnDef::from_arrow(field.name(), field.data_type(), field.is_nullable()))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    let setup = writer
+        .begin_write_transaction("main", "t", &columns, WriteMode::Replace)
+        .unwrap();
+    writer
+        .publish_snapshot(
+            setup.table_id,
+            "main",
+            "t",
+            setup.snapshot_id,
+            WriteMode::Replace,
+            setup.base_snapshot_id,
+            &columns,
+            &setup.column_ids,
+        )
+        .unwrap();
+    writer
+        .set_partition_spec(
+            setup.table_id,
+            &[("id".to_string(), PartitionTransform::Identity)],
+        )
+        .unwrap();
+    let provider = SqliteMetadataProvider::new(&format!(
+        "sqlite:{}",
+        temp_dir.path().join("test.db").display()
+    ))
+    .await
+    .unwrap();
+    let snapshot = provider.get_current_snapshot().unwrap();
+    let partition_id = provider
+        .get_partition_spec(setup.table_id, snapshot)
+        .unwrap()
+        .unwrap()
+        .partition_id;
+    let batch = RecordBatch::try_new(
+        table_schema(),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 1, 1])),
+            Arc::new(Int32Array::from(vec![30, 10, 20])),
+        ],
+    )
+    .unwrap();
+    let mut session = DuckLakeTableWriter::new(writer.clone(), object_store())
+        .unwrap()
+        .begin_write("main", "t", table_schema().as_ref(), WriteMode::Append)
+        .unwrap()
+        .with_partition_values(partition_id, vec![(0, Some("1".to_string()))]);
+    session.write_batch(&batch).unwrap();
+    session.finish().await.unwrap();
+
+    let ctx = writable_ctx(&temp_dir).await;
+    let snapshot_before = provider.get_current_snapshot().unwrap();
+    let err = ctx
+        .sql("UPDATE ducklake.main.t SET id = 2 WHERE id = 1")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "UPDATE operation on table 'ducklake.main.t'\ncaused by\n\
+         This feature is not implemented: UPDATE of partition column 'id' is not supported; \
+         rewrite the table under a new partition spec instead",
+    );
+    let provider_after_rejection = SqliteMetadataProvider::new(&format!(
+        "sqlite:{}",
+        temp_dir.path().join("test.db").display()
+    ))
+    .await
+    .unwrap();
+    assert_eq!(
+        provider_after_rejection.get_current_snapshot().unwrap(),
+        snapshot_before,
+    );
+    assert_eq!(
+        provider_after_rejection
+            .get_table_file_metadata_page(setup.table_id, snapshot_before, None, 16)
+            .unwrap()
+            .len(),
+        1,
+    );
+    let mut pairs_after_rejection = read_pairs(&temp_dir).await;
+    pairs_after_rejection.sort();
+    assert_eq!(pairs_after_rejection, vec![(1, 10), (1, 20), (1, 30)]);
+
+    assert_eq!(
+        run_dml_count(
+            &ctx,
+            "UPDATE ducklake.main.t SET val = val + 1 WHERE id = 1"
+        )
+        .await,
+        3,
+    );
+
+    let provider = SqliteMetadataProvider::new(&format!(
+        "sqlite:{}",
+        temp_dir.path().join("test.db").display()
+    ))
+    .await
+    .unwrap();
+    let snapshot = provider.get_current_snapshot().unwrap();
+    let mut files = provider
+        .get_table_file_metadata_page(setup.table_id, snapshot, None, 16)
+        .unwrap();
+    files.sort_by_key(|metadata| metadata.file.data_file_id);
+    let output = files.last().unwrap();
+    let mut pairs = read_pairs(&temp_dir).await;
+    pairs.sort();
+
+    assert_eq!(files.len(), 2);
+    assert_eq!(output.file.partition_id, Some(partition_id));
+    assert_eq!(
+        output.file.partition_values,
+        vec![(0, Some("1".to_string()))],
+    );
+    assert_eq!(pairs, vec![(1, 11), (1, 21), (1, 31)]);
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn update_sets_value_where_id() {


### PR DESCRIPTION
### Summary

Keep partition generations and values intact when merge compaction, delete-driven rewrites, or SQL
`UPDATE` replace data files. Compaction groups only compatible files, recovers missing values
through the metadata provider, and writes the source partition metadata onto each output file.

DuckLake stores a file's partition generation on `ducklake_data_file` and the values shared by all
rows in `ducklake_file_partition_value`. Older files retain the partition keys active when they
were written. See
[partitioned data files](https://ducklake.select/docs/stable/specification/tables/ducklake_data_file),
[file partition values](https://ducklake.select/docs/stable/specification/tables/ducklake_file_partition_value),
and [partition evolution](https://ducklake.select/docs/stable/duckdb/advanced_features/partitioning).

```mermaid
flowchart TD
    Files["Candidate files"] --> Hydrate["Load partition IDs and values"]
    Hydrate --> Group["Group by schema version, partition ID, and values"]
    Group --> Merge["Merge, rewrite, or update within one group"]
    Merge --> Output["Register output with the same partition metadata"]
    Output --> Snapshot["Commit replacement snapshot"]
```

### Changes

- Carry `partition_id` and ordered partition values with paged file metadata.
- Add a bounded `get_file_partition_values` provider hook for readers whose file query does not
  include the values.
- Hydrate missing values before compaction and fail explicitly when a provider reports a
  partitioned file but cannot supply them.
- Group merge candidates by schema version, partition generation, and exact values.
- Preserve partition metadata on both merge and rewrite output files.
- Preserve partition metadata on SQL `UPDATE` output for non-partition columns.
- Reject assignment to an active partition column before scans, file writes, or snapshot metadata
  changes. A partition-key change requires a deliberate table rewrite under a new partition spec.
- Add PostgreSQL single-catalog and multicatalog reads for partition IDs and values.
- Persist partition metadata in PostgreSQL compaction commits.
- Add `TableWriteSession::with_partition_values` so streaming partitioned writes can register the
  same standard file metadata.

### Commit and branch

- Independent branch: `ducklake-partition-compaction`.
- Commit: `4c5c940 fix(write): preserve partition metadata in rewrites`.
- Base: upstream `c546400` from PR #206.
- The branch retains upstream's existing compaction sort path and does not depend on the streamed
  compaction PR.
- The complete local integration retains the equivalent stacked commit `55a92a8`.

### Verification

- SQLite compaction and SQL `UPDATE` partition-preservation tests: passed.
- SQLite partition-column rejection test proves the snapshot, live file count, and table values
  remain unchanged while a non-partition update still succeeds.
- PostgreSQL compaction and SQL `UPDATE` partition-preservation tests: passed.
- `CARGO_BUILD_JOBS=4 cargo check --all-features`: passed.
- `git show --check` passes for all five proposed commits.

### PostgreSQL check

The focused PostgreSQL checks ran with:

```bash
CARGO_BUILD_JOBS=4 cargo test --all-features \
  --test compaction_postgres_tests \
  compaction_preserves_postgres_partition_values -- --ignored --exact
CARGO_BUILD_JOBS=4 cargo test --all-features \
  --test sql_update_postgres_tests \
  update_preserves_postgres_partition_values -- --ignored --exact
```

Each test starts an ephemeral `postgres` Docker container through `testcontainers`, initializes a
real multicatalog, performs the rewrite, and reads the live file metadata back through
`MulticatalogProvider`. The assertions cover the exact partition ID, ordered partition values, live
file count, and query results.
