### PR TITLE
Stream sorted targeted rewrites

### DIFF
--- a/examples/compaction_demo.rs
+++ b/examples/compaction_demo.rs
@@ -135,6 +135,7 @@ async fn main() -> anyhow::Result<()> {
                 &state,
                 RewriteOptions {
                     delete_threshold: 0.5,
+                    ..RewriteOptions::default()
                 },
             )
             .await

--- a/src/compaction.rs
+++ b/src/compaction.rs
@@ -36,13 +36,19 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use arrow::array::{ArrayRef, Int64Array, RecordBatch};
+use arrow::compute::SortOptions;
 use arrow::datatypes::{DataType, Field, Schema};
 use datafusion::catalog::Session;
+use datafusion::datasource::memory::MemorySourceConfig;
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_expr::{LexOrdering, PhysicalSortExpr, expressions::Column};
+use datafusion::physical_plan::{ExecutionPlan, sorts::sort::SortExec};
 
 use crate::metadata_provider::DuckLakeTableFile;
 use crate::metadata_writer::{CompactionOutputFile, CompactionSourceFile, SourceRetirement};
 use crate::partition::PartitionSpec;
 use crate::row_id::EMBEDDED_SNAPSHOT_ID_COLUMN_NAME;
+use crate::sort::{SortDirection, SortSpec};
 use crate::table::DuckLakeTable;
 use crate::table_writer::DuckLakeTableWriter;
 use crate::{DuckLakeError, Result};
@@ -83,12 +89,17 @@ pub struct RewriteOptions {
     /// delete file is at least this value. DuckDB's default is `0.95`. Must be in
     /// `[0.0, 1.0]`.
     pub delete_threshold: f64,
+    /// When set, rewrite only these currently-live data files, regardless of
+    /// their delete fraction. This supports explicit physical maintenance such
+    /// as re-applying a table sort order without changing logical rows.
+    pub data_file_ids: Option<Vec<i64>>,
 }
 
 impl Default for RewriteOptions {
     fn default() -> Self {
         Self {
             delete_threshold: 0.95,
+            data_file_ids: None,
         }
     }
 }
@@ -168,6 +179,54 @@ fn partition_value_pairs(values: &[Option<String>]) -> Vec<(i32, Option<String>)
         .enumerate()
         .map(|(index, value)| (index as i32, value.clone()))
         .collect()
+}
+
+/// Stream compaction output through DataFusion's spilling sort.
+///
+/// Batches may carry trailing embedded columns beyond `data_schema`. Sort keys
+/// resolve to the leading data columns, so embedded row lineage stays attached.
+/// An absent sort specification returns the input stream. An unsupported expression
+/// or missing sort column fails before any rewritten file is committed.
+pub(crate) fn sorted_rewrite_output(
+    context: Arc<TaskContext>,
+    batches: Vec<RecordBatch>,
+    data_schema: &Schema,
+    sort_spec: Option<&SortSpec>,
+) -> Result<SendableRecordBatchStream> {
+    let schema = batches
+        .first()
+        .ok_or_else(|| DuckLakeError::Internal("cannot sort empty compaction input".to_string()))?
+        .schema();
+    let input = MemorySourceConfig::try_new_exec(&[batches], Arc::clone(&schema), None)?;
+    let Some(sort_spec) = sort_spec else {
+        return Ok(input.execute(0, Arc::clone(&context))?);
+    };
+    let keys = sort_spec.producible_columns().ok_or_else(|| {
+        DuckLakeError::InvalidConfig(format!(
+            "DuckLake sort order {} contains an unsupported expression; \
+             datafusion-ducklake can write only bare-column sort keys",
+            sort_spec.sort_id
+        ))
+    })?;
+
+    let mut expressions = Vec::with_capacity(keys.len());
+    for (name, direction, null_order) in keys {
+        let index = data_schema.index_of(&name).map_err(|_| {
+            DuckLakeError::InvalidConfig(format!(
+                "DuckLake sort key '{name}' is not present in the rewrite schema"
+            ))
+        })?;
+        expressions.push(PhysicalSortExpr::new(
+            Arc::new(Column::new(&name, index)),
+            SortOptions {
+                descending: direction == SortDirection::Desc,
+                nulls_first: null_order.nulls_first(),
+            },
+        ));
+    }
+    let ordering = LexOrdering::new(expressions)
+        .ok_or_else(|| DuckLakeError::Internal("sort order is empty".to_string()))?;
+    Ok(SortExec::new(ordering, input).execute(0, context)?)
 }
 
 impl DuckLakeTable {
@@ -398,7 +457,8 @@ impl DuckLakeTable {
             if merged.is_empty() {
                 continue;
             }
-            let merged = crate::sort::sort_batches_by_spec(
+            let merged = sorted_rewrite_output(
+                state.task_ctx(),
                 merged,
                 physical_schema.as_ref(),
                 sort_spec.as_ref(),
@@ -413,12 +473,12 @@ impl DuckLakeTable {
                 crate::partition::hive_subpath(&names, &partition_values)
             });
             let file = table_writer
-                .write_compacted_file(
+                .write_compacted_file_stream(
                     schema_name,
                     self.table_name(),
                     physical_schema.as_ref(),
                     &column_ids,
-                    &merged,
+                    merged,
                     partial,
                     subpath.as_deref(),
                 )
@@ -503,17 +563,26 @@ impl DuckLakeTable {
         let mut files_processed = 0usize;
         let mut rows_written = 0i64;
 
+        let selected_ids = opts
+            .data_file_ids
+            .map(|ids| ids.into_iter().collect::<HashSet<_>>());
         let table_files = self.files()?;
         for tf in &table_files {
             let record_count = tf.max_row_count.unwrap_or(0);
             let delete_count = tf.delete_count.unwrap_or(0);
-            // Only files with a live delete file masking >= threshold of the rows.
-            if tf.delete_file_id.is_none() || record_count <= 0 {
-                continue;
-            }
-            let ratio = delete_count as f64 / record_count as f64;
-            if ratio < opts.delete_threshold {
-                continue;
+            if let Some(selected_ids) = &selected_ids {
+                if !selected_ids.contains(&tf.data_file_id) {
+                    continue;
+                }
+            } else {
+                // Threshold selection only applies to files with live deletes.
+                if tf.delete_file_id.is_none() || record_count <= 0 {
+                    continue;
+                }
+                let ratio = delete_count as f64 / record_count as f64;
+                if ratio < opts.delete_threshold {
+                    continue;
+                }
             }
 
             let scan = self.build_update_scan(state, tf).await?;
@@ -530,7 +599,8 @@ impl DuckLakeTable {
 
             let live_rows = out.matched_count;
             if live_rows > 0 {
-                let sorted = crate::sort::sort_batches_by_spec(
+                let sorted = sorted_rewrite_output(
+                    state.task_ctx(),
                     out.updated_batches,
                     physical_schema.as_ref(),
                     sort_spec.as_ref(),
@@ -545,12 +615,12 @@ impl DuckLakeTable {
                     crate::partition::hive_subpath(&names, &partition_values)
                 });
                 let file = table_writer
-                    .write_compacted_file(
+                    .write_compacted_file_stream(
                         schema_name,
                         self.table_name(),
                         physical_schema.as_ref(),
                         &column_ids,
-                        &sorted,
+                        sorted,
                         false,
                         subpath.as_deref(),
                     )
@@ -588,5 +658,49 @@ impl DuckLakeTable {
             files_created: outputs.len(),
             rows_written,
         })
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sort::{DUCKDB_DIALECT, NullOrder, SortDirection, SortField};
+    use arrow::array::Int64Array;
+    use datafusion::prelude::SessionContext;
+
+    #[test]
+    fn sorted_rewrite_output_rejects_expression_sort_key() {
+        let data_schema = Schema::new(vec![Field::new("id", DataType::Int64, false)]);
+        let batch = RecordBatch::try_new(
+            Arc::new(data_schema.clone()),
+            vec![Arc::new(Int64Array::from(vec![2, 1]))],
+        )
+        .unwrap();
+        let sort_spec = SortSpec {
+            sort_id: 7,
+            fields: vec![SortField {
+                sort_key_index: 0,
+                expression: "lower(id)".to_string(),
+                dialect: DUCKDB_DIALECT.to_string(),
+                direction: SortDirection::Asc,
+                null_order: NullOrder::NullsLast,
+            }],
+        };
+
+        let result = sorted_rewrite_output(
+            SessionContext::new().task_ctx(),
+            vec![batch],
+            &data_schema,
+            Some(&sort_spec),
+        );
+        let err = match result {
+            Ok(_) => panic!("expression sort key must be rejected"),
+            Err(e) => e,
+        };
+
+        assert_eq!(
+            err.to_string(),
+            "Invalid configuration: DuckLake sort order 7 contains an unsupported expression; \
+             datafusion-ducklake can write only bare-column sort keys",
+        );
     }
 }

--- a/src/multicatalog_provider.rs
+++ b/src/multicatalog_provider.rs
@@ -20,6 +20,7 @@ use crate::metadata_provider::{
     reconstruct_list_columns, reconstruct_list_columns_with_table,
 };
 use crate::partition::PartitionSpec;
+use crate::sort::SortSpec;
 use sqlx::AssertSqlSafe;
 use sqlx::Row;
 use sqlx::postgres::{PgPool, PgPoolOptions, PgRow};
@@ -546,6 +547,47 @@ impl MetadataProvider for MulticatalogProvider {
                 })
                 .collect::<Result<Vec<_>>>()?;
             Ok(PartitionSpec::from_rows(parsed, prune_safe))
+        })
+    }
+
+    fn get_sort_spec(&self, table_id: i64, snapshot_id: i64) -> Result<Option<SortSpec>> {
+        // Keyed by the globally unique table_id, so no catalog scoping is needed.
+        block_on(async {
+            let rows = match sqlx::query(
+                "SELECT si.sort_id, se.sort_key_index, se.expression, se.dialect,
+                        se.sort_direction, se.null_order
+                 FROM ducklake_sort_info AS si
+                 JOIN ducklake_sort_expression AS se
+                   ON se.sort_id = si.sort_id AND se.table_id = si.table_id
+                 WHERE si.table_id = $1
+                   AND $2 >= si.begin_snapshot
+                   AND ($3 < si.end_snapshot OR si.end_snapshot IS NULL)
+                 ORDER BY se.sort_key_index",
+            )
+            .bind(table_id)
+            .bind(snapshot_id)
+            .bind(snapshot_id)
+            .fetch_all(&self.pool)
+            .await
+            {
+                Ok(rows) => rows,
+                Err(error) if is_missing_statistics_table(&error) => return Ok(None),
+                Err(error) => return Err(error.into()),
+            };
+            let parsed = rows
+                .iter()
+                .map(|row| {
+                    Ok::<_, crate::DuckLakeError>((
+                        row.try_get::<i64, _>(0)?,
+                        i32::try_from(row.try_get::<i64, _>(1)?).unwrap_or(0),
+                        row.try_get::<String, _>(2)?,
+                        row.try_get::<String, _>(3)?,
+                        row.try_get::<String, _>(4)?,
+                        row.try_get::<String, _>(5)?,
+                    ))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(SortSpec::from_rows(parsed))
         })
     }
 

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -15,11 +15,10 @@
 //!
 //! Scope note: this crate *produces* sort orders only for **bare column references**
 //! (`SORTED BY (device_id, ts DESC)`). A spec whose expression is anything more
-//! complex is *tolerated on read* (round-tripped verbatim) but never applied on our
-//! writes — we simply write unsorted, which is always correct (only the min/max
-//! locality, i.e. pruning effectiveness, is affected). This mirrors how
-//! [`crate::partition`] tolerates `bucket`/unknown transforms on read but never
-//! produces them.
+//! complex is *tolerated on read* and round-tripped verbatim. Any operation that
+//! would write or rewrite data rejects the unsupported expression before committing,
+//! because silently producing unsorted files would violate the table's active sort
+//! contract.
 
 /// A sort key's direction. Serializes to the catalog `sort_direction` string
 /// (`"ASC"` / `"DESC"`), matching DuckLake's on-disk form.
@@ -93,7 +92,7 @@ pub const DUCKDB_DIALECT: &str = "duckdb";
 /// `column_id` — DuckLake sort keys are expression-based. For a spec this crate
 /// produced, `expression` is a bare column name; for a spec written by DuckDB it may
 /// be any expression, in which case [`SortField::column_candidate`] returns `None`
-/// and the write path skips sorting.
+/// and the write path rejects the unsupported sort contract.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SortField {
     /// 0-based position of this key within the sort order.
@@ -130,8 +129,7 @@ impl SortField {
     /// column name if it is one. A bare column is either an unquoted simple
     /// identifier (`ts`, `device_id`) or a double-quoted identifier (`"My Col"`,
     /// unquoted here). Anything else — function calls, arithmetic, qualified names,
-    /// multiple tokens — yields `None`, so the write path leaves such files unsorted
-    /// rather than guessing.
+    /// multiple tokens — yields `None`.
     pub fn column_candidate(&self) -> Option<String> {
         parse_bare_column(&self.expression)
     }
@@ -181,7 +179,7 @@ pub struct SortSpec {
 impl SortSpec {
     /// Whether this crate can *apply* this sort on write: true only when every key
     /// is a bare column reference. A spec containing any non-column expression is
-    /// not producible (we tolerate it on read but write such files unsorted).
+    /// not producible and must be rejected by data-writing operations.
     pub fn is_producible(&self) -> bool {
         !self.fields.is_empty() && self.fields.iter().all(|f| f.column_candidate().is_some())
     }

--- a/src/table.rs
+++ b/src/table.rs
@@ -3642,6 +3642,10 @@ mod tests {
         );
     }
 
+    // `sort_ordering_for` is `#[cfg(feature = "write")]`, so the test that exercises
+    // it needs the same gate — otherwise a read-only feature combination fails to
+    // compile the test target.
+    #[cfg(feature = "write")]
     #[test]
     fn sort_ordering_rejects_expression_sort_key() {
         let schema = Schema::new(vec![Field::new("id", DataType::Int64, false)]);

--- a/src/table.rs
+++ b/src/table.rs
@@ -2759,14 +2759,14 @@ impl TableProvider for DuckLakeTable {
         // present in the write schema — wrap the input in a global SortExec so each
         // written file's rows are ordered, tightening per-file min/max statistics
         // for range pruning. Sorting is applied before the partition split, so each
-        // per-partition file remains a sorted subsequence. sort_on_insert defaults
-        // to true; a non-producible or absent spec leaves the input unsorted, which
-        // is always correct (only pruning effectiveness is affected).
+        // per-partition file remains a sorted subsequence. An unsupported expression
+        // or missing sort column is rejected before execution rather than silently
+        // producing files that violate the active sort contract.
         let live_sort = self
             .provider
             .get_sort_spec(self.table_id, head_snapshot)
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
-        let ordering = sort_ordering_for(&input.schema(), live_sort.as_ref());
+        let ordering = sort_ordering_for(&input.schema(), live_sort.as_ref())?;
         // Wrap the input in a SortExec now AND declare the same requirement on
         // DuckLakeInsertExec, so DataFusion's EnforceSorting keeps the ordering
         // (a plain SortExec with no downstream ordering requirement would be
@@ -3023,21 +3023,33 @@ fn is_object_store_not_found(err: &DataFusionError) -> bool {
 }
 
 /// The `LexOrdering` for a table's live sort spec against `schema`, or `None` when
-/// there is no producible sort order or a sort key is absent from the write schema
-/// (a column dropped after `SET SORTED BY` — sorting is skipped rather than failing
-/// the write, since correctness never depends on the ordering).
+/// the table has no sort order. Unsupported expressions and missing sort columns
+/// fail the write before data is committed.
 #[cfg(feature = "write")]
 fn sort_ordering_for(
     schema: &arrow::datatypes::Schema,
     sort_spec: Option<&crate::sort::SortSpec>,
-) -> Option<datafusion::physical_expr::LexOrdering> {
-    let keys = sort_spec.and_then(|spec| spec.producible_columns())?;
+) -> datafusion::common::Result<Option<datafusion::physical_expr::LexOrdering>> {
+    let Some(sort_spec) = sort_spec else {
+        return Ok(None);
+    };
+    let keys = sort_spec.producible_columns().ok_or_else(|| {
+        DataFusionError::NotImplemented(format!(
+            "DuckLake sort order {} contains an unsupported expression; \
+             datafusion-ducklake can write only bare-column sort keys",
+            sort_spec.sort_id
+        ))
+    })?;
     if keys.is_empty() {
-        return None;
+        return Ok(None);
     }
     let mut sort_exprs = Vec::with_capacity(keys.len());
     for (name, direction, null_order) in &keys {
-        let index = schema.index_of(name).ok()?;
+        let index = schema.index_of(name).map_err(|_| {
+            DataFusionError::Plan(format!(
+                "DuckLake sort key '{name}' is not present in the write schema"
+            ))
+        })?;
         let column = Arc::new(datafusion::physical_expr::expressions::Column::new(
             name, index,
         ));
@@ -3051,7 +3063,7 @@ fn sort_ordering_for(
             ),
         );
     }
-    datafusion::physical_expr::LexOrdering::new(sort_exprs)
+    Ok(datafusion::physical_expr::LexOrdering::new(sort_exprs))
 }
 
 #[cfg(test)]
@@ -3627,6 +3639,29 @@ mod tests {
         assert_eq!(
             parse_statistic_scalar("123.45", &decimal, &DataType::Decimal128(10, 2)),
             Some(ScalarValue::Decimal128(Some(12_345), 10, 2))
+        );
+    }
+
+    #[test]
+    fn sort_ordering_rejects_expression_sort_key() {
+        let schema = Schema::new(vec![Field::new("id", DataType::Int64, false)]);
+        let sort_spec = crate::sort::SortSpec {
+            sort_id: 9,
+            fields: vec![crate::sort::SortField {
+                sort_key_index: 0,
+                expression: "lower(id)".to_string(),
+                dialect: crate::sort::DUCKDB_DIALECT.to_string(),
+                direction: crate::sort::SortDirection::Asc,
+                null_order: crate::sort::NullOrder::NullsLast,
+            }],
+        };
+
+        let err = sort_ordering_for(&schema, Some(&sort_spec)).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "This feature is not implemented: DuckLake sort order 9 contains an unsupported \
+             expression; datafusion-ducklake can write only bare-column sort keys",
         );
     }
 }

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -6,6 +6,10 @@ use std::sync::Arc;
 
 use arrow::datatypes::{Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
+use datafusion::error::DataFusionError;
+use datafusion::execution::SendableRecordBatchStream;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use futures::StreamExt;
 use object_store::ObjectStore;
 use object_store::buffered::BufWriter as ObjectBufWriter;
 use object_store::path::Path as ObjectPath;
@@ -624,6 +628,52 @@ impl DuckLakeTableWriter {
         embed_snapshot_id: bool,
         partition_subpath: Option<&str>,
     ) -> Result<DataFileInfo> {
+        let stream_schema = batches.first().map_or_else(
+            || {
+                let mut fields: Vec<Field> = data_schema
+                    .fields()
+                    .iter()
+                    .map(|field| field.as_ref().clone())
+                    .collect();
+                fields.push(embedded_rowid_field());
+                if embed_snapshot_id {
+                    fields.push(embedded_snapshot_id_field());
+                }
+                Arc::new(Schema::new(fields))
+            },
+            RecordBatch::schema,
+        );
+        let batches = batches.to_vec();
+        let stream =
+            futures::stream::iter(batches.into_iter().map(Ok::<RecordBatch, DataFusionError>));
+        let stream = Box::pin(RecordBatchStreamAdapter::new(stream_schema, stream));
+        self.write_compacted_file_stream(
+            schema_name,
+            table_name,
+            data_schema,
+            data_column_ids,
+            stream,
+            embed_snapshot_id,
+            partition_subpath,
+        )
+        .await
+    }
+
+    /// Write one compacted parquet file from a record-batch stream.
+    ///
+    /// This lets compaction feed a spilling DataFusion sort directly into
+    /// Parquet without retaining the sorted output in memory.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn write_compacted_file_stream(
+        &self,
+        schema_name: &str,
+        table_name: &str,
+        data_schema: &Schema,
+        data_column_ids: &[i64],
+        mut batches: SendableRecordBatchStream,
+        embed_snapshot_id: bool,
+        partition_subpath: Option<&str>,
+    ) -> Result<DataFileInfo> {
         let scoped_base = match self.metadata.catalog_id() {
             Some(id) => join_paths(&self.base_key_path, &format!("cat_{id}"))?,
             None => self.base_key_path.clone(),
@@ -669,7 +719,9 @@ impl DuckLakeTableWriter {
         let staging = std::io::BufWriter::new(temp.reopen()?);
         let mut writer = ArrowWriter::try_new(staging, schema_with_ids.clone(), Some(props))?;
         let mut row_count: i64 = 0;
-        for batch in batches {
+        let mut nan_flags: Vec<Option<bool>> = Vec::new();
+        while let Some(batch) = batches.next().await {
+            let batch = batch?;
             if batch.num_columns() != schema_with_ids.fields().len() {
                 return Err(crate::error::DuckLakeError::InvalidConfig(format!(
                     "write_compacted_file: batch has {} columns, expected {}",
@@ -679,6 +731,11 @@ impl DuckLakeTableWriter {
             }
             let batch_with_ids =
                 RecordBatch::try_new(schema_with_ids.clone(), batch.columns().to_vec())?;
+            crate::stats_collect::accumulate_nan_flags(
+                &mut nan_flags,
+                &batch,
+                data_column_ids.len(),
+            );
             writer.write(&batch_with_ids)?;
             row_count += batch.num_rows() as i64;
         }
@@ -697,20 +754,8 @@ impl DuckLakeTableWriter {
             return Err(e.into());
         }
 
-        // Harvest per-column stats for the compacted file, exactly as a normal
-        // write does — mirroring official DuckLake, whose compaction reuses the
-        // same WRITTEN_FILE_STATISTICS path. `data_column_ids` covers only the
-        // catalog data columns, so the trailing embedded rowid/snapshot columns
-        // are skipped by the harvest. NaN flags are computed from the batches
-        // (the footer carries no NaN signal).
-        let mut nan_flags: Vec<Option<bool>> = Vec::new();
-        for batch in batches {
-            crate::stats_collect::accumulate_nan_flags(
-                &mut nan_flags,
-                batch,
-                data_column_ids.len(),
-            );
-        }
+        // Collect stats for catalog columns only. Track NaN values while
+        // consuming the stream because the Parquet footer omits that signal.
         let column_stats = crate::stats_collect::collect_column_stats(
             temp.path(),
             data_column_ids,

--- a/src/update_exec.rs
+++ b/src/update_exec.rs
@@ -55,6 +55,7 @@ use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
 use futures::stream::{self, TryStreamExt};
 
+use crate::compaction::sorted_rewrite_output;
 use crate::metadata_writer::{DeleteFileEntry, MetadataWriter, WriteMode};
 use crate::table::{DuckLakeTable, UpdateSourceScan};
 use crate::table_writer::DuckLakeTableWriter;
@@ -265,6 +266,16 @@ impl ExecutionPlan for DuckLakeUpdateExec {
             // Append the rewritten rows (embedding their original rowids) AND
             // apply every positional delete in ONE snapshot.
             let physical_schema = table.physical_schema();
+            let sort_spec = table
+                .live_sort_spec()
+                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+            let mut updated_batches = sorted_rewrite_output(
+                Arc::clone(&context),
+                updated_batches,
+                physical_schema.as_ref(),
+                sort_spec.as_ref(),
+            )
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
             let mut session = table_writer
                 .begin_write_with_embedded_rowid(
                     &schema_name,
@@ -273,9 +284,9 @@ impl ExecutionPlan for DuckLakeUpdateExec {
                     WriteMode::Append,
                 )
                 .map_err(|e| DataFusionError::External(Box::new(e)))?;
-            for batch in &updated_batches {
+            while let Some(batch) = updated_batches.try_next().await? {
                 session
-                    .write_batch(batch)
+                    .write_batch(&batch)
                     .map_err(|e| DataFusionError::External(Box::new(e)))?;
             }
             session

--- a/tests/compaction_postgres_tests.rs
+++ b/tests/compaction_postgres_tests.rs
@@ -18,10 +18,11 @@ use arrow::datatypes::{DataType, Field, Schema};
 use datafusion::prelude::*;
 use datafusion_ducklake::{
     CompactionResult, DuckLakeCatalog, DuckLakeTable, DuckLakeTableWriter, MergeOptions,
-    MetadataProvider, MetadataWriter, MulticatalogManager, MulticatalogProvider,
-    PostgresMetadataWriter, RewriteOptions,
+    MetadataProvider, MetadataWriter, MulticatalogManager, MulticatalogProvider, NullOrder,
+    PostgresMetadataWriter, RewriteOptions, SortDirection, SortField,
 };
 use object_store::local::LocalFileSystem;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use sqlx::AssertSqlSafe;
 use sqlx::Row;
 use sqlx::postgres::{PgPool, PgPoolOptions};
@@ -122,6 +123,33 @@ async fn live_files(pool: &PgPool, cat_name: &str) -> Vec<datafusion_ducklake::D
         .unwrap()
 }
 
+fn file_values(data: &std::path::Path, catalog_id: i64, path: &str) -> Vec<i32> {
+    let file = std::fs::File::open(
+        data.join(format!("cat_{catalog_id}"))
+            .join("public")
+            .join("t")
+            .join(path),
+    )
+    .unwrap();
+    ParquetRecordBatchReaderBuilder::try_new(file)
+        .unwrap()
+        .build()
+        .unwrap()
+        .map(|batch| {
+            let batch = batch.unwrap();
+            batch
+                .column_by_name("val")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap()
+                .values()
+                .to_vec()
+        })
+        .collect::<Vec<_>>()
+        .concat()
+}
+
 async fn scalar_i64(pool: &PgPool, sql: &str, cat: i64) -> i64 {
     sqlx::query(AssertSqlSafe(sql))
         .bind(cat)
@@ -182,7 +210,7 @@ async fn merge_adjacent_files_postgres() {
         .unwrap();
 
     // Three INSERTs -> three small data files at three origin snapshots.
-    DuckLakeTableWriter::new(writer_for(&pool, cat, &data).await, os.clone())
+    let created = DuckLakeTableWriter::new(writer_for(&pool, cat, &data).await, os.clone())
         .unwrap()
         .write_table("public", "t", &[batch(vec![1, 2], vec![10, 20])])
         .await
@@ -207,6 +235,13 @@ async fn merge_adjacent_files_postgres() {
     assert_eq!(live_files(&pool, cat_name).await.len(), 3, "three files");
     let rows_before = vec![(1, 10), (2, 20), (3, 30), (4, 40), (5, 50), (6, 60)];
     assert_eq!(read_rows(&pool, cat_name, None).await, rows_before);
+    writer_for(&pool, cat, &data)
+        .await
+        .set_sort_spec(
+            created.table_id,
+            &[SortField::column(0, "val", SortDirection::Desc, NullOrder::NullsLast)],
+        )
+        .unwrap();
 
     // Merge: the multicatalog reader must surface begin_snapshot/schema_version
     // (else this silently no-ops), then commit_compaction removes the sources.
@@ -223,6 +258,10 @@ async fn merge_adjacent_files_postgres() {
         files[0].partial_max,
         Some(pre_merge),
         "partial_max = max origin snapshot"
+    );
+    assert_eq!(
+        file_values(&data, cat, &files[0].file.path),
+        vec![60, 50, 40, 30, 20, 10],
     );
     // Sources removed from the catalog and scheduled for deletion (catalog-scoped).
     assert_eq!(
@@ -264,7 +303,7 @@ async fn rewrite_data_files_postgres() {
         .unwrap();
 
     // One file of ten rows.
-    DuckLakeTableWriter::new(writer_for(&pool, cat, &data).await, os.clone())
+    let created = DuckLakeTableWriter::new(writer_for(&pool, cat, &data).await, os.clone())
         .unwrap()
         .write_table(
             "public",
@@ -272,6 +311,13 @@ async fn rewrite_data_files_postgres() {
             &[batch((1..=10).collect(), (1..=10).map(|v| v * 10).collect())],
         )
         .await
+        .unwrap();
+    writer_for(&pool, cat, &data)
+        .await
+        .set_sort_spec(
+            created.table_id,
+            &[SortField::column(0, "val", SortDirection::Desc, NullOrder::NullsLast)],
+        )
         .unwrap();
 
     // Delete eight of ten rows via SQL (a positional delete file).
@@ -301,6 +347,7 @@ async fn rewrite_data_files_postgres() {
             &s,
             RewriteOptions {
                 delete_threshold: 0.5,
+                ..RewriteOptions::default()
             },
         )
         .await
@@ -318,8 +365,89 @@ async fn rewrite_data_files_postgres() {
         "a rewrite output is not partial"
     );
     assert_eq!(files[0].delete_file_id, None, "no live delete file");
+    assert_eq!(file_values(&data, cat, &files[0].file.path), vec![100, 90]);
     assert_eq!(
         read_rows(&pool, cat_name, None).await,
         vec![(9, 90), (10, 100)]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn rewrite_targets_explicit_postgres_data_files() {
+    let (pool, _container) = spin_up_postgres().await.unwrap();
+    let temp = TempDir::new().unwrap();
+    let data = temp.path().join("data");
+    std::fs::create_dir_all(&data).unwrap();
+    let store: ObjStore = Arc::new(LocalFileSystem::new());
+    let catalog_name = "cat";
+    let catalog_id = MulticatalogManager::new(pool.clone())
+        .create_catalog(catalog_name)
+        .await
+        .unwrap();
+    let writer = writer_for(&pool, catalog_id, &data).await;
+    let metadata: Arc<dyn MetadataWriter> = writer.clone();
+    let created = DuckLakeTableWriter::new(Arc::clone(&metadata), Arc::clone(&store))
+        .unwrap()
+        .write_table("public", "t", &[batch(vec![1, 2], vec![10, 20])])
+        .await
+        .unwrap();
+    DuckLakeTableWriter::new(metadata, store)
+        .unwrap()
+        .append_table("public", "t", &[batch(vec![3, 4], vec![30, 40])])
+        .await
+        .unwrap();
+    writer
+        .set_sort_spec(
+            created.table_id,
+            &[SortField::column(0, "val", SortDirection::Desc, NullOrder::NullsLast)],
+        )
+        .unwrap();
+    let mut before = live_files(&pool, catalog_name).await;
+    before.sort_by_key(|file| file.data_file_id);
+    let selected_id = before[0].data_file_id;
+    let unaffected_path = before[1].file.path.clone();
+
+    let result = with_writable_table(
+        &pool,
+        catalog_id,
+        catalog_name,
+        &data,
+        |table, state| async move {
+            table
+                .rewrite_data_files(
+                    &state,
+                    RewriteOptions {
+                        data_file_ids: Some(vec![selected_id]),
+                        ..RewriteOptions::default()
+                    },
+                )
+                .await
+        },
+    )
+    .await;
+
+    let after = live_files(&pool, catalog_name).await;
+    let rewritten = after
+        .iter()
+        .find(|file| file.file.path != unaffected_path)
+        .unwrap();
+    assert_eq!(
+        result,
+        CompactionResult {
+            files_processed: 1,
+            files_created: 1,
+            rows_written: 2,
+        },
+    );
+    assert_eq!(after.len(), 2);
+    assert!(after.iter().any(|file| file.file.path == unaffected_path),);
+    assert_eq!(
+        file_values(&data, catalog_id, &rewritten.file.path),
+        vec![20, 10],
+    );
+    assert_eq!(
+        read_rows(&pool, catalog_name, None).await,
+        vec![(1, 10), (2, 20), (3, 30), (4, 40)],
     );
 }

--- a/tests/compaction_sqlite_tests.rs
+++ b/tests/compaction_sqlite_tests.rs
@@ -14,17 +14,20 @@ use std::sync::Arc;
 use arrow::array::{Array, Int32Array, Int64Array};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
+use datafusion::execution::memory_pool::FairSpillPool;
+use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::prelude::*;
 use object_store::local::LocalFileSystem;
-use sqlx::AssertSqlSafe;
-use sqlx::Row;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use sqlx::sqlite::SqlitePool;
+use sqlx::{AssertSqlSafe, Row};
 use tempfile::TempDir;
 
 use datafusion_ducklake::maintenance::{CleanupCriteria, cleanup_old_files_sqlite};
 use datafusion_ducklake::{
     CompactionResult, DuckLakeCatalog, DuckLakeTable, DuckLakeTableWriter, MergeOptions,
-    MetadataWriter, RewriteOptions, SqliteMetadataProvider, SqliteMetadataWriter,
+    MetadataProvider, MetadataWriter, NullOrder, RewriteOptions, SortDirection, SortField,
+    SqliteMetadataProvider, SqliteMetadataWriter,
 };
 
 fn two_col_schema() -> Arc<Schema> {
@@ -171,6 +174,28 @@ async fn read_id_rowid(temp: &TempDir) -> Vec<(i32, i64)> {
     out
 }
 
+fn file_values(temp: &TempDir, path: &str) -> Vec<i32> {
+    let file =
+        std::fs::File::open(temp.path().join("data").join("main").join("t").join(path)).unwrap();
+    ParquetRecordBatchReaderBuilder::try_new(file)
+        .unwrap()
+        .build()
+        .unwrap()
+        .map(|batch| {
+            let batch = batch.unwrap();
+            batch
+                .column_by_name("val")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap()
+                .values()
+                .to_vec()
+        })
+        .collect::<Vec<_>>()
+        .concat()
+}
+
 /// Downcast the writable `main.t` provider to a `DuckLakeTable` and run `op` on
 /// it (the compaction ops are `DuckLakeTable` methods). A fresh writable catalog
 /// is opened so the table binds to the latest snapshot.
@@ -179,10 +204,21 @@ where
     F: FnOnce(DuckLakeTable, datafusion::execution::SessionState) -> Fut,
     Fut: std::future::Future<Output = CompactionResult>,
 {
+    with_writable_table_context(temp, SessionContext::new(), op).await
+}
+
+async fn with_writable_table_context<F, Fut>(
+    temp: &TempDir,
+    ctx: SessionContext,
+    op: F,
+) -> CompactionResult
+where
+    F: FnOnce(DuckLakeTable, datafusion::execution::SessionState) -> Fut,
+    Fut: std::future::Future<Output = CompactionResult>,
+{
     let writer = SqliteMetadataWriter::new(&db_url(temp)).await.unwrap();
     let provider = SqliteMetadataProvider::new(&db_url(temp)).await.unwrap();
     let catalog = DuckLakeCatalog::with_writer(Arc::new(provider), Arc::new(writer)).unwrap();
-    let ctx = SessionContext::new();
     ctx.register_catalog("ducklake", Arc::new(catalog));
     let provider = ctx
         .catalog("ducklake")
@@ -397,6 +433,7 @@ async fn rewrite_preserves_partition_assignment() {
         &temp,
         RewriteOptions {
             delete_threshold: 0.5,
+            data_file_ids: None,
         },
     )
     .await;
@@ -433,6 +470,147 @@ async fn rewrite_preserves_partition_assignment() {
     );
     // And the surviving rows read back.
     assert_eq!(read_rows(&temp).await, vec![(9, 1), (10, 1)]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rewrite_can_target_explicit_data_files_without_deletes() {
+    let temp = TempDir::new().unwrap();
+    seed(&temp, vec![1, 2], vec![10, 20]).await;
+    append(&temp, vec![3, 4], vec![30, 40]).await;
+    let p = pool(&temp).await;
+    let table_id = scalar_i64(
+        &p,
+        "SELECT table_id FROM ducklake_table WHERE table_name = 't'",
+    )
+    .await;
+    let provider = SqliteMetadataProvider::new(&ro_url(&temp)).await.unwrap();
+    let snapshot = provider.get_current_snapshot().unwrap();
+    let mut before = provider
+        .get_table_file_metadata_page(table_id, snapshot, None, 10)
+        .unwrap();
+    before.sort_by_key(|metadata| metadata.file.data_file_id);
+    let selected_id = before[0].file.data_file_id;
+    let unaffected_path = before[1].file.file.path.clone();
+
+    assert_eq!(
+        run_rewrite(
+            &temp,
+            RewriteOptions {
+                data_file_ids: Some(vec![selected_id]),
+                ..RewriteOptions::default()
+            },
+        )
+        .await,
+        CompactionResult {
+            files_processed: 1,
+            files_created: 1,
+            rows_written: 2,
+        },
+    );
+
+    let provider = SqliteMetadataProvider::new(&ro_url(&temp)).await.unwrap();
+    let snapshot = provider.get_current_snapshot().unwrap();
+    let after = provider
+        .get_table_file_metadata_page(table_id, snapshot, None, 10)
+        .unwrap();
+
+    assert_eq!(after.len(), 2);
+    assert!(
+        after
+            .iter()
+            .any(|metadata| metadata.file.file.path == unaffected_path),
+    );
+    assert_eq!(
+        read_rows(&temp).await,
+        vec![(1, 10), (2, 20), (3, 30), (4, 40)]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn sorted_merge_under_memory_limit_preserves_rowids_and_snapshot_lineage() {
+    const MEMORY_LIMIT: usize = 256 * 1024;
+    const ROWS_PER_SNAPSHOT: i32 = 16_384;
+    const TOTAL_ROWS: i32 = ROWS_PER_SNAPSHOT * 2;
+
+    let temp = TempDir::new().unwrap();
+    seed(
+        &temp,
+        (0..ROWS_PER_SNAPSHOT).collect(),
+        (0..ROWS_PER_SNAPSHOT).collect(),
+    )
+    .await;
+    let p = pool(&temp).await;
+    let first_snapshot = scalar_i64(&p, "SELECT MAX(snapshot_id) FROM ducklake_snapshot").await;
+    append(
+        &temp,
+        (ROWS_PER_SNAPSHOT..TOTAL_ROWS).collect(),
+        (ROWS_PER_SNAPSHOT..TOTAL_ROWS).collect(),
+    )
+    .await;
+    let table_id = scalar_i64(
+        &p,
+        "SELECT table_id FROM ducklake_table WHERE table_name = 't'",
+    )
+    .await;
+    SqliteMetadataWriter::new(&db_url(&temp))
+        .await
+        .unwrap()
+        .set_sort_spec(
+            table_id,
+            &[SortField::column(0, "val", SortDirection::Desc, NullOrder::NullsLast)],
+        )
+        .unwrap();
+    let rowids_before = read_id_rowid(&temp).await;
+    assert_eq!(
+        usize::try_from(TOTAL_ROWS).unwrap()
+            * (2 * std::mem::size_of::<i32>() + std::mem::size_of::<i64>()),
+        2 * MEMORY_LIMIT,
+    );
+
+    let runtime = RuntimeEnvBuilder::new()
+        .with_memory_limit(MEMORY_LIMIT, 1.0)
+        .with_temp_file_path(temp.path().join("spill"))
+        .build_arc()
+        .unwrap();
+    let config = SessionConfig::new()
+        .with_batch_size(1024)
+        .with_sort_spill_reservation_bytes(16 * 1024);
+    let ctx = SessionContext::new_with_config_rt(config, runtime);
+    let result = with_writable_table_context(&temp, ctx, |table, state| async move {
+        table
+            .merge_adjacent_files(&state, MergeOptions::default())
+            .await
+            .unwrap()
+    })
+    .await;
+
+    let provider = SqliteMetadataProvider::new(&ro_url(&temp)).await.unwrap();
+    let snapshot = provider.get_current_snapshot().unwrap();
+    let files = provider
+        .get_table_file_metadata_page(table_id, snapshot, None, 10)
+        .unwrap();
+    let expected_first_snapshot = (0..ROWS_PER_SNAPSHOT)
+        .map(|value| (value, value))
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        result,
+        CompactionResult {
+            files_processed: 2,
+            files_created: 1,
+            rows_written: i64::from(TOTAL_ROWS),
+        },
+    );
+    assert_eq!(files.len(), 1);
+    assert_eq!(
+        file_values(&temp, &files[0].file.file.path),
+        (0..TOTAL_ROWS).rev().collect::<Vec<_>>(),
+    );
+    assert_eq!(read_id_rowid(&temp).await, rowids_before);
+    assert_eq!(
+        read_rows_at(&temp, first_snapshot).await,
+        expected_first_snapshot,
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -587,14 +765,14 @@ async fn merge_coalesces_small_files_preserving_results_rowids_and_time_travel()
     assert_eq!(scheduled, 3, "three source files scheduled for deletion");
 
     // changes_made records the compaction.
-    let changes: String = sqlx::query(AssertSqlSafe(format!(
-        "SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id = {new_snapshot}"
-    )))
-    .fetch_one(&p)
-    .await
-    .unwrap()
-    .try_get(0)
-    .unwrap();
+    let changes: String =
+        sqlx::query("SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id = ?")
+            .bind(new_snapshot)
+            .fetch_one(&p)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
     assert_eq!(changes, format!("compacted_table:{tid}"));
 
     // Identical query results, and rowid lineage preserved across the rewrite.
@@ -615,6 +793,140 @@ async fn merge_coalesces_small_files_preserving_results_rowids_and_time_travel()
         read_rows_at(&temp, pre_snapshot).await,
         rows_before,
         "time travel to pre-merge snapshot returns the original rows"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn merge_applies_sqlite_sort_order_to_physical_output() {
+    let temp = TempDir::new().unwrap();
+    seed(&temp, vec![1, 2], vec![20, 10]).await;
+    append(&temp, vec![3, 4], vec![40, 30]).await;
+    append(&temp, vec![5, 6], vec![60, 50]).await;
+    let p = pool(&temp).await;
+    let table_id = scalar_i64(&p, "SELECT table_id FROM ducklake_table LIMIT 1").await;
+    let writer = SqliteMetadataWriter::new(&db_url(&temp)).await.unwrap();
+    writer
+        .set_sort_spec(
+            table_id,
+            &[SortField::column(0, "val", SortDirection::Desc, NullOrder::NullsLast)],
+        )
+        .unwrap();
+
+    let result = run_merge(&temp, MergeOptions::default()).await;
+
+    let live_path: String =
+        sqlx::query_scalar("SELECT path FROM ducklake_data_file WHERE end_snapshot IS NULL")
+            .fetch_one(&p)
+            .await
+            .unwrap();
+    assert_eq!(
+        result,
+        CompactionResult {
+            files_processed: 3,
+            files_created: 1,
+            rows_written: 6,
+        },
+    );
+    assert_eq!(file_values(&temp, &live_path), vec![60, 50, 40, 30, 20, 10]);
+    assert_eq!(
+        read_rows(&temp).await,
+        vec![(1, 20), (2, 10), (3, 40), (4, 30), (5, 60), (6, 50)],
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn sorted_merge_with_limited_memory_preserves_row_and_snapshot_lineage() {
+    const ROWS_PER_FILE: i32 = 30_000;
+    const ROW_COUNT: i32 = ROWS_PER_FILE * 3;
+
+    let temp = TempDir::new().unwrap();
+    seed(
+        &temp,
+        (0..ROWS_PER_FILE).collect(),
+        (0..ROWS_PER_FILE).map(|id| id * 3).collect(),
+    )
+    .await;
+    let p = pool(&temp).await;
+    let first_snapshot = scalar_i64(&p, "SELECT MAX(snapshot_id) FROM ducklake_snapshot").await;
+    append(
+        &temp,
+        (ROWS_PER_FILE..ROWS_PER_FILE * 2).collect(),
+        (0..ROWS_PER_FILE).map(|id| id * 3 + 1).collect(),
+    )
+    .await;
+    append(
+        &temp,
+        (ROWS_PER_FILE * 2..ROW_COUNT).collect(),
+        (0..ROWS_PER_FILE).map(|id| id * 3 + 2).collect(),
+    )
+    .await;
+    let table_id = scalar_i64(&p, "SELECT table_id FROM ducklake_table LIMIT 1").await;
+    let writer = SqliteMetadataWriter::new(&db_url(&temp)).await.unwrap();
+    writer
+        .set_sort_spec(
+            table_id,
+            &[SortField::column(0, "val", SortDirection::Asc, NullOrder::NullsLast)],
+        )
+        .unwrap();
+    let rowids_before = read_id_rowid(&temp).await;
+
+    let spill = TempDir::new().unwrap();
+    let runtime = Arc::new(
+        RuntimeEnvBuilder::new()
+            .with_memory_pool(Arc::new(FairSpillPool::new(1 << 20)))
+            .with_temp_file_path(spill.path())
+            .build()
+            .unwrap(),
+    );
+    let provider = SqliteMetadataProvider::new(&db_url(&temp)).await.unwrap();
+    let writer = SqliteMetadataWriter::new(&db_url(&temp)).await.unwrap();
+    let catalog = DuckLakeCatalog::with_writer(Arc::new(provider), Arc::new(writer)).unwrap();
+    let config = SessionConfig::new()
+        .with_batch_size(1_024)
+        .with_sort_spill_reservation_bytes(128 << 10);
+    let ctx = SessionContext::new_with_config_rt(config, runtime);
+    ctx.register_catalog("ducklake", Arc::new(catalog));
+    let provider = ctx
+        .catalog("ducklake")
+        .unwrap()
+        .schema("main")
+        .unwrap()
+        .table("t")
+        .await
+        .unwrap()
+        .unwrap();
+    let table = (provider.as_ref() as &dyn std::any::Any)
+        .downcast_ref::<DuckLakeTable>()
+        .unwrap();
+
+    let result = table
+        .merge_adjacent_files(&ctx.state(), MergeOptions::default())
+        .await
+        .unwrap();
+
+    let live_path: String =
+        sqlx::query_scalar("SELECT path FROM ducklake_data_file WHERE end_snapshot IS NULL")
+            .fetch_one(&p)
+            .await
+            .unwrap();
+    assert_eq!(
+        result,
+        CompactionResult {
+            files_processed: 3,
+            files_created: 1,
+            rows_written: i64::from(ROW_COUNT),
+        },
+    );
+    assert_eq!(
+        file_values(&temp, &live_path),
+        (0..ROW_COUNT).collect::<Vec<_>>(),
+    );
+    assert_eq!(read_id_rowid(&temp).await, rowids_before);
+    assert_eq!(
+        read_rows_at(&temp, first_snapshot).await,
+        (0..ROWS_PER_FILE)
+            .map(|id| (id, id * 3))
+            .collect::<Vec<_>>(),
     );
 }
 
@@ -668,6 +980,7 @@ async fn rewrite_drops_deleted_rows_and_retires_data_and_delete_files() {
         &temp,
         RewriteOptions {
             delete_threshold: 0.5,
+            ..RewriteOptions::default()
         },
     )
     .await;
@@ -756,14 +1069,14 @@ async fn rewrite_drops_deleted_rows_and_retires_data_and_delete_files() {
     );
 
     // changes_made records the compaction.
-    let changes: String = sqlx::query(AssertSqlSafe(format!(
-        "SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id = {new_snapshot}"
-    )))
-    .fetch_one(&p)
-    .await
-    .unwrap()
-    .try_get(0)
-    .unwrap();
+    let changes: String =
+        sqlx::query("SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id = ?")
+            .bind(new_snapshot)
+            .fetch_one(&p)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
     assert_eq!(changes, format!("compacted_table:{tid}"));
 
     // Rowid lineage of the surviving rows preserved (row 9 was position 8, row 10 position 9).

--- a/tests/sql_update_postgres_tests.rs
+++ b/tests/sql_update_postgres_tests.rs
@@ -16,10 +16,11 @@ use arrow::array::{Array, Int32Array, Int64Array, RecordBatch, UInt64Array};
 use arrow::datatypes::{DataType, Field, Schema};
 use datafusion::prelude::*;
 use datafusion_ducklake::{
-    DuckLakeCatalog, DuckLakeTableWriter, MetadataWriter, MulticatalogManager,
-    MulticatalogProvider, PostgresMetadataWriter,
+    DuckLakeCatalog, DuckLakeTableWriter, MetadataProvider, MetadataWriter, MulticatalogManager,
+    MulticatalogProvider, NullOrder, PostgresMetadataWriter, SortDirection, SortField,
 };
 use object_store::local::LocalFileSystem;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use sqlx::postgres::{PgPool, PgPoolOptions};
 use tempfile::TempDir;
 use testcontainers::ContainerAsync;
@@ -170,5 +171,90 @@ async fn update_where_end_to_end_postgres() {
         read_rowid_rows(&pool, cat_name).await,
         vec![(0, 1, 10), (1, 2, 200), (2, 3, 30), (3, 4, 400)],
         "values updated in place; rowids 1 and 3 preserved across the rewrite"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn update_applies_postgres_sort_order() {
+    let (pool, _container) = spin_up_postgres().await.unwrap();
+    let temp = TempDir::new().unwrap();
+    let data = temp.path().join("data");
+    std::fs::create_dir_all(&data).unwrap();
+    let catalog_name = "cat";
+    let catalog_id = MulticatalogManager::new(pool.clone())
+        .create_catalog(catalog_name)
+        .await
+        .unwrap();
+    let writer = writer_for(&pool, catalog_id, &data).await;
+    let metadata: Arc<dyn MetadataWriter> = writer.clone();
+    let batch = RecordBatch::try_new(
+        schema(),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 1, 1])),
+            Arc::new(Int32Array::from(vec![30, 10, 20])),
+        ],
+    )
+    .unwrap();
+    let created = DuckLakeTableWriter::new(metadata, Arc::new(LocalFileSystem::new()))
+        .unwrap()
+        .write_table("public", "t", &[batch])
+        .await
+        .unwrap();
+    writer
+        .set_sort_spec(
+            created.table_id,
+            &[SortField::column(0, "val", SortDirection::Asc, NullOrder::NullsLast)],
+        )
+        .unwrap();
+
+    let ctx = writable_ctx(&pool, catalog_name, catalog_id, &data).await;
+    let batches = ctx
+        .sql(&format!(
+            "UPDATE {catalog_name}.public.t SET val = val + 1 WHERE id = 1"
+        ))
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let count = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .unwrap()
+        .value(0);
+    let provider = MulticatalogProvider::with_pool(pool.clone(), catalog_name)
+        .await
+        .unwrap();
+    let snapshot = provider.get_current_snapshot().unwrap();
+    let mut files = provider
+        .get_table_file_metadata_page(created.table_id, snapshot, None, 16)
+        .unwrap();
+    files.sort_by_key(|metadata| metadata.file.data_file_id);
+    let output = files.last().unwrap();
+    let path = data
+        .join(format!("cat_{catalog_id}"))
+        .join("public/t")
+        .join(&output.file.file.path);
+    let file = std::fs::File::open(path).unwrap();
+    let output_batch = ParquetRecordBatchReaderBuilder::try_new(file)
+        .unwrap()
+        .build()
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap();
+    let values = output_batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .unwrap();
+
+    assert_eq!(count, 3);
+    assert_eq!(files.len(), 2);
+    assert_eq!(
+        values.values().iter().copied().collect::<Vec<_>>(),
+        vec![11, 21, 31],
     );
 }

--- a/tests/sql_update_tests.rs
+++ b/tests/sql_update_tests.rs
@@ -15,9 +15,11 @@ use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use datafusion::prelude::*;
 use object_store::local::LocalFileSystem;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use sqlx::sqlite::SqlitePool;
 use tempfile::TempDir;
 
+use datafusion_ducklake::sort::{NullOrder, SortDirection, SortField};
 use datafusion_ducklake::{
     DuckLakeCatalog, DuckLakeTableWriter, MetadataProvider, MetadataWriter, SqliteMetadataProvider,
     SqliteMetadataWriter, register_ducklake_functions,
@@ -209,6 +211,80 @@ async fn live_data_file_count(temp_dir: &TempDir) -> i64 {
 }
 
 // ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_applies_sort_order() {
+    let temp_dir = TempDir::new().unwrap();
+    seed_table(&temp_dir, vec![1, 1, 1], vec![30, 10, 20]).await;
+    let writer = Arc::new(make_writer(&temp_dir).await);
+    let provider = SqliteMetadataProvider::new(&format!(
+        "sqlite:{}",
+        temp_dir.path().join("test.db").display()
+    ))
+    .await
+    .unwrap();
+    let snapshot = provider.get_current_snapshot().unwrap();
+    let schema = provider
+        .get_schema_by_name("main", snapshot)
+        .unwrap()
+        .unwrap();
+    let table = provider
+        .get_table_by_name(schema.schema_id, "t", snapshot)
+        .unwrap()
+        .unwrap();
+    writer
+        .set_sort_spec(
+            table.table_id,
+            &[SortField::column(0, "val", SortDirection::Asc, NullOrder::NullsLast)],
+        )
+        .unwrap();
+
+    let ctx = writable_ctx(&temp_dir).await;
+    assert_eq!(
+        run_dml_count(
+            &ctx,
+            "UPDATE ducklake.main.t SET val = val + 1 WHERE id = 1"
+        )
+        .await,
+        3,
+    );
+
+    let provider = SqliteMetadataProvider::new(&format!(
+        "sqlite:{}",
+        temp_dir.path().join("test.db").display()
+    ))
+    .await
+    .unwrap();
+    let snapshot = provider.get_current_snapshot().unwrap();
+    let mut files = provider
+        .get_table_file_metadata_page(table.table_id, snapshot, None, 16)
+        .unwrap();
+    files.sort_by_key(|metadata| metadata.file.data_file_id);
+    let output = files.last().unwrap();
+    let path = temp_dir
+        .path()
+        .join("data/main/t")
+        .join(&output.file.file.path);
+    let file = std::fs::File::open(path).unwrap();
+    let batch = ParquetRecordBatchReaderBuilder::try_new(file)
+        .unwrap()
+        .build()
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap();
+    let values = batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .unwrap();
+
+    assert_eq!(files.len(), 2);
+    assert_eq!(
+        values.values().iter().copied().collect::<Vec<_>>(),
+        vec![11, 21, 31],
+    );
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn update_sets_value_where_id() {


### PR DESCRIPTION
### Summary

Use DataFusion's external sort for every file-rewrite path, stream the sorted output into Parquet,
and allow callers to target explicit live data files. This extends the producible-column sort
contract introduced by upstream PR #206 without replacing its public `SortField` and
`set_sort_spec` API.

DuckLake documents that sorted merge compaction uses the current table sort order. See
[merge adjacent files](https://ducklake.select/docs/stable/duckdb/maintenance/merge_adjacent_files).

```mermaid
flowchart LR
    Selection["Threshold or explicit data file IDs"] --> Inputs["Rewrite input batches"]
    Inputs --> Source["DataFusion memory source"]
    Source --> Sort["SortExec with spill support"]
    Sort --> Stream["Record batch stream"]
    Stream --> Parquet["Parquet writer"]
    Parquet --> Stats["File statistics and lineage"]
    Stats --> Commit["Compaction snapshot"]
```

### Problem

The original implementation concatenated every batch in a compaction bin and built Arrow sort
indices for the complete result. The sort could therefore add a second large in-memory copy of the
bin. It also made the rewrite path easy to diverge from the merge path.

### Changes

- Replace whole-bin Arrow concatenation and index sorting with DataFusion `SortExec`.
- Use the session task context so `SortExec` can spill when the runtime has a bounded memory pool
  and an enabled disk manager.
- Stream sorted merge and rewrite output into one Parquet file without retaining the sorted result.
- Apply the same sorted rewrite path to SQL `UPDATE` output.
- Keep embedded row IDs and origin snapshot IDs attached to their rows through the sort.
- Preserve Parquet statistics, NaN tracking, row counts, and source lineage while consuming the
  stream.
- Implement `MulticatalogProvider::get_sort_spec` so PostgreSQL compaction sees the active order.
- Return the input stream unchanged when the table has no sort specification.
- Reject expression-based sort keys and missing sort columns before insert, merge, rewrite, or
  `UPDATE` can commit unsorted output. The library continues to read and expose arbitrary DuckLake
  sort expressions, but only bare-column keys are currently executable.
- Add `RewriteOptions::data_file_ids` so maintenance callers can rewrite only selected live files;
  threshold-based delete compaction remains the default.

The compaction scan still materializes each selected bin as record batches before sorting.
`target_file_size` bounds source file bytes, and `max_merged_files` bounds source count, but neither
is a strict peak-memory bound. The change removes the extra concatenated sort copy; it does not
make the full compaction input streaming.

### Commit and branch

- Refreshed independent branch: `ducklake-streamed-compaction-independent`.
- Commit: `150c456 feat(compaction): add sort-aware targeted rewrites`.
- Base: current upstream `0335553`.
- The branch inherits upstream partition parity and does not depend on snapshot metadata, bounded
  pruning, or restore.
- The local aggregate carries the equivalent commit `7b8457b`.

### Verification

- `CARGO_BUILD_JOBS=8 cargo clippy --all-targets --all-features --no-deps -- -D warnings`: passed.
- The complete SQLite compaction integration target: 14 passed.
- Unsupported-expression tests for ordinary insert and compaction output: passed.
- PostgreSQL targeted rewrite and SQL `UPDATE` physical-order tests: passed.

### Specification proof

| DuckLake rule                                                                                                                                                                               | Implementation invariant                                                                                                                                                        | Discriminating proof                                                                                                                             |
| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
| [Merge compaction](https://ducklake.select/docs/stable/duckdb/maintenance/merge_adjacent_files) preserves time travel and change feeds through embedded origin snapshots and `partial_max`. | Sorting carries each row's embedded row ID and origin snapshot through the DataFusion stream and registers the output lineage unchanged.                                        | `sorted_merge_under_memory_limit_preserves_rowids_and_snapshot_lineage` asserts exact row IDs and snapshot ownership after a spill-capable sort. |
| A sorted table uses its current sort order for compaction.                                                                                                                                  | Merge, delete rewrite, and SQL `UPDATE` share one sort execution path resolved from the active table sort specification.                                                        | SQLite and PostgreSQL physical-order tests assert the exact output sequence.                                                                     |
| [Rewrite compaction](https://ducklake.select/docs/stable/duckdb/maintenance/rewrite_data_files) replaces a heavily deleted file with its non-deleted rows.                                  | Explicit targeting changes candidate selection only; the standard rewrite still applies positional deletes, retires its sources, and registers replacement metadata atomically. | `rewrite_targets_explicit_postgres_data_files` asserts exact selected files, live rows, and replacement metadata.                                |
| Compaction must not change logical row identity.                                                                                                                                            | The writer sorts complete rows, including the internal row-lineage columns, instead of reconstructing identifiers.                                                              | The complete 14-test SQLite compaction target covers merge, rewrite, time travel, change feed, and row-ID preservation.                          |

`RewriteOptions::data_file_ids` and spill-aware execution are library APIs. They do not add or
reinterpret DuckLake metadata.

### PostgreSQL check

The focused PostgreSQL checks ran with:

```bash
CARGO_BUILD_JOBS=4 cargo test --all-features \
  --test compaction_postgres_tests \
  rewrite_targets_explicit_postgres_data_files -- --ignored --exact
CARGO_BUILD_JOBS=4 cargo test --all-features \
  --test sql_update_postgres_tests \
  update_applies_postgres_sort_order -- --ignored --exact
```

Each test starts an ephemeral `postgres` Docker container through `testcontainers`, initializes a
real multicatalog, executes the rewrite, reads the registered Parquet output, and asserts both the
physical row order and PostgreSQL file metadata.
