### PR TITLE
Add DuckLake snapshot change metadata

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,8 +134,8 @@ pub use insert_exec::DuckLakeInsertExec;
 #[cfg(feature = "write")]
 pub use metadata_writer::{
     ColumnDef, ColumnStat, CommitIds, CompactionOutputFile, CompactionSourceFile, DataFileInfo,
-    DeleteFileEntry, DeleteFileInfo, MetadataWriter, SourceRetirement, WriteMode, WriteResult,
-    WriteSetupResult,
+    DeleteFileEntry, DeleteFileInfo, MetadataWriter, SnapshotCommitMetadata, SourceRetirement,
+    WriteMode, WriteResult, WriteSetupResult,
 };
 #[cfg(feature = "write-duckdb")]
 pub use metadata_writer_duckdb::DuckdbMetadataWriter;
@@ -152,6 +152,8 @@ pub use multicatalog_provider::MulticatalogProvider;
 #[cfg(feature = "write")]
 pub use sql::execute_ducklake_sql;
 #[cfg(feature = "write")]
-pub use table_writer::{DuckLakeTableWriter, DuckLakeWriteOptions, TableWriteSession};
+pub use table_writer::{
+    DuckLakeTableWriter, DuckLakeWriteOptions, TableWriteOptions, TableWriteSession,
+};
 #[cfg(feature = "write")]
 pub use update_exec::DuckLakeUpdateExec;

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -3,7 +3,9 @@
 //! This module provides the `MetadataWriter` trait for writing metadata to DuckLake catalogs,
 //! along with helper types for column definitions and data file registration.
 
+use crate::types::{arrow_to_ducklake_type, ducklake_to_arrow_type};
 use crate::{DuckLakeError, Result};
+use arrow::datatypes::DataType;
 
 /// Maximum allowed length for catalog entity names (schemas, tables, columns).
 pub const MAX_NAME_LENGTH: usize = 1024;
@@ -43,8 +45,105 @@ pub enum WriteMode {
     /// Keep existing data and append new records
     Append,
 }
-use crate::types::{arrow_to_ducklake_type, ducklake_to_arrow_type};
-use arrow::datatypes::DataType;
+
+pub(crate) fn table_write_changes(
+    table_id: i64,
+    mode: WriteMode,
+    has_deletes: bool,
+    replaced_existing_data: bool,
+) -> String {
+    match (mode, has_deletes, replaced_existing_data) {
+        (WriteMode::Append, false, _) | (WriteMode::Replace, false, false) => {
+            format!("inserted_into_table:{table_id}")
+        },
+        (WriteMode::Append | WriteMode::Replace, true, _) | (WriteMode::Replace, false, true) => {
+            format!("deleted_from_table:{table_id},inserted_into_table:{table_id}")
+        },
+    }
+}
+
+pub(crate) fn quote_snapshot_name(name: &str) -> String {
+    format!("\"{}\"", name.replace('"', "\"\""))
+}
+
+pub(crate) fn quote_snapshot_table(schema_name: &str, table_name: &str) -> String {
+    format!(
+        "{}.{}",
+        quote_snapshot_name(schema_name),
+        quote_snapshot_name(table_name)
+    )
+}
+
+/// Optional values stored in a DuckLake snapshot change row.
+///
+/// The fields map to `author`, `commit_message`, and `commit_extra_info` in
+/// `ducklake_snapshot_changes`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SnapshotCommitMetadata {
+    author: Option<String>,
+    message: Option<String>,
+    extra_info: Option<String>,
+}
+
+impl SnapshotCommitMetadata {
+    /// Creates empty commit metadata.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            author: None,
+            message: None,
+            extra_info: None,
+        }
+    }
+
+    /// Sets the snapshot author.
+    #[must_use]
+    pub fn with_author(mut self, author: impl Into<String>) -> Self {
+        self.author = Some(author.into());
+        self
+    }
+
+    /// Sets the snapshot commit message.
+    #[must_use]
+    pub fn with_message(mut self, message: impl Into<String>) -> Self {
+        self.message = Some(message.into());
+        self
+    }
+
+    /// Sets opaque extra information for the snapshot.
+    #[must_use]
+    pub fn with_extra_info(mut self, extra_info: impl Into<String>) -> Self {
+        self.extra_info = Some(extra_info.into());
+        self
+    }
+
+    /// Returns the snapshot author.
+    #[must_use]
+    pub fn author(&self) -> Option<&str> {
+        self.author.as_deref()
+    }
+
+    /// Returns the snapshot commit message.
+    #[must_use]
+    pub fn message(&self) -> Option<&str> {
+        self.message.as_deref()
+    }
+
+    /// Returns the snapshot extra information.
+    #[must_use]
+    pub fn extra_info(&self) -> Option<&str> {
+        self.extra_info.as_deref()
+    }
+
+    fn ensure_supported_by_default(&self) -> Result<()> {
+        if self.author.is_some() || self.message.is_some() || self.extra_info.is_some() {
+            return Err(DuckLakeError::InvalidConfig(
+                "commit metadata is not supported by this metadata writer".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
 
 /// Column definition for creating or updating a table's schema.
 ///
@@ -889,6 +988,83 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
         }
     }
 
+    /// Registers one data file and attaches commit metadata.
+    ///
+    /// The default implementation accepts empty metadata and otherwise returns
+    /// an error. Metadata backends that support these fields override it.
+    #[allow(clippy::too_many_arguments)]
+    fn register_data_file_with_commit_metadata(
+        &self,
+        table_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        snapshot_id: i64,
+        file: &DataFileInfo,
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+        commit_metadata: &SnapshotCommitMetadata,
+        expected_base_snapshot_id: Option<i64>,
+    ) -> Result<CommitIds> {
+        if expected_base_snapshot_id.is_some() {
+            return Err(DuckLakeError::InvalidConfig(
+                "conditional writes are not supported by this metadata writer".to_string(),
+            ));
+        }
+        commit_metadata.ensure_supported_by_default()?;
+        self.register_data_file(
+            table_id,
+            schema_name,
+            table_name,
+            snapshot_id,
+            file,
+            mode,
+            base_snapshot,
+            columns,
+            column_ids,
+        )
+    }
+
+    /// Registers multiple data files and attaches commit metadata.
+    ///
+    /// The default implementation accepts empty metadata and otherwise returns
+    /// an error. Metadata backends that support these fields override it.
+    #[allow(clippy::too_many_arguments)]
+    fn register_data_files_with_commit_metadata(
+        &self,
+        table_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        snapshot_id: i64,
+        files: &[DataFileInfo],
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+        commit_metadata: &SnapshotCommitMetadata,
+        expected_base_snapshot_id: Option<i64>,
+    ) -> Result<CommitIds> {
+        if expected_base_snapshot_id.is_some() {
+            return Err(DuckLakeError::InvalidConfig(
+                "conditional multi-file writes are not supported by this metadata writer"
+                    .to_string(),
+            ));
+        }
+        commit_metadata.ensure_supported_by_default()?;
+        self.register_data_files(
+            table_id,
+            schema_name,
+            table_name,
+            snapshot_id,
+            files,
+            mode,
+            base_snapshot,
+            columns,
+            column_ids,
+        )
+    }
+
     /// Register a positional delete file for a single data file, superseding any
     /// prior live delete file for it (at most one is live per data file).
     ///
@@ -957,6 +1133,46 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
         Err(DuckLakeError::InvalidConfig(
             "register_data_file_with_deletes is not supported by this metadata writer".to_string(),
         ))
+    }
+
+    /// Registers a data file with positional deletes and commit metadata.
+    ///
+    /// The default implementation accepts empty metadata and otherwise returns
+    /// an error. Metadata backends that support these fields override it.
+    #[allow(clippy::too_many_arguments)]
+    fn register_data_file_with_deletes_and_commit_metadata(
+        &self,
+        table_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        snapshot_id: i64,
+        file: &DataFileInfo,
+        deletes: &[DeleteFileEntry],
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+        commit_metadata: &SnapshotCommitMetadata,
+        expected_base_snapshot_id: Option<i64>,
+    ) -> Result<CommitIds> {
+        if expected_base_snapshot_id.is_some() {
+            return Err(DuckLakeError::InvalidConfig(
+                "conditional combined writes are not supported by this metadata writer".to_string(),
+            ));
+        }
+        commit_metadata.ensure_supported_by_default()?;
+        self.register_data_file_with_deletes(
+            table_id,
+            schema_name,
+            table_name,
+            snapshot_id,
+            file,
+            deletes,
+            mode,
+            base_snapshot,
+            columns,
+            column_ids,
+        )
     }
 
     /// Apply positional deletes to one or more existing data files in a SINGLE

--- a/src/metadata_writer_duckdb.rs
+++ b/src/metadata_writer_duckdb.rs
@@ -39,8 +39,9 @@
 use crate::Result;
 use crate::error::{TypeChangeOperation, TypeChangeWriteMode};
 use crate::metadata_writer::{
-    ColumnDef, ColumnStat, CommitIds, DataFileInfo, MetadataWriter, WriteMode, WriteSetupResult,
-    columns_differ, validate_name,
+    ColumnDef, ColumnStat, CommitIds, DataFileInfo, MetadataWriter, SnapshotCommitMetadata,
+    WriteMode, WriteSetupResult, columns_differ, quote_snapshot_name, quote_snapshot_table,
+    table_write_changes, validate_name,
 };
 use crate::partition::PartitionTransform;
 use duckdb::{Connection, OptionalExt, Transaction, params};
@@ -73,6 +74,14 @@ CREATE TABLE IF NOT EXISTS ducklake_snapshot (
     snapshot_id BIGINT PRIMARY KEY,
     snapshot_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     schema_version BIGINT NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS ducklake_snapshot_changes (
+    snapshot_id BIGINT PRIMARY KEY,
+    changes_made VARCHAR,
+    author VARCHAR,
+    commit_message VARCHAR,
+    commit_extra_info VARCHAR
 );
 
 CREATE TABLE IF NOT EXISTS ducklake_schema_versions (
@@ -321,7 +330,101 @@ fn insert_snapshot(tx: &Transaction<'_>) -> Result<(i64, i64)> {
          VALUES (?, CURRENT_TIMESTAMP, ?)",
         params![snapshot_id, schema_version],
     )?;
+    tx.execute(
+        "INSERT INTO ducklake_snapshot_changes (snapshot_id, changes_made)
+         VALUES (?, NULL)",
+        params![snapshot_id],
+    )?;
     Ok((snapshot_id, schema_version))
+}
+
+fn record_snapshot_changes(
+    tx: &Transaction<'_>,
+    snapshot_id: i64,
+    changes_made: &str,
+    commit_metadata: &SnapshotCommitMetadata,
+) -> Result<()> {
+    let changes_made = (!changes_made.is_empty()).then_some(changes_made);
+    tx.execute(
+        "UPDATE ducklake_snapshot_changes
+         SET changes_made = CASE
+                 WHEN changes_made IS NULL THEN ?
+                 WHEN ? IS NULL THEN changes_made
+                 ELSE changes_made || ',' || ?
+             END,
+             author = ?,
+             commit_message = ?,
+             commit_extra_info = ?
+         WHERE snapshot_id = ?",
+        params![
+            changes_made,
+            changes_made,
+            changes_made,
+            commit_metadata.author(),
+            commit_metadata.message(),
+            commit_metadata.extra_info(),
+            snapshot_id,
+        ],
+    )?;
+    Ok(())
+}
+
+fn record_table_write_changes(
+    tx: &Transaction<'_>,
+    snapshot_id: i64,
+    table_id: i64,
+    schema_name: &str,
+    table_name: &str,
+    mode: WriteMode,
+    commit_metadata: &SnapshotCommitMetadata,
+) -> Result<()> {
+    let (schema_begin_snapshot, table_begin_snapshot): (i64, i64) = tx.query_row(
+        "SELECT s.begin_snapshot, t.begin_snapshot
+         FROM ducklake_table t
+         JOIN ducklake_schema s ON s.schema_id = t.schema_id
+         WHERE t.table_id = ?",
+        params![table_id],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+    let altered: bool = tx.query_row(
+        "SELECT EXISTS(
+            SELECT 1 FROM ducklake_schema_versions
+            WHERE table_id = ? AND begin_snapshot = ?
+         )",
+        params![table_id, snapshot_id],
+        |row| row.get(0),
+    )?;
+    let replaced_existing_data: bool = tx.query_row(
+        "SELECT EXISTS(
+            SELECT 1 FROM ducklake_data_file
+            WHERE table_id = ? AND end_snapshot = ?
+         )",
+        params![table_id, snapshot_id],
+        |row| row.get(0),
+    )?;
+
+    let mut changes = Vec::new();
+    if schema_begin_snapshot == snapshot_id {
+        changes.push(format!(
+            "created_schema:{}",
+            quote_snapshot_name(schema_name)
+        ));
+    }
+    if table_begin_snapshot == snapshot_id {
+        changes.push(format!(
+            "created_table:{}",
+            quote_snapshot_table(schema_name, table_name)
+        ));
+    } else if altered {
+        changes.push(format!("altered_table:{table_id}"));
+    }
+    changes.push(table_write_changes(
+        table_id,
+        mode,
+        false,
+        replaced_existing_data,
+    ));
+    record_snapshot_changes(tx, snapshot_id, &changes.join(","), commit_metadata)
 }
 
 /// Bump the per-catalog monotonic `schema_version` on a DDL snapshot to
@@ -705,6 +808,12 @@ impl MetadataWriter for DuckdbMetadataWriter {
             params![name, schema_path, snapshot_id],
             |row| row.get(0),
         )?;
+        record_snapshot_changes(
+            &tx,
+            snapshot_id,
+            &format!("created_schema:{}", quote_snapshot_name(name)),
+            &SnapshotCommitMetadata::default(),
+        )?;
         tx.commit()?;
         Ok((schema_id, true))
     }
@@ -734,12 +843,24 @@ impl MetadataWriter for DuckdbMetadataWriter {
             return Ok((table_id, false));
         }
 
+        let schema_name: String = tx.query_row(
+            "SELECT schema_name FROM ducklake_schema WHERE schema_id = ?",
+            params![schema_id],
+            |row| row.get(0),
+        )?;
+
         let table_path = path.unwrap_or(name);
         let table_id: i64 = tx.query_row(
             "INSERT INTO ducklake_table (schema_id, table_name, path, path_is_relative, begin_snapshot)
              VALUES (?, ?, ?, true, ?) RETURNING table_id",
             params![schema_id, name, table_path, snapshot_id],
             |row| row.get(0),
+        )?;
+        record_snapshot_changes(
+            &tx,
+            snapshot_id,
+            &format!("created_table:{}", quote_snapshot_table(&schema_name, name)),
+            &SnapshotCommitMetadata::default(),
         )?;
         tx.commit()?;
         Ok((table_id, true))
@@ -789,6 +910,19 @@ impl MetadataWriter for DuckdbMetadataWriter {
             column_ids.push(column_id);
         }
 
+        let table_begin_snapshot: i64 = tx.query_row(
+            "SELECT begin_snapshot FROM ducklake_table WHERE table_id = ?",
+            params![table_id],
+            |row| row.get(0),
+        )?;
+        if table_begin_snapshot != snapshot_id {
+            record_snapshot_changes(
+                &tx,
+                snapshot_id,
+                &format!("altered_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )?;
+        }
         tx.commit()?;
         Ok(column_ids)
     }
@@ -796,17 +930,49 @@ impl MetadataWriter for DuckdbMetadataWriter {
     fn register_data_file(
         &self,
         table_id: i64,
-        // The schema/table were created at begin, so the names are unused here;
-        // accepted only to satisfy the trait shared with multicatalog Postgres.
-        _schema_name: &str,
-        _table_name: &str,
-        _snapshot_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        snapshot_id: i64,
         file: &DataFileInfo,
         mode: WriteMode,
         base_snapshot: i64,
         columns: &[ColumnDef],
         column_ids: &[i64],
     ) -> Result<CommitIds> {
+        self.register_data_file_with_commit_metadata(
+            table_id,
+            schema_name,
+            table_name,
+            snapshot_id,
+            file,
+            mode,
+            base_snapshot,
+            columns,
+            column_ids,
+            &SnapshotCommitMetadata::default(),
+            None,
+        )
+    }
+
+    fn register_data_file_with_commit_metadata(
+        &self,
+        table_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        _snapshot_id: i64,
+        file: &DataFileInfo,
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+        commit_metadata: &SnapshotCommitMetadata,
+        expected_base_snapshot_id: Option<i64>,
+    ) -> Result<CommitIds> {
+        if expected_base_snapshot_id.is_some() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "conditional writes are not supported by the DuckDB metadata writer".to_string(),
+            ));
+        }
         let mut conn = self.connection();
         let tx = conn.transaction()?;
 
@@ -873,6 +1039,15 @@ impl MetadataWriter for DuckdbMetadataWriter {
             params![file.record_count, file.record_count, file.file_size_bytes, table_id],
         )?;
 
+        record_table_write_changes(
+            &tx,
+            snapshot_id,
+            table_id,
+            schema_name,
+            table_name,
+            mode,
+            commit_metadata,
+        )?;
         let schema_id: i64 = tx.query_row(
             "SELECT schema_id FROM ducklake_table WHERE table_id = ?",
             params![table_id],
@@ -891,15 +1066,50 @@ impl MetadataWriter for DuckdbMetadataWriter {
     fn register_data_files(
         &self,
         table_id: i64,
-        _schema_name: &str,
-        _table_name: &str,
-        _snapshot_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        snapshot_id: i64,
         files: &[DataFileInfo],
         mode: WriteMode,
         base_snapshot: i64,
         columns: &[ColumnDef],
         column_ids: &[i64],
     ) -> Result<CommitIds> {
+        self.register_data_files_with_commit_metadata(
+            table_id,
+            schema_name,
+            table_name,
+            snapshot_id,
+            files,
+            mode,
+            base_snapshot,
+            columns,
+            column_ids,
+            &SnapshotCommitMetadata::default(),
+            None,
+        )
+    }
+
+    fn register_data_files_with_commit_metadata(
+        &self,
+        table_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        _snapshot_id: i64,
+        files: &[DataFileInfo],
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+        commit_metadata: &SnapshotCommitMetadata,
+        expected_base_snapshot_id: Option<i64>,
+    ) -> Result<CommitIds> {
+        if expected_base_snapshot_id.is_some() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "conditional multi-file writes are not supported by the DuckDB metadata writer"
+                    .to_string(),
+            ));
+        }
         if files.is_empty() {
             return Err(crate::DuckLakeError::InvalidConfig(
                 "register_data_files: files must be non-empty".to_string(),
@@ -963,6 +1173,15 @@ impl MetadataWriter for DuckdbMetadataWriter {
                  file_size_bytes = file_size_bytes + ?
              WHERE table_id = ?",
             params![total_records, total_records, total_bytes, table_id],
+        )?;
+        record_table_write_changes(
+            &tx,
+            snapshot_id,
+            table_id,
+            schema_name,
+            table_name,
+            mode,
+            commit_metadata,
         )?;
         let schema_id: i64 = tx.query_row(
             "SELECT schema_id FROM ducklake_table WHERE table_id = ?",
@@ -1044,6 +1263,12 @@ impl MetadataWriter for DuckdbMetadataWriter {
 
         let new_schema_version = bump_schema_version(&tx, new_snapshot)?;
         record_schema_version(&tx, new_snapshot, new_schema_version, table_id)?;
+        record_snapshot_changes(
+            &tx,
+            new_snapshot,
+            &format!("altered_table:{table_id}"),
+            &SnapshotCommitMetadata::default(),
+        )?;
         tx.commit()?;
         Ok(new_snapshot)
     }
@@ -1096,6 +1321,12 @@ impl MetadataWriter for DuckdbMetadataWriter {
         }
         let new_schema_version = bump_schema_version(&tx, new_snapshot)?;
         record_schema_version(&tx, new_snapshot, new_schema_version, table_id)?;
+        record_snapshot_changes(
+            &tx,
+            new_snapshot,
+            &format!("altered_table:{table_id}"),
+            &SnapshotCommitMetadata::default(),
+        )?;
         tx.commit()?;
         Ok(new_snapshot)
     }
@@ -1196,6 +1427,12 @@ impl MetadataWriter for DuckdbMetadataWriter {
         }
 
         // A sort-order change does NOT bump schema_version.
+        record_snapshot_changes(
+            &tx,
+            new_snapshot,
+            &format!("altered_table:{table_id}"),
+            &SnapshotCommitMetadata::default(),
+        )?;
         tx.commit()?;
         Ok(new_snapshot)
     }
@@ -1220,6 +1457,12 @@ impl MetadataWriter for DuckdbMetadataWriter {
             return Ok(head);
         }
         // A sort-order change does NOT bump schema_version.
+        record_snapshot_changes(
+            &tx,
+            new_snapshot,
+            &format!("altered_table:{table_id}"),
+            &SnapshotCommitMetadata::default(),
+        )?;
         tx.commit()?;
         Ok(new_snapshot)
     }
@@ -1227,9 +1470,8 @@ impl MetadataWriter for DuckdbMetadataWriter {
     fn publish_snapshot(
         &self,
         table_id: i64,
-        // The schema/table were created at begin; names unused (trait parity).
-        _schema_name: &str,
-        _table_name: &str,
+        schema_name: &str,
+        table_name: &str,
         _snapshot_id: i64,
         mode: WriteMode,
         base_snapshot: i64,
@@ -1245,6 +1487,15 @@ impl MetadataWriter for DuckdbMetadataWriter {
         let tx = conn.transaction()?;
         let snapshot_id =
             finalize_snapshot(&tx, table_id, columns, column_ids, mode, base_snapshot)?;
+        record_table_write_changes(
+            &tx,
+            snapshot_id,
+            table_id,
+            schema_name,
+            table_name,
+            mode,
+            &SnapshotCommitMetadata::default(),
+        )?;
         let schema_id: i64 = tx.query_row(
             "SELECT schema_id FROM ducklake_table WHERE table_id = ?",
             params![table_id],
@@ -1323,6 +1574,9 @@ impl MetadataWriter for DuckdbMetadataWriter {
         // "not partitioned").
         conn.execute_batch(
             "ALTER TABLE ducklake_data_file ADD COLUMN IF NOT EXISTS partition_id BIGINT",
+        )?;
+        conn.execute_batch(
+            "ALTER TABLE ducklake_snapshot_changes ALTER COLUMN changes_made DROP NOT NULL",
         )?;
         // Seed the monotonic column_id allocator (snapshot_id uses MAX+1, and
         // schema/table/data_file/delete_file ids use sequences, so none of those

--- a/src/metadata_writer_mysql.rs
+++ b/src/metadata_writer_mysql.rs
@@ -34,8 +34,9 @@ use crate::Result;
 use crate::error::{TypeChangeOperation, TypeChangeWriteMode};
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
-    ColumnDef, ColumnStat, CommitIds, DataFileInfo, MetadataWriter, WriteMode, WriteSetupResult,
-    columns_differ, validate_name,
+    ColumnDef, ColumnStat, CommitIds, DataFileInfo, MetadataWriter, SnapshotCommitMetadata,
+    WriteMode, WriteSetupResult, columns_differ, quote_snapshot_name, quote_snapshot_table,
+    table_write_changes, validate_name,
 };
 use crate::partition::PartitionTransform;
 use sqlx::Row;
@@ -65,6 +66,13 @@ const SQL_CREATE_TABLES: &[&str] = &[
         snapshot_id BIGINT NOT NULL PRIMARY KEY,
         snapshot_time DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
         schema_version BIGINT NOT NULL DEFAULT 0
+    ) ENGINE = InnoDB"#,
+    r#"CREATE TABLE IF NOT EXISTS ducklake_snapshot_changes (
+        snapshot_id BIGINT NOT NULL PRIMARY KEY,
+        changes_made TEXT,
+        author TEXT,
+        commit_message TEXT,
+        commit_extra_info TEXT
     ) ENGINE = InnoDB"#,
     r#"CREATE TABLE IF NOT EXISTS ducklake_schema_versions (
         begin_snapshot BIGINT NOT NULL,
@@ -408,7 +416,111 @@ async fn insert_snapshot(tx: &mut sqlx::Transaction<'_, sqlx::MySql>) -> Result<
     .bind(schema_version)
     .execute(&mut **tx)
     .await?;
+    sqlx::query(
+        "INSERT INTO ducklake_snapshot_changes (snapshot_id, changes_made)
+         VALUES (?, NULL)",
+    )
+    .bind(snapshot_id)
+    .execute(&mut **tx)
+    .await?;
     Ok((snapshot_id, schema_version))
+}
+
+async fn record_snapshot_changes(
+    tx: &mut sqlx::Transaction<'_, sqlx::MySql>,
+    snapshot_id: i64,
+    changes_made: &str,
+    commit_metadata: &SnapshotCommitMetadata,
+) -> Result<()> {
+    let changes_made = (!changes_made.is_empty()).then_some(changes_made);
+    sqlx::query(
+        "UPDATE ducklake_snapshot_changes
+         SET changes_made = CASE
+                 WHEN changes_made IS NULL THEN ?
+                 WHEN ? IS NULL THEN changes_made
+                 ELSE CONCAT(changes_made, ',', ?)
+             END,
+             author = ?,
+             commit_message = ?,
+             commit_extra_info = ?
+         WHERE snapshot_id = ?",
+    )
+    .bind(changes_made)
+    .bind(changes_made)
+    .bind(changes_made)
+    .bind(commit_metadata.author())
+    .bind(commit_metadata.message())
+    .bind(commit_metadata.extra_info())
+    .bind(snapshot_id)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+async fn record_table_write_changes(
+    tx: &mut sqlx::Transaction<'_, sqlx::MySql>,
+    snapshot_id: i64,
+    table_id: i64,
+    schema_name: &str,
+    table_name: &str,
+    mode: WriteMode,
+    commit_metadata: &SnapshotCommitMetadata,
+) -> Result<()> {
+    let row = sqlx::query(
+        "SELECT s.begin_snapshot AS schema_begin_snapshot,
+                t.begin_snapshot AS table_begin_snapshot
+         FROM ducklake_table t
+         JOIN ducklake_schema s ON s.schema_id = t.schema_id
+         WHERE t.table_id = ?",
+    )
+    .bind(table_id)
+    .fetch_one(&mut **tx)
+    .await?;
+    let schema_begin_snapshot: i64 = row.try_get("schema_begin_snapshot")?;
+    let table_begin_snapshot: i64 = row.try_get("table_begin_snapshot")?;
+    let altered: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+            SELECT 1 FROM ducklake_schema_versions
+            WHERE table_id = ? AND begin_snapshot = ?
+         )",
+    )
+    .bind(table_id)
+    .bind(snapshot_id)
+    .fetch_one(&mut **tx)
+    .await?;
+    let replaced_existing_data: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+            SELECT 1 FROM ducklake_data_file
+            WHERE table_id = ? AND end_snapshot = ?
+         )",
+    )
+    .bind(table_id)
+    .bind(snapshot_id)
+    .fetch_one(&mut **tx)
+    .await?;
+
+    let mut changes = Vec::new();
+    if schema_begin_snapshot == snapshot_id {
+        changes.push(format!(
+            "created_schema:{}",
+            quote_snapshot_name(schema_name)
+        ));
+    }
+    if table_begin_snapshot == snapshot_id {
+        changes.push(format!(
+            "created_table:{}",
+            quote_snapshot_table(schema_name, table_name)
+        ));
+    } else if altered {
+        changes.push(format!("altered_table:{table_id}"));
+    }
+    changes.push(table_write_changes(
+        table_id,
+        mode,
+        false,
+        replaced_existing_data,
+    ));
+    record_snapshot_changes(tx, snapshot_id, &changes.join(","), commit_metadata).await
 }
 
 /// Bump the per-catalog monotonic `schema_version` on a DDL snapshot to
@@ -751,15 +863,17 @@ impl MetadataWriter for MySqlMetadataWriter {
     ) -> Result<(i64, bool)> {
         validate_name(name, "Schema")?;
         block_on(async {
+            let mut tx = self.pool.begin().await?;
             let existing = sqlx::query(
                 "SELECT schema_id FROM ducklake_schema
                  WHERE schema_name = ? AND end_snapshot IS NULL",
             )
             .bind(name)
-            .fetch_optional(&self.pool)
+            .fetch_optional(&mut *tx)
             .await?;
 
             if let Some(row) = existing {
+                tx.commit().await?;
                 return Ok((row.try_get(0)?, false));
             }
 
@@ -772,9 +886,17 @@ impl MetadataWriter for MySqlMetadataWriter {
             .bind(name)
             .bind(schema_path)
             .bind(snapshot_id)
-            .execute(&self.pool)
+            .execute(&mut *tx)
             .await?;
 
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &format!("created_schema:{}", quote_snapshot_name(name)),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
+            tx.commit().await?;
             Ok((result.last_insert_id() as i64, true))
         })
     }
@@ -788,18 +910,26 @@ impl MetadataWriter for MySqlMetadataWriter {
     ) -> Result<(i64, bool)> {
         validate_name(name, "Table")?;
         block_on(async {
+            let mut tx = self.pool.begin().await?;
             let existing = sqlx::query(
                 "SELECT table_id FROM ducklake_table
                  WHERE schema_id = ? AND table_name = ? AND end_snapshot IS NULL",
             )
             .bind(schema_id)
             .bind(name)
-            .fetch_optional(&self.pool)
+            .fetch_optional(&mut *tx)
             .await?;
 
             if let Some(row) = existing {
+                tx.commit().await?;
                 return Ok((row.try_get(0)?, false));
             }
+
+            let schema_name: String =
+                sqlx::query_scalar("SELECT schema_name FROM ducklake_schema WHERE schema_id = ?")
+                    .bind(schema_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
 
             let table_path = path.unwrap_or(name);
             let result = sqlx::query(
@@ -810,9 +940,17 @@ impl MetadataWriter for MySqlMetadataWriter {
             .bind(name)
             .bind(table_path)
             .bind(snapshot_id)
-            .execute(&self.pool)
+            .execute(&mut *tx)
             .await?;
 
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &format!("created_table:{}", quote_snapshot_table(&schema_name, name)),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
+            tx.commit().await?;
             Ok((result.last_insert_id() as i64, true))
         })
     }
@@ -866,6 +1004,20 @@ impl MetadataWriter for MySqlMetadataWriter {
                 column_ids.push(column_id);
             }
 
+            let table_begin_snapshot: i64 =
+                sqlx::query_scalar("SELECT begin_snapshot FROM ducklake_table WHERE table_id = ?")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
+            if table_begin_snapshot != snapshot_id {
+                record_snapshot_changes(
+                    &mut tx,
+                    snapshot_id,
+                    &format!("altered_table:{table_id}"),
+                    &SnapshotCommitMetadata::default(),
+                )
+                .await?;
+            }
             tx.commit().await?;
             Ok(column_ids)
         })
@@ -874,17 +1026,49 @@ impl MetadataWriter for MySqlMetadataWriter {
     fn register_data_file(
         &self,
         table_id: i64,
-        // MySQL created the schema/table at begin, so the names are unused here;
-        // accepted only to satisfy the trait shared with multicatalog Postgres.
-        _schema_name: &str,
-        _table_name: &str,
-        _snapshot_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        snapshot_id: i64,
         file: &DataFileInfo,
         mode: WriteMode,
         base_snapshot: i64,
         columns: &[ColumnDef],
         column_ids: &[i64],
     ) -> Result<CommitIds> {
+        self.register_data_file_with_commit_metadata(
+            table_id,
+            schema_name,
+            table_name,
+            snapshot_id,
+            file,
+            mode,
+            base_snapshot,
+            columns,
+            column_ids,
+            &SnapshotCommitMetadata::default(),
+            None,
+        )
+    }
+
+    fn register_data_file_with_commit_metadata(
+        &self,
+        table_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        _snapshot_id: i64,
+        file: &DataFileInfo,
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+        commit_metadata: &SnapshotCommitMetadata,
+        expected_base_snapshot_id: Option<i64>,
+    ) -> Result<CommitIds> {
+        if expected_base_snapshot_id.is_some() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "conditional writes are not supported by the MySQL metadata writer".to_string(),
+            ));
+        }
         block_on(async {
             // Single atomic commit: insert the deferred snapshot row + finalize the
             // column generation + retire the prior generation (Replace), then
@@ -967,6 +1151,16 @@ impl MetadataWriter for MySqlMetadataWriter {
             .execute(&mut *tx)
             .await?;
 
+            record_table_write_changes(
+                &mut tx,
+                snapshot_id,
+                table_id,
+                schema_name,
+                table_name,
+                mode,
+                commit_metadata,
+            )
+            .await?;
             let schema_id: i64 =
                 sqlx::query("SELECT schema_id FROM ducklake_table WHERE table_id = ?")
                     .bind(table_id)
@@ -987,15 +1181,50 @@ impl MetadataWriter for MySqlMetadataWriter {
     fn register_data_files(
         &self,
         table_id: i64,
-        _schema_name: &str,
-        _table_name: &str,
-        _snapshot_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        snapshot_id: i64,
         files: &[DataFileInfo],
         mode: WriteMode,
         base_snapshot: i64,
         columns: &[ColumnDef],
         column_ids: &[i64],
     ) -> Result<CommitIds> {
+        self.register_data_files_with_commit_metadata(
+            table_id,
+            schema_name,
+            table_name,
+            snapshot_id,
+            files,
+            mode,
+            base_snapshot,
+            columns,
+            column_ids,
+            &SnapshotCommitMetadata::default(),
+            None,
+        )
+    }
+
+    fn register_data_files_with_commit_metadata(
+        &self,
+        table_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        _snapshot_id: i64,
+        files: &[DataFileInfo],
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+        commit_metadata: &SnapshotCommitMetadata,
+        expected_base_snapshot_id: Option<i64>,
+    ) -> Result<CommitIds> {
+        if expected_base_snapshot_id.is_some() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "conditional multi-file writes are not supported by the MySQL metadata writer"
+                    .to_string(),
+            ));
+        }
         if files.is_empty() {
             return Err(crate::DuckLakeError::InvalidConfig(
                 "register_data_files: files must be non-empty".to_string(),
@@ -1073,6 +1302,16 @@ impl MetadataWriter for MySqlMetadataWriter {
             .bind(total_bytes)
             .bind(table_id)
             .execute(&mut *tx)
+            .await?;
+            record_table_write_changes(
+                &mut tx,
+                snapshot_id,
+                table_id,
+                schema_name,
+                table_name,
+                mode,
+                commit_metadata,
+            )
             .await?;
             let schema_id: i64 =
                 sqlx::query("SELECT schema_id FROM ducklake_table WHERE table_id = ?")
@@ -1159,6 +1398,13 @@ impl MetadataWriter for MySqlMetadataWriter {
 
             let new_schema_version = bump_schema_version(&mut tx, new_snapshot).await?;
             record_schema_version(&mut tx, new_snapshot, new_schema_version, table_id).await?;
+            record_snapshot_changes(
+                &mut tx,
+                new_snapshot,
+                &format!("altered_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
             tx.commit().await?;
             Ok(new_snapshot)
         })
@@ -1220,6 +1466,13 @@ impl MetadataWriter for MySqlMetadataWriter {
             }
             let new_schema_version = bump_schema_version(&mut tx, new_snapshot).await?;
             record_schema_version(&mut tx, new_snapshot, new_schema_version, table_id).await?;
+            record_snapshot_changes(
+                &mut tx,
+                new_snapshot,
+                &format!("altered_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
             tx.commit().await?;
             Ok(new_snapshot)
         })
@@ -1331,6 +1584,13 @@ impl MetadataWriter for MySqlMetadataWriter {
             }
 
             // A sort-order change does NOT bump schema_version.
+            record_snapshot_changes(
+                &mut tx,
+                new_snapshot,
+                &format!("altered_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
             tx.commit().await?;
             Ok(new_snapshot)
         })
@@ -1359,6 +1619,13 @@ impl MetadataWriter for MySqlMetadataWriter {
                 return Ok(head);
             }
             // A sort-order change does NOT bump schema_version.
+            record_snapshot_changes(
+                &mut tx,
+                new_snapshot,
+                &format!("altered_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
             tx.commit().await?;
             Ok(new_snapshot)
         })
@@ -1367,9 +1634,8 @@ impl MetadataWriter for MySqlMetadataWriter {
     fn publish_snapshot(
         &self,
         table_id: i64,
-        // MySQL created the schema/table at begin; names unused (trait parity).
-        _schema_name: &str,
-        _table_name: &str,
+        schema_name: &str,
+        table_name: &str,
         _snapshot_id: i64,
         mode: WriteMode,
         base_snapshot: i64,
@@ -1386,6 +1652,16 @@ impl MetadataWriter for MySqlMetadataWriter {
             let snapshot_id =
                 finalize_snapshot(&mut tx, table_id, columns, column_ids, mode, base_snapshot)
                     .await?;
+            record_table_write_changes(
+                &mut tx,
+                snapshot_id,
+                table_id,
+                schema_name,
+                table_name,
+                mode,
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
             let schema_id: i64 =
                 sqlx::query("SELECT schema_id FROM ducklake_table WHERE table_id = ?")
                     .bind(table_id)
@@ -1490,6 +1766,19 @@ impl MetadataWriter for MySqlMetadataWriter {
             .await?;
             if has_partition_id == 0 {
                 sqlx::query("ALTER TABLE ducklake_data_file ADD COLUMN partition_id BIGINT")
+                    .execute(&self.pool)
+                    .await?;
+            }
+            let changes_nullable: String = sqlx::query_scalar(
+                "SELECT is_nullable FROM information_schema.columns
+                 WHERE table_schema = DATABASE()
+                   AND table_name = 'ducklake_snapshot_changes'
+                   AND column_name = 'changes_made'",
+            )
+            .fetch_one(&self.pool)
+            .await?;
+            if changes_nullable == "NO" {
+                sqlx::query("ALTER TABLE ducklake_snapshot_changes MODIFY changes_made TEXT NULL")
                     .execute(&self.pool)
                     .await?;
             }

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -14,8 +14,8 @@ use crate::error::{TypeChangeOperation, TypeChangeWriteMode};
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
     ColumnDef, ColumnStat, CommitIds, DataFileInfo, DeleteFileEntry, DeleteFileInfo,
-    MetadataWriter, WriteMode, WriteSetupResult, columns_differ, validate_delete_entries,
-    validate_name,
+    MetadataWriter, SnapshotCommitMetadata, WriteMode, WriteSetupResult, columns_differ,
+    table_write_changes, validate_delete_entries, validate_name,
 };
 use crate::partition::PartitionTransform;
 use sqlx::AssertSqlSafe;
@@ -158,16 +158,16 @@ pub(crate) const SQL_CREATE_STANDARD_TABLES: &[&str] = &[
     // NULL means "not partitioned", correct for every pre-partitioning file.
     r#"ALTER TABLE ducklake_data_file
         ADD COLUMN IF NOT EXISTS partition_id BIGINT"#,
-    // Per-snapshot change ledger (DuckLake spec). The compaction commit records
-    // `compacted_table:<table_id>` here so DuckDB and other spec readers can
-    // attribute the snapshot; other commit paths do not populate it yet.
+    // Per-snapshot change ledger (DuckLake spec).
     r#"CREATE TABLE IF NOT EXISTS ducklake_snapshot_changes (
         snapshot_id BIGINT PRIMARY KEY,
-        changes_made VARCHAR NOT NULL,
+        changes_made VARCHAR,
         author VARCHAR,
         commit_message VARCHAR,
         commit_extra_info VARCHAR
     )"#,
+    r#"ALTER TABLE ducklake_snapshot_changes
+        ALTER COLUMN changes_made DROP NOT NULL"#,
     // Partition spec generations (DuckLake spec); end_snapshot NULL == active.
     // partition_id is IDENTITY so set_partition_spec allocates it via RETURNING
     // (like the other ids on the multicatalog path). No catalog_id needed —
@@ -1164,7 +1164,62 @@ async fn finalize_snapshot(
         retire_prior_generation(table_id, snapshot_id, tx).await?;
     }
 
+    let mut ddl_changes = Vec::new();
+    if schema_was_created {
+        ddl_changes.push(format!(
+            "created_schema:{}",
+            crate::metadata_writer::quote_snapshot_name(schema_name),
+        ));
+    }
+    if table_was_created {
+        ddl_changes.push(format!(
+            "created_table:{}",
+            crate::metadata_writer::quote_snapshot_table(schema_name, table_name),
+        ));
+    } else if is_ddl {
+        ddl_changes.push(format!("altered_table:{table_id}"));
+    }
+    if !ddl_changes.is_empty() {
+        record_snapshot_changes(
+            tx,
+            snapshot_id,
+            &ddl_changes.join(","),
+            &SnapshotCommitMetadata::default(),
+        )
+        .await?;
+    }
+
     Ok((snapshot_id, schema_id, table_id))
+}
+
+async fn record_snapshot_changes(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    snapshot_id: i64,
+    changes_made: &str,
+    commit_metadata: &SnapshotCommitMetadata,
+) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO ducklake_snapshot_changes
+             (snapshot_id, changes_made, author, commit_message, commit_extra_info)
+         VALUES ($1, $2, $3, $4, $5)
+         ON CONFLICT (snapshot_id) DO UPDATE SET
+             changes_made = CASE
+                 WHEN ducklake_snapshot_changes.changes_made IS NULL THEN EXCLUDED.changes_made
+                 WHEN EXCLUDED.changes_made IS NULL THEN ducklake_snapshot_changes.changes_made
+                 ELSE ducklake_snapshot_changes.changes_made || ',' || EXCLUDED.changes_made
+             END,
+             author = EXCLUDED.author,
+             commit_message = EXCLUDED.commit_message,
+             commit_extra_info = EXCLUDED.commit_extra_info",
+    )
+    .bind(snapshot_id)
+    .bind((!changes_made.is_empty()).then_some(changes_made))
+    .bind(commit_metadata.author())
+    .bind(commit_metadata.message())
+    .bind(commit_metadata.extra_info())
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
 }
 
 impl MetadataWriter for PostgresMetadataWriter {
@@ -1189,6 +1244,8 @@ impl MetadataWriter for PostgresMetadataWriter {
             .execute(&mut *tx)
             .await?;
 
+            record_snapshot_changes(&mut tx, snapshot_id, "", &SnapshotCommitMetadata::default())
+                .await?;
             tx.commit().await?;
             Ok(snapshot_id)
         })
@@ -1294,6 +1351,14 @@ impl MetadataWriter for PostgresMetadataWriter {
             .execute(&mut *tx)
             .await?;
 
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &format!("altered_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
+
             // Retire the live row, insert the new version with the SAME column_id
             // (OVERRIDING SYSTEM VALUE — column_id is IDENTITY). Retire-before-insert
             // keeps the live-version partial unique index satisfied at all times.
@@ -1375,6 +1440,16 @@ impl MetadataWriter for PostgresMetadataWriter {
             .execute(&mut *tx)
             .await?;
 
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &format!(
+                    "created_schema:{}",
+                    crate::metadata_writer::quote_snapshot_name(name),
+                ),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
             tx.commit().await?;
             Ok((schema_id, true))
         })
@@ -1408,6 +1483,12 @@ impl MetadataWriter for PostgresMetadataWriter {
                 return Ok((id, false));
             }
 
+            let schema_name: String =
+                sqlx::query_scalar("SELECT schema_name FROM ducklake_schema WHERE schema_id = $1")
+                    .bind(schema_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
+
             let table_path = path.unwrap_or(name);
             let row = sqlx::query(
                 "INSERT INTO ducklake_table (schema_id, table_name, path, path_is_relative, begin_snapshot)
@@ -1421,6 +1502,16 @@ impl MetadataWriter for PostgresMetadataWriter {
             .await?;
             let id: i64 = row.try_get(0)?;
 
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &format!(
+                    "created_table:{}",
+                    crate::metadata_writer::quote_snapshot_table(&schema_name, name),
+                ),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
             tx.commit().await?;
             Ok((id, true))
         })
@@ -1441,6 +1532,11 @@ impl MetadataWriter for PostgresMetadataWriter {
             let mut tx = self.pool.begin().await?;
             lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
             assert_table_in_catalog(self.catalog_id, table_id, &mut tx).await?;
+            let table_begin_snapshot: i64 =
+                sqlx::query_scalar("SELECT begin_snapshot FROM ducklake_table WHERE table_id = $1")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
 
             sqlx::query(
                 "UPDATE ducklake_column SET end_snapshot = $1
@@ -1468,6 +1564,15 @@ impl MetadataWriter for PostgresMetadataWriter {
                 column_ids.push(row.try_get(0)?);
             }
 
+            if table_begin_snapshot != snapshot_id {
+                record_snapshot_changes(
+                    &mut tx,
+                    snapshot_id,
+                    &format!("altered_table:{table_id}"),
+                    &SnapshotCommitMetadata::default(),
+                )
+                .await?;
+            }
             tx.commit().await?;
             Ok(column_ids)
         })
@@ -1478,12 +1583,41 @@ impl MetadataWriter for PostgresMetadataWriter {
         table_id: i64,
         schema_name: &str,
         table_name: &str,
+        snapshot_id: i64,
+        file: &DataFileInfo,
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+    ) -> Result<CommitIds> {
+        self.register_data_file_with_commit_metadata(
+            table_id,
+            schema_name,
+            table_name,
+            snapshot_id,
+            file,
+            mode,
+            base_snapshot,
+            columns,
+            column_ids,
+            &SnapshotCommitMetadata::default(),
+            None,
+        )
+    }
+
+    fn register_data_file_with_commit_metadata(
+        &self,
+        table_id: i64,
+        schema_name: &str,
+        table_name: &str,
         _snapshot_id: i64,
         file: &DataFileInfo,
         mode: WriteMode,
         base_snapshot: i64,
         columns: &[ColumnDef],
         column_ids: &[i64],
+        commit_metadata: &SnapshotCommitMetadata,
+        expected_base_snapshot_id: Option<i64>,
     ) -> Result<CommitIds> {
         block_on(async {
             // Single atomic commit. finalize_snapshot writes ALL metadata (the
@@ -1500,6 +1634,12 @@ impl MetadataWriter for PostgresMetadataWriter {
             let mut tx = self.pool.begin().await?;
             lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
             assert_table_not_in_other_catalog(self.catalog_id, table_id, &mut tx).await?;
+
+            if mode != WriteMode::Replace
+                && let Some(expected_base_snapshot_id) = expected_base_snapshot_id
+            {
+                detect_replace_conflict(table_id, expected_base_snapshot_id, &mut tx).await?;
+            }
 
             let (snapshot_id, schema_id, table_id) = finalize_snapshot(
                 self.catalog_id,
@@ -1586,6 +1726,19 @@ impl MetadataWriter for PostgresMetadataWriter {
             .execute(&mut *tx)
             .await?;
 
+            let replaced_existing_data: bool = sqlx::query_scalar(
+                "SELECT EXISTS(
+                    SELECT 1 FROM ducklake_data_file
+                    WHERE table_id = $1 AND end_snapshot = $2
+                 )",
+            )
+            .bind(table_id)
+            .bind(snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            let changes_made = table_write_changes(table_id, mode, false, replaced_existing_data);
+            record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata).await?;
+
             // advance_catalog_head MUST be the last write before commit.
             advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
 
@@ -1604,12 +1757,42 @@ impl MetadataWriter for PostgresMetadataWriter {
         table_id: i64,
         schema_name: &str,
         table_name: &str,
+        snapshot_id: i64,
+        files: &[DataFileInfo],
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+    ) -> Result<CommitIds> {
+        self.register_data_files_with_commit_metadata(
+            table_id,
+            schema_name,
+            table_name,
+            snapshot_id,
+            files,
+            mode,
+            base_snapshot,
+            columns,
+            column_ids,
+            &SnapshotCommitMetadata::default(),
+            None,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn register_data_files_with_commit_metadata(
+        &self,
+        table_id: i64,
+        schema_name: &str,
+        table_name: &str,
         _snapshot_id: i64,
         files: &[DataFileInfo],
         mode: WriteMode,
         base_snapshot: i64,
         columns: &[ColumnDef],
         column_ids: &[i64],
+        commit_metadata: &SnapshotCommitMetadata,
+        expected_base_snapshot_id: Option<i64>,
     ) -> Result<CommitIds> {
         if files.is_empty() {
             return Err(crate::DuckLakeError::InvalidConfig(
@@ -1620,6 +1803,11 @@ impl MetadataWriter for PostgresMetadataWriter {
             let mut tx = self.pool.begin().await?;
             lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
             assert_table_not_in_other_catalog(self.catalog_id, table_id, &mut tx).await?;
+            if mode != WriteMode::Replace
+                && let Some(expected_base_snapshot_id) = expected_base_snapshot_id
+            {
+                detect_replace_conflict(table_id, expected_base_snapshot_id, &mut tx).await?;
+            }
             let (snapshot_id, schema_id, table_id) = finalize_snapshot(
                 self.catalog_id,
                 schema_name,
@@ -1702,6 +1890,18 @@ impl MetadataWriter for PostgresMetadataWriter {
             .bind(table_id)
             .execute(&mut *tx)
             .await?;
+            let replaced_existing_data: bool = sqlx::query_scalar(
+                "SELECT EXISTS(
+                    SELECT 1 FROM ducklake_data_file
+                    WHERE table_id = $1 AND end_snapshot = $2
+                 )",
+            )
+            .bind(table_id)
+            .bind(snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            let changes_made = table_write_changes(table_id, mode, false, replaced_existing_data);
+            record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata).await?;
             // advance_catalog_head MUST be the last write before commit.
             advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
             tx.commit().await?;
@@ -1826,6 +2026,13 @@ impl MetadataWriter for PostgresMetadataWriter {
                 .await?;
             }
 
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &format!("altered_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
             tx.commit().await?;
             Ok(snapshot_id)
         })
@@ -1870,7 +2077,7 @@ impl MetadataWriter for PostgresMetadataWriter {
             assert_table_in_catalog(self.catalog_id, table_id, &mut tx).await?;
 
             // Nothing to reset → report the current head without a new snapshot.
-            let has_live: Option<i64> = sqlx::query_scalar(
+            let has_live: Option<i32> = sqlx::query_scalar(
                 "SELECT 1 FROM ducklake_partition_info
                  WHERE table_id = $1 AND end_snapshot IS NULL LIMIT 1",
             )
@@ -1936,6 +2143,13 @@ impl MetadataWriter for PostgresMetadataWriter {
             .execute(&mut *tx)
             .await?;
 
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &format!("altered_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
             tx.commit().await?;
             Ok(snapshot_id)
         })
@@ -2049,6 +2263,13 @@ impl MetadataWriter for PostgresMetadataWriter {
                 .await?;
             }
 
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &format!("altered_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
             tx.commit().await?;
             Ok(snapshot_id)
         })
@@ -2061,7 +2282,7 @@ impl MetadataWriter for PostgresMetadataWriter {
             assert_table_in_catalog(self.catalog_id, table_id, &mut tx).await?;
 
             // Nothing to reset → report the current head without a new snapshot.
-            let has_live: Option<i64> = sqlx::query_scalar(
+            let has_live: Option<i32> = sqlx::query_scalar(
                 "SELECT 1 FROM ducklake_sort_info
                  WHERE table_id = $1 AND end_snapshot IS NULL LIMIT 1",
             )
@@ -2088,7 +2309,13 @@ impl MetadataWriter for PostgresMetadataWriter {
             .bind(table_id)
             .execute(&mut *tx)
             .await?;
-
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &format!("altered_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
             tx.commit().await?;
             Ok(snapshot_id)
         })
@@ -2273,6 +2500,13 @@ impl MetadataWriter for PostgresMetadataWriter {
             .execute(&mut *tx)
             .await?;
 
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &format!("inserted_into_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
             advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
             tx.commit().await?;
             Ok(CommitIds {
@@ -2408,6 +2642,13 @@ impl MetadataWriter for PostgresMetadataWriter {
                     .fetch_one(&mut *tx)
                     .await?;
 
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &format!("deleted_from_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
             // advance_catalog_head MUST be the last write before commit.
             advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
 
@@ -2426,6 +2667,36 @@ impl MetadataWriter for PostgresMetadataWriter {
         table_id: i64,
         schema_name: &str,
         table_name: &str,
+        snapshot_id: i64,
+        file: &DataFileInfo,
+        deletes: &[DeleteFileEntry],
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+    ) -> Result<CommitIds> {
+        self.register_data_file_with_deletes_and_commit_metadata(
+            table_id,
+            schema_name,
+            table_name,
+            snapshot_id,
+            file,
+            deletes,
+            mode,
+            base_snapshot,
+            columns,
+            column_ids,
+            &SnapshotCommitMetadata::default(),
+            None,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn register_data_file_with_deletes_and_commit_metadata(
+        &self,
+        table_id: i64,
+        schema_name: &str,
+        table_name: &str,
         _snapshot_id: i64,
         file: &DataFileInfo,
         deletes: &[DeleteFileEntry],
@@ -2433,6 +2704,8 @@ impl MetadataWriter for PostgresMetadataWriter {
         base_snapshot: i64,
         columns: &[ColumnDef],
         column_ids: &[i64],
+        commit_metadata: &SnapshotCommitMetadata,
+        expected_base_snapshot_id: Option<i64>,
     ) -> Result<CommitIds> {
         validate_delete_entries(mode, deletes)?;
         block_on(async {
@@ -2445,6 +2718,12 @@ impl MetadataWriter for PostgresMetadataWriter {
             let mut tx = self.pool.begin().await?;
             lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
             assert_table_not_in_other_catalog(self.catalog_id, table_id, &mut tx).await?;
+
+            if mode != WriteMode::Replace
+                && let Some(expected_base_snapshot_id) = expected_base_snapshot_id
+            {
+                detect_replace_conflict(table_id, expected_base_snapshot_id, &mut tx).await?;
+            }
 
             let (snapshot_id, schema_id, table_id) = finalize_snapshot(
                 self.catalog_id,
@@ -2605,6 +2884,20 @@ impl MetadataWriter for PostgresMetadataWriter {
                 .await?;
             }
 
+            let replaced_existing_data: bool = sqlx::query_scalar(
+                "SELECT EXISTS(
+                    SELECT 1 FROM ducklake_data_file
+                    WHERE table_id = $1 AND end_snapshot = $2
+                 )",
+            )
+            .bind(table_id)
+            .bind(snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            let changes_made =
+                table_write_changes(table_id, mode, !deletes.is_empty(), replaced_existing_data);
+            record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata).await?;
+
             // advance_catalog_head MUST be the last write before commit.
             advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
 
@@ -2743,6 +3036,13 @@ impl MetadataWriter for PostgresMetadataWriter {
                     .fetch_one(&mut *tx)
                     .await?;
 
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &format!("deleted_from_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
             // advance_catalog_head MUST be the last write before commit.
             advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
 
@@ -3097,6 +3397,13 @@ impl MetadataWriter for PostgresMetadataWriter {
             .execute(&mut *tx)
             .await?;
 
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &format!("deleted_from_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
             // advance_catalog_head MUST be the last write before commit.
             advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
 
@@ -3227,6 +3534,13 @@ impl MetadataWriter for PostgresMetadataWriter {
             let (columns, column_ids) = live_columns_for_stats(table_id, &mut tx).await?;
             recompute_table_column_stats(&mut tx, table_id, &columns, &column_ids).await?;
 
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &format!("deleted_from_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
             // advance_catalog_head MUST be the last write before commit.
             advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
 
@@ -3267,6 +3581,24 @@ impl MetadataWriter for PostgresMetadataWriter {
             )
             .await?;
 
+            let replaced_existing_data: bool = sqlx::query_scalar(
+                "SELECT EXISTS(
+                    SELECT 1 FROM ducklake_data_file
+                    WHERE table_id = $1 AND end_snapshot = $2
+                 )",
+            )
+            .bind(table_id)
+            .bind(snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            let changes_made = table_write_changes(table_id, mode, false, replaced_existing_data);
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &changes_made,
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
             advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
 
             tx.commit().await?;

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -10,8 +10,8 @@ use crate::maintenance::{
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
     ColumnDef, ColumnStat, CommitIds, DataFileInfo, DeleteFileEntry, DeleteFileInfo,
-    MetadataWriter, WriteMode, WriteSetupResult, columns_differ, validate_delete_entries,
-    validate_name,
+    MetadataWriter, SnapshotCommitMetadata, WriteMode, WriteSetupResult, columns_differ,
+    table_write_changes, validate_delete_entries, validate_name,
 };
 use crate::partition::PartitionTransform;
 use sqlx::AssertSqlSafe;
@@ -135,13 +135,10 @@ CREATE TABLE IF NOT EXISTS ducklake_data_file (
 );
 
 -- Per-snapshot change ledger (DuckLake spec). One row per snapshot recording
--- what the commit did, as a comma-separated `changes_made` string (e.g.
--- `compacted_table:<table_id>` for a compaction). Written by the compaction
--- commit so DuckDB and other spec readers can attribute the snapshot; other
--- commit paths in this crate do not populate it yet.
+-- what the commit did, as a comma-separated `changes_made` string.
 CREATE TABLE IF NOT EXISTS ducklake_snapshot_changes (
     snapshot_id INTEGER PRIMARY KEY,
-    changes_made VARCHAR NOT NULL,
+    changes_made VARCHAR,
     author VARCHAR,
     commit_message VARCHAR,
     commit_extra_info VARCHAR
@@ -303,6 +300,9 @@ impl SqliteMetadataWriter {
             .max_connections(max_connections)
             .connect(connection_string)
             .await?;
+
+        // Existing catalogs must migrate even when callers skip `initialize_schema`
+        migrate_snapshot_changes_nullable(&pool).await?;
         Ok(Self {
             pool,
         })
@@ -380,6 +380,13 @@ impl SqliteMetadataWriter {
                 .await?;
             }
 
+            record_snapshot_changes(
+                &mut tx,
+                drop_snapshot,
+                &format!("dropped_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
             tx.commit().await?;
             Ok(true)
         })
@@ -950,6 +957,79 @@ async fn migrate_add_partition_id(pool: &SqlitePool) -> Result<()> {
     Ok(())
 }
 
+async fn migrate_snapshot_changes_nullable(pool: &SqlitePool) -> Result<()> {
+    let info = sqlx::query("SELECT name FROM pragma_table_info('ducklake_snapshot_changes')")
+        .fetch_all(pool)
+        .await?;
+    if info.is_empty() {
+        return Ok(());
+    }
+
+    let columns = info
+        .iter()
+        .map(|row| row.try_get::<String, _>("name"))
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    for (name, statement) in [
+        (
+            "author",
+            "ALTER TABLE ducklake_snapshot_changes ADD COLUMN author VARCHAR DEFAULT NULL",
+        ),
+        (
+            "commit_message",
+            "ALTER TABLE ducklake_snapshot_changes ADD COLUMN commit_message VARCHAR DEFAULT NULL",
+        ),
+        (
+            "commit_extra_info",
+            "ALTER TABLE ducklake_snapshot_changes ADD COLUMN commit_extra_info VARCHAR DEFAULT NULL",
+        ),
+    ] {
+        if !columns.iter().any(|column| column == name) {
+            sqlx::query(statement).execute(pool).await?;
+        }
+    }
+
+    let not_null: i64 = sqlx::query_scalar(
+        "SELECT `notnull` FROM pragma_table_info('ducklake_snapshot_changes')
+         WHERE name = 'changes_made'",
+    )
+    .fetch_one(pool)
+    .await?;
+    if not_null == 0 {
+        return Ok(());
+    }
+
+    let mut tx = pool.begin().await?;
+    sqlx::query(
+        "CREATE TABLE ducklake_snapshot_changes__migrate (
+            snapshot_id INTEGER PRIMARY KEY,
+            changes_made VARCHAR,
+            author VARCHAR,
+            commit_message VARCHAR,
+            commit_extra_info VARCHAR
+        )",
+    )
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query(
+        "INSERT INTO ducklake_snapshot_changes__migrate
+             (snapshot_id, changes_made, author, commit_message, commit_extra_info)
+         SELECT snapshot_id, NULLIF(changes_made, ''), author, commit_message, commit_extra_info
+         FROM ducklake_snapshot_changes",
+    )
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query("DROP TABLE ducklake_snapshot_changes")
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query(
+        "ALTER TABLE ducklake_snapshot_changes__migrate RENAME TO ducklake_snapshot_changes",
+    )
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(())
+}
+
 /// Optimistic-concurrency check for a `Replace` commit (mirrors the Postgres
 /// writer). Run while holding the SQLite write lock, before retiring the prior
 /// generation: if any data file of the table has `begin_snapshot` or
@@ -1035,7 +1115,16 @@ async fn insert_snapshot(tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>) -> Result
     )
     .fetch_one(&mut **tx)
     .await?;
-    Ok((row.try_get(0)?, row.try_get(1)?))
+    let snapshot_id = row.try_get(0)?;
+    let schema_version = row.try_get(1)?;
+    sqlx::query(
+        "INSERT INTO ducklake_snapshot_changes (snapshot_id, changes_made)
+         VALUES (?, NULL)",
+    )
+    .bind(snapshot_id)
+    .execute(&mut **tx)
+    .await?;
+    Ok((snapshot_id, schema_version))
 }
 
 /// Bump the per-catalog monotonic `schema_version` on a DDL snapshot to
@@ -1280,9 +1369,15 @@ async fn recompute_table_column_stats(
     Ok(())
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "snapshot finalization requires the complete atomic write state"
+)]
 async fn finalize_snapshot(
     tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
     table_id: i64,
+    schema_name: &str,
+    table_name: &str,
     columns: &[ColumnDef],
     column_ids: &[i64],
     mode: WriteMode,
@@ -1294,10 +1389,22 @@ async fn finalize_snapshot(
     // is corrected to a DDL bump below once we've classified the commit.
     let (snapshot_id, mut schema_version) = insert_snapshot(tx).await?;
 
-    // Classify this commit as DDL vs pure data write. `current` is the table's live
-    // columns ordered by `column_order`; an empty set means a brand-new table (the
-    // creating write is DDL). Mirrors the Postgres writer's
-    // `table_was_created || columns_differ` and upstream `SchemaChangesMade()`.
+    // Classify this commit as DDL vs pure data write. The table's begin snapshot
+    // identifies creation even when it has no columns; using an empty live-column
+    // set would misclassify a later schemaless Replace as another create.
+    let (schema_begin_snapshot, table_begin_snapshot): (i64, i64) = sqlx::query_as(
+        "SELECT schema.begin_snapshot, table_meta.begin_snapshot
+         FROM ducklake_table table_meta
+         JOIN ducklake_schema schema ON schema.schema_id = table_meta.schema_id
+         WHERE table_meta.table_id = ?",
+    )
+    .bind(table_id)
+    .fetch_one(&mut **tx)
+    .await?;
+
+    // `current` is the table's live columns ordered by `column_order`. Mirrors
+    // the Postgres writer's `table_was_created || columns_differ` and upstream
+    // `SchemaChangesMade()`.
     use std::collections::{HashMap, HashSet};
     let current = sqlx::query(
         "SELECT column_name, column_type, column_order, nulls_allowed
@@ -1318,7 +1425,8 @@ async fn finalize_snapshot(
             .unwrap_or(true);
         existing.push((name, ty, nullable));
     }
-    let is_ddl = existing.is_empty() || columns_differ(&existing, columns);
+    let table_was_created = table_begin_snapshot == snapshot_id;
+    let is_ddl = table_was_created || columns_differ(&existing, columns);
     if is_ddl {
         // A DDL commit bumps the per-catalog schema_version (the insert above only
         // carried it forward). A pure data write keeps the carried value.
@@ -1416,7 +1524,60 @@ async fn finalize_snapshot(
     if is_ddl {
         record_schema_version(tx, snapshot_id, schema_version, table_id).await?;
     }
+    let mut ddl_changes = Vec::new();
+    if table_was_created {
+        if schema_begin_snapshot == table_begin_snapshot {
+            ddl_changes.push(format!(
+                "created_schema:{}",
+                crate::metadata_writer::quote_snapshot_name(schema_name),
+            ));
+        }
+        ddl_changes.push(format!(
+            "created_table:{}",
+            crate::metadata_writer::quote_snapshot_table(schema_name, table_name),
+        ));
+    } else if is_ddl {
+        ddl_changes.push(format!("altered_table:{table_id}"));
+    }
+    if !ddl_changes.is_empty() {
+        record_snapshot_changes(
+            tx,
+            snapshot_id,
+            &ddl_changes.join(","),
+            &SnapshotCommitMetadata::default(),
+        )
+        .await?;
+    }
     Ok(snapshot_id)
+}
+
+async fn record_snapshot_changes(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    snapshot_id: i64,
+    changes_made: &str,
+    commit_metadata: &SnapshotCommitMetadata,
+) -> Result<()> {
+    let changes_made = (!changes_made.is_empty()).then_some(changes_made);
+    sqlx::query(
+        "UPDATE ducklake_snapshot_changes
+         SET changes_made = CASE
+                 WHEN changes_made IS NULL THEN ?
+                 WHEN ? IS NULL THEN changes_made
+                 ELSE changes_made || ',' || ?
+             END,
+             author = ?, commit_message = ?, commit_extra_info = ?
+         WHERE snapshot_id = ?",
+    )
+    .bind(changes_made)
+    .bind(changes_made)
+    .bind(changes_made)
+    .bind(commit_metadata.author())
+    .bind(commit_metadata.message())
+    .bind(commit_metadata.extra_info())
+    .bind(snapshot_id)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
 }
 
 impl MetadataWriter for SqliteMetadataWriter {
@@ -1429,8 +1590,9 @@ impl MetadataWriter for SqliteMetadataWriter {
     fn create_snapshot(&self) -> Result<i64> {
         block_on(async {
             let mut tx = self.pool.begin().await?;
-            // A bare snapshot carries no schema change of its own → carry
-            // schema_version forward (no DDL bump, no ledger row).
+            // A bare snapshot carries no schema change of its own, so carry
+            // schema_version forward with the empty change summary inserted by
+            // `insert_snapshot`.
             let (snapshot_id, _schema_version) = insert_snapshot(&mut tx).await?;
             tx.commit().await?;
             Ok(snapshot_id)
@@ -1445,16 +1607,19 @@ impl MetadataWriter for SqliteMetadataWriter {
     ) -> Result<(i64, bool)> {
         validate_name(name, "Schema")?;
         block_on(async {
+            let mut tx = self.pool.begin().await?;
             let existing = sqlx::query(
                 "SELECT schema_id FROM ducklake_schema
                  WHERE schema_name = ? AND end_snapshot IS NULL",
             )
             .bind(name)
-            .fetch_optional(&self.pool)
+            .fetch_optional(&mut *tx)
             .await?;
 
             if let Some(row) = existing {
-                return Ok((row.try_get(0)?, false));
+                let schema_id = row.try_get(0)?;
+                tx.commit().await?;
+                return Ok((schema_id, false));
             }
 
             let schema_path = path.unwrap_or(name);
@@ -1465,10 +1630,21 @@ impl MetadataWriter for SqliteMetadataWriter {
             .bind(name)
             .bind(schema_path)
             .bind(snapshot_id)
-            .fetch_one(&self.pool)
+            .fetch_one(&mut *tx)
             .await?;
-
-            Ok((row.try_get(0)?, true))
+            let schema_id = row.try_get(0)?;
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &format!(
+                    "created_schema:{}",
+                    crate::metadata_writer::quote_snapshot_name(name),
+                ),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
+            tx.commit().await?;
+            Ok((schema_id, true))
         })
     }
 
@@ -1481,18 +1657,27 @@ impl MetadataWriter for SqliteMetadataWriter {
     ) -> Result<(i64, bool)> {
         validate_name(name, "Table")?;
         block_on(async {
+            let mut tx = self.pool.begin().await?;
             let existing = sqlx::query(
                 "SELECT table_id FROM ducklake_table
                  WHERE schema_id = ? AND table_name = ? AND end_snapshot IS NULL",
             )
             .bind(schema_id)
             .bind(name)
-            .fetch_optional(&self.pool)
+            .fetch_optional(&mut *tx)
             .await?;
 
             if let Some(row) = existing {
-                return Ok((row.try_get(0)?, false));
+                let table_id = row.try_get(0)?;
+                tx.commit().await?;
+                return Ok((table_id, false));
             }
+
+            let schema_name: String =
+                sqlx::query_scalar("SELECT schema_name FROM ducklake_schema WHERE schema_id = ?")
+                    .bind(schema_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
 
             let table_path = path.unwrap_or(name);
             let row = sqlx::query(
@@ -1503,10 +1688,21 @@ impl MetadataWriter for SqliteMetadataWriter {
             .bind(name)
             .bind(table_path)
             .bind(snapshot_id)
-            .fetch_one(&self.pool)
+            .fetch_one(&mut *tx)
             .await?;
-
-            Ok((row.try_get(0)?, true))
+            let table_id = row.try_get(0)?;
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &format!(
+                    "created_table:{}",
+                    crate::metadata_writer::quote_snapshot_table(&schema_name, name),
+                ),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
+            tx.commit().await?;
+            Ok((table_id, true))
         })
     }
 
@@ -1600,6 +1796,13 @@ impl MetadataWriter for SqliteMetadataWriter {
 
             // Record the schema-change ledger row so consumers can detect the change.
             record_schema_version(&mut tx, new_snapshot, new_schema_version, table_id).await?;
+            record_snapshot_changes(
+                &mut tx,
+                new_snapshot,
+                &format!("altered_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
 
             // TODO(commit-time type guard, task #4): close the window where an Append
             // whose staging began before this promote commits afterward under the old
@@ -1690,6 +1893,13 @@ impl MetadataWriter for SqliteMetadataWriter {
             // Setting a spec is DDL: bump + record schema_version.
             let new_schema_version = bump_schema_version(&mut tx, new_snapshot).await?;
             record_schema_version(&mut tx, new_snapshot, new_schema_version, table_id).await?;
+            record_snapshot_changes(
+                &mut tx,
+                new_snapshot,
+                &format!("altered_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
 
             tx.commit().await?;
             Ok(new_snapshot)
@@ -1755,6 +1965,13 @@ impl MetadataWriter for SqliteMetadataWriter {
             // Removing the spec is DDL: bump + record schema_version.
             let new_schema_version = bump_schema_version(&mut tx, new_snapshot).await?;
             record_schema_version(&mut tx, new_snapshot, new_schema_version, table_id).await?;
+            record_snapshot_changes(
+                &mut tx,
+                new_snapshot,
+                &format!("altered_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
             tx.commit().await?;
             Ok(new_snapshot)
         })
@@ -1871,6 +2088,13 @@ impl MetadataWriter for SqliteMetadataWriter {
 
             // A sort-order change does NOT bump schema_version (see the trait doc):
             // it does not alter the logical schema, only future write layout.
+            record_snapshot_changes(
+                &mut tx,
+                new_snapshot,
+                &format!("altered_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
             tx.commit().await?;
             Ok(new_snapshot)
         })
@@ -1901,6 +2125,13 @@ impl MetadataWriter for SqliteMetadataWriter {
                 return Ok(head);
             }
             // A sort-order change does NOT bump schema_version.
+            record_snapshot_changes(
+                &mut tx,
+                new_snapshot,
+                &format!("altered_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
             tx.commit().await?;
             Ok(new_snapshot)
         })
@@ -1921,6 +2152,11 @@ impl MetadataWriter for SqliteMetadataWriter {
             // Use a transaction to ensure atomicity: if column insertion fails,
             // we don't leave existing columns marked as ended
             let mut tx = self.pool.begin().await?;
+            let table_begin_snapshot: i64 =
+                sqlx::query_scalar("SELECT begin_snapshot FROM ducklake_table WHERE table_id = ?")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
 
             sqlx::query(
                 "UPDATE ducklake_column SET end_snapshot = ?
@@ -1956,6 +2192,15 @@ impl MetadataWriter for SqliteMetadataWriter {
                 column_ids.push(column_id);
             }
 
+            if table_begin_snapshot != snapshot_id {
+                record_snapshot_changes(
+                    &mut tx,
+                    snapshot_id,
+                    &format!("altered_table:{table_id}"),
+                    &SnapshotCommitMetadata::default(),
+                )
+                .await?;
+            }
             tx.commit().await?;
             Ok(column_ids)
         })
@@ -1964,16 +2209,43 @@ impl MetadataWriter for SqliteMetadataWriter {
     fn register_data_file(
         &self,
         table_id: i64,
-        // SQLite created the schema/table at begin, so the names are unused here;
-        // accepted only to satisfy the trait shared with multicatalog Postgres.
-        _schema_name: &str,
-        _table_name: &str,
+        schema_name: &str,
+        table_name: &str,
+        snapshot_id: i64,
+        file: &DataFileInfo,
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+    ) -> Result<CommitIds> {
+        self.register_data_file_with_commit_metadata(
+            table_id,
+            schema_name,
+            table_name,
+            snapshot_id,
+            file,
+            mode,
+            base_snapshot,
+            columns,
+            column_ids,
+            &SnapshotCommitMetadata::default(),
+            None,
+        )
+    }
+
+    fn register_data_file_with_commit_metadata(
+        &self,
+        table_id: i64,
+        schema_name: &str,
+        table_name: &str,
         _snapshot_id: i64,
         file: &DataFileInfo,
         mode: WriteMode,
         base_snapshot: i64,
         columns: &[ColumnDef],
         column_ids: &[i64],
+        commit_metadata: &SnapshotCommitMetadata,
+        expected_base_snapshot_id: Option<i64>,
     ) -> Result<CommitIds> {
         block_on(async {
             // Single atomic commit: insert the deferred snapshot row + finalize
@@ -1983,9 +2255,22 @@ impl MetadataWriter for SqliteMetadataWriter {
             // only ever resolves to fully-populated data (no empty-read window).
             let mut tx = self.pool.begin().await?;
 
-            let snapshot_id =
-                finalize_snapshot(&mut tx, table_id, columns, column_ids, mode, base_snapshot)
-                    .await?;
+            let snapshot_id = finalize_snapshot(
+                &mut tx,
+                table_id,
+                schema_name,
+                table_name,
+                columns,
+                column_ids,
+                mode,
+                base_snapshot,
+            )
+            .await?;
+            if mode != WriteMode::Replace
+                && let Some(expected_base_snapshot_id) = expected_base_snapshot_id
+            {
+                detect_replace_conflict(&mut tx, table_id, expected_base_snapshot_id).await?;
+            }
 
             // Partition-spec fence: this file must be consistent with the table's live
             // partition generation at commit time (both directions — see
@@ -2064,6 +2349,19 @@ impl MetadataWriter for SqliteMetadataWriter {
             .execute(&mut *tx)
             .await?;
 
+            let replaced_existing_data = sqlx::query_scalar(
+                "SELECT EXISTS(
+                    SELECT 1 FROM ducklake_data_file
+                    WHERE table_id = ? AND end_snapshot = ?
+                 )",
+            )
+            .bind(table_id)
+            .bind(snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            let changes_made = table_write_changes(table_id, mode, false, replaced_existing_data);
+            record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata).await?;
+
             let schema_id: i64 =
                 sqlx::query("SELECT schema_id FROM ducklake_table WHERE table_id = ?")
                     .bind(table_id)
@@ -2084,14 +2382,44 @@ impl MetadataWriter for SqliteMetadataWriter {
     fn register_data_files(
         &self,
         table_id: i64,
-        _schema_name: &str,
-        _table_name: &str,
+        schema_name: &str,
+        table_name: &str,
+        snapshot_id: i64,
+        files: &[DataFileInfo],
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+    ) -> Result<CommitIds> {
+        self.register_data_files_with_commit_metadata(
+            table_id,
+            schema_name,
+            table_name,
+            snapshot_id,
+            files,
+            mode,
+            base_snapshot,
+            columns,
+            column_ids,
+            &SnapshotCommitMetadata::default(),
+            None,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn register_data_files_with_commit_metadata(
+        &self,
+        table_id: i64,
+        schema_name: &str,
+        table_name: &str,
         _snapshot_id: i64,
         files: &[DataFileInfo],
         mode: WriteMode,
         base_snapshot: i64,
         columns: &[ColumnDef],
         column_ids: &[i64],
+        commit_metadata: &SnapshotCommitMetadata,
+        expected_base_snapshot_id: Option<i64>,
     ) -> Result<CommitIds> {
         if files.is_empty() {
             return Err(crate::DuckLakeError::InvalidConfig(
@@ -2103,9 +2431,22 @@ impl MetadataWriter for SqliteMetadataWriter {
             // (Replace) retire the prior generation ONCE, then insert every file with
             // a distinct row_id_start from the advancing row-lineage counter.
             let mut tx = self.pool.begin().await?;
-            let snapshot_id =
-                finalize_snapshot(&mut tx, table_id, columns, column_ids, mode, base_snapshot)
-                    .await?;
+            let snapshot_id = finalize_snapshot(
+                &mut tx,
+                table_id,
+                schema_name,
+                table_name,
+                columns,
+                column_ids,
+                mode,
+                base_snapshot,
+            )
+            .await?;
+            if mode != WriteMode::Replace
+                && let Some(expected_base_snapshot_id) = expected_base_snapshot_id
+            {
+                detect_replace_conflict(&mut tx, table_id, expected_base_snapshot_id).await?;
+            }
             // Partition-spec fence (both directions, every file): each file must be
             // consistent with the table's live partition generation at commit time —
             // no file stamped with a retired partition_id, and no non-empty
@@ -2181,6 +2522,18 @@ impl MetadataWriter for SqliteMetadataWriter {
             .bind(table_id)
             .execute(&mut *tx)
             .await?;
+            let replaced_existing_data = sqlx::query_scalar(
+                "SELECT EXISTS(
+                    SELECT 1 FROM ducklake_data_file
+                    WHERE table_id = ? AND end_snapshot = ?
+                 )",
+            )
+            .bind(table_id)
+            .bind(snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            let changes_made = table_write_changes(table_id, mode, false, replaced_existing_data);
+            record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata).await?;
             let schema_id: i64 =
                 sqlx::query("SELECT schema_id FROM ducklake_table WHERE table_id = ?")
                     .bind(table_id)
@@ -2200,7 +2553,6 @@ impl MetadataWriter for SqliteMetadataWriter {
     fn set_delete_file(
         &self,
         table_id: i64,
-        // SQLite created the schema/table at begin; names unused (trait parity).
         _schema_name: &str,
         _table_name: &str,
         _snapshot_id: i64,
@@ -2292,6 +2644,15 @@ impl MetadataWriter for SqliteMetadataWriter {
             .execute(&mut *tx)
             .await?;
 
+            let changes_made = format!("deleted_from_table:{table_id}");
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &changes_made,
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
+
             let schema_id: i64 =
                 sqlx::query_scalar("SELECT schema_id FROM ducklake_table WHERE table_id = ?")
                     .bind(table_id)
@@ -2311,9 +2672,38 @@ impl MetadataWriter for SqliteMetadataWriter {
     fn register_data_file_with_deletes(
         &self,
         table_id: i64,
-        // SQLite created the schema/table at begin; names unused (trait parity).
-        _schema_name: &str,
-        _table_name: &str,
+        schema_name: &str,
+        table_name: &str,
+        snapshot_id: i64,
+        file: &DataFileInfo,
+        deletes: &[DeleteFileEntry],
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+    ) -> Result<CommitIds> {
+        self.register_data_file_with_deletes_and_commit_metadata(
+            table_id,
+            schema_name,
+            table_name,
+            snapshot_id,
+            file,
+            deletes,
+            mode,
+            base_snapshot,
+            columns,
+            column_ids,
+            &SnapshotCommitMetadata::default(),
+            None,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn register_data_file_with_deletes_and_commit_metadata(
+        &self,
+        table_id: i64,
+        schema_name: &str,
+        table_name: &str,
         _snapshot_id: i64,
         file: &DataFileInfo,
         deletes: &[DeleteFileEntry],
@@ -2321,6 +2711,8 @@ impl MetadataWriter for SqliteMetadataWriter {
         base_snapshot: i64,
         columns: &[ColumnDef],
         column_ids: &[i64],
+        commit_metadata: &SnapshotCommitMetadata,
+        expected_base_snapshot_id: Option<i64>,
     ) -> Result<CommitIds> {
         validate_delete_entries(mode, deletes)?;
         block_on(async {
@@ -2331,9 +2723,22 @@ impl MetadataWriter for SqliteMetadataWriter {
             // ever resolves to the fully-applied mutation.
             let mut tx = self.pool.begin().await?;
 
-            let snapshot_id =
-                finalize_snapshot(&mut tx, table_id, columns, column_ids, mode, base_snapshot)
-                    .await?;
+            let snapshot_id = finalize_snapshot(
+                &mut tx,
+                table_id,
+                schema_name,
+                table_name,
+                columns,
+                column_ids,
+                mode,
+                base_snapshot,
+            )
+            .await?;
+            if mode != WriteMode::Replace
+                && let Some(expected_base_snapshot_id) = expected_base_snapshot_id
+            {
+                detect_replace_conflict(&mut tx, table_id, expected_base_snapshot_id).await?;
+            }
 
             // Partition-spec fence: the new row versions are a NEW write, so they
             // must agree with the table's live partition generation exactly as
@@ -2479,6 +2884,20 @@ impl MetadataWriter for SqliteMetadataWriter {
                 .await?;
             }
 
+            let replaced_existing_data = sqlx::query_scalar(
+                "SELECT EXISTS(
+                    SELECT 1 FROM ducklake_data_file
+                    WHERE table_id = ? AND end_snapshot = ?
+                 )",
+            )
+            .bind(table_id)
+            .bind(snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            let changes_made =
+                table_write_changes(table_id, mode, !deletes.is_empty(), replaced_existing_data);
+            record_snapshot_changes(&mut tx, snapshot_id, &changes_made, commit_metadata).await?;
+
             let schema_id: i64 =
                 sqlx::query_scalar("SELECT schema_id FROM ducklake_table WHERE table_id = ?")
                     .bind(table_id)
@@ -2497,7 +2916,6 @@ impl MetadataWriter for SqliteMetadataWriter {
     fn commit_positional_deletes(
         &self,
         table_id: i64,
-        // SQLite created the schema/table at begin; names unused (trait parity).
         _schema_name: &str,
         _table_name: &str,
         base_snapshot: i64,
@@ -2596,6 +3014,15 @@ impl MetadataWriter for SqliteMetadataWriter {
                 .execute(&mut *tx)
                 .await?;
             }
+
+            let changes_made = format!("deleted_from_table:{table_id}");
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &changes_made,
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
 
             let schema_id: i64 =
                 sqlx::query_scalar("SELECT schema_id FROM ducklake_table WHERE table_id = ?")
@@ -2832,16 +3259,10 @@ impl MetadataWriter for SqliteMetadataWriter {
             .await?;
 
             // Attribute the snapshot for spec readers (DuckDB reads this ledger).
-            sqlx::query(
-                "INSERT INTO ducklake_snapshot_changes
-                     (snapshot_id, changes_made, commit_message)
-                 VALUES (?, ?, ?)",
-            )
-            .bind(snapshot_id)
-            .bind(format!("compacted_table:{table_id}"))
-            .bind("datafusion compaction")
-            .execute(&mut *tx)
-            .await?;
+            let changes_made = format!("compacted_table:{table_id}");
+            let commit_metadata =
+                SnapshotCommitMetadata::new().with_message("datafusion compaction");
+            record_snapshot_changes(&mut tx, snapshot_id, &changes_made, &commit_metadata).await?;
 
             let schema_id: i64 =
                 sqlx::query_scalar("SELECT schema_id FROM ducklake_table WHERE table_id = ?")
@@ -2973,6 +3394,15 @@ impl MetadataWriter for SqliteMetadataWriter {
             let (columns, column_ids) = live_columns_for_stats(table_id, &mut tx).await?;
             recompute_table_column_stats(&mut tx, table_id, &columns, &column_ids).await?;
 
+            let changes_made = format!("deleted_from_table:{table_id}");
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &changes_made,
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
+
             tx.commit().await?;
             Ok(Some(snapshot_id))
         })
@@ -3053,6 +3483,15 @@ impl MetadataWriter for SqliteMetadataWriter {
             .execute(&mut *tx)
             .await?;
 
+            let changes_made = format!("deleted_from_table:{table_id}");
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &changes_made,
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
+
             tx.commit().await?;
             Ok(live_rows)
         })
@@ -3061,9 +3500,8 @@ impl MetadataWriter for SqliteMetadataWriter {
     fn publish_snapshot(
         &self,
         table_id: i64,
-        // SQLite created the schema/table at begin; names unused (trait parity).
-        _schema_name: &str,
-        _table_name: &str,
+        schema_name: &str,
+        table_name: &str,
         _snapshot_id: i64,
         mode: WriteMode,
         base_snapshot: i64,
@@ -3079,9 +3517,35 @@ impl MetadataWriter for SqliteMetadataWriter {
         // register_data_file instead.
         block_on(async {
             let mut tx = self.pool.begin().await?;
-            let snapshot_id =
-                finalize_snapshot(&mut tx, table_id, columns, column_ids, mode, base_snapshot)
-                    .await?;
+            let snapshot_id = finalize_snapshot(
+                &mut tx,
+                table_id,
+                schema_name,
+                table_name,
+                columns,
+                column_ids,
+                mode,
+                base_snapshot,
+            )
+            .await?;
+            let replaced_existing_data = sqlx::query_scalar(
+                "SELECT EXISTS(
+                    SELECT 1 FROM ducklake_data_file
+                    WHERE table_id = ? AND end_snapshot = ?
+                 )",
+            )
+            .bind(table_id)
+            .bind(snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            let changes_made = table_write_changes(table_id, mode, false, replaced_existing_data);
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &changes_made,
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
             let schema_id: i64 =
                 sqlx::query("SELECT schema_id FROM ducklake_table WHERE table_id = ?")
                     .bind(table_id)
@@ -3181,6 +3645,7 @@ impl MetadataWriter for SqliteMetadataWriter {
             // Upgrade a pre-existing catalog to carry ducklake_data_file.partition_id
             // (idempotent, lossless — NULL means "not partitioned").
             migrate_add_partition_id(&self.pool).await?;
+            migrate_snapshot_changes_nullable(&self.pool).await?;
             // Seed the monotonic id allocators. snapshot_id and column_id are
             // reserved in begin_write_transaction and inserted at the commit, so
             // they can't use rowid autoincrement (inserting the ducklake_snapshot
@@ -3549,6 +4014,184 @@ mod tests {
         assert_eq!(cnt2, 2, "migration must be idempotent");
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn migrate_snapshot_changes_to_nullable() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("legacy.db");
+        let conn_str = format!("sqlite:{}?mode=rwc", db_path.display());
+        let pool = SqlitePool::connect(&conn_str).await.unwrap();
+        sqlx::query(
+            "CREATE TABLE ducklake_snapshot_changes (
+                snapshot_id INTEGER PRIMARY KEY,
+                changes_made VARCHAR NOT NULL,
+                author VARCHAR,
+                commit_message VARCHAR,
+                commit_extra_info VARCHAR
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO ducklake_snapshot_changes
+                 (snapshot_id, changes_made, author, commit_message, commit_extra_info)
+             VALUES (1, '', NULL, NULL, NULL),
+                    (2, 'inserted_into_table:7', 'author', 'message', 'extra')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        migrate_snapshot_changes_nullable(&pool).await.unwrap();
+
+        let not_null: i64 = sqlx::query_scalar(
+            "SELECT `notnull` FROM pragma_table_info('ducklake_snapshot_changes')
+             WHERE name = 'changes_made'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let rows = sqlx::query_as::<
+            _,
+            (
+                i64,
+                Option<String>,
+                Option<String>,
+                Option<String>,
+                Option<String>,
+            ),
+        >(
+            "SELECT snapshot_id, changes_made, author, commit_message, commit_extra_info
+             FROM ducklake_snapshot_changes ORDER BY snapshot_id",
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(not_null, 0);
+        assert_eq!(
+            rows,
+            vec![
+                (1, None, None, None, None),
+                (
+                    2,
+                    Some("inserted_into_table:7".to_string()),
+                    Some("author".to_string()),
+                    Some("message".to_string()),
+                    Some("extra".to_string()),
+                ),
+            ],
+        );
+
+        migrate_snapshot_changes_nullable(&pool).await.unwrap();
+        let row_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ducklake_snapshot_changes")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(row_count, 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn open_legacy_snapshot_changes_with_plain_new() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("legacy.db");
+        let conn_str = format!("sqlite:{}?mode=rwc", db_path.display());
+        let writer = SqliteMetadataWriter::new_with_init(&conn_str)
+            .await
+            .unwrap();
+
+        sqlx::query("DROP TABLE ducklake_snapshot_changes")
+            .execute(&writer.pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE ducklake_snapshot_changes (
+                snapshot_id INTEGER PRIMARY KEY,
+                changes_made VARCHAR NOT NULL
+            )",
+        )
+        .execute(&writer.pool)
+        .await
+        .unwrap();
+        drop(writer);
+
+        let writer = SqliteMetadataWriter::new(&conn_str).await.unwrap();
+        let snapshot_id = writer.create_snapshot().unwrap();
+        let changes_made: Option<String> = sqlx::query_scalar(
+            "SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id = ?",
+        )
+        .bind(snapshot_id)
+        .fetch_one(&writer.pool)
+        .await
+        .unwrap();
+        assert_eq!(changes_made, None);
+
+        let commit_metadata = SnapshotCommitMetadata::new()
+            .with_author("Jane Doe")
+            .with_message("Imported official catalog")
+            .with_extra_info("migration-regression");
+        let mut tx = writer.pool.begin().await.unwrap();
+        record_snapshot_changes(
+            &mut tx,
+            snapshot_id,
+            "inserted_into_table:7",
+            &commit_metadata,
+        )
+        .await
+        .unwrap();
+        tx.commit().await.unwrap();
+
+        let columns = sqlx::query(
+            "SELECT name, `notnull` FROM pragma_table_info('ducklake_snapshot_changes')",
+        )
+        .fetch_all(&writer.pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|row| {
+            (
+                row.try_get::<String, _>("name").unwrap(),
+                row.try_get::<i64, _>("notnull").unwrap(),
+            )
+        })
+        .collect::<Vec<_>>();
+        let row = sqlx::query_as::<
+            _,
+            (
+                Option<String>,
+                Option<String>,
+                Option<String>,
+                Option<String>,
+            ),
+        >(
+            "SELECT changes_made, author, commit_message, commit_extra_info
+             FROM ducklake_snapshot_changes WHERE snapshot_id = ?",
+        )
+        .bind(snapshot_id)
+        .fetch_one(&writer.pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            columns,
+            vec![
+                ("snapshot_id".to_string(), 0),
+                ("changes_made".to_string(), 0),
+                ("author".to_string(), 0),
+                ("commit_message".to_string(), 0),
+                ("commit_extra_info".to_string(), 0),
+            ],
+        );
+        assert_eq!(
+            row,
+            (
+                Some("inserted_into_table:7".to_string()),
+                Some("Jane Doe".to_string()),
+                Some("Imported official catalog".to_string()),
+                Some("migration-regression".to_string()),
+            ),
+        );
+    }
+
     /// An existing catalog whose `ducklake_snapshot` predates `schema_version`
     /// (the pre-#151 shape) must gain the column in place: idempotent, lossless,
     /// and existing snapshot rows take the `DEFAULT 0`. `CREATE TABLE IF NOT
@@ -3684,6 +4327,61 @@ mod tests {
         assert_eq!(column_ids.len(), 2);
         assert_eq!(column_ids[0], 1);
         assert_eq!(column_ids[1], 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ddl_snapshots_record_spec_change_tokens() {
+        let (writer, _temp) = create_test_writer().await;
+        let bare_snapshot = writer.create_snapshot().unwrap();
+        let ddl_snapshot = writer.create_snapshot().unwrap();
+        let (schema_id, _) = writer
+            .get_or_create_schema("ma\"in", None, ddl_snapshot)
+            .unwrap();
+        let (table_id, _) = writer
+            .get_or_create_table(schema_id, "ev\"ents", None, ddl_snapshot)
+            .unwrap();
+        writer
+            .set_columns(
+                table_id,
+                &[ColumnDef::new("id", "int64", false).unwrap()],
+                ddl_snapshot,
+            )
+            .unwrap();
+        let partition_snapshot = writer
+            .set_partition_spec(
+                table_id,
+                &[("id".to_string(), PartitionTransform::Identity)],
+            )
+            .unwrap();
+        let reset_snapshot = writer.reset_partition_spec(table_id).unwrap();
+
+        let rows = sqlx::query_as::<_, (i64, Option<String>)>(
+            "SELECT snapshot_id, changes_made
+             FROM ducklake_snapshot_changes
+             ORDER BY snapshot_id",
+        )
+        .fetch_all(&writer.pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            rows,
+            vec![
+                (bare_snapshot, None),
+                (
+                    ddl_snapshot,
+                    Some(
+                        "created_schema:\"ma\"\"in\",created_table:\"ma\"\"in\".\"ev\"\"ents\""
+                            .to_string(),
+                    ),
+                ),
+                (
+                    partition_snapshot,
+                    Some(format!("altered_table:{table_id}"))
+                ),
+                (reset_snapshot, Some(format!("altered_table:{table_id}"))),
+            ],
+        );
     }
 
     /// Phase C (catalog-state faithfulness): a type promotion must leave the
@@ -3959,6 +4657,141 @@ mod tests {
             )
             .unwrap();
         assert_eq!(committed.snapshot_id, 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn snapshot_changes_are_atomic_with_append_and_replace() {
+        let (writer, _temp) = create_test_writer().await;
+        let snapshot_id = reserve_snapshot(&writer).await;
+        let (schema_id, _) = writer
+            .get_or_create_schema("main", None, snapshot_id)
+            .unwrap();
+        let (table_id, _) = writer
+            .get_or_create_table(schema_id, "users", None, snapshot_id)
+            .unwrap();
+
+        let appended = writer
+            .register_data_file(
+                table_id,
+                "main",
+                "users",
+                snapshot_id,
+                &DataFileInfo::new("append.parquet", 1024, 100),
+                WriteMode::Append,
+                0,
+                &[],
+                &[],
+            )
+            .unwrap();
+
+        let replacement_snapshot_id = reserve_snapshot(&writer).await;
+        let commit_metadata = SnapshotCommitMetadata::new()
+            .with_author("Jane Doe")
+            .with_message("Replace imported data")
+            .with_extra_info("opaque-application-value");
+        let replaced = writer
+            .register_data_file_with_commit_metadata(
+                table_id,
+                "main",
+                "users",
+                replacement_snapshot_id,
+                &DataFileInfo::new("replace.parquet", 512, 50),
+                WriteMode::Replace,
+                appended.snapshot_id,
+                &[],
+                &[],
+                &commit_metadata,
+                None,
+            )
+            .unwrap();
+
+        let rows = sqlx::query(
+            "SELECT snapshot_id, changes_made, author, commit_message, commit_extra_info
+             FROM ducklake_snapshot_changes
+             ORDER BY snapshot_id",
+        )
+        .fetch_all(&writer.pool)
+        .await
+        .unwrap();
+        let actual = rows
+            .iter()
+            .map(|row| {
+                (
+                    row.try_get::<i64, _>("snapshot_id").unwrap(),
+                    row.try_get::<String, _>("changes_made").unwrap(),
+                    row.try_get::<Option<String>, _>("author").unwrap(),
+                    row.try_get::<Option<String>, _>("commit_message").unwrap(),
+                    row.try_get::<Option<String>, _>("commit_extra_info")
+                        .unwrap(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            actual,
+            vec![
+                (
+                    appended.snapshot_id,
+                    format!(
+                        "created_schema:\"main\",created_table:\"main\".\"users\",\
+                         inserted_into_table:{table_id}"
+                    ),
+                    None,
+                    None,
+                    None,
+                ),
+                (
+                    replaced.snapshot_id,
+                    format!("deleted_from_table:{table_id},inserted_into_table:{table_id}"),
+                    Some("Jane Doe".to_string()),
+                    Some("Replace imported data".to_string()),
+                    Some("opaque-application-value".to_string()),
+                ),
+            ],
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn initial_replace_records_insertion_without_deletion() {
+        let (writer, _temp) = create_test_writer().await;
+        let snapshot_id = reserve_snapshot(&writer).await;
+        let (schema_id, _) = writer
+            .get_or_create_schema("main", None, snapshot_id)
+            .unwrap();
+        let (table_id, _) = writer
+            .get_or_create_table(schema_id, "events", None, snapshot_id)
+            .unwrap();
+
+        let committed = writer
+            .register_data_file(
+                table_id,
+                "main",
+                "events",
+                snapshot_id,
+                &DataFileInfo::new("initial.parquet", 100, 3),
+                WriteMode::Replace,
+                0,
+                &[],
+                &[],
+            )
+            .unwrap();
+        let changes_made: String = sqlx::query_scalar(
+            "SELECT changes_made
+             FROM ducklake_snapshot_changes
+             WHERE snapshot_id = ?",
+        )
+        .bind(committed.snapshot_id)
+        .fetch_one(&writer.pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            changes_made,
+            format!(
+                "created_schema:\"main\",created_table:\"main\".\"events\",\
+                 inserted_into_table:{table_id}"
+            ),
+        );
     }
 
     /// Reserve the next snapshot id the way `begin_write_transaction` now does

--- a/src/multicatalog.rs
+++ b/src/multicatalog.rs
@@ -457,6 +457,15 @@ impl MulticatalogManager {
             .await?;
         }
 
+        sqlx::query(
+            "INSERT INTO ducklake_snapshot_changes
+                 (snapshot_id, changes_made, author, commit_message, commit_extra_info)
+             VALUES ($1, $2, NULL, NULL, NULL)",
+        )
+        .bind(drop_snapshot)
+        .bind(format!("dropped_table:{table_id}"))
+        .execute(&mut *tx)
+        .await?;
         tx.commit().await?;
         Ok(true)
     }

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -22,8 +22,8 @@ use uuid::Uuid;
 
 use crate::Result;
 use crate::metadata_writer::{
-    ColumnDef, DataFileInfo, DeleteFileEntry, DeleteFileInfo, MetadataWriter, WriteMode,
-    WriteResult, validate_delete_entries,
+    ColumnDef, DataFileInfo, DeleteFileEntry, DeleteFileInfo, MetadataWriter,
+    SnapshotCommitMetadata, WriteMode, WriteResult, validate_delete_entries,
 };
 use crate::path_resolver::join_paths;
 use crate::row_id::{embedded_rowid_field, embedded_snapshot_id_field};
@@ -72,6 +72,44 @@ pub struct DuckLakeWriteOptions {
     /// Max parquet files a partitioned streaming write keeps open at once; `None`
     /// leaves the writer default ([`DEFAULT_MAX_OPEN_PARTITIONS`]).
     pub max_open_partitions: Option<usize>,
+}
+
+/// Options shared by streaming and partitioned table writes.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct TableWriteOptions {
+    /// Metadata recorded in the snapshot change row.
+    pub commit_metadata: SnapshotCommitMetadata,
+    /// Catalog snapshot against which this write read its input.
+    ///
+    /// The commit fails if the target table's data-file generation changed
+    /// after this snapshot. Commits to other tables do not cause a conflict.
+    pub expected_base_snapshot_id: Option<i64>,
+}
+
+impl TableWriteOptions {
+    /// Creates default write options.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            commit_metadata: SnapshotCommitMetadata::new(),
+            expected_base_snapshot_id: None,
+        }
+    }
+
+    /// Attaches metadata to the committed snapshot.
+    #[must_use]
+    pub fn with_commit_metadata(mut self, commit_metadata: SnapshotCommitMetadata) -> Self {
+        self.commit_metadata = commit_metadata;
+        self
+    }
+
+    /// Requires the write to commit against the target table's data-file
+    /// generation visible at `snapshot_id`.
+    #[must_use]
+    pub const fn with_expected_base_snapshot_id(mut self, snapshot_id: i64) -> Self {
+        self.expected_base_snapshot_id = Some(snapshot_id);
+        self
+    }
 }
 
 /// High-level writer for DuckLake tables.
@@ -524,6 +562,7 @@ impl DuckLakeTableWriter {
             table_name: table_name.to_string(),
             snapshot_id: setup.snapshot_id,
             base_snapshot_id: setup.base_snapshot_id,
+            expected_base_snapshot_id: None,
             table_id: setup.table_id,
             columns,
             column_ids: setup.column_ids,
@@ -538,6 +577,7 @@ impl DuckLakeTableWriter {
             partition_sink,
             roller,
             rolled: Vec::new(),
+            commit_metadata: SnapshotCommitMetadata::default(),
         })
     }
 
@@ -871,6 +911,63 @@ impl DuckLakeTableWriter {
         key_names: &[String],
         groups: Vec<PartitionGroup>,
     ) -> Result<WriteResult> {
+        self.write_partitioned_with_commit_metadata(
+            schema_name,
+            table_name,
+            arrow_schema,
+            mode,
+            partition_id,
+            key_names,
+            groups,
+            &SnapshotCommitMetadata::default(),
+        )
+        .await
+    }
+
+    /// Writes a partitioned dataset with metadata attached to its snapshot.
+    ///
+    /// Returns an error when the configured metadata writer does not support
+    /// non-empty commit metadata.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn write_partitioned_with_commit_metadata(
+        &self,
+        schema_name: &str,
+        table_name: &str,
+        arrow_schema: &Schema,
+        mode: WriteMode,
+        partition_id: i64,
+        key_names: &[String],
+        groups: Vec<PartitionGroup>,
+        commit_metadata: &SnapshotCommitMetadata,
+    ) -> Result<WriteResult> {
+        let options = TableWriteOptions::new().with_commit_metadata(commit_metadata.clone());
+        self.write_partitioned_with_options(
+            schema_name,
+            table_name,
+            arrow_schema,
+            mode,
+            partition_id,
+            key_names,
+            groups,
+            &options,
+        )
+        .await
+    }
+
+    /// Writes a partitioned dataset with snapshot metadata and an optional
+    /// replacement precondition.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn write_partitioned_with_options(
+        &self,
+        schema_name: &str,
+        table_name: &str,
+        arrow_schema: &Schema,
+        mode: WriteMode,
+        partition_id: i64,
+        key_names: &[String],
+        groups: Vec<PartitionGroup>,
+        options: &TableWriteOptions,
+    ) -> Result<WriteResult> {
         if groups.is_empty() {
             return Err(crate::error::DuckLakeError::InvalidConfig(
                 "write_partitioned: no partition groups".to_string(),
@@ -928,16 +1025,20 @@ impl DuckLakeTableWriter {
             ));
         }
 
-        let committed = self.metadata.register_data_files(
+        let committed = self.metadata.register_data_files_with_commit_metadata(
             setup.table_id,
             schema_name,
             table_name,
             setup.snapshot_id,
             &file_infos,
             mode,
-            setup.base_snapshot_id,
+            options
+                .expected_base_snapshot_id
+                .unwrap_or(setup.base_snapshot_id),
             &columns,
             &setup.column_ids,
+            &options.commit_metadata,
+            options.expected_base_snapshot_id,
         )?;
 
         Ok(WriteResult {
@@ -1656,6 +1757,8 @@ pub struct TableWriteSession {
     /// `register_data_file` so a `Replace` commit can abort if another writer
     /// published a newer generation of the table since this write began.
     base_snapshot_id: i64,
+    /// Explicit table-state precondition supplied through [`TableWriteOptions`].
+    expected_base_snapshot_id: Option<i64>,
     table_id: i64,
     /// Column generation for this write (in `column_order`). Threaded to the
     /// metadata writer at `finish()` so single-catalog backends, which defer the
@@ -1696,9 +1799,31 @@ pub struct TableWriteSession {
     roller: Option<RollingFileWriter>,
     /// Files the roller has finished, awaiting upload at `finish`.
     rolled: Vec<StagedFile>,
+    commit_metadata: SnapshotCommitMetadata,
 }
 
 impl TableWriteSession {
+    /// Applies snapshot metadata and an optional table-state precondition.
+    #[must_use]
+    pub fn with_options(mut self, options: &TableWriteOptions) -> Self {
+        self.commit_metadata = options.commit_metadata.clone();
+        if let Some(snapshot_id) = options.expected_base_snapshot_id {
+            self.base_snapshot_id = snapshot_id;
+        }
+        self.expected_base_snapshot_id = options.expected_base_snapshot_id;
+        self
+    }
+
+    /// Attaches metadata to the snapshot committed by this write.
+    ///
+    /// [`Self::finish`] returns an error when the configured metadata writer
+    /// does not support non-empty commit metadata.
+    #[must_use]
+    pub fn with_commit_metadata(mut self, commit_metadata: SnapshotCommitMetadata) -> Self {
+        self.commit_metadata = commit_metadata;
+        self
+    }
+
     pub fn write_batch(&mut self, batch: &RecordBatch) -> Result<()> {
         // Rolling or partitioned target: validate up front so the shared borrow of
         // `self` that `validate_batch_schema` takes is released before the roller or
@@ -1809,7 +1934,7 @@ impl TableWriteSession {
                 return self.finish_single_file().await;
             }
             let records_written: i64 = file_infos.iter().map(|f| f.record_count).sum();
-            let committed = self.metadata.register_data_files(
+            let committed = self.metadata.register_data_files_with_commit_metadata(
                 self.table_id,
                 &self.schema_name,
                 &self.table_name,
@@ -1819,6 +1944,8 @@ impl TableWriteSession {
                 self.base_snapshot_id,
                 &self.columns,
                 &self.column_ids,
+                &self.commit_metadata,
+                self.expected_base_snapshot_id,
             )?;
             return Ok(WriteResult {
                 snapshot_id: committed.snapshot_id,
@@ -1839,7 +1966,7 @@ impl TableWriteSession {
                 return self.finish_single_file().await;
             }
             let records_written: i64 = file_infos.iter().map(|f| f.record_count).sum();
-            let committed = self.metadata.register_data_files(
+            let committed = self.metadata.register_data_files_with_commit_metadata(
                 self.table_id,
                 &self.schema_name,
                 &self.table_name,
@@ -1849,6 +1976,8 @@ impl TableWriteSession {
                 self.base_snapshot_id,
                 &self.columns,
                 &self.column_ids,
+                &self.commit_metadata,
+                self.expected_base_snapshot_id,
             )?;
             return Ok(WriteResult {
                 snapshot_id: committed.snapshot_id,
@@ -1868,7 +1997,7 @@ impl TableWriteSession {
         // register_data_file returns the ids actually committed (snapshot id
         // assigned at commit; real schema/table ids, which may differ from the
         // begin-time reservations under a concurrent create). Report those.
-        let committed = self.metadata.register_data_file(
+        let committed = self.metadata.register_data_file_with_commit_metadata(
             self.table_id,
             &self.schema_name,
             &self.table_name,
@@ -1878,6 +2007,8 @@ impl TableWriteSession {
             self.base_snapshot_id,
             &self.columns,
             &self.column_ids,
+            &self.commit_metadata,
+            self.expected_base_snapshot_id,
         )?;
 
         Ok(WriteResult {
@@ -1939,18 +2070,22 @@ impl TableWriteSession {
         } else {
             self.upload_staged().await?
         };
-        let committed = self.metadata.register_data_file_with_deletes(
-            self.table_id,
-            &self.schema_name,
-            &self.table_name,
-            self.snapshot_id,
-            &file_info,
-            deletes,
-            self.mode,
-            self.base_snapshot_id,
-            &self.columns,
-            &self.column_ids,
-        )?;
+        let committed = self
+            .metadata
+            .register_data_file_with_deletes_and_commit_metadata(
+                self.table_id,
+                &self.schema_name,
+                &self.table_name,
+                self.snapshot_id,
+                &file_info,
+                deletes,
+                self.mode,
+                self.base_snapshot_id,
+                &self.columns,
+                &self.column_ids,
+                &self.commit_metadata,
+                self.expected_base_snapshot_id,
+            )?;
 
         Ok(WriteResult {
             snapshot_id: committed.snapshot_id,

--- a/tests/it/concurrent_write_tests.rs
+++ b/tests/it/concurrent_write_tests.rs
@@ -7,7 +7,9 @@ use arrow::array::{Int32Array, StringArray};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use datafusion_ducklake::metadata_writer::MetadataWriter;
-use datafusion_ducklake::{DuckLakeTableWriter, SqliteMetadataWriter, WriteMode};
+use datafusion_ducklake::{
+    DuckLakeTableWriter, SqliteMetadataWriter, TableWriteOptions, WriteMode,
+};
 use object_store::ObjectStoreExt;
 use object_store::local::LocalFileSystem;
 use tempfile::TempDir;
@@ -152,6 +154,147 @@ async fn test_concurrent_writes_same_table_append() {
         let result = task.await.expect("Task panicked");
         assert_eq!(result.unwrap().records_written, 1);
     }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn replacement_rejects_table_change_after_expected_snapshot() {
+    let temp_dir = TempDir::new().unwrap();
+    let (writer, _): (SqliteMetadataWriter, _) = create_test_writer(&temp_dir).await;
+    let writer: Arc<dyn MetadataWriter> = Arc::new(writer);
+    let table_writer =
+        DuckLakeTableWriter::new(Arc::clone(&writer), create_object_store()).unwrap();
+
+    let initial = table_writer
+        .write_table(
+            "main",
+            "shared_table",
+            &[create_user_batch(&[1], &["initial"])],
+        )
+        .await
+        .unwrap();
+    let appended = table_writer
+        .append_table(
+            "main",
+            "shared_table",
+            &[create_user_batch(&[2], &["concurrent"])],
+        )
+        .await
+        .unwrap();
+
+    let options = TableWriteOptions::new().with_expected_base_snapshot_id(initial.snapshot_id);
+    let mut replacement = table_writer
+        .begin_write(
+            "main",
+            "shared_table",
+            &create_user_schema(),
+            WriteMode::Replace,
+        )
+        .unwrap()
+        .with_options(&options);
+    replacement
+        .write_batch(&create_user_batch(&[3], &["replacement"]))
+        .unwrap();
+    let error = replacement.finish().await.unwrap_err();
+
+    assert!(appended.snapshot_id > initial.snapshot_id);
+    assert_eq!(
+        error.to_string(),
+        format!(
+            "Write conflict: Replace on table {} conflicts with a concurrent write committed since \
+             snapshot {}; aborting (retry the write against the new generation)",
+            initial.table_id, initial.snapshot_id,
+        ),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn replacement_accepts_current_expected_snapshot() {
+    let temp_dir = TempDir::new().unwrap();
+    let (writer, _): (SqliteMetadataWriter, _) = create_test_writer(&temp_dir).await;
+    let writer: Arc<dyn MetadataWriter> = Arc::new(writer);
+    let table_writer =
+        DuckLakeTableWriter::new(Arc::clone(&writer), create_object_store()).unwrap();
+
+    let initial = table_writer
+        .write_table(
+            "main",
+            "shared_table",
+            &[create_user_batch(&[1], &["initial"])],
+        )
+        .await
+        .unwrap();
+    let options = TableWriteOptions::new().with_expected_base_snapshot_id(initial.snapshot_id);
+    let mut replacement = table_writer
+        .begin_write(
+            "main",
+            "shared_table",
+            &create_user_schema(),
+            WriteMode::Replace,
+        )
+        .unwrap()
+        .with_options(&options);
+    replacement
+        .write_batch(&create_user_batch(&[2], &["replacement"]))
+        .unwrap();
+
+    let result = replacement.finish().await.unwrap();
+
+    assert_eq!(result.snapshot_id, initial.snapshot_id + 1);
+    assert_eq!(result.table_id, initial.table_id);
+    assert_eq!(result.schema_id, initial.schema_id);
+    assert_eq!(result.files_written, 1);
+    assert_eq!(result.records_written, 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn conditional_append_rejects_table_change_after_expected_snapshot() {
+    let temp_dir = TempDir::new().unwrap();
+    let (writer, _): (SqliteMetadataWriter, _) = create_test_writer(&temp_dir).await;
+    let writer: Arc<dyn MetadataWriter> = Arc::new(writer);
+    let table_writer =
+        DuckLakeTableWriter::new(Arc::clone(&writer), create_object_store()).unwrap();
+
+    let initial = table_writer
+        .write_table(
+            "main",
+            "shared_table",
+            &[create_user_batch(&[1], &["initial"])],
+        )
+        .await
+        .unwrap();
+    let options = TableWriteOptions::new().with_expected_base_snapshot_id(initial.snapshot_id);
+    let mut conditional = table_writer
+        .begin_write(
+            "main",
+            "shared_table",
+            &create_user_schema(),
+            WriteMode::Append,
+        )
+        .unwrap()
+        .with_options(&options);
+    conditional
+        .write_batch(&create_user_batch(&[3], &["conditional"]))
+        .unwrap();
+    let appended = table_writer
+        .append_table(
+            "main",
+            "shared_table",
+            &[create_user_batch(&[2], &["concurrent"])],
+        )
+        .await
+        .unwrap();
+
+    let error = conditional.finish().await.unwrap_err();
+
+    assert!(appended.snapshot_id > initial.snapshot_id);
+    assert_eq!(
+        error.to_string(),
+        format!(
+            "Write conflict: Replace on table {} conflicts with a concurrent write committed since \
+             snapshot {}; aborting (retry the write against the new generation)",
+            initial.table_id, initial.snapshot_id,
+        ),
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/it/maintenance_sqlite_tests.rs
+++ b/tests/it/maintenance_sqlite_tests.rs
@@ -137,6 +137,17 @@ async fn drop_table_tombstones_children_and_is_idempotent() {
     )
     .await;
     assert_eq!(next_row_id, 5, "next_row_id preserved");
+    let drop_change: String = sqlx::query_scalar(
+        "SELECT changes_made
+         FROM ducklake_snapshot_changes
+         WHERE snapshot_id = (
+             SELECT MAX(snapshot_id) FROM ducklake_snapshot
+         )",
+    )
+    .fetch_one(&p)
+    .await
+    .unwrap();
+    assert_eq!(drop_change, format!("dropped_table:{}", s.table_id));
 
     // Second drop is a no-op.
     let dropped_again = h.writer.drop_table("main", "users").unwrap();

--- a/tests/it/multicatalog_postgres_tests.rs
+++ b/tests/it/multicatalog_postgres_tests.rs
@@ -9,10 +9,13 @@
 //! - Per-catalog dense `schema_version` allocation
 //! - No orphan mapping rows after writes
 
-use datafusion_ducklake::metadata_writer::{ColumnDef, MetadataWriter, WriteMode};
+use datafusion_ducklake::metadata_writer::{
+    ColumnDef, DataFileInfo, MetadataWriter, SnapshotCommitMetadata, WriteMode,
+};
 use datafusion_ducklake::{
-    DuckLakeError, DuckLakeTableWriter, MulticatalogManager, PostgresMetadataWriter,
-    TypeChangeOperation, TypeChangeWriteMode, initialize_multicatalog_schema,
+    DuckLakeError, DuckLakeTableWriter, MulticatalogManager, NullOrder, PartitionTransform,
+    PostgresMetadataWriter, SortDirection, SortField, TableWriteOptions, TypeChangeOperation,
+    TypeChangeWriteMode, initialize_multicatalog_schema,
 };
 use sqlx::AssertSqlSafe;
 use sqlx::Row;
@@ -93,6 +96,14 @@ async fn current_head(pool: &PgPool, catalog_id: i64) -> i64 {
     .unwrap()
 }
 
+async fn snapshot_changes(pool: &PgPool, snapshot_id: i64) -> Option<String> {
+    sqlx::query_scalar("SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id = $1")
+        .bind(snapshot_id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
 /// Total record_count of the files visible to a reader at the current head —
 /// the same window predicate the read path applies.
 async fn visible_records_at_head(pool: &PgPool, catalog_id: i64, table_id: i64) -> i64 {
@@ -110,6 +121,493 @@ async fn visible_records_at_head(pool: &PgPool, catalog_id: i64, table_id: i64) 
     .unwrap()
     .try_get(0)
     .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn postgres_writes_record_snapshot_changes_and_commit_metadata() {
+    let (pool, _container) = spin_up_postgres().await.unwrap();
+    let catalog_id = MulticatalogManager::new(pool.clone())
+        .create_catalog("snapshot_changes")
+        .await
+        .unwrap();
+    let writer = PostgresMetadataWriter::with_pool(pool.clone(), catalog_id)
+        .await
+        .unwrap();
+
+    let first = writer
+        .begin_write_transaction("public", "events", &cols(), WriteMode::Replace)
+        .unwrap();
+    let first_commit = writer
+        .register_data_file(
+            first.table_id,
+            "public",
+            "events",
+            first.snapshot_id,
+            &DataFileInfo::new("first.parquet", 1_024, 11),
+            WriteMode::Replace,
+            first.base_snapshot_id,
+            &cols(),
+            &first.column_ids,
+        )
+        .unwrap();
+
+    let second = writer
+        .begin_write_transaction("public", "events", &cols(), WriteMode::Append)
+        .unwrap();
+    let commit_metadata = SnapshotCommitMetadata::new()
+        .with_author("Jane Doe")
+        .with_message("Append imported events")
+        .with_extra_info("opaque-import-id");
+    let second_commit = writer
+        .register_data_file_with_commit_metadata(
+            second.table_id,
+            "public",
+            "events",
+            second.snapshot_id,
+            &DataFileInfo::new("second.parquet", 2_048, 17),
+            WriteMode::Append,
+            second.base_snapshot_id,
+            &cols(),
+            &second.column_ids,
+            &commit_metadata,
+            None,
+        )
+        .unwrap();
+
+    let rows = sqlx::query(
+        "SELECT c.snapshot_id, c.changes_made, c.author, c.commit_message,
+                c.commit_extra_info
+         FROM ducklake_snapshot_changes c
+         JOIN ducklake_catalog_snapshot_map m ON m.snapshot_id = c.snapshot_id
+         WHERE m.catalog_id = $1
+         ORDER BY c.snapshot_id",
+    )
+    .bind(catalog_id)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    let actual = rows
+        .iter()
+        .map(|row| {
+            (
+                row.try_get::<i64, _>("snapshot_id").unwrap(),
+                row.try_get::<String, _>("changes_made").unwrap(),
+                row.try_get::<Option<String>, _>("author").unwrap(),
+                row.try_get::<Option<String>, _>("commit_message").unwrap(),
+                row.try_get::<Option<String>, _>("commit_extra_info")
+                    .unwrap(),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        actual,
+        vec![
+            (
+                first_commit.snapshot_id,
+                format!(
+                    "created_schema:\"public\",created_table:\"public\".\"events\",\
+                     inserted_into_table:{}",
+                    first.table_id
+                ),
+                None,
+                None,
+                None,
+            ),
+            (
+                second_commit.snapshot_id,
+                format!("inserted_into_table:{}", second.table_id),
+                Some("Jane Doe".to_string()),
+                Some("Append imported events".to_string()),
+                Some("opaque-import-id".to_string()),
+            ),
+        ],
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn postgres_fileless_and_partition_ddl_record_snapshot_changes() {
+    let (pool, _container) = spin_up_postgres().await.unwrap();
+    let catalog_id = MulticatalogManager::new(pool.clone())
+        .create_catalog("snapshot_ddl")
+        .await
+        .unwrap();
+    let writer = PostgresMetadataWriter::with_pool(pool.clone(), catalog_id)
+        .await
+        .unwrap();
+
+    let bare_snapshot = writer.create_snapshot().unwrap();
+    let setup = writer
+        .begin_write_transaction("ma\"in", "ev\"ents", &cols(), WriteMode::Replace)
+        .unwrap();
+    let published = writer
+        .publish_snapshot(
+            setup.table_id,
+            "ma\"in",
+            "ev\"ents",
+            setup.snapshot_id,
+            WriteMode::Replace,
+            setup.base_snapshot_id,
+            &cols(),
+            &setup.column_ids,
+        )
+        .unwrap();
+    let partition_snapshot = writer
+        .set_partition_spec(
+            setup.table_id,
+            &[("id".to_string(), PartitionTransform::Identity)],
+        )
+        .unwrap();
+    let reset_snapshot = writer.reset_partition_spec(setup.table_id).unwrap();
+
+    let rows = sqlx::query_as::<_, (i64, Option<String>)>(
+        "SELECT changes.snapshot_id, changes.changes_made
+         FROM ducklake_snapshot_changes changes
+         JOIN ducklake_catalog_snapshot_map map
+           ON map.snapshot_id = changes.snapshot_id
+         WHERE map.catalog_id = $1
+         ORDER BY changes.snapshot_id",
+    )
+    .bind(catalog_id)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+
+    assert_eq!(
+        rows,
+        vec![
+            (bare_snapshot, None),
+            (
+                published.snapshot_id,
+                Some(format!(
+                    "created_schema:\"ma\"\"in\",created_table:\"ma\"\"in\".\"ev\"\"ents\",\
+                     inserted_into_table:{}",
+                    setup.table_id,
+                )),
+            ),
+            (
+                partition_snapshot,
+                Some(format!("altered_table:{}", setup.table_id)),
+            ),
+            (
+                reset_snapshot,
+                Some(format!("altered_table:{}", setup.table_id)),
+            ),
+        ],
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn postgres_partitioned_write_honors_expected_snapshot() {
+    use std::sync::Arc;
+
+    use arrow::array::Int64Array;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use object_store::ObjectStore;
+    use object_store::local::LocalFileSystem;
+    use tempfile::TempDir;
+
+    let (pool, _container) = spin_up_postgres().await.unwrap();
+    let catalog_id = MulticatalogManager::new(pool.clone())
+        .create_catalog("partition_fencing")
+        .await
+        .unwrap();
+    let temp = TempDir::new().unwrap();
+    let data_path = temp.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+    let writer = Arc::new(
+        PostgresMetadataWriter::with_pool(pool.clone(), catalog_id)
+            .await
+            .unwrap(),
+    );
+    writer.set_data_path(data_path.to_str().unwrap()).unwrap();
+    let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+    let metadata: Arc<dyn MetadataWriter> = writer.clone();
+    let table_writer = DuckLakeTableWriter::new(metadata, store).unwrap();
+    let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+    let initial_batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![Arc::new(Int64Array::from(vec![1]))],
+    )
+    .unwrap();
+    let initial = table_writer
+        .write_table("public", "events", &[initial_batch])
+        .await
+        .unwrap();
+    let partition_snapshot = writer
+        .set_partition_spec(
+            initial.table_id,
+            &[("id".to_string(), PartitionTransform::Identity)],
+        )
+        .unwrap();
+    let partition_id: i64 = sqlx::query_scalar(
+        "SELECT partition_id FROM ducklake_partition_info
+         WHERE table_id = $1 AND end_snapshot IS NULL",
+    )
+    .bind(initial.table_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let options = TableWriteOptions::new().with_expected_base_snapshot_id(partition_snapshot);
+    let append_batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![Arc::new(Int64Array::from(vec![2]))],
+    )
+    .unwrap();
+
+    let appended = table_writer
+        .write_partitioned_with_options(
+            "public",
+            "events",
+            schema.as_ref(),
+            WriteMode::Append,
+            partition_id,
+            &["id".to_string()],
+            vec![(vec![Some("2".to_string())], vec![append_batch])],
+            &options,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(appended.snapshot_id, partition_snapshot + 1);
+    assert_eq!(appended.table_id, initial.table_id);
+    assert_eq!(appended.schema_id, initial.schema_id);
+    assert_eq!(appended.files_written, 1);
+    assert_eq!(appended.records_written, 1);
+
+    let stale_batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![Arc::new(Int64Array::from(vec![3]))],
+    )
+    .unwrap();
+    let error = table_writer
+        .write_partitioned_with_options(
+            "public",
+            "events",
+            schema.as_ref(),
+            WriteMode::Append,
+            partition_id,
+            &["id".to_string()],
+            vec![(vec![Some("3".to_string())], vec![stale_batch])],
+            &options,
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        format!(
+            "Write conflict: Replace on table {} conflicts with a concurrent write committed since \
+             snapshot {}; aborting (retry the write against the new generation)",
+            initial.table_id, partition_snapshot,
+        ),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn conditional_append_rejects_table_change_after_expected_snapshot() {
+    let (pool, _container) = spin_up_postgres().await.unwrap();
+    let catalog_id = MulticatalogManager::new(pool.clone())
+        .create_catalog("conditional_append")
+        .await
+        .unwrap();
+    let writer = PostgresMetadataWriter::with_pool(pool.clone(), catalog_id)
+        .await
+        .unwrap();
+
+    let initial = writer
+        .begin_write_transaction("public", "events", &cols(), WriteMode::Replace)
+        .unwrap();
+    let initial_commit = writer
+        .register_data_file(
+            initial.table_id,
+            "public",
+            "events",
+            initial.snapshot_id,
+            &DataFileInfo::new("initial.parquet", 1_024, 11),
+            WriteMode::Replace,
+            initial.base_snapshot_id,
+            &cols(),
+            &initial.column_ids,
+        )
+        .unwrap();
+    let conditional = writer
+        .begin_write_transaction("public", "events", &cols(), WriteMode::Append)
+        .unwrap();
+    let concurrent = writer
+        .begin_write_transaction("public", "events", &cols(), WriteMode::Append)
+        .unwrap();
+    let concurrent_commit = writer
+        .register_data_file(
+            concurrent.table_id,
+            "public",
+            "events",
+            concurrent.snapshot_id,
+            &DataFileInfo::new("concurrent.parquet", 2_048, 17),
+            WriteMode::Append,
+            concurrent.base_snapshot_id,
+            &cols(),
+            &concurrent.column_ids,
+        )
+        .unwrap();
+
+    let error = writer
+        .register_data_file_with_commit_metadata(
+            conditional.table_id,
+            "public",
+            "events",
+            conditional.snapshot_id,
+            &DataFileInfo::new("conditional.parquet", 4_096, 23),
+            WriteMode::Append,
+            initial_commit.snapshot_id,
+            &cols(),
+            &conditional.column_ids,
+            &SnapshotCommitMetadata::default(),
+            Some(initial_commit.snapshot_id),
+        )
+        .unwrap_err();
+
+    assert!(matches!(error, DuckLakeError::Conflict(_)));
+    assert_eq!(
+        current_head(&pool, catalog_id).await,
+        concurrent_commit.snapshot_id
+    );
+    assert_eq!(
+        visible_records_at_head(&pool, catalog_id, initial.table_id).await,
+        28,
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn conditional_append_with_new_column_does_not_conflict_with_itself() {
+    let (pool, _container) = spin_up_postgres().await.unwrap();
+    let catalog_id = MulticatalogManager::new(pool.clone())
+        .create_catalog("conditional_column_append")
+        .await
+        .unwrap();
+    let writer = PostgresMetadataWriter::with_pool(pool.clone(), catalog_id)
+        .await
+        .unwrap();
+
+    let initial = writer
+        .begin_write_transaction("public", "events", &cols(), WriteMode::Replace)
+        .unwrap();
+    let initial_commit = writer
+        .register_data_file(
+            initial.table_id,
+            "public",
+            "events",
+            initial.snapshot_id,
+            &DataFileInfo::new("initial.parquet", 1_024, 11),
+            WriteMode::Replace,
+            initial.base_snapshot_id,
+            &cols(),
+            &initial.column_ids,
+        )
+        .unwrap();
+    let mut extended_columns = cols();
+    extended_columns.push(ColumnDef::new("note", "varchar", true).unwrap());
+    let conditional = writer
+        .begin_write_transaction("public", "events", &extended_columns, WriteMode::Append)
+        .unwrap();
+
+    let committed = writer
+        .register_data_file_with_commit_metadata(
+            conditional.table_id,
+            "public",
+            "events",
+            conditional.snapshot_id,
+            &DataFileInfo::new("extended.parquet", 2_048, 17),
+            WriteMode::Append,
+            conditional.base_snapshot_id,
+            &extended_columns,
+            &conditional.column_ids,
+            &SnapshotCommitMetadata::default(),
+            Some(initial_commit.snapshot_id),
+        )
+        .unwrap();
+
+    assert_eq!(committed.table_id, initial.table_id);
+    assert_eq!(
+        snapshot_changes(&pool, committed.snapshot_id).await,
+        Some(format!(
+            "altered_table:{},inserted_into_table:{}",
+            initial.table_id, initial.table_id,
+        )),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn postgres_sort_ddl_records_snapshot_changes() {
+    let (pool, _container) = spin_up_postgres().await.unwrap();
+    let catalog_id = MulticatalogManager::new(pool.clone())
+        .create_catalog("sort_order")
+        .await
+        .unwrap();
+    let writer = PostgresMetadataWriter::with_pool(pool.clone(), catalog_id)
+        .await
+        .unwrap();
+    let setup = writer
+        .begin_write_transaction("public", "events", &cols(), WriteMode::Replace)
+        .unwrap();
+    writer
+        .register_data_file(
+            setup.table_id,
+            "public",
+            "events",
+            setup.snapshot_id,
+            &DataFileInfo::new("events.parquet", 1_024, 11),
+            WriteMode::Replace,
+            setup.base_snapshot_id,
+            &cols(),
+            &setup.column_ids,
+        )
+        .unwrap();
+
+    let field = SortField::column(0, "name", SortDirection::Desc, NullOrder::NullsFirst);
+    let set_snapshot = writer.set_sort_spec(setup.table_id, &[field]).unwrap();
+
+    let row = sqlx::query(
+        "SELECT e.expression, e.dialect, e.sort_direction, e.null_order, c.changes_made
+         FROM ducklake_sort_info i
+         JOIN ducklake_sort_expression e
+           ON e.sort_id = i.sort_id AND e.table_id = i.table_id
+         JOIN ducklake_snapshot_changes c ON c.snapshot_id = i.begin_snapshot
+         WHERE i.table_id = $1 AND i.end_snapshot IS NULL",
+    )
+    .bind(setup.table_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(row.try_get::<String, _>("expression").unwrap(), "name");
+    assert_eq!(row.try_get::<String, _>("dialect").unwrap(), "duckdb");
+    assert_eq!(row.try_get::<String, _>("sort_direction").unwrap(), "DESC");
+    assert_eq!(
+        row.try_get::<String, _>("null_order").unwrap(),
+        "NULLS_FIRST"
+    );
+    assert_eq!(
+        row.try_get::<String, _>("changes_made").unwrap(),
+        format!("altered_table:{}", setup.table_id),
+    );
+
+    let reset_snapshot = writer.reset_sort_spec(setup.table_id).unwrap();
+    assert!(reset_snapshot > set_snapshot);
+    let end_snapshot: i64 =
+        sqlx::query("SELECT end_snapshot FROM ducklake_sort_info WHERE table_id = $1")
+            .bind(setup.table_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
+    assert_eq!(end_snapshot, reset_snapshot);
 }
 
 /// #864: the postgres `set_delete_file` write — fenced, cumulative,
@@ -173,6 +671,10 @@ async fn set_delete_file_postgres_cumulative_and_fenced() {
         .unwrap();
     assert!(ids1.snapshot_id > base1, "head advances");
     assert_eq!(current_head(&pool, cat).await, ids1.snapshot_id);
+    assert_eq!(
+        snapshot_changes(&pool, ids1.snapshot_id).await,
+        Some(format!("deleted_from_table:{table_id}")),
+    );
     let (live_count, live_id, dcount, begin): (i64, i64, i64, i64) = {
         let row = sqlx::query(
             "SELECT COUNT(*), MIN(delete_file_id), MIN(delete_count), MIN(begin_snapshot)
@@ -251,6 +753,10 @@ async fn set_delete_file_postgres_cumulative_and_fenced() {
         prior_end,
         Some(ids2.snapshot_id),
         "prior delete file retired at the new snapshot"
+    );
+    assert_eq!(
+        snapshot_changes(&pool, ids2.snapshot_id).await,
+        Some(format!("deleted_from_table:{table_id}")),
     );
 }
 
@@ -2405,6 +2911,14 @@ async fn drop_table_in_catalog_bumps_schema_version_as_ddl() {
         v_drop, 2,
         "drop snapshot must bump schema_version (DDL change)"
     );
+    let drop_change: String = sqlx::query_scalar(
+        "SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id = $1",
+    )
+    .bind(drop_snap)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(drop_change, format!("dropped_table:{}", s.table_id));
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -4489,6 +5003,67 @@ async fn multicatalog_append_racing_promote_does_not_bump_schema_version() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn retire_appends_since_records_snapshot_changes() {
+    let (pool, _container) = spin_up_postgres().await.unwrap();
+    let catalog_id = MulticatalogManager::new(pool.clone())
+        .create_catalog("retire_append_changes")
+        .await
+        .unwrap();
+    let writer = PostgresMetadataWriter::with_pool(pool.clone(), catalog_id)
+        .await
+        .unwrap();
+
+    let initial = writer
+        .begin_write_transaction("public", "events", &cols(), WriteMode::Replace)
+        .unwrap();
+    let initial_commit = writer
+        .register_data_file(
+            initial.table_id,
+            "public",
+            "events",
+            initial.snapshot_id,
+            &DataFileInfo::new("initial.parquet", 1_024, 11),
+            WriteMode::Replace,
+            initial.base_snapshot_id,
+            &cols(),
+            &initial.column_ids,
+        )
+        .unwrap();
+    let appended = writer
+        .begin_write_transaction("public", "events", &cols(), WriteMode::Append)
+        .unwrap();
+    writer
+        .register_data_file(
+            appended.table_id,
+            "public",
+            "events",
+            appended.snapshot_id,
+            &DataFileInfo::new("appended.parquet", 2_048, 17),
+            WriteMode::Append,
+            appended.base_snapshot_id,
+            &cols(),
+            &appended.column_ids,
+        )
+        .unwrap();
+
+    let retired_snapshot = writer
+        .retire_appends_since(initial.table_id, initial_commit.snapshot_id)
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(current_head(&pool, catalog_id).await, retired_snapshot);
+    assert_eq!(
+        snapshot_changes(&pool, retired_snapshot).await,
+        Some(format!("deleted_from_table:{}", initial.table_id)),
+    );
+    assert_eq!(
+        visible_records_at_head(&pool, catalog_id, initial.table_id).await,
+        11,
+    );
+}
+
 /// `register_existing_data_file` adopts the caller's `column_ids` (so a copied
 /// parquet's embedded field-ids resolve), creates the table/file/snapshot, and
 /// advances the catalog head — replace then append, without re-minting ids.
@@ -4522,6 +5097,14 @@ async fn register_existing_data_file_adopts_column_ids() {
         current_head(&pool, cat).await,
         out.snapshot_id,
         "head advances to the committed snapshot"
+    );
+    assert_eq!(
+        snapshot_changes(&pool, out.snapshot_id).await,
+        Some(format!(
+            "created_schema:\"public\",created_table:\"public\".\"orders\",\
+             inserted_into_table:{}",
+            out.table_id,
+        )),
     );
 
     let cols_got: Vec<(String, i64)> = sqlx::query(
@@ -4559,6 +5142,10 @@ async fn register_existing_data_file_adopts_column_ids() {
         .unwrap();
     assert_eq!(out2.table_id, out.table_id, "same table");
     assert_eq!(current_head(&pool, cat).await, out2.snapshot_id);
+    assert_eq!(
+        snapshot_changes(&pool, out2.snapshot_id).await,
+        Some(format!("inserted_into_table:{}", out.table_id)),
+    );
 
     let live_files: i64 = sqlx::query(
         "SELECT COUNT(*) FROM ducklake_data_file WHERE table_id = $1 AND end_snapshot IS NULL",

--- a/tests/it/mysql_metadata_writer_test.rs
+++ b/tests/it/mysql_metadata_writer_test.rs
@@ -11,8 +11,9 @@
 
 use datafusion_ducklake::{
     ColumnDef, DataFileInfo, MetadataProvider, MetadataWriter, MySqlMetadataProvider,
-    MySqlMetadataWriter, WriteMode,
+    MySqlMetadataWriter, SnapshotCommitMetadata, WriteMode,
 };
+use sqlx::Row;
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::mysql::Mysql;
 
@@ -35,6 +36,8 @@ async fn mysql_writer_roundtrip_write_then_read() {
         ColumnDef::new("id", "int64", false).unwrap(),
         ColumnDef::new("name", "varchar", true).unwrap(),
     ];
+    let bare_snapshot = writer.create_snapshot().unwrap();
+    assert_eq!(bare_snapshot, 1, "bare snapshot is snapshot 1");
 
     // Real write path: begin (reserve ids, get-or-create schema/table) then
     // commit by registering a data file.
@@ -43,7 +46,7 @@ async fn mysql_writer_roundtrip_write_then_read() {
         .unwrap();
     let file = DataFileInfo::new("data_001.parquet", 1024, 4).with_footer_size(128);
     let committed = writer
-        .register_data_file(
+        .register_data_file_with_commit_metadata(
             setup.table_id,
             "main",
             "users",
@@ -53,10 +56,14 @@ async fn mysql_writer_roundtrip_write_then_read() {
             setup.base_snapshot_id,
             &columns,
             &setup.column_ids,
+            &SnapshotCommitMetadata::new()
+                .with_author("Jane Doe")
+                .with_message("Initial import")
+                .with_extra_info("opaque-import-id"),
+            None,
         )
         .unwrap();
-    // First write commits snapshot 1 on a fresh catalog.
-    assert_eq!(committed.snapshot_id, 1, "first write commits snapshot 1");
+    assert_eq!(committed.snapshot_id, 2, "first write commits snapshot 2");
 
     // A fileless CREATE TABLE exercises the publish_snapshot override.
     let cols2 = vec![ColumnDef::new("c1", "int32", true).unwrap()];
@@ -78,6 +85,56 @@ async fn mysql_writer_roundtrip_write_then_read() {
     assert!(
         committed2.snapshot_id > committed.snapshot_id,
         "second commit advances the head"
+    );
+
+    let pool = sqlx::MySqlPool::connect(&conn_str).await.unwrap();
+    let rows = sqlx::query(
+        "SELECT snapshot_id, changes_made, author, commit_message, commit_extra_info
+         FROM ducklake_snapshot_changes
+         ORDER BY snapshot_id",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    let changes = rows
+        .iter()
+        .map(|row| {
+            (
+                row.try_get::<i64, _>("snapshot_id").unwrap(),
+                row.try_get::<Option<String>, _>("changes_made").unwrap(),
+                row.try_get::<Option<String>, _>("author").unwrap(),
+                row.try_get::<Option<String>, _>("commit_message").unwrap(),
+                row.try_get::<Option<String>, _>("commit_extra_info")
+                    .unwrap(),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        changes,
+        vec![
+            (bare_snapshot, None, None, None, None),
+            (
+                committed.snapshot_id,
+                Some(format!(
+                    "created_schema:\"main\",created_table:\"main\".\"users\",\
+                     inserted_into_table:{}",
+                    setup.table_id
+                )),
+                Some("Jane Doe".to_string()),
+                Some("Initial import".to_string()),
+                Some("opaque-import-id".to_string()),
+            ),
+            (
+                committed2.snapshot_id,
+                Some(format!(
+                    "created_table:\"main\".\"empty_t\",inserted_into_table:{}",
+                    setup2.table_id
+                )),
+                None,
+                None,
+                None,
+            ),
+        ],
     );
 
     // --- Read side ---------------------------------------------------------

--- a/tests/it/sorted_write_duckdb_tests.rs
+++ b/tests/it/sorted_write_duckdb_tests.rs
@@ -12,7 +12,8 @@
 use datafusion_ducklake::metadata_provider::MetadataProvider;
 use datafusion_ducklake::sort::{NullOrder, SortDirection, SortField};
 use datafusion_ducklake::{
-    ColumnDef, DuckdbMetadataProvider, DuckdbMetadataWriter, MetadataWriter, WriteMode,
+    ColumnDef, DataFileInfo, DuckdbMetadataProvider, DuckdbMetadataWriter, MetadataWriter,
+    SnapshotCommitMetadata, WriteMode,
 };
 use tempfile::TempDir;
 
@@ -94,5 +95,113 @@ fn duckdb_set_get_reset_sort_spec() {
     assert!(
         provider.get_sort_spec(table_id, snap).unwrap().is_none(),
         "sort spec cleared after RESET"
+    );
+}
+
+#[test]
+fn duckdb_records_snapshot_changes_and_commit_metadata() {
+    let temp = TempDir::new().unwrap();
+    let db_str = temp
+        .path()
+        .join("snapshot_changes.ducklake")
+        .to_str()
+        .unwrap()
+        .to_string();
+    let columns = vec![ColumnDef::new("id", "int64", false).unwrap()];
+    let bare_snapshot;
+    let first_commit;
+    let second_commit;
+    let table_id;
+
+    {
+        let writer = DuckdbMetadataWriter::new_with_init(&db_str).unwrap();
+        bare_snapshot = writer.create_snapshot().unwrap();
+        let first = writer
+            .begin_write_transaction("main", "events", &columns, WriteMode::Replace)
+            .unwrap();
+        table_id = first.table_id;
+        first_commit = writer
+            .register_data_file_with_commit_metadata(
+                first.table_id,
+                "main",
+                "events",
+                first.snapshot_id,
+                &DataFileInfo::new("first.parquet", 100, 3),
+                WriteMode::Replace,
+                first.base_snapshot_id,
+                &columns,
+                &first.column_ids,
+                &SnapshotCommitMetadata::new()
+                    .with_author("Jane Doe")
+                    .with_message("Initial import")
+                    .with_extra_info("opaque-import-id"),
+                None,
+            )
+            .unwrap();
+
+        let second = writer
+            .begin_write_transaction("main", "events", &columns, WriteMode::Replace)
+            .unwrap();
+        second_commit = writer
+            .register_data_file(
+                second.table_id,
+                "main",
+                "events",
+                second.snapshot_id,
+                &DataFileInfo::new("second.parquet", 200, 5),
+                WriteMode::Replace,
+                second.base_snapshot_id,
+                &columns,
+                &second.column_ids,
+            )
+            .unwrap();
+    }
+
+    let connection = duckdb::Connection::open(&db_str).unwrap();
+    let mut statement = connection
+        .prepare(
+            "SELECT snapshot_id, changes_made, author, commit_message, commit_extra_info
+             FROM ducklake_snapshot_changes
+             ORDER BY snapshot_id",
+        )
+        .unwrap();
+    let rows = statement
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, Option<String>>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, Option<String>>(3)?,
+                row.get::<_, Option<String>>(4)?,
+            ))
+        })
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    assert_eq!(
+        rows,
+        vec![
+            (bare_snapshot, None, None, None, None),
+            (
+                first_commit.snapshot_id,
+                Some(format!(
+                    "created_schema:\"main\",created_table:\"main\".\"events\",\
+                     inserted_into_table:{table_id}"
+                )),
+                Some("Jane Doe".to_string()),
+                Some("Initial import".to_string()),
+                Some("opaque-import-id".to_string()),
+            ),
+            (
+                second_commit.snapshot_id,
+                Some(format!(
+                    "deleted_from_table:{table_id},inserted_into_table:{table_id}"
+                )),
+                None,
+                None,
+                None,
+            ),
+        ],
     );
 }

--- a/tests/it/sql_delete_postgres_tests.rs
+++ b/tests/it/sql_delete_postgres_tests.rs
@@ -101,6 +101,14 @@ async fn catalog_snapshot_count(pool: &PgPool, cat: i64) -> i64 {
         .unwrap()
 }
 
+async fn snapshot_changes(pool: &PgPool, snapshot_id: i64) -> Option<String> {
+    sqlx::query_scalar("SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id = $1")
+        .bind(snapshot_id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
 /// Drives the two new commit primitives directly on the Postgres writer:
 /// (1) `commit_positional_deletes` for a WHERE delete, asserting the read
 /// reflects it and it lands as exactly one catalog snapshot; (2) `commit_truncate`
@@ -230,6 +238,10 @@ async fn positional_delete_and_truncate_commit_postgres() {
         delete_snap, commit.snapshot_id,
         "delete file's begin_snapshot is the committed head"
     );
+    assert_eq!(
+        snapshot_changes(&pool, commit.snapshot_id).await,
+        Some(format!("deleted_from_table:{}", table_meta.table_id)),
+    );
 
     // --- commit_truncate: remove the two survivors. ---
     let head2 = MulticatalogProvider::with_pool(pool.clone(), cat_name)
@@ -248,6 +260,18 @@ async fn positional_delete_and_truncate_commit_postgres() {
         read_pairs(&pool, cat_name).await,
         Vec::<(i32, i32)>::new(),
         "table empty"
+    );
+    let truncate_snapshot: i64 = sqlx::query_scalar(
+        "SELECT COALESCE(MAX(snapshot_id), 0) FROM ducklake_catalog_snapshot_map
+         WHERE catalog_id = $1",
+    )
+    .bind(cat)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        snapshot_changes(&pool, truncate_snapshot).await,
+        Some(format!("deleted_from_table:{}", table_meta.table_id)),
     );
     let snaps_after_truncate = catalog_snapshot_count(&pool, cat).await;
 


### PR DESCRIPTION
### Summary

Record `ducklake_snapshot_changes` rows for SQLite, PostgreSQL, DuckDB, and MySQL data-write and DDL
paths. Expose the optional author, commit message, and extra information defined by DuckLake. The
API accepts opaque metadata and does not assign uniqueness or lookup semantics to extra
information.

This closes a specification gap: creating a snapshot requires both the snapshot row and its change
row. See the DuckLake
[snapshot creation transaction](https://ducklake.select/docs/stable/specification/queries#creating-a-new-snapshot)
and
[snapshot changes table](https://ducklake.select/docs/stable/specification/tables/ducklake_snapshot_changes).
The emitted values also match DuckLake's official reader: `created_table` carries a quoted
`"schema"."table"` catalog entry, and a snapshot with no changes stores SQL `NULL`.

```mermaid
sequenceDiagram
    participant Caller
    participant Writer as Table writer
    participant SQL as Metadata transaction
    Caller->>Writer: Write with TableWriteOptions
    Writer->>SQL: Check expected table snapshot when supplied
    Writer->>SQL: Allocate snapshot and register files
    Writer->>SQL: Insert snapshot changes
    SQL-->>Caller: Commit files and metadata atomically
```

### Changes

- Add `SnapshotCommitMetadata` with optional `author`, `message`, and `extra_info` values.
- Add `TableWriteOptions` for commit metadata and an optional expected table snapshot.
- Keep the existing streaming and partitioned write entry points unchanged; add options-based entry
  points and builders.
- Forward commit metadata and expected-snapshot preconditions through single-file, rolled, and
  partitioned streaming commits.
- Record `changes_made` for append, replacement, delete, compaction, fileless publish, partition
  DDL, table drop, and bare snapshot paths, including writes without optional metadata.
- Report an initial replacement as an insertion when it retires no prior files.
- Record SQL-quoted `created_schema`, schema-qualified `created_table`, `altered_table`, and
  `dropped_table` tokens.
- Store `NULL` for change-free snapshots and migrate legacy non-null `changes_made` columns on all
  four metadata backends, including SQLite catalogs reopened through plain `new()`.
- Add missing SQLite `author`, `commit_message`, and `commit_extra_info` columns before rebuilding
  older official snapshot-change tables.
- Apply the same commit metadata contract to SQLite, catalog-scoped PostgreSQL, DuckDB, and MySQL.
- Record PostgreSQL change tokens for adopted files, positional deletes, delete files, truncation,
  and append retirement before advancing the catalog head.
- Run PostgreSQL expected-snapshot checks before `finalize_snapshot` can insert the current write's
  column rows.
- Reject stale appends, replacements, combined writes, and compaction commits when the target table
  changed after the expected snapshot.
- Make `TableWriteSession::with_options` infallible and use exact conflict assertions in the
  concurrency regressions.
- Keep the PostgreSQL `INT4` decode fix for empty partition and sort reset probes.
- Retain compatibility for external `MetadataWriter` implementations through default trait methods.

### Deliberate non-goals

- No generated replay identifier.
- No exact-value lookup by `commit_extra_info`.
- No uniqueness constraint on extra information.
- No application-specific metadata schema.

Applications may use the opaque field for their own purpose, but the library only stores the
standard DuckLake values.

### Commit and branch

- Refreshed independent branch: `ducklake-snapshot-commit-metadata-independent`.
- Commit: `19babbe feat(write): add snapshot metadata and write preconditions`.
- Base: current upstream `2a52b80`.
- The branch inherits upstream SQLx 0.9 and partition parity and has no dependency on another
  unmerged topic.

### Verification

- `cargo fmt --all -- --check`: passed.
- `CARGO_BUILD_JOBS=8 cargo clippy --all-targets --all-features --no-deps -- -D warnings`: passed.
- The complete no-default-feature CI matrix passed for every metadata and write backend combination.
- `CARGO_BUILD_JOBS=8 cargo test --features "skip-tests-with-docker write-sqlite"`: passed with
  313 library tests, 306 integration tests, and 8 doc tests; 2 tests were ignored.
- `CARGO_BUILD_JOBS=8 cargo test --features "duckdb-bundled encryption metadata-mysql
  metadata-postgres metadata-sqlite write-sqlite"`: passed with 323 library tests, 339 integration
  tests, and 8 doc tests; 14 tests were ignored.
- `RUSTDOCFLAGS='-D warnings' CARGO_BUILD_JOBS=8 cargo doc --no-deps --all-features`: passed.
- Focused SQLite migration, DuckDB ledger, MySQL writer, and PostgreSQL conflict and ledger tests
  passed against their real backends.
- `open_legacy_snapshot_changes_with_plain_new`: passed, proving plain reopen accepts a NULL change
  row and adds all three optional commit metadata columns.

### Specification proof

| DuckLake rule                                                                                                                                                                                                                                                       | Implementation invariant                                                                                            | Discriminating proof                                                                                                   |
| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
| Every data change creates both a [`ducklake_snapshot`](https://ducklake.select/docs/stable/specification/tables/ducklake_snapshot) row and a [`ducklake_snapshot_changes`](https://ducklake.select/docs/stable/specification/tables/ducklake_snapshot_changes) row. | Each writer records the change row in the same metadata transaction that publishes the snapshot and files.          | `snapshot_changes_are_atomic_with_append_and_replace` asserts exact snapshot and change rows after append and replace. |
| `changes_made` uses the specification's fixed high-level tokens.                                                                                                                                                                                                    | Write, DDL, compaction, and deletion paths emit the specified token and identifier form.                            | SQLite and PostgreSQL tests assert exact `inserted_into_table`, `deleted_from_table`, and DDL values.                  |
| Official DuckLake parses `created_table` as a quoted catalog entry and stores no-change snapshots as `NULL`.                                                                                                                                                        | Every backend writes `"schema"."table"`, preserves embedded quotes, and uses a nullable change column.              | Backend round trips assert qualified names and `NULL`; SQLite reopen tests prove legacy rows and columns migrate.      |
| `author`, `commit_message`, and `commit_extra_info` are optional snapshot fields.                                                                                                                                                                                   | `SnapshotCommitMetadata` forwards optional opaque strings without imposing application semantics.                   | PostgreSQL, DuckDB, and MySQL round trips assert all three exact values.                                               |
| A snapshot ID and file ID remain monotonic catalog identifiers.                                                                                                                                                                                                     | Write preconditions reject a stale base before the transaction can publish a competing snapshot or file generation. | `conditional_append_rejects_table_change_after_expected_snapshot` asserts no snapshot is published on conflict.        |

The expected-base option is a library concurrency control, not a new DuckLake metadata concept. It
changes no specified table shape or value encoding.

### PostgreSQL check

The focused PostgreSQL self-conflict regression ran with:

```bash
CARGO_BUILD_JOBS=8 cargo test --features "metadata-postgres write-postgres" \
  conditional_append_with_new_column_does_not_conflict_with_itself -- --nocapture
```

The test starts an ephemeral PostgreSQL container, appends a newly added column with a current
precondition, and proves the writer does not match the column row it is about to insert. Focused
tests also assert exact PostgreSQL ledger values for adopted files, delete files, positional deletes,
truncation, and append retirement.

The interop choices follow DuckLake's official
[`ParseCatalogEntry`](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/common/ducklake_util.cpp),
[`created_table` encoding](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_transaction_state.cpp),
and
[`SQLStringOrNull` snapshot insertion](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_metadata_manager.cpp).

### Review boundary

This PR owns snapshot transaction metadata and general optimistic write preconditions. It does not
redesign sort metadata, compaction execution, or partition preservation. It implements the covered
snapshot-change contract, but it does not claim complete DuckLake 1.0 conformance for the library.
