### PR TITLE
feat(partition): partition parity for compaction, the low-level writers, and promote

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,10 +229,21 @@ runtime.register_object_store(&Url::parse("s3://ducklake-data/")?, s3);
 - No SQL-level time travel (`AS OF`); a catalog binds to one snapshot, selectable programmatically via `DuckLakeCatalog::with_snapshot`
 - Complex types (nested lists, structs, maps) have minimal support (many cases return errors)
 - Partitioning (`identity` + temporal `year`/`month`/`day`/`hour`) is supported: read + pruning on
-  all backends, and partitioned writes on SQLite (via `set_partition_spec`/`reset_partition_spec`
-  or the `ALTER TABLE … SET/RESET PARTITIONED BY` SQL hook `execute_ducklake_sql`). `bucket(N)` is
-  tolerated on read but not pruned or produced; partitioned writes for DuckDB/Postgres/MySQL are
-  not yet wired. See `src/partition.rs`.
+  all backends, and partitioned writes on every writable backend, declared via
+  `set_partition_spec`/`reset_partition_spec` or the `ALTER TABLE … SET/RESET PARTITIONED BY` SQL
+  hook `execute_ducklake_sql`. `bucket(N)` is tolerated on read but not pruned or produced (a
+  partitioned write to a `bucket` spec is refused rather than silently unpartitioned).
+  Every write path honours the spec: SQL `INSERT`, the low-level `write_rows`/`write_table`/
+  `append_table`, the streaming `begin_write` session (one open file per partition, capped by
+  `max_open_partitions`), compaction (merges only within a partition, preserving each output's
+  generation), and promote (`register_existing_data_file`, which carries caller-supplied values —
+  see its docs for the contract). `enforce_partition_fence` guards every commit path, so a file
+  can never land inconsistent with the table's live spec. See `src/partition.rs`.
+  Not yet supported: `UPDATE`/upsert on a partitioned table — the new row versions span one file
+  per partition, but the atomic append+delete commit registers a single data file; the session's
+  `finish_with_deletes` refuses it with a typed error. Likewise
+  `begin_write_with_embedded_rowid` and `begin_write_to_path`, which write to one
+  caller-determined file.
 - DuckDB-encrypted (non-PME) Parquet files are not supported
 - Data inlining is not read (see `COMPATIBILITY.md` for the `COUNT(*)` undercount caveat)
 - No optional metadata caching layer (all lookups are dynamic)

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -107,7 +107,8 @@ the read backend: `--no-default-features --features metadata-duckdb` (requires
 | Parquet Modular Encryption (PME) reads (feature `encryption`) | ✅ |
 | Configurable writer output (compression, row-group sizing) | ✅  |
 | Table partitioning — read + file pruning (all backends); `identity` + `year`/`month`/`day`/`hour` transforms (`bucket(N)` tolerated, not pruned) | ✅ |
-| Partitioned writes — split into per-partition files in one snapshot (SQLite; DuckDB/Postgres/MySQL not yet wired), via `set_partition_spec`/`reset_partition_spec` or `execute_ducklake_sql` (`ALTER TABLE … SET/RESET PARTITIONED BY`) | 🟧 |
+| Partitioned writes — split into per-partition files in one snapshot, on every writable backend, via `set_partition_spec`/`reset_partition_spec` or `execute_ducklake_sql` (`ALTER TABLE … SET/RESET PARTITIONED BY`). Honoured by SQL `INSERT`, the low-level write entry points, the streaming session, compaction, and promote | ✅ |
+| Partitioned `UPDATE` / upsert — the append+delete commit registers one data file, but the new row versions span one file per partition | ❌ |
 | Multi-catalog (PostgreSQL, **experimental** — library-specific, not in the DuckLake spec) | ✅ |
 
 Maintenance and `DROP TABLE` are driven through the Rust API (`maintenance` module and
@@ -181,12 +182,16 @@ Known edges:
 - Two concurrent `CREATE TABLE` of the same name on the PostgreSQL multi-catalog path are
   rejected by a unique index, surfacing as a raw database unique-violation rather than a
   clean `Conflict`. A `DROP` racing a write can likewise surface as a raw unique-violation.
-- An `INSERT` reads the table's partition state at plan time and fences on it at commit time,
-  in both directions: if a concurrent `SET`/`RESET PARTITIONED BY` changes that state between
-  planning and commit, the `INSERT` aborts with `Conflict` (re-open the catalog and retry)
-  rather than committing files inconsistent with the live spec — never a file stamped with a
-  retired `partition_id` (spec retired mid-flight), and never a `partition_id`-less file in a
-  table that became partitioned mid-flight.
+- A write resolves the table's partition spec inside its write transaction and fences on it at
+  commit time, so a file inconsistent with the live spec is never committed — never one stamped
+  with a retired `partition_id`, and never a `partition_id`-less file in a partitioned table.
+  A `SET PARTITIONED BY` landing after an unpartitioned write was *planned* is absorbed: the
+  write lays its rows out per the new spec instead of failing. A spec change landing after the
+  resolve, or a `RESET` that retires the generation a pre-split write already targeted, aborts
+  with `Conflict` (re-open the catalog and retry).
+- Compaction merges only *within* a partition and carries each output's `partition_id` and values
+  over from its sources, including a retired generation — those rows really do have that
+  generation's layout, so preserving it keeps them prunable exactly as before.
 
 ---
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -182,13 +182,15 @@ Known edges:
 - Two concurrent `CREATE TABLE` of the same name on the PostgreSQL multi-catalog path are
   rejected by a unique index, surfacing as a raw database unique-violation rather than a
   clean `Conflict`. A `DROP` racing a write can likewise surface as a raw unique-violation.
-- A write resolves the table's partition spec inside its write transaction and fences on it at
-  commit time, so a file inconsistent with the live spec is never committed — never one stamped
-  with a retired `partition_id`, and never a `partition_id`-less file in a partitioned table.
-  A `SET PARTITIONED BY` landing after an unpartitioned write was *planned* is absorbed: the
-  write lays its rows out per the new spec instead of failing. A spec change landing after the
-  resolve, or a `RESET` that retires the generation a pre-split write already targeted, aborts
-  with `Conflict` (re-open the catalog and retry).
+- Every commit path is fenced on the table's live partition generation, so a file inconsistent
+  with the live spec is never committed — never one stamped with a retired `partition_id`, and
+  never a `partition_id`-less file in a partitioned table.
+- A `SET`/`RESET PARTITIONED BY` that lands between an `INSERT` being planned and committed aborts
+  the `INSERT` with `Conflict`; re-open the catalog and retry, and the retry plans against the new
+  spec. The write is never silently re-laid-out under a spec its plan did not see — a concurrent
+  layout change is reported, not absorbed.
+- The low-level writer entry points have no plan step, so they resolve the live spec inside their
+  own write transaction and lay out accordingly; a spec change racing that commit still fences.
 - Compaction merges only *within* a partition and carries each output's `partition_id` and values
   over from its sources, including a retired generation — those rows really do have that
   generation's layout, so preserving it keeps them prunable exactly as before.

--- a/src/compaction.rs
+++ b/src/compaction.rs
@@ -41,6 +41,7 @@ use datafusion::catalog::Session;
 
 use crate::metadata_provider::DuckLakeTableFile;
 use crate::metadata_writer::{CompactionOutputFile, CompactionSourceFile, SourceRetirement};
+use crate::partition::PartitionSpec;
 use crate::row_id::EMBEDDED_SNAPSHOT_ID_COLUMN_NAME;
 use crate::table::DuckLakeTable;
 use crate::table_writer::DuckLakeTableWriter;
@@ -193,17 +194,80 @@ fn sort_compaction_output(
     Ok(vec![RecordBatch::try_new(full_schema, sorted_columns)?])
 }
 
+/// A file's partition identity, normalized for grouping and comparison: the spec
+/// generation it was written under (`None` for an unpartitioned file) and its
+/// per-key values ordered by `partition_key_index`.
+///
+/// Two files may be merged only when this matches exactly. Ordering by it also
+/// clusters same-partition files together, so bin-packing needs no extra pass.
+fn partition_key(file: &DuckLakeTableFile) -> (Option<i64>, Vec<Option<String>>) {
+    let mut values = file.partition_values.clone();
+    values.sort_by_key(|(index, _)| *index);
+    (
+        file.partition_id,
+        values.into_iter().map(|(_, value)| value).collect(),
+    )
+}
+
+/// Re-key normalized partition values back to the `(partition_key_index, value)`
+/// pairs [`DataFileInfo::with_partition`] persists.
+fn partition_value_pairs(values: &[Option<String>]) -> Vec<(i32, Option<String>)> {
+    values
+        .iter()
+        .enumerate()
+        .map(|(index, value)| (index as i32, value.clone()))
+        .collect()
+}
+
 impl DuckLakeTable {
+    /// The live partition spec's key column names in key order, used only to build
+    /// the readable Hive directory of a compaction output.
+    ///
+    /// Empty when the table is unpartitioned, when `partition_id` is a *retired*
+    /// generation (whose key order may differ from the live one, so live names would
+    /// mislabel the directory), or when a key's column has since been dropped. The
+    /// catalog is the authoritative source of partition values, so degrading to
+    /// positional `key=…` naming costs readability only — never correctness.
+    #[cfg(feature = "write")]
+    fn partition_path_names(
+        &self,
+        live: Option<&PartitionSpec>,
+        partition_id: i64,
+        column_ids: &[i64],
+    ) -> Vec<String> {
+        let Some(spec) = live.filter(|spec| spec.partition_id == partition_id) else {
+            return Vec::new();
+        };
+        let schema = self.physical_schema();
+        let names: Option<Vec<String>> = spec
+            .columns
+            .iter()
+            .map(|column| {
+                let index = column_ids.iter().position(|id| *id == column.column_id)?;
+                Some(schema.field(index).name().to_string())
+            })
+            .collect();
+        names.unwrap_or_default()
+    }
+
     /// Merge several small adjacent data files of this table into fewer larger
     /// ones, committing the new layout in ONE snapshot.
     ///
     /// Candidates are the table's live files that have no live delete file, whose
     /// size is in `[min_file_size, target_file_size)`, and whose origin snapshot
     /// and schema version are known. They are grouped by schema version (so a DDL
-    /// boundary is never crossed) and, within a group, bin-packed in
-    /// `data_file_id` order until a bin reaches `target_file_size`; only bins of
-    /// two or more files are merged. Delete-bearing files are deliberately left
-    /// to [`rewrite_data_files`](Self::rewrite_data_files).
+    /// boundary is never crossed) AND by partition identity — matching official
+    /// DuckLake, which merges only *within* a partition — and, within a group,
+    /// bin-packed in `data_file_id` order until a bin reaches `target_file_size`;
+    /// only bins of two or more files are merged. Delete-bearing files are
+    /// deliberately left to [`rewrite_data_files`](Self::rewrite_data_files).
+    ///
+    /// A merged file inherits its sources' `partition_id` and partition values and
+    /// lands in their Hive directory: every file in a bin shares one partition, so
+    /// the output belongs to exactly that partition. The inherited generation may be
+    /// a *retired* one (files written before a `SET`/`RESET PARTITIONED BY`); that is
+    /// correct — the merged rows really do have that generation's layout, and
+    /// preserving it keeps them prunable exactly as before.
     ///
     /// Each source file's live rows are read with their original rowids
     /// preserved; a merged file that spans more than one origin snapshot is
@@ -249,17 +313,28 @@ impl DuckLakeTable {
                     && (f.file.file_size_bytes as u64) < opts.target_file_size
             })
             .collect();
-        candidates.sort_by_key(|f| (f.schema_version.unwrap_or(0), f.data_file_id));
+        // Sort by (schema_version, partition identity, data_file_id) so both the
+        // DDL boundary and the partition boundary fall out of the sort, and files
+        // stay in data_file_id order (adjacency) within a partition.
+        candidates
+            .sort_by_key(|f| (f.schema_version.unwrap_or(0), partition_key(f), f.data_file_id));
         candidates.truncate(opts.max_merged_files);
 
-        // Bin-pack within each schema-version run; only bins of >= 2 files merge.
+        // Bin-pack within each (schema-version, partition) run; only bins of >= 2
+        // files merge. Merging across partitions would produce a file that belongs
+        // to no single partition — unprunable, and unrepresentable in
+        // `ducklake_file_partition_value`.
         let mut bins: Vec<Vec<&DuckLakeTableFile>> = Vec::new();
         let mut i = 0;
         while i < candidates.len() {
             let version = candidates[i].schema_version;
+            let partition = partition_key(candidates[i]);
             let mut running: u64 = 0;
             let mut bin: Vec<&DuckLakeTableFile> = Vec::new();
-            while i < candidates.len() && candidates[i].schema_version == version {
+            while i < candidates.len()
+                && candidates[i].schema_version == version
+                && partition_key(candidates[i]) == partition
+            {
                 bin.push(candidates[i]);
                 running += candidates[i].file.file_size_bytes as u64;
                 i += 1;
@@ -288,6 +363,9 @@ impl DuckLakeTable {
         // bounds each output near target_file_size, so no extra file rollover is
         // needed here.
         let sort_spec = self.live_sort_spec()?;
+        // Only for naming the output's Hive directory; the partition identity a
+        // merged file carries comes from its sources, not from this.
+        let live_partition_spec = self.live_partition_spec()?;
 
         let mut sources: Vec<CompactionSourceFile> = Vec::new();
         let mut outputs: Vec<CompactionOutputFile> = Vec::new();
@@ -366,6 +444,18 @@ impl DuckLakeTable {
             }
             let merged =
                 sort_compaction_output(merged, physical_schema.as_ref(), sort_spec.as_ref())?;
+            // Every file in the bin shares one partition identity (that is the
+            // grouping key), so the merged output inherits it: same Hive directory,
+            // same `partition_id` + values in the catalog.
+            let (partition_id, partition_values) = partition_key(bin[0]);
+            let subpath = partition_id.map(|pid| {
+                let names = self.partition_path_names(
+                    live_partition_spec.as_ref(),
+                    pid,
+                    &column_ids,
+                );
+                crate::partition::hive_subpath(&names, &partition_values)
+            });
             let file = table_writer
                 .write_compacted_file(
                     schema_name,
@@ -374,8 +464,13 @@ impl DuckLakeTable {
                     &column_ids,
                     &merged,
                     partial,
+                    subpath.as_deref(),
                 )
                 .await?;
+            let file = match partition_id {
+                Some(pid) => file.with_partition(pid, partition_value_pairs(&partition_values)),
+                None => file,
+            };
             outputs.push(CompactionOutputFile {
                 file,
                 partial_max,
@@ -443,6 +538,9 @@ impl DuckLakeTable {
         // Re-apply the table's live sort order to each rewritten file so its rows
         // stay ordered (tight min/max) after the delete-driven rewrite.
         let sort_spec = self.live_sort_spec()?;
+        // Only for naming the output's Hive directory (see `partition_path_names`);
+        // a rewritten file inherits its partition identity from the file it replaces.
+        let live_partition_spec = self.live_partition_spec()?;
 
         let mut sources: Vec<CompactionSourceFile> = Vec::new();
         let mut outputs: Vec<CompactionOutputFile> = Vec::new();
@@ -481,6 +579,18 @@ impl DuckLakeTable {
                     physical_schema.as_ref(),
                     sort_spec.as_ref(),
                 )?;
+                // The rewrite drops deleted rows from ONE source file, so the output
+                // holds a subset of that file's rows and therefore its exact
+                // partition: inherit the identity and the Hive directory.
+                let (partition_id, partition_values) = partition_key(tf);
+                let subpath = partition_id.map(|pid| {
+                    let names = self.partition_path_names(
+                        live_partition_spec.as_ref(),
+                        pid,
+                        &column_ids,
+                    );
+                    crate::partition::hive_subpath(&names, &partition_values)
+                });
                 let file = table_writer
                     .write_compacted_file(
                         schema_name,
@@ -489,8 +599,13 @@ impl DuckLakeTable {
                         &column_ids,
                         &sorted,
                         false,
+                        subpath.as_deref(),
                     )
                     .await?;
+                let file = match partition_id {
+                    Some(pid) => file.with_partition(pid, partition_value_pairs(&partition_values)),
+                    None => file,
+                };
                 rows_written += live_rows as i64;
                 // A rewrite output holds only currently-live rows and begins at
                 // the compaction snapshot (begin_snapshot = None); its

--- a/src/compaction.rs
+++ b/src/compaction.rs
@@ -316,8 +316,13 @@ impl DuckLakeTable {
         // Sort by (schema_version, partition identity, data_file_id) so both the
         // DDL boundary and the partition boundary fall out of the sort, and files
         // stay in data_file_id order (adjacency) within a partition.
-        candidates
-            .sort_by_key(|f| (f.schema_version.unwrap_or(0), partition_key(f), f.data_file_id));
+        candidates.sort_by_key(|f| {
+            (
+                f.schema_version.unwrap_or(0),
+                partition_key(f),
+                f.data_file_id,
+            )
+        });
         candidates.truncate(opts.max_merged_files);
 
         // Bin-pack within each (schema-version, partition) run; only bins of >= 2
@@ -449,11 +454,8 @@ impl DuckLakeTable {
             // same `partition_id` + values in the catalog.
             let (partition_id, partition_values) = partition_key(bin[0]);
             let subpath = partition_id.map(|pid| {
-                let names = self.partition_path_names(
-                    live_partition_spec.as_ref(),
-                    pid,
-                    &column_ids,
-                );
+                let names =
+                    self.partition_path_names(live_partition_spec.as_ref(), pid, &column_ids);
                 crate::partition::hive_subpath(&names, &partition_values)
             });
             let file = table_writer
@@ -584,11 +586,8 @@ impl DuckLakeTable {
                 // partition: inherit the identity and the Hive directory.
                 let (partition_id, partition_values) = partition_key(tf);
                 let subpath = partition_id.map(|pid| {
-                    let names = self.partition_path_names(
-                        live_partition_spec.as_ref(),
-                        pid,
-                        &column_ids,
-                    );
+                    let names =
+                        self.partition_path_names(live_partition_spec.as_ref(), pid, &column_ids);
                     crate::partition::hive_subpath(&names, &partition_values)
                 });
                 let file = table_writer

--- a/src/compaction.rs
+++ b/src/compaction.rs
@@ -145,55 +145,6 @@ fn append_snapshot_column(batch: &RecordBatch, origin: i64) -> Result<RecordBatc
     Ok(RecordBatch::try_new(Arc::new(Schema::new(fields)), cols)?)
 }
 
-/// Reorder the rows of a compaction output by the table's live sort order, as one
-/// sorted batch. `batches` may carry trailing embedded columns (rowid, and for a
-/// partial file the per-row snapshot id) beyond `data_schema`; sort keys resolve
-/// to `data_schema` positions (the leading columns), so the embedded columns
-/// travel with their rows. Returns `batches` unchanged when there is no producible
-/// sort order, a key is not in the schema, or there are no rows — sorting only
-/// affects statistics locality, never correctness.
-fn sort_compaction_output(
-    batches: Vec<RecordBatch>,
-    data_schema: &Schema,
-    sort_spec: Option<&crate::sort::SortSpec>,
-) -> Result<Vec<RecordBatch>> {
-    let Some(keys) = sort_spec.and_then(|spec| spec.producible_columns()) else {
-        return Ok(batches);
-    };
-    if keys.is_empty() || batches.iter().all(|b| b.num_rows() == 0) {
-        return Ok(batches);
-    }
-    let mut resolved = Vec::with_capacity(keys.len());
-    for (name, direction, null_order) in &keys {
-        let Ok(index) = data_schema.index_of(name) else {
-            return Ok(batches);
-        };
-        resolved.push((
-            index,
-            arrow::compute::SortOptions {
-                descending: matches!(direction, crate::sort::SortDirection::Desc),
-                nulls_first: null_order.nulls_first(),
-            },
-        ));
-    }
-    let full_schema = batches[0].schema();
-    let combined = arrow::compute::concat_batches(&full_schema, &batches)?;
-    let sort_columns: Vec<arrow::compute::SortColumn> = resolved
-        .iter()
-        .map(|(index, options)| arrow::compute::SortColumn {
-            values: Arc::clone(combined.column(*index)),
-            options: Some(*options),
-        })
-        .collect();
-    let indices = arrow::compute::lexsort_to_indices(&sort_columns, None)?;
-    let sorted_columns = combined
-        .columns()
-        .iter()
-        .map(|c| arrow::compute::take(c, &indices, None))
-        .collect::<std::result::Result<Vec<ArrayRef>, _>>()?;
-    Ok(vec![RecordBatch::try_new(full_schema, sorted_columns)?])
-}
-
 /// A file's partition identity, normalized for grouping and comparison: the spec
 /// generation it was written under (`None` for an unpartitioned file) and its
 /// per-key values ordered by `partition_key_index`.
@@ -447,8 +398,11 @@ impl DuckLakeTable {
             if merged.is_empty() {
                 continue;
             }
-            let merged =
-                sort_compaction_output(merged, physical_schema.as_ref(), sort_spec.as_ref())?;
+            let merged = crate::sort::sort_batches_by_spec(
+                merged,
+                physical_schema.as_ref(),
+                sort_spec.as_ref(),
+            )?;
             // Every file in the bin shares one partition identity (that is the
             // grouping key), so the merged output inherits it: same Hive directory,
             // same `partition_id` + values in the catalog.
@@ -576,7 +530,7 @@ impl DuckLakeTable {
 
             let live_rows = out.matched_count;
             if live_rows > 0 {
-                let sorted = sort_compaction_output(
+                let sorted = crate::sort::sort_batches_by_spec(
                     out.updated_batches,
                     physical_schema.as_ref(),
                     sort_spec.as_ref(),

--- a/src/insert_exec.rs
+++ b/src/insert_exec.rs
@@ -7,9 +7,8 @@
 use std::fmt::{self, Debug};
 use std::sync::Arc;
 
-use arrow::array::{ArrayRef, RecordBatch, UInt32Array, UInt64Array};
+use arrow::array::{ArrayRef, RecordBatch, UInt64Array};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
-use datafusion::common::ScalarValue;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::execution::object_store::ObjectStoreUrl;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
@@ -19,30 +18,12 @@ use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, Pla
 use futures::stream::{self, TryStreamExt};
 
 use crate::metadata_writer::{MetadataWriter, WriteMode};
-use crate::partition::PartitionTransform;
-use crate::table_writer::{DuckLakeTableWriter, PartitionGroup};
+use crate::table_writer::DuckLakeTableWriter;
 
-/// Resolved partition spec for the write path: how `DuckLakeInsertExec` splits
-/// incoming rows into per-partition files. Built by `DuckLakeTable::insert_into`
-/// from the table's active [`crate::partition::PartitionSpec`].
-#[derive(Debug, Clone)]
-pub struct PartitionWriteSpec {
-    /// The active spec generation (`ducklake_partition_info.partition_id`).
-    pub partition_id: i64,
-    /// Partition keys, in key order.
-    pub keys: Vec<PartitionWriteKey>,
-}
-
-/// One partition key resolved for the write path.
-#[derive(Debug, Clone)]
-pub struct PartitionWriteKey {
-    /// Column index in the INSERT input schema.
-    pub input_index: usize,
-    /// Column name (used only for the readable Hive-style path).
-    pub name: String,
-    /// Transform applied to the column value to form the partition value.
-    pub transform: PartitionTransform,
-}
+// The resolved write-side partition spec lives in `partition` (it is shared with
+// the low-level writer paths and the UPDATE rewrite); re-exported here because
+// `DuckLakeInsertExec::new` takes it.
+pub use crate::partition::{PartitionWriteKey, PartitionWriteSpec};
 
 /// Schema for the output of insert operations (count of rows inserted)
 fn make_insert_count_schema() -> SchemaRef {
@@ -258,7 +239,12 @@ impl ExecutionPlan for DuckLakeInsertExec {
                 && !batches.is_empty()
             {
                 let output_schema_ref: SchemaRef = Arc::new(schema_without_metadata.clone());
-                let groups = split_batches_by_partition(&output_schema_ref, &batches, spec)?;
+                let groups = crate::partition::split_batches_by_partition(
+                    &output_schema_ref,
+                    &batches,
+                    spec,
+                )
+                .map_err(|e| DataFusionError::External(Box::new(e)))?;
                 if !groups.is_empty() {
                     let key_names: Vec<String> = spec.keys.iter().map(|k| k.name.clone()).collect();
                     let result = table_writer
@@ -334,110 +320,9 @@ impl ExecutionPlan for DuckLakeInsertExec {
     }
 }
 
-/// Apply a partition transform to a whole column array: identity returns the
-/// column unchanged; the temporal transforms return an `Int32` calendar component
-/// (year/month/day/hour) via Arrow's `date_part`. Only producible transforms are
-/// valid here — `DuckLakeTable::insert_into` rejects `bucket`/unknown up front.
-fn transform_array(transform: &PartitionTransform, array: &ArrayRef) -> DataFusionResult<ArrayRef> {
-    use arrow::compute::{DatePart, date_part};
-    let part = match transform {
-        PartitionTransform::Identity => return Ok(Arc::clone(array)),
-        PartitionTransform::Year => DatePart::Year,
-        PartitionTransform::Month => DatePart::Month,
-        PartitionTransform::Day => DatePart::Day,
-        PartitionTransform::Hour => DatePart::Hour,
-        other => {
-            return Err(DataFusionError::NotImplemented(format!(
-                "partitioned write with transform '{}' is not supported",
-                other.to_catalog_string()
-            )));
-        },
-    };
-    Ok(date_part(array, part)?)
-}
-
-/// Split the input into groups keyed by the tuple of transformed, DuckDB-canonical
-/// partition values — one group (one output file) per distinct key. Returns
-/// `(values, batches)` per group, where `values[i]` is the encoded value for
-/// partition key `i` (`None` for SQL NULL). Rows sharing a key land in the same
-/// group regardless of which input batch they came from.
-fn split_batches_by_partition(
-    output_schema: &SchemaRef,
-    batches: &[RecordBatch],
-    spec: &PartitionWriteSpec,
-) -> DataFusionResult<Vec<PartitionGroup>> {
-    use arrow::compute::{concat_batches, take};
-    use std::collections::HashMap;
-
-    if batches.is_empty() {
-        return Ok(Vec::new());
-    }
-    let input_schema = batches[0].schema();
-    let combined = concat_batches(&input_schema, batches)?;
-    let num_rows = combined.num_rows();
-    if num_rows == 0 {
-        return Ok(Vec::new());
-    }
-
-    // Transform each partition-key column once for the whole dataset.
-    let mut transformed: Vec<ArrayRef> = Vec::with_capacity(spec.keys.len());
-    for key in &spec.keys {
-        transformed.push(transform_array(
-            &key.transform,
-            combined.column(key.input_index),
-        )?);
-    }
-
-    // Group row indices by the encoded partition-value tuple.
-    let mut groups: HashMap<Vec<Option<String>>, Vec<u32>> = HashMap::new();
-    for row in 0..num_rows {
-        let mut values: Vec<Option<String>> = Vec::with_capacity(spec.keys.len());
-        for array in &transformed {
-            let scalar = ScalarValue::try_from_array(array, row)?;
-            // `encode_scalar` returns `None` for BOTH a genuine SQL NULL and a
-            // non-null value of a type it cannot encode. Those must not be
-            // conflated: silently mapping an unencodable non-null value to `None`
-            // would group every distinct such value into one file with a NULL
-            // partition value (data corruption). A NULL is a legitimate partition
-            // value; an unencodable non-null value is a hard error.
-            let encoded = if scalar.is_null() {
-                None
-            } else {
-                match crate::stats_encode::encode_scalar(&scalar) {
-                    Some(encoded) => Some(encoded),
-                    None => {
-                        return Err(DataFusionError::NotImplemented(format!(
-                            "partitioned write: partition-key value of type {} cannot be \
-                             encoded; partitioning by this column type is not supported",
-                            array.data_type()
-                        )));
-                    },
-                }
-            };
-            values.push(encoded);
-        }
-        groups.entry(values).or_default().push(row as u32);
-    }
-
-    // Materialize one batch per group via `take` (output uses the clean schema).
-    let mut result = Vec::with_capacity(groups.len());
-    for (values, indices) in groups {
-        let index_array = UInt32Array::from(indices);
-        let columns = combined
-            .columns()
-            .iter()
-            .map(|c| take(c, &index_array, None))
-            .collect::<Result<Vec<_>, _>>()?;
-        let batch = RecordBatch::try_new(output_schema.clone(), columns)?;
-        result.push((values, vec![batch]));
-    }
-    Ok(result)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::StringArray;
 
     #[test]
     fn test_insert_count_schema() {
@@ -445,74 +330,5 @@ mod tests {
         assert_eq!(schema.fields().len(), 1);
         assert_eq!(schema.field(0).name(), "count");
         assert_eq!(schema.field(0).data_type(), &DataType::UInt64);
-    }
-
-    fn identity_region_spec() -> PartitionWriteSpec {
-        PartitionWriteSpec {
-            partition_id: 1,
-            keys: vec![PartitionWriteKey {
-                input_index: 0,
-                name: "region".to_string(),
-                transform: PartitionTransform::Identity,
-            }],
-        }
-    }
-
-    #[test]
-    fn split_groups_by_identity_and_keeps_null_partition() {
-        let schema: SchemaRef = Arc::new(Schema::new(vec![Field::new(
-            "region",
-            DataType::Utf8,
-            true,
-        )]));
-        let batch = RecordBatch::try_new(
-            schema.clone(),
-            vec![Arc::new(StringArray::from(vec![Some("us"), None, Some("us")])) as ArrayRef],
-        )
-        .unwrap();
-        let groups = split_batches_by_partition(
-            &schema,
-            std::slice::from_ref(&batch),
-            &identity_region_spec(),
-        )
-        .unwrap();
-        // "us" (2 rows) and a legitimate NULL partition (1 row).
-        assert_eq!(groups.len(), 2);
-        let total: usize = groups
-            .iter()
-            .flat_map(|(_, b)| b)
-            .map(|b| b.num_rows())
-            .sum();
-        assert_eq!(total, 3);
-        let mut values: Vec<Option<String>> = groups.iter().map(|(v, _)| v[0].clone()).collect();
-        values.sort();
-        assert_eq!(values, vec![None, Some("us".to_string())]);
-    }
-
-    #[test]
-    fn split_errors_on_unencodable_non_null_value_instead_of_corrupting() {
-        let schema: SchemaRef = Arc::new(Schema::new(vec![Field::new(
-            "region",
-            DataType::Utf8,
-            true,
-        )]));
-        // A NUL byte makes the value unencodable (encode_scalar returns None) but it
-        // is NOT null — it must error, not silently collapse into a NULL partition
-        // and commingle with genuinely-null rows.
-        let batch = RecordBatch::try_new(
-            schema.clone(),
-            vec![Arc::new(StringArray::from(vec![Some("a\u{0}b")])) as ArrayRef],
-        )
-        .unwrap();
-        let err = split_batches_by_partition(
-            &schema,
-            std::slice::from_ref(&batch),
-            &identity_region_spec(),
-        )
-        .unwrap_err();
-        assert!(
-            err.to_string().to_lowercase().contains("encode"),
-            "expected an encode error, got: {err}"
-        );
     }
 }

--- a/src/insert_exec.rs
+++ b/src/insert_exec.rs
@@ -270,10 +270,16 @@ impl ExecutionPlan for DuckLakeInsertExec {
             // commits them in one snapshot. Only for non-empty input — an empty
             // Replace still needs the single-file truncate marker below, and empty
             // Append already returned above.
+            //
+            // `_unpartitioned_as_planned`: reaching here means the plan resolved the
+            // table as unpartitioned. If a SET PARTITIONED BY went live since, the
+            // commit fence must reject so the caller re-plans against the new spec —
+            // this write must NOT quietly re-lay-out its rows under a spec the plan
+            // never saw.
             let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
             if total_rows > 0 {
                 let result = table_writer
-                    .write_rows(
+                    .write_rows_unpartitioned_as_planned(
                         &schema_name,
                         &table_name,
                         &schema_without_metadata,

--- a/src/metadata_provider_postgres.rs
+++ b/src/metadata_provider_postgres.rs
@@ -55,7 +55,11 @@ fn decode_table_file(row: &PgRow, snapshot_id: i64) -> Result<DuckLakeTableFile>
         partial_max: row.try_get(16)?,
         max_row_count: row.try_get(7)?,
         delete_count,
-        partition_id: None,
+        // Column 18 is present on the select-path query (which projects
+        // `data.partition_id`) and absent on callers that share this decoder
+        // without it; `try_get` failing there degrades to `None`, matching the
+        // pre-partition behaviour. Per-key values are filled in by the caller.
+        partition_id: row.try_get(18).unwrap_or(None),
         partition_values: Vec::new(),
     })
 }
@@ -108,11 +112,16 @@ struct SchemaCapabilities {
     delete_file_partial_max: bool,
     /// The `ducklake_schema_versions` table exists.
     schema_versions: bool,
+    /// `ducklake_data_file.partition_id` exists.
+    data_file_partition_id: bool,
 }
 
 impl SchemaCapabilities {
     fn all(&self) -> bool {
-        self.data_file_partial_max && self.delete_file_partial_max && self.schema_versions
+        self.data_file_partial_max
+            && self.delete_file_partial_max
+            && self.schema_versions
+            && self.data_file_partition_id
     }
 }
 
@@ -169,13 +178,15 @@ impl PostgresMetadataProvider {
         if let Some(caps) = self.schema_capabilities.get() {
             return Ok(*caps);
         }
-        let row: (bool, bool, bool) = sqlx::query_as(
+        let row: (bool, bool, bool, bool) = sqlx::query_as(
             "SELECT
                EXISTS (SELECT 1 FROM information_schema.columns
                        WHERE table_name = 'ducklake_data_file' AND column_name = 'partial_max'),
                EXISTS (SELECT 1 FROM information_schema.columns
                        WHERE table_name = 'ducklake_delete_file' AND column_name = 'partial_max'),
-               to_regclass('ducklake_schema_versions') IS NOT NULL",
+               to_regclass('ducklake_schema_versions') IS NOT NULL,
+               EXISTS (SELECT 1 FROM information_schema.columns
+                       WHERE table_name = 'ducklake_data_file' AND column_name = 'partition_id')",
         )
         .fetch_one(&self.pool)
         .await?;
@@ -183,6 +194,7 @@ impl PostgresMetadataProvider {
             data_file_partial_max: row.0,
             delete_file_partial_max: row.1,
             schema_versions: row.2,
+            data_file_partition_id: row.3,
         };
         if caps.all() {
             let _ = self.schema_capabilities.set(caps);
@@ -354,6 +366,13 @@ impl MetadataProvider for PostgresMetadataProvider {
             } else {
                 "NULL::bigint"
             };
+            // A catalog predating partition support has no `partition_id` column;
+            // such a catalog holds no partitioned files either, so NULL is exact.
+            let partition_id_expr = if caps.data_file_partition_id {
+                "data.partition_id::bigint"
+            } else {
+                "NULL::bigint"
+            };
             let schema_version_expr = if caps.schema_versions {
                 "(SELECT sv.schema_version::bigint
                   FROM ducklake_schema_versions sv
@@ -383,7 +402,8 @@ impl MetadataProvider for PostgresMetadataProvider {
                     del.delete_count,
                     data.begin_snapshot::bigint AS data_begin_snapshot,
                     {partial_max_expr} AS data_partial_max,
-                    {schema_version_expr} AS data_schema_version
+                    {schema_version_expr} AS data_schema_version,
+                    {partition_id_expr} AS data_partition_id
                 FROM ducklake_data_file AS data
                 LEFT JOIN ducklake_delete_file AS del
                     ON data.data_file_id = del.data_file_id
@@ -404,9 +424,54 @@ impl MetadataProvider for PostgresMetadataProvider {
                 .fetch_all(&self.pool)
                 .await?;
 
-            rows.iter()
+            let mut files: Vec<DuckLakeTableFile> = rows
+                .iter()
                 .map(|row| decode_table_file(row, snapshot_id))
-                .collect()
+                .collect::<Result<Vec<_>>>()?;
+
+            // Enrich with per-file partition values. Compaction reads its candidates
+            // through this path and must group by, and preserve, each file's exact
+            // partition — without the values it would merge across partitions and
+            // strip the assignment. Scoped by the fetched id range; a catalog
+            // predating partition support simply yields no rows.
+            if let (Some(min), Some(max)) = (
+                files.iter().map(|f| f.data_file_id).min(),
+                files.iter().map(|f| f.data_file_id).max(),
+            ) {
+                let mut values_by_file: HashMap<i64, Vec<(i32, Option<String>)>> = HashMap::new();
+                match sqlx::query(
+                    "SELECT data_file_id, partition_key_index, partition_value
+                     FROM ducklake_file_partition_value
+                     WHERE table_id = $1 AND data_file_id >= $2 AND data_file_id <= $3",
+                )
+                .bind(table_id)
+                .bind(min)
+                .bind(max)
+                .fetch_all(&self.pool)
+                .await
+                {
+                    Ok(rows) => {
+                        for row in rows {
+                            let data_file_id: i64 = row.try_get(0)?;
+                            let key_index: i32 =
+                                i32::try_from(row.try_get::<i64, _>(1)?).unwrap_or(0);
+                            let value: Option<String> = row.try_get(2)?;
+                            values_by_file
+                                .entry(data_file_id)
+                                .or_default()
+                                .push((key_index, value));
+                        }
+                    },
+                    Err(error) if is_missing_statistics_table(&error) => {},
+                    Err(error) => return Err(error.into()),
+                }
+                for file in &mut files {
+                    if let Some(values) = values_by_file.remove(&file.data_file_id) {
+                        file.partition_values = values;
+                    }
+                }
+            }
+            Ok(files)
         })
     }
 

--- a/src/metadata_provider_sqlite.rs
+++ b/src/metadata_provider_sqlite.rs
@@ -63,7 +63,11 @@ fn decode_table_file(row: &SqliteRow, snapshot_id: i64) -> Result<DuckLakeTableF
         partial_max: row.try_get(16)?,
         max_row_count: row.try_get(7)?,
         delete_count,
-        partition_id: None,
+        // Column 18 is present on the select-path query (which projects
+        // `data.partition_id`) and absent on callers that share this decoder
+        // without it; `try_get` failing there degrades to `None`, matching the
+        // pre-partition behaviour. Per-key values are filled in by the caller.
+        partition_id: row.try_get(18).unwrap_or(None),
         partition_values: Vec::new(),
     })
 }
@@ -430,14 +434,20 @@ impl MetadataProvider for SqliteMetadataProvider {
     ) -> Result<Vec<DuckLakeTableFile>> {
         block_on(async {
             // Backward compatibility: minimal / pre-v1.0 catalogs may lack the
-            // `partial_max` column and the `ducklake_schema_versions` ledger.
-            // Detect both and degrade those projections to NULL so plain reads
-            // still work (both are consumed only by compaction; `partial_max`
-            // also by time-travel reads of partial files, which such catalogs
-            // never contain).
+            // `partial_max` and `partition_id` columns and the
+            // `ducklake_schema_versions` ledger. Detect each and degrade those
+            // projections to NULL so plain reads still work (all are consumed only
+            // by compaction; `partial_max` also by time-travel reads of partial
+            // files, which such catalogs never contain).
             let caps = self.schema_capabilities().await?;
             let partial_max_expr = if caps.data_file_partial_max {
                 "data.partial_max"
+            } else {
+                "NULL"
+            };
+            // Such a catalog holds no partitioned files either, so NULL is exact.
+            let partition_id_expr = if caps.data_file_partition_id {
+                "data.partition_id"
             } else {
                 "NULL"
             };
@@ -470,7 +480,8 @@ impl MetadataProvider for SqliteMetadataProvider {
                     del.delete_count,
                     data.begin_snapshot AS data_begin_snapshot,
                     {partial_max_expr} AS data_partial_max,
-                    {schema_version_expr} AS data_schema_version
+                    {schema_version_expr} AS data_schema_version,
+                    {partition_id_expr} AS data_partition_id
                 FROM ducklake_data_file AS data
                 LEFT JOIN ducklake_delete_file AS del
                     ON data.data_file_id = del.data_file_id
@@ -491,9 +502,50 @@ impl MetadataProvider for SqliteMetadataProvider {
                 .fetch_all(&self.pool)
                 .await?;
 
-            rows.iter()
+            let mut files: Vec<DuckLakeTableFile> = rows
+                .iter()
                 .map(|row| decode_table_file(row, snapshot_id))
-                .collect()
+                .collect::<Result<Vec<_>>>()?;
+
+            // Enrich with per-file partition values. Compaction reads its candidates
+            // through this path and must group by, and preserve, each file's exact
+            // partition — without the values it would merge across partitions and
+            // strip the assignment. Scoped by the fetched id range; a catalog
+            // predating partition support simply yields no rows.
+            if let (Some(min), Some(max)) = (
+                files.iter().map(|f| f.data_file_id).min(),
+                files.iter().map(|f| f.data_file_id).max(),
+            ) {
+                let mut values_by_file: HashMap<i64, Vec<(i32, Option<String>)>> = HashMap::new();
+                match sqlx::query(SQL_GET_FILE_PARTITION_VALUES)
+                    .bind(table_id)
+                    .bind(min - 1)
+                    .bind(max)
+                    .fetch_all(&self.pool)
+                    .await
+                {
+                    Ok(rows) => {
+                        for row in rows {
+                            let data_file_id: i64 = row.try_get(0)?;
+                            let key_index: i32 =
+                                i32::try_from(row.try_get::<i64, _>(1)?).unwrap_or(0);
+                            let value: Option<String> = row.try_get(2)?;
+                            values_by_file
+                                .entry(data_file_id)
+                                .or_default()
+                                .push((key_index, value));
+                        }
+                    },
+                    Err(error) if is_missing_statistics_table(&error) => {},
+                    Err(error) => return Err(error.into()),
+                }
+                for file in &mut files {
+                    if let Some(values) = values_by_file.remove(&file.data_file_id) {
+                        file.partition_values = values;
+                    }
+                }
+            }
+            Ok(files)
         })
     }
 

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -620,6 +620,30 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
         ))
     }
 
+    /// The table's currently-live partition spec (`ducklake_partition_info` with
+    /// `end_snapshot IS NULL`, joined to its key columns), or `None` when the table
+    /// is unpartitioned.
+    ///
+    /// The write paths need this from the *writer* side: a caller reaching
+    /// [`crate::table_writer::DuckLakeTableWriter`] directly (rather than through SQL
+    /// `INSERT`) has no [`crate::metadata_provider::MetadataProvider`] to ask, but
+    /// still must lay its files out per the spec and stamp the right `partition_id` —
+    /// otherwise [`enforce_partition_fence`] rejects the commit. Resolved against the
+    /// write schema by [`crate::partition::PartitionWriteSpec::resolve`].
+    ///
+    /// The returned spec is for WRITING only: `prune_safe` is always `false`, since
+    /// deciding whether a mapping may prune arbitrary live files needs the full
+    /// generation history that the read path loads.
+    ///
+    /// Reading it at write-planning time is inherently racy against a concurrent
+    /// `SET`/`RESET PARTITIONED BY` — [`enforce_partition_fence`] is what makes the
+    /// commit safe, by re-checking the live generation inside the commit transaction.
+    ///
+    /// Default: `None` (backends without partition support are never partitioned).
+    fn live_partition_spec(&self, _table_id: i64) -> Result<Option<crate::partition::PartitionSpec>> {
+        Ok(None)
+    }
+
     /// Remove the table's partition spec — the commit behind `ALTER TABLE …
     /// RESET PARTITIONED BY`.
     ///

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -318,6 +318,75 @@ pub(crate) fn enforce_partition_fence(
     }
 }
 
+/// Validate the partition values a caller attached to a file it is *promoting*
+/// (registering an already-written parquet, rather than one this crate wrote)
+/// against the live spec's `transforms`, in key order.
+///
+/// A promoted file is registered byte-for-byte, so whether its rows really do all
+/// share these values cannot be established from the catalog — that is the caller's
+/// assertion. Official DuckLake makes the same assumption, taking the values from
+/// the file's Hive path and validating only their shape
+/// (`IsValidTransformedHivePartitionValue` checks bucket range; `MapHiveColumn`
+/// checks castability). This mirrors that, checking what the catalog can prove:
+///
+/// - one value per partition key, no more and no fewer;
+/// - key indices exactly `0..n-1`, each once (a duplicated or out-of-range index
+///   would silently drop or mis-assign a key on read);
+/// - for `bucket(N)`, a non-NULL value that parses as an integer in `0..N`.
+///
+/// Values for `identity` and the temporal transforms are opaque strings here: the
+/// column type they must cast to is not part of the spec, so type checking belongs
+/// to whoever produced them. A caller that cannot vouch for the file's contents
+/// should verify against the parquet footer's per-column min/max before promoting —
+/// for `identity`, `min == max == value` proves the file is single-partition.
+pub(crate) fn validate_promoted_partition_values(
+    table_id: i64,
+    transforms: &[String],
+    file: &DataFileInfo,
+) -> Result<()> {
+    use crate::partition::PartitionTransform;
+
+    if file.partition_values.len() != transforms.len() {
+        return Err(DuckLakeError::InvalidConfig(format!(
+            "promoted file for table {table_id} carries {} partition value(s) but the table's \
+             live partition spec has {} key(s)",
+            file.partition_values.len(),
+            transforms.len()
+        )));
+    }
+    let mut seen = vec![false; transforms.len()];
+    for (key_index, value) in &file.partition_values {
+        let index = usize::try_from(*key_index).ok().filter(|i| *i < seen.len());
+        let Some(index) = index else {
+            return Err(DuckLakeError::InvalidConfig(format!(
+                "promoted file for table {table_id} has partition_key_index {key_index}, outside \
+                 the live spec's 0..{} keys",
+                transforms.len()
+            )));
+        };
+        if seen[index] {
+            return Err(DuckLakeError::InvalidConfig(format!(
+                "promoted file for table {table_id} repeats partition_key_index {key_index}"
+            )));
+        }
+        seen[index] = true;
+
+        if let PartitionTransform::Bucket(buckets) = PartitionTransform::parse(&transforms[index]) {
+            let valid = value
+                .as_deref()
+                .and_then(|v| v.trim().parse::<i64>().ok())
+                .is_some_and(|b| b >= 0 && b < i64::from(buckets));
+            if !valid {
+                return Err(DuckLakeError::InvalidConfig(format!(
+                    "promoted file for table {table_id} has partition value {value:?} for \
+                     bucket({buckets}) key {key_index}; expected an integer in 0..{buckets}"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
 /// A positional delete file to register via [`MetadataWriter::set_delete_file`].
 /// Mirrors [`DataFileInfo`]; the parquet has the standard `(file_path, pos)`
 /// schema. Must be cumulative for its data file (all still-deleted positions),
@@ -989,12 +1058,20 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
     /// no-op return, so a delete-only orphan (no appended data file) still yields
     /// `Conflict`, not a silent no-op.
     ///
-    /// The guard covers every snapshot-visible change table this crate writes —
-    /// data files, delete files, and columns. This crate's write path produces no
-    /// inlined-data or partition-value rows (those DuckLake-spec tables are not part
-    /// of its schema), so there is nothing else to check. If inlined-data or
-    /// partition write support is ever added, extend the guard to reject a post-base
-    /// row there too, or this could silently treat such a delta as a pure append.
+    /// The guard covers the snapshot-visible change tables that can make a delta
+    /// non-append: data files, delete files, and columns. Per-file partition values
+    /// need no check — they hang off `data_file_id`, so retiring a file leaves its
+    /// values attached exactly as any other retired file's are. This crate writes no
+    /// inlined-data rows, so there is nothing else to check; if inlined-data support
+    /// is added, extend the guard to reject a post-base row there too.
+    ///
+    /// Not covered: a `SET`/`RESET PARTITIONED BY` committed after `base_snapshot`.
+    /// It changes no column, so the delta still reads as a pure append and the
+    /// appended files are retired — leaving the new spec in place with no data under
+    /// it. That is a consistent state (the retry re-appends under the live spec), but
+    /// it is not a *revert* to `base_snapshot`; a caller needing exact reversion must
+    /// serialize partition DDL against this, as the contract below already requires
+    /// for writes.
     ///
     /// Recomputes the visible stat totals (`record_count`, `file_size_bytes`, and
     /// the per-column stats) from the surviving live files, and preserves
@@ -1028,6 +1105,28 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
     /// with [`crate::DuckLakeError::InvalidConfig`]. Rowids are freshly assigned
     /// (the source `row_id_start` is not preserved), so indexes keyed on the
     /// source's rowids do not carry over.
+    ///
+    /// # Partitioning
+    ///
+    /// Nothing is rewritten here, so a partition assignment can only be *carried*,
+    /// not derived: set it with [`DataFileInfo::with_partition`] and it is persisted
+    /// (`ducklake_data_file.partition_id` + `ducklake_file_partition_value`).
+    /// Promoting into a partitioned table without it is refused by the partition
+    /// fence — an unpartitioned file cannot satisfy a live spec.
+    ///
+    /// The caller asserts the file holds rows of exactly ONE partition; only that
+    /// caller can know, since the values are not checked against the file's contents.
+    /// Official DuckLake's `ducklake_add_data_files` works the same way, reading the
+    /// values from the file's Hive path and validating only their shape. What IS
+    /// checked here is the shape against the live spec (see
+    /// [`validate_promoted_partition_values`]).
+    ///
+    /// Two ways to satisfy the contract safely: copy the values from the source
+    /// catalog when promoting files that a partitioned DuckLake table already wrote
+    /// (they are single-partition by construction), or, for a file of unknown
+    /// provenance, check the parquet footer's per-column min/max first — for an
+    /// `identity` key, `min == max == value` proves the file is single-partition
+    /// without reading a row.
     ///
     /// Default: unsupported; only multicatalog Postgres, whose column ids are
     /// reusable across catalogs, implements it.
@@ -1125,6 +1224,113 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
 mod tests {
     use super::*;
     use crate::DuckLakeError;
+
+    fn promoted(values: Vec<(i32, Option<String>)>) -> DataFileInfo {
+        DataFileInfo::new("f.parquet", 1024, 10).with_partition(7, values)
+    }
+
+    #[test]
+    fn promoted_values_must_match_the_live_key_count() {
+        let transforms = vec!["identity".to_string(), "year".to_string()];
+        // One value for a two-key spec: the second key would silently have none.
+        let err = validate_promoted_partition_values(
+            1,
+            &transforms,
+            &promoted(vec![(0, Some("us".into()))]),
+        )
+        .unwrap_err();
+        assert!(matches!(err, DuckLakeError::InvalidConfig(_)), "got {err}");
+        // Correct count passes.
+        assert!(
+            validate_promoted_partition_values(
+                1,
+                &transforms,
+                &promoted(vec![(0, Some("us".into())), (1, Some("2024".into()))]),
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn promoted_values_reject_duplicate_or_out_of_range_key_index() {
+        let transforms = vec!["identity".to_string(), "year".to_string()];
+        // Same key twice: one spec key ends up unassigned.
+        assert!(
+            validate_promoted_partition_values(
+                1,
+                &transforms,
+                &promoted(vec![(0, Some("us".into())), (0, Some("eu".into()))]),
+            )
+            .is_err()
+        );
+        // Index past the end of the spec.
+        assert!(
+            validate_promoted_partition_values(
+                1,
+                &transforms,
+                &promoted(vec![(0, Some("us".into())), (5, Some("2024".into()))]),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn promoted_bucket_values_must_be_in_range() {
+        let transforms = vec!["bucket(8)".to_string()];
+        assert!(
+            validate_promoted_partition_values(
+                1,
+                &transforms,
+                &promoted(vec![(0, Some("3".into()))])
+            )
+            .is_ok()
+        );
+        for bad in ["8", "-1", "abc"] {
+            assert!(
+                validate_promoted_partition_values(
+                    1,
+                    &transforms,
+                    &promoted(vec![(0, Some(bad.to_string()))]),
+                )
+                .is_err(),
+                "bucket value {bad} must be rejected"
+            );
+        }
+        // NULL is not a valid bucket either — a bucket transform always yields one.
+        assert!(
+            validate_promoted_partition_values(1, &transforms, &promoted(vec![(0, None)])).is_err()
+        );
+    }
+
+    #[test]
+    fn promoted_null_value_is_legal_for_identity() {
+        // A NULL partition value is a legitimate partition (DuckDB's
+        // __HIVE_DEFAULT_PARTITION__), so it must pass for a non-bucket key.
+        let transforms = vec!["identity".to_string()];
+        assert!(
+            validate_promoted_partition_values(1, &transforms, &promoted(vec![(0, None)])).is_ok()
+        );
+    }
+
+    #[test]
+    fn fence_exempts_empty_file_but_rejects_rows_without_partition() {
+        // A 0-row Replace truncate marker carries no partitioned data.
+        let empty = DataFileInfo::new("empty.parquet", 0, 0);
+        assert!(enforce_partition_fence(1, Some(7), &empty).is_ok());
+        // A row-bearing file with no partition cannot live in a partitioned table.
+        let rows = DataFileInfo::new("f.parquet", 1024, 10);
+        assert!(matches!(
+            enforce_partition_fence(1, Some(7), &rows),
+            Err(DuckLakeError::Conflict(_))
+        ));
+        // ...but is fine when the table has no live spec.
+        assert!(enforce_partition_fence(1, None, &rows).is_ok());
+        // A file stamped with a retired generation is rejected.
+        assert!(matches!(
+            enforce_partition_fence(1, Some(9), &promoted(vec![(0, Some("us".into()))])),
+            Err(DuckLakeError::Conflict(_))
+        ));
+    }
 
     #[test]
     fn test_column_def_new() {

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -332,7 +332,11 @@ pub(crate) fn enforce_partition_fence(
 /// - one value per partition key, no more and no fewer;
 /// - key indices exactly `0..n-1`, each once (a duplicated or out-of-range index
 ///   would silently drop or mis-assign a key on read);
-/// - for `bucket(N)`, a non-NULL value that parses as an integer in `0..N`.
+/// - for `bucket(N)`, a value that parses as an integer in `0..N`, or SQL NULL.
+///   NULL is legal for every transform — a NULL input yields a NULL partition value,
+///   which is a partition in its own right (DuckDB's `__HIVE_DEFAULT_PARTITION__`).
+///   Official agrees: `IsValidTransformedHivePartitionValue` returns early for a NULL
+///   hive value before its bucket-range check.
 ///
 /// Values for `identity` and the temporal transforms are opaque strings here: the
 /// column type they must cast to is not part of the spec, so type checking belongs
@@ -342,6 +346,7 @@ pub(crate) fn enforce_partition_fence(
 pub(crate) fn validate_promoted_partition_values(
     table_id: i64,
     transforms: &[String],
+    key_column_types: &[Option<DataType>],
     file: &DataFileInfo,
 ) -> Result<()> {
     use crate::partition::PartitionTransform;
@@ -371,17 +376,24 @@ pub(crate) fn validate_promoted_partition_values(
         }
         seen[index] = true;
 
-        if let PartitionTransform::Bucket(buckets) = PartitionTransform::parse(&transforms[index]) {
-            let valid = value
-                .as_deref()
-                .and_then(|v| v.trim().parse::<i64>().ok())
-                .is_some_and(|b| b >= 0 && b < i64::from(buckets));
-            if !valid {
-                return Err(DuckLakeError::InvalidConfig(format!(
-                    "promoted file for table {table_id} has partition value {value:?} for \
-                     bucket({buckets}) key {key_index}; expected an integer in 0..{buckets}"
-                )));
-            }
+        // Check the value is well-formed for the transform and, for `identity`, that
+        // it casts to the key column's type — official does the same
+        // (`MapHiveColumn` errors when the Hive value will not cast). A NULL value is
+        // legitimate under any transform and always passes. An unknown column type
+        // (a key column absent from the promoted schema) skips the type check rather
+        // than guessing.
+        let transform = PartitionTransform::parse(&transforms[index]);
+        let column_type = key_column_types
+            .get(index)
+            .and_then(|t| t.clone())
+            .unwrap_or(DataType::Utf8);
+        if !transform.value_is_well_formed(value.as_deref(), &column_type) {
+            return Err(DuckLakeError::InvalidConfig(format!(
+                "promoted file for table {table_id} has partition value {value:?} for key \
+                 {key_index} with transform '{}' on a {column_type} column; the value is not \
+                 valid for that key",
+                transform.to_catalog_string()
+            )));
         }
     }
     Ok(())
@@ -1229,6 +1241,12 @@ mod tests {
         DataFileInfo::new("f.parquet", 1024, 10).with_partition(7, values)
     }
 
+    /// Key column types for a spec whose keys are all string-typed — the permissive
+    /// case, so these tests exercise arity/index/transform rules in isolation.
+    fn utf8_types(n: usize) -> Vec<Option<DataType>> {
+        vec![Some(DataType::Utf8); n]
+    }
+
     #[test]
     fn promoted_values_must_match_the_live_key_count() {
         let transforms = vec!["identity".to_string(), "year".to_string()];
@@ -1236,6 +1254,7 @@ mod tests {
         let err = validate_promoted_partition_values(
             1,
             &transforms,
+            &utf8_types(transforms.len()),
             &promoted(vec![(0, Some("us".into()))]),
         )
         .unwrap_err();
@@ -1245,6 +1264,7 @@ mod tests {
             validate_promoted_partition_values(
                 1,
                 &transforms,
+                &utf8_types(transforms.len()),
                 &promoted(vec![(0, Some("us".into())), (1, Some("2024".into()))]),
             )
             .is_ok()
@@ -1259,6 +1279,7 @@ mod tests {
             validate_promoted_partition_values(
                 1,
                 &transforms,
+                &utf8_types(transforms.len()),
                 &promoted(vec![(0, Some("us".into())), (0, Some("eu".into()))]),
             )
             .is_err()
@@ -1268,6 +1289,7 @@ mod tests {
             validate_promoted_partition_values(
                 1,
                 &transforms,
+                &utf8_types(transforms.len()),
                 &promoted(vec![(0, Some("us".into())), (5, Some("2024".into()))]),
             )
             .is_err()
@@ -1281,6 +1303,7 @@ mod tests {
             validate_promoted_partition_values(
                 1,
                 &transforms,
+                &utf8_types(transforms.len()),
                 &promoted(vec![(0, Some("3".into()))])
             )
             .is_ok()
@@ -1290,15 +1313,81 @@ mod tests {
                 validate_promoted_partition_values(
                     1,
                     &transforms,
+                    &utf8_types(transforms.len()),
                     &promoted(vec![(0, Some(bad.to_string()))]),
                 )
                 .is_err(),
                 "bucket value {bad} must be rejected"
             );
         }
-        // NULL is not a valid bucket either — a bucket transform always yields one.
+        // NULL IS valid for a bucket key: a NULL input yields a NULL partition
+        // value, which official accepts too (IsValidTransformedHivePartitionValue
+        // returns early on a NULL hive value, before its range check).
         assert!(
-            validate_promoted_partition_values(1, &transforms, &promoted(vec![(0, None)])).is_err()
+            validate_promoted_partition_values(
+                1,
+                &transforms,
+                &utf8_types(transforms.len()),
+                &promoted(vec![(0, None)])
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn promoted_identity_value_must_cast_to_the_key_column_type() {
+        let transforms = vec!["identity".to_string()];
+        let int_key = vec![Some(DataType::Int32)];
+        // A value that cannot be an Int32 partition key is impossible for the file to
+        // hold, and would be persisted then used as an EXACT pruning bound.
+        let err = validate_promoted_partition_values(
+            1,
+            &transforms,
+            &int_key,
+            &promoted(vec![(0, Some("abc".into()))]),
+        )
+        .unwrap_err();
+        assert!(matches!(err, DuckLakeError::InvalidConfig(_)), "got {err}");
+        // A well-formed integer passes, as does NULL.
+        for value in [Some("42".to_string()), None] {
+            assert!(
+                validate_promoted_partition_values(
+                    1,
+                    &transforms,
+                    &int_key,
+                    &promoted(vec![(0, value.clone())]),
+                )
+                .is_ok(),
+                "value {value:?} must be accepted for an Int32 identity key"
+            );
+        }
+    }
+
+    #[test]
+    fn promoted_temporal_value_must_be_its_calendar_component() {
+        // A `month` key's value is 1..=12; 13 or a date string is not a month.
+        let transforms = vec!["month".to_string()];
+        let date_key = vec![Some(DataType::Date32)];
+        for bad in ["13", "0", "2024-06"] {
+            assert!(
+                validate_promoted_partition_values(
+                    1,
+                    &transforms,
+                    &date_key,
+                    &promoted(vec![(0, Some(bad.to_string()))]),
+                )
+                .is_err(),
+                "month value {bad} must be rejected"
+            );
+        }
+        assert!(
+            validate_promoted_partition_values(
+                1,
+                &transforms,
+                &date_key,
+                &promoted(vec![(0, Some("6".into()))]),
+            )
+            .is_ok()
         );
     }
 
@@ -1308,7 +1397,13 @@ mod tests {
         // __HIVE_DEFAULT_PARTITION__), so it must pass for a non-bucket key.
         let transforms = vec!["identity".to_string()];
         assert!(
-            validate_promoted_partition_values(1, &transforms, &promoted(vec![(0, None)])).is_ok()
+            validate_promoted_partition_values(
+                1,
+                &transforms,
+                &utf8_types(transforms.len()),
+                &promoted(vec![(0, None)])
+            )
+            .is_ok()
         );
     }
 

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -640,7 +640,10 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
     /// commit safe, by re-checking the live generation inside the commit transaction.
     ///
     /// Default: `None` (backends without partition support are never partitioned).
-    fn live_partition_spec(&self, _table_id: i64) -> Result<Option<crate::partition::PartitionSpec>> {
+    fn live_partition_spec(
+        &self,
+        _table_id: i64,
+    ) -> Result<Option<crate::partition::PartitionSpec>> {
         Ok(None)
     }
 

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -709,7 +709,7 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
     /// [`crate::table_writer::DuckLakeTableWriter`] directly (rather than through SQL
     /// `INSERT`) has no [`crate::metadata_provider::MetadataProvider`] to ask, but
     /// still must lay its files out per the spec and stamp the right `partition_id` —
-    /// otherwise [`enforce_partition_fence`] rejects the commit. Resolved against the
+    /// otherwise `enforce_partition_fence` rejects the commit. Resolved against the
     /// write schema by [`crate::partition::PartitionWriteSpec::resolve`].
     ///
     /// The returned spec is for WRITING only: `prune_safe` is always `false`, since
@@ -717,7 +717,7 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
     /// generation history that the read path loads.
     ///
     /// Reading it at write-planning time is inherently racy against a concurrent
-    /// `SET`/`RESET PARTITIONED BY` — [`enforce_partition_fence`] is what makes the
+    /// `SET`/`RESET PARTITIONED BY` — `enforce_partition_fence` is what makes the
     /// commit safe, by re-checking the live generation inside the commit transaction.
     ///
     /// Default: `None` (backends without partition support are never partitioned).
@@ -1131,7 +1131,7 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
     /// Official DuckLake's `ducklake_add_data_files` works the same way, reading the
     /// values from the file's Hive path and validating only their shape. What IS
     /// checked here is the shape against the live spec (see
-    /// [`validate_promoted_partition_values`]).
+    /// `validate_promoted_partition_values`).
     ///
     /// Two ways to satisfy the contract safely: copy the values from the source
     /// catalog when promoting files that a partitioned DuckLake table already wrote

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -745,6 +745,25 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
         ))
     }
 
+    /// The table's currently-live sort spec (`ducklake_sort_info` with
+    /// `end_snapshot IS NULL`, joined to its expressions), or `None` when the table
+    /// has no sort order.
+    ///
+    /// The counterpart of `live_partition_spec` for sort: a caller reaching
+    /// [`crate::table_writer::DuckLakeTableWriter`] directly has no
+    /// [`crate::metadata_provider::MetadataProvider`] to ask, but a bulk write should
+    /// still lay its rows out in the table's sort order so successive files cover
+    /// contiguous, non-overlapping ranges.
+    ///
+    /// Unlike partitioning, getting this wrong is not a correctness problem — an
+    /// unsorted file reads back fine, it just prunes less well — so there is no
+    /// commit-time fence for sort.
+    ///
+    /// Default: `None` (backends without sort support are never sorted).
+    fn live_sort_spec(&self, _table_id: i64) -> Result<Option<crate::sort::SortSpec>> {
+        Ok(None)
+    }
+
     /// Set the table's sort spec — the commit behind `ALTER TABLE … SET SORTED BY
     /// (…)`.
     ///

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -1140,6 +1140,20 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
     /// `identity` key, `min == max == value` proves the file is single-partition
     /// without reading a row.
     ///
+    /// Promoting into a partitioned table WITHOUT an assignment is refused with a
+    /// message naming the fix — not the partition fence's concurrency wording, which
+    /// would misdescribe what went wrong.
+    ///
+    /// # Sort order
+    ///
+    /// A table's sort order is NOT enforced here: promoting an unsorted file into a
+    /// sorted table is allowed, not an error. Sort order only affects how tight a
+    /// file's min/max statistics are — an unsorted file reads back correctly, it just
+    /// prunes less well, and a later compaction re-sorts it. Contrast partitioning,
+    /// where a wrong value makes the read path prune away live rows, which is why
+    /// that IS enforced. Official DuckLake's `ducklake_add_data_files` likewise
+    /// ignores sort order entirely.
+    ///
     /// Default: unsupported; only multicatalog Postgres, whose column ids are
     /// reusable across catalogs, implements it.
     #[allow(clippy::too_many_arguments)]
@@ -1364,31 +1378,35 @@ mod tests {
     }
 
     #[test]
-    fn promoted_temporal_value_must_be_its_calendar_component() {
-        // A `month` key's value is 1..=12; 13 or a date string is not a month.
+    fn promoted_temporal_value_must_parse_as_an_integer_and_no_more() {
+        // Official types a temporal partition key as BIGINT and only casts
+        // (GetPartitionKeyType / MapPartitionColumns) — it does NOT range-check the
+        // calendar component. So a non-integer is rejected, but an out-of-range
+        // month like 13 must be ACCEPTED, or we would refuse a value official takes.
         let transforms = vec!["month".to_string()];
         let date_key = vec![Some(DataType::Date32)];
-        for bad in ["13", "0", "2024-06"] {
-            assert!(
-                validate_promoted_partition_values(
-                    1,
-                    &transforms,
-                    &date_key,
-                    &promoted(vec![(0, Some(bad.to_string()))]),
-                )
-                .is_err(),
-                "month value {bad} must be rejected"
-            );
-        }
         assert!(
             validate_promoted_partition_values(
                 1,
                 &transforms,
                 &date_key,
-                &promoted(vec![(0, Some("6".into()))]),
+                &promoted(vec![(0, Some("2024-06".into()))]),
             )
-            .is_ok()
+            .is_err(),
+            "a non-integer month value must be rejected"
         );
+        for accepted in ["6", "13", "0"] {
+            assert!(
+                validate_promoted_partition_values(
+                    1,
+                    &transforms,
+                    &date_key,
+                    &promoted(vec![(0, Some(accepted.to_string()))]),
+                )
+                .is_ok(),
+                "month value {accepted} must be accepted (official does not range-check)"
+            );
+        }
     }
 
     #[test]

--- a/src/metadata_writer_duckdb.rs
+++ b/src/metadata_writer_duckdb.rs
@@ -1048,7 +1048,10 @@ impl MetadataWriter for DuckdbMetadataWriter {
         Ok(new_snapshot)
     }
 
-    fn live_partition_spec(&self, table_id: i64) -> Result<Option<crate::partition::PartitionSpec>> {
+    fn live_partition_spec(
+        &self,
+        table_id: i64,
+    ) -> Result<Option<crate::partition::PartitionSpec>> {
         let conn = self.connection();
         let mut stmt = conn.prepare(
             "SELECT pi.partition_id, pc.partition_key_index, pc.column_id, pc.transform

--- a/src/metadata_writer_duckdb.rs
+++ b/src/metadata_writer_duckdb.rs
@@ -1100,6 +1100,32 @@ impl MetadataWriter for DuckdbMetadataWriter {
         Ok(new_snapshot)
     }
 
+    fn live_sort_spec(&self, table_id: i64) -> Result<Option<crate::sort::SortSpec>> {
+        let conn = self.connection();
+        let mut stmt = conn.prepare(
+            "SELECT si.sort_id, se.sort_key_index, se.expression, se.dialect,
+                    se.sort_direction, se.null_order
+             FROM ducklake_sort_info AS si
+             JOIN ducklake_sort_expression AS se
+               ON se.sort_id = si.sort_id AND se.table_id = si.table_id
+             WHERE si.table_id = ? AND si.end_snapshot IS NULL
+             ORDER BY se.sort_key_index",
+        )?;
+        let rows = stmt
+            .query_map(duckdb::params![table_id], |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    i32::try_from(row.get::<_, i64>(1)?).unwrap_or(0),
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
+                    row.get::<_, String>(5)?,
+                ))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(crate::sort::SortSpec::from_rows(rows))
+    }
+
     fn set_sort_spec(&self, table_id: i64, fields: &[crate::sort::SortField]) -> Result<i64> {
         if fields.is_empty() {
             return Err(crate::DuckLakeError::InvalidConfig(

--- a/src/metadata_writer_duckdb.rs
+++ b/src/metadata_writer_duckdb.rs
@@ -1048,6 +1048,30 @@ impl MetadataWriter for DuckdbMetadataWriter {
         Ok(new_snapshot)
     }
 
+    fn live_partition_spec(&self, table_id: i64) -> Result<Option<crate::partition::PartitionSpec>> {
+        let conn = self.connection();
+        let mut stmt = conn.prepare(
+            "SELECT pi.partition_id, pc.partition_key_index, pc.column_id, pc.transform
+             FROM ducklake_partition_info AS pi
+             JOIN ducklake_partition_column AS pc
+               ON pc.partition_id = pi.partition_id AND pc.table_id = pi.table_id
+             WHERE pi.table_id = ? AND pi.end_snapshot IS NULL
+             ORDER BY pc.partition_key_index",
+        )?;
+        let rows = stmt
+            .query_map(duckdb::params![table_id], |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    i32::try_from(row.get::<_, i64>(1)?).unwrap_or(0),
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, String>(3)?,
+                ))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        // prune_safe = false: this spec is for laying out a write, never pruning.
+        Ok(crate::partition::PartitionSpec::from_rows(rows, false))
+    }
+
     fn reset_partition_spec(&self, table_id: i64) -> Result<i64> {
         let mut conn = self.connection();
         let tx = conn.transaction()?;

--- a/src/metadata_writer_mysql.rs
+++ b/src/metadata_writer_mysql.rs
@@ -1225,6 +1225,37 @@ impl MetadataWriter for MySqlMetadataWriter {
         })
     }
 
+    fn live_sort_spec(&self, table_id: i64) -> Result<Option<crate::sort::SortSpec>> {
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT si.sort_id, se.sort_key_index, se.expression, se.dialect,
+                        se.sort_direction, se.null_order
+                 FROM ducklake_sort_info AS si
+                 JOIN ducklake_sort_expression AS se
+                   ON se.sort_id = si.sort_id AND se.table_id = si.table_id
+                 WHERE si.table_id = ? AND si.end_snapshot IS NULL
+                 ORDER BY se.sort_key_index",
+            )
+            .bind(table_id)
+            .fetch_all(&self.pool)
+            .await?;
+            let parsed = rows
+                .iter()
+                .map(|row| {
+                    Ok::<_, crate::DuckLakeError>((
+                        row.try_get::<i64, _>(0)?,
+                        i32::try_from(row.try_get::<i64, _>(1)?).unwrap_or(0),
+                        row.try_get::<String, _>(2)?,
+                        row.try_get::<String, _>(3)?,
+                        row.try_get::<String, _>(4)?,
+                        row.try_get::<String, _>(5)?,
+                    ))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(crate::sort::SortSpec::from_rows(parsed))
+        })
+    }
+
     fn set_sort_spec(&self, table_id: i64, fields: &[crate::sort::SortField]) -> Result<i64> {
         if fields.is_empty() {
             return Err(crate::DuckLakeError::InvalidConfig(

--- a/src/metadata_writer_mysql.rs
+++ b/src/metadata_writer_mysql.rs
@@ -1164,6 +1164,35 @@ impl MetadataWriter for MySqlMetadataWriter {
         })
     }
 
+    fn live_partition_spec(&self, table_id: i64) -> Result<Option<crate::partition::PartitionSpec>> {
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT pi.partition_id, pc.partition_key_index, pc.column_id, pc.transform
+                 FROM ducklake_partition_info AS pi
+                 JOIN ducklake_partition_column AS pc
+                   ON pc.partition_id = pi.partition_id AND pc.table_id = pi.table_id
+                 WHERE pi.table_id = ? AND pi.end_snapshot IS NULL
+                 ORDER BY pc.partition_key_index",
+            )
+            .bind(table_id)
+            .fetch_all(&self.pool)
+            .await?;
+            let parsed = rows
+                .iter()
+                .map(|row| {
+                    Ok::<_, crate::DuckLakeError>((
+                        row.try_get::<i64, _>(0)?,
+                        i32::try_from(row.try_get::<i64, _>(1)?).unwrap_or(0),
+                        row.try_get::<i64, _>(2)?,
+                        row.try_get::<String, _>(3)?,
+                    ))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            // prune_safe = false: this spec is for laying out a write, never pruning.
+            Ok(crate::partition::PartitionSpec::from_rows(parsed, false))
+        })
+    }
+
     fn reset_partition_spec(&self, table_id: i64) -> Result<i64> {
         block_on(async {
             let mut tx = self.pool.begin().await?;

--- a/src/metadata_writer_mysql.rs
+++ b/src/metadata_writer_mysql.rs
@@ -1164,7 +1164,10 @@ impl MetadataWriter for MySqlMetadataWriter {
         })
     }
 
-    fn live_partition_spec(&self, table_id: i64) -> Result<Option<crate::partition::PartitionSpec>> {
+    fn live_partition_spec(
+        &self,
+        table_id: i64,
+    ) -> Result<Option<crate::partition::PartitionSpec>> {
         block_on(async {
             let rows = sqlx::query(
                 "SELECT pi.partition_id, pc.partition_key_index, pc.column_id, pc.transform

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -2128,11 +2128,42 @@ impl MetadataWriter for PostgresMetadataWriter {
             .fetch_one(&mut *tx)
             .await?;
 
-            sqlx::query(
+            // Partition-spec fence + validation. A promoted file is registered
+            // as-is, so the caller is asserting it already holds rows of exactly one
+            // partition (official DuckLake's ducklake_add_data_files makes the same
+            // assumption, deriving the values from the file's Hive path). We check
+            // everything checkable without reading the data: the file agrees with the
+            // live generation, and its values fit that generation's keys.
+            let live_partition_id: Option<i64> = sqlx::query_scalar(
+                "SELECT partition_id FROM ducklake_partition_info
+                 WHERE table_id = $1 AND end_snapshot IS NULL",
+            )
+            .bind(table_id)
+            .fetch_optional(&mut *tx)
+            .await?;
+            crate::metadata_writer::enforce_partition_fence(table_id, live_partition_id, file)?;
+            if let Some(partition_id) = live_partition_id.filter(|_| file.partition_id.is_some()) {
+                let transforms: Vec<String> = sqlx::query_scalar(
+                    "SELECT transform FROM ducklake_partition_column
+                     WHERE table_id = $1 AND partition_id = $2
+                     ORDER BY partition_key_index",
+                )
+                .bind(table_id)
+                .bind(partition_id)
+                .fetch_all(&mut *tx)
+                .await?;
+                crate::metadata_writer::validate_promoted_partition_values(
+                    table_id,
+                    &transforms,
+                    file,
+                )?;
+            }
+
+            let data_file_id: i64 = sqlx::query_scalar(
                 "INSERT INTO ducklake_data_file
                      (table_id, path, path_is_relative, file_size_bytes,
                       footer_size, record_count, row_id_start, begin_snapshot)
-                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING data_file_id",
             )
             .bind(table_id)
             .bind(&file.path)
@@ -2142,8 +2173,13 @@ impl MetadataWriter for PostgresMetadataWriter {
             .bind(file.record_count)
             .bind(row_id_start)
             .bind(snapshot_id)
-            .execute(&mut *tx)
+            .fetch_one(&mut *tx)
             .await?;
+            // Persist the caller-supplied partition assignment. Without this a
+            // promoted file lands with no partition_id and no
+            // ducklake_file_partition_value rows, i.e. unprunable and inconsistent
+            // with the table's spec.
+            insert_partition_metadata(&mut tx, table_id, data_file_id, file).await?;
 
             sqlx::query(
                 "UPDATE ducklake_table_stats
@@ -2344,6 +2380,18 @@ impl MetadataWriter for PostgresMetadataWriter {
                 &mut tx,
             )
             .await?;
+
+            // Partition-spec fence: the new row versions are a NEW write, so they
+            // must agree with the table's live partition generation exactly as
+            // register_data_file's do.
+            let live_partition_id: Option<i64> = sqlx::query_scalar(
+                "SELECT partition_id FROM ducklake_partition_info
+                 WHERE table_id = $1 AND end_snapshot IS NULL",
+            )
+            .bind(table_id)
+            .fetch_optional(&mut *tx)
+            .await?;
+            crate::metadata_writer::enforce_partition_fence(table_id, live_partition_id, file)?;
 
             // Register the new data file (the inserted row versions), exactly as
             // register_data_file: seed stats, draw the row-id range, insert, and

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -2143,8 +2143,8 @@ impl MetadataWriter for PostgresMetadataWriter {
             .await?;
             crate::metadata_writer::enforce_partition_fence(table_id, live_partition_id, file)?;
             if let Some(partition_id) = live_partition_id.filter(|_| file.partition_id.is_some()) {
-                let transforms: Vec<String> = sqlx::query_scalar(
-                    "SELECT transform FROM ducklake_partition_column
+                let key_rows = sqlx::query(
+                    "SELECT transform, column_id FROM ducklake_partition_column
                      WHERE table_id = $1 AND partition_id = $2
                      ORDER BY partition_key_index",
                 )
@@ -2152,9 +2152,28 @@ impl MetadataWriter for PostgresMetadataWriter {
                 .bind(partition_id)
                 .fetch_all(&mut *tx)
                 .await?;
+                let mut transforms = Vec::with_capacity(key_rows.len());
+                let mut key_column_types = Vec::with_capacity(key_rows.len());
+                for row in &key_rows {
+                    transforms.push(row.try_get::<String, _>(0)?);
+                    // Resolve each key's column_id to the Arrow type of the matching
+                    // promoted column, so an `identity` value can be cast-checked the
+                    // way official's MapHiveColumn does.
+                    let column_id: i64 = row.try_get(1)?;
+                    key_column_types.push(
+                        column_ids
+                            .iter()
+                            .position(|id| *id == column_id)
+                            .and_then(|index| columns.get(index))
+                            .and_then(|column| {
+                                crate::types::ducklake_to_arrow_type(column.ducklake_type()).ok()
+                            }),
+                    );
+                }
                 crate::metadata_writer::validate_promoted_partition_values(
                     table_id,
                     &transforms,
+                    &key_column_types,
                     file,
                 )?;
             }

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -2141,6 +2141,20 @@ impl MetadataWriter for PostgresMetadataWriter {
             .bind(table_id)
             .fetch_optional(&mut *tx)
             .await?;
+            // Diagnose the promote-specific case before the shared fence: a caller
+            // that supplied no partition assignment for a partitioned table has not
+            // lost a race, so the fence's "concurrent SET PARTITIONED BY … retry"
+            // wording would send them chasing a problem that does not exist. Tell
+            // them what to actually do instead.
+            if file.partition_id.is_none() && file.record_count > 0 && live_partition_id.is_some() {
+                return Err(crate::DuckLakeError::InvalidConfig(format!(
+                    "cannot promote {} into table {table_id}: the table is partitioned, so a \
+                     registered file must declare the single partition its rows belong to. \
+                     Attach it with DataFileInfo::with_partition (copy the values from the \
+                     source catalog, or derive them from the file's Hive path).",
+                    file.path
+                )));
+            }
             crate::metadata_writer::enforce_partition_fence(table_id, live_partition_id, file)?;
             if let Some(partition_id) = live_partition_id.filter(|_| file.partition_id.is_some()) {
                 let key_rows = sqlx::query(

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -1824,7 +1824,10 @@ impl MetadataWriter for PostgresMetadataWriter {
         })
     }
 
-    fn live_partition_spec(&self, table_id: i64) -> Result<Option<crate::partition::PartitionSpec>> {
+    fn live_partition_spec(
+        &self,
+        table_id: i64,
+    ) -> Result<Option<crate::partition::PartitionSpec>> {
         block_on(async {
             let rows = sqlx::query(
                 "SELECT pi.partition_id, pc.partition_key_index, pc.column_id, pc.transform

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -1824,6 +1824,35 @@ impl MetadataWriter for PostgresMetadataWriter {
         })
     }
 
+    fn live_partition_spec(&self, table_id: i64) -> Result<Option<crate::partition::PartitionSpec>> {
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT pi.partition_id, pc.partition_key_index, pc.column_id, pc.transform
+                 FROM ducklake_partition_info AS pi
+                 JOIN ducklake_partition_column AS pc
+                   ON pc.partition_id = pi.partition_id AND pc.table_id = pi.table_id
+                 WHERE pi.table_id = $1 AND pi.end_snapshot IS NULL
+                 ORDER BY pc.partition_key_index",
+            )
+            .bind(table_id)
+            .fetch_all(&self.pool)
+            .await?;
+            let parsed = rows
+                .iter()
+                .map(|row| {
+                    Ok::<_, crate::DuckLakeError>((
+                        row.try_get::<i64, _>(0)?,
+                        i32::try_from(row.try_get::<i64, _>(1)?).unwrap_or(0),
+                        row.try_get::<i64, _>(2)?,
+                        row.try_get::<String, _>(3)?,
+                    ))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            // prune_safe = false: this spec is for laying out a write, never pruning.
+            Ok(crate::partition::PartitionSpec::from_rows(parsed, false))
+        })
+    }
+
     fn reset_partition_spec(&self, table_id: i64) -> Result<i64> {
         block_on(async {
             let mut tx = self.pool.begin().await?;

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -2146,7 +2146,14 @@ impl MetadataWriter for PostgresMetadataWriter {
             // lost a race, so the fence's "concurrent SET PARTITIONED BY … retry"
             // wording would send them chasing a problem that does not exist. Tell
             // them what to actually do instead.
-            if file.partition_id.is_none() && file.record_count > 0 && live_partition_id.is_some() {
+            //
+            // Deliberately NOT exempting a 0-row file, unlike the shared fence.
+            // That exemption exists for the empty-Replace truncate marker a write
+            // session emits, which has no promote equivalent — a promoted file is one
+            // the caller actually produced. Official agrees: `AddFileToTable` compares
+            // the derived value count against the spec's key count with no row-count
+            // exception, so an empty file with no assignment is rejected there too.
+            if file.partition_id.is_none() && live_partition_id.is_some() {
                 return Err(crate::DuckLakeError::InvalidConfig(format!(
                     "cannot promote {} into table {table_id}: the table is partitioned, so a \
                      registered file must declare the single partition its rows belong to. \

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -1934,6 +1934,37 @@ impl MetadataWriter for PostgresMetadataWriter {
         })
     }
 
+    fn live_sort_spec(&self, table_id: i64) -> Result<Option<crate::sort::SortSpec>> {
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT si.sort_id, se.sort_key_index, se.expression, se.dialect,
+                        se.sort_direction, se.null_order
+                 FROM ducklake_sort_info AS si
+                 JOIN ducklake_sort_expression AS se
+                   ON se.sort_id = si.sort_id AND se.table_id = si.table_id
+                 WHERE si.table_id = $1 AND si.end_snapshot IS NULL
+                 ORDER BY se.sort_key_index",
+            )
+            .bind(table_id)
+            .fetch_all(&self.pool)
+            .await?;
+            let parsed = rows
+                .iter()
+                .map(|row| {
+                    Ok::<_, crate::DuckLakeError>((
+                        row.try_get::<i64, _>(0)?,
+                        i32::try_from(row.try_get::<i64, _>(1)?).unwrap_or(0),
+                        row.try_get::<String, _>(2)?,
+                        row.try_get::<String, _>(3)?,
+                        row.try_get::<String, _>(4)?,
+                        row.try_get::<String, _>(5)?,
+                    ))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(crate::sort::SortSpec::from_rows(parsed))
+        })
+    }
+
     fn set_sort_spec(&self, table_id: i64, fields: &[crate::sort::SortField]) -> Result<i64> {
         if fields.is_empty() {
             return Err(crate::DuckLakeError::InvalidConfig(

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -1691,7 +1691,10 @@ impl MetadataWriter for SqliteMetadataWriter {
         })
     }
 
-    fn live_partition_spec(&self, table_id: i64) -> Result<Option<crate::partition::PartitionSpec>> {
+    fn live_partition_spec(
+        &self,
+        table_id: i64,
+    ) -> Result<Option<crate::partition::PartitionSpec>> {
         block_on(async {
             let rows = sqlx::query(
                 "SELECT pi.partition_id, pc.partition_key_index, pc.column_id, pc.transform

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -2299,6 +2299,18 @@ impl MetadataWriter for SqliteMetadataWriter {
                 finalize_snapshot(&mut tx, table_id, columns, column_ids, mode, base_snapshot)
                     .await?;
 
+            // Partition-spec fence: the new row versions are a NEW write, so they
+            // must agree with the table's live partition generation exactly as
+            // register_data_file's do.
+            let live_partition_id: Option<i64> = sqlx::query_scalar(
+                "SELECT partition_id FROM ducklake_partition_info
+                 WHERE table_id = ? AND end_snapshot IS NULL",
+            )
+            .bind(table_id)
+            .fetch_optional(&mut *tx)
+            .await?;
+            crate::metadata_writer::enforce_partition_fence(table_id, live_partition_id, file)?;
+
             // Register the new data file (inserted row versions), as in
             // register_data_file. Deletes are accounted at read time
             // (delete_count), so record_count stays gross — no adjustment for them.

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -1691,6 +1691,35 @@ impl MetadataWriter for SqliteMetadataWriter {
         })
     }
 
+    fn live_partition_spec(&self, table_id: i64) -> Result<Option<crate::partition::PartitionSpec>> {
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT pi.partition_id, pc.partition_key_index, pc.column_id, pc.transform
+                 FROM ducklake_partition_info AS pi
+                 JOIN ducklake_partition_column AS pc
+                   ON pc.partition_id = pi.partition_id AND pc.table_id = pi.table_id
+                 WHERE pi.table_id = ? AND pi.end_snapshot IS NULL
+                 ORDER BY pc.partition_key_index",
+            )
+            .bind(table_id)
+            .fetch_all(&self.pool)
+            .await?;
+            let parsed = rows
+                .iter()
+                .map(|row| {
+                    Ok::<_, crate::DuckLakeError>((
+                        row.try_get::<i64, _>(0)?,
+                        i32::try_from(row.try_get::<i64, _>(1)?).unwrap_or(0),
+                        row.try_get::<i64, _>(2)?,
+                        row.try_get::<String, _>(3)?,
+                    ))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            // prune_safe = false: this spec is for laying out a write, never pruning.
+            Ok(crate::partition::PartitionSpec::from_rows(parsed, false))
+        })
+    }
+
     fn reset_partition_spec(&self, table_id: i64) -> Result<i64> {
         block_on(async {
             let mut tx = self.pool.begin().await?;

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -1755,6 +1755,37 @@ impl MetadataWriter for SqliteMetadataWriter {
         })
     }
 
+    fn live_sort_spec(&self, table_id: i64) -> Result<Option<crate::sort::SortSpec>> {
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT si.sort_id, se.sort_key_index, se.expression, se.dialect,
+                        se.sort_direction, se.null_order
+                 FROM ducklake_sort_info AS si
+                 JOIN ducklake_sort_expression AS se
+                   ON se.sort_id = si.sort_id AND se.table_id = si.table_id
+                 WHERE si.table_id = ? AND si.end_snapshot IS NULL
+                 ORDER BY se.sort_key_index",
+            )
+            .bind(table_id)
+            .fetch_all(&self.pool)
+            .await?;
+            let parsed = rows
+                .iter()
+                .map(|row| {
+                    Ok::<_, crate::DuckLakeError>((
+                        row.try_get::<i64, _>(0)?,
+                        i32::try_from(row.try_get::<i64, _>(1)?).unwrap_or(0),
+                        row.try_get::<String, _>(2)?,
+                        row.try_get::<String, _>(3)?,
+                        row.try_get::<String, _>(4)?,
+                        row.try_get::<String, _>(5)?,
+                    ))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(crate::sort::SortSpec::from_rows(parsed))
+        })
+    }
+
     fn set_sort_spec(&self, table_id: i64, fields: &[crate::sort::SortField]) -> Result<i64> {
         if fields.is_empty() {
             return Err(crate::DuckLakeError::InvalidConfig(

--- a/src/multicatalog_provider.rs
+++ b/src/multicatalog_provider.rs
@@ -65,7 +65,11 @@ fn decode_table_file(row: &PgRow, snapshot_id: i64) -> Result<DuckLakeTableFile>
         partial_max: row.try_get(16)?,
         max_row_count: row.try_get(7)?,
         delete_count,
-        partition_id: None,
+        // Column 18 is present on the select-path query (which projects
+        // `data.partition_id`) and absent on callers that share this decoder
+        // without it; `try_get` failing there degrades to `None`, matching the
+        // pre-partition behaviour. Per-key values are filled in by the caller.
+        partition_id: row.try_get(18).unwrap_or(None),
         partition_values: Vec::new(),
     })
 }
@@ -85,11 +89,16 @@ struct SchemaCapabilities {
     delete_file_partial_max: bool,
     /// The `ducklake_schema_versions` table exists.
     schema_versions: bool,
+    /// `ducklake_data_file.partition_id` exists.
+    data_file_partition_id: bool,
 }
 
 impl SchemaCapabilities {
     fn all(&self) -> bool {
-        self.data_file_partial_max && self.delete_file_partial_max && self.schema_versions
+        self.data_file_partial_max
+            && self.delete_file_partial_max
+            && self.schema_versions
+            && self.data_file_partition_id
     }
 }
 
@@ -169,13 +178,15 @@ impl MulticatalogProvider {
         if let Some(caps) = self.schema_capabilities.get() {
             return Ok(*caps);
         }
-        let row: (bool, bool, bool) = sqlx::query_as(
+        let row: (bool, bool, bool, bool) = sqlx::query_as(
             "SELECT
                EXISTS (SELECT 1 FROM information_schema.columns
                        WHERE table_name = 'ducklake_data_file' AND column_name = 'partial_max'),
                EXISTS (SELECT 1 FROM information_schema.columns
                        WHERE table_name = 'ducklake_delete_file' AND column_name = 'partial_max'),
-               to_regclass('ducklake_schema_versions') IS NOT NULL",
+               to_regclass('ducklake_schema_versions') IS NOT NULL,
+               EXISTS (SELECT 1 FROM information_schema.columns
+                       WHERE table_name = 'ducklake_data_file' AND column_name = 'partition_id')",
         )
         .fetch_one(&self.pool)
         .await?;
@@ -183,6 +194,7 @@ impl MulticatalogProvider {
             data_file_partial_max: row.0,
             delete_file_partial_max: row.1,
             schema_versions: row.2,
+            data_file_partition_id: row.3,
         };
         if caps.all() {
             let _ = self.schema_capabilities.set(caps);
@@ -377,6 +389,13 @@ impl MetadataProvider for MulticatalogProvider {
             } else {
                 "NULL::bigint"
             };
+            // A catalog predating partition support has no `partition_id` column;
+            // such a catalog holds no partitioned files either, so NULL is exact.
+            let partition_id_expr = if caps.data_file_partition_id {
+                "data.partition_id::bigint"
+            } else {
+                "NULL::bigint"
+            };
             let schema_version_expr = if caps.schema_versions {
                 "(SELECT sv.schema_version::bigint
                   FROM ducklake_schema_versions sv
@@ -406,7 +425,8 @@ impl MetadataProvider for MulticatalogProvider {
                     del.delete_count,
                     data.begin_snapshot::bigint AS data_begin_snapshot,
                     {partial_max_expr} AS data_partial_max,
-                    {schema_version_expr} AS data_schema_version
+                    {schema_version_expr} AS data_schema_version,
+                    {partition_id_expr} AS data_partition_id
                 FROM ducklake_data_file AS data
                 LEFT JOIN ducklake_delete_file AS del
                     ON data.data_file_id = del.data_file_id
@@ -427,9 +447,54 @@ impl MetadataProvider for MulticatalogProvider {
                 .fetch_all(&self.pool)
                 .await?;
 
-            rows.iter()
+            let mut files: Vec<DuckLakeTableFile> = rows
+                .iter()
                 .map(|row| decode_table_file(row, snapshot_id))
-                .collect()
+                .collect::<Result<Vec<_>>>()?;
+
+            // Enrich with per-file partition values. Compaction reads its candidates
+            // through this path and must group by, and preserve, each file's exact
+            // partition — without the values it would merge across partitions and
+            // strip the assignment. Scoped by the fetched id range; a catalog
+            // predating partition support simply yields no rows.
+            if let (Some(min), Some(max)) = (
+                files.iter().map(|f| f.data_file_id).min(),
+                files.iter().map(|f| f.data_file_id).max(),
+            ) {
+                let mut values_by_file: HashMap<i64, Vec<(i32, Option<String>)>> = HashMap::new();
+                match sqlx::query(
+                    "SELECT data_file_id, partition_key_index, partition_value
+                     FROM ducklake_file_partition_value
+                     WHERE table_id = $1 AND data_file_id >= $2 AND data_file_id <= $3",
+                )
+                .bind(table_id)
+                .bind(min)
+                .bind(max)
+                .fetch_all(&self.pool)
+                .await
+                {
+                    Ok(rows) => {
+                        for row in rows {
+                            let data_file_id: i64 = row.try_get(0)?;
+                            let key_index: i32 =
+                                i32::try_from(row.try_get::<i64, _>(1)?).unwrap_or(0);
+                            let value: Option<String> = row.try_get(2)?;
+                            values_by_file
+                                .entry(data_file_id)
+                                .or_default()
+                                .push((key_index, value));
+                        }
+                    },
+                    Err(error) if is_missing_statistics_table(&error) => {},
+                    Err(error) => return Err(error.into()),
+                }
+                for file in &mut files {
+                    if let Some(values) = values_by_file.remove(&file.data_file_id) {
+                        file.partition_values = values;
+                    }
+                }
+            }
+            Ok(files)
         })
     }
 

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -167,6 +167,250 @@ fn year_bounds(year: i64, data_type: &DataType) -> Option<(ScalarValue, ScalarVa
     Some((min, max))
 }
 
+/// A partition spec resolved against a concrete write schema: how a write path
+/// splits incoming rows into per-partition files.
+///
+/// Built by [`PartitionWriteSpec::resolve`] from the table's live
+/// [`PartitionSpec`]. Every write path that produces NEW rows for a partitioned
+/// table goes through this — SQL `INSERT` ([`crate::insert_exec::DuckLakeInsertExec`]),
+/// the low-level writer entry points, and the UPDATE rewrite — so all of them lay
+/// files out the same way and stamp the same `partition_id`.
+#[derive(Debug, Clone)]
+pub struct PartitionWriteSpec {
+    /// The active spec generation (`ducklake_partition_info.partition_id`).
+    pub partition_id: i64,
+    /// Partition keys, in key order.
+    pub keys: Vec<PartitionWriteKey>,
+}
+
+/// One partition key resolved for the write path.
+#[derive(Debug, Clone)]
+pub struct PartitionWriteKey {
+    /// Column index in the write input schema.
+    pub input_index: usize,
+    /// Column name (used only for the readable Hive-style path).
+    pub name: String,
+    /// Transform applied to the column value to form the partition value.
+    pub transform: PartitionTransform,
+}
+
+impl PartitionWriteSpec {
+    /// Resolve `spec` against the columns a write is about to produce:
+    /// `column_ids[i]` is the catalog `column_id` of `schema` field `i` (the 1:1
+    /// pairing every write path already has).
+    ///
+    /// Errors with [`crate::DuckLakeError::Unsupported`] on a transform this crate
+    /// cannot PRODUCE (`bucket`/unknown) — writing unpartitioned files into a table
+    /// whose spec demands them would violate the spec, so a partitioned write must
+    /// fail loudly rather than silently degrade. Errors with
+    /// [`crate::DuckLakeError::Internal`] if a partition key names a column absent
+    /// from the write schema (the catalog and the write disagree).
+    pub fn resolve(
+        spec: &PartitionSpec,
+        column_ids: &[i64],
+        schema: &arrow::datatypes::Schema,
+    ) -> crate::Result<PartitionWriteSpec> {
+        let mut keys = Vec::with_capacity(spec.columns.len());
+        for column in &spec.columns {
+            if !column.transform.is_producible() {
+                return Err(crate::DuckLakeError::Unsupported(format!(
+                    "writing to a table partitioned by '{}' is not supported",
+                    column.transform.to_catalog_string()
+                )));
+            }
+            let index = column_ids
+                .iter()
+                .position(|id| *id == column.column_id)
+                .ok_or_else(|| {
+                    crate::DuckLakeError::Internal(format!(
+                        "partition column_id {} not found in table schema",
+                        column.column_id
+                    ))
+                })?;
+            let name = schema
+                .fields()
+                .get(index)
+                .map(|f| f.name().to_string())
+                .ok_or_else(|| {
+                    crate::DuckLakeError::Internal(format!(
+                        "partition column index {index} out of range for write schema"
+                    ))
+                })?;
+            keys.push(PartitionWriteKey {
+                input_index: index,
+                name,
+                transform: column.transform.clone(),
+            });
+        }
+        Ok(PartitionWriteSpec {
+            partition_id: spec.partition_id,
+            keys,
+        })
+    }
+
+    /// The partition-key column names in key order — the input to
+    /// [`hive_subpath`].
+    pub(crate) fn key_names(&self) -> Vec<String> {
+        self.keys.iter().map(|k| k.name.clone()).collect()
+    }
+}
+
+/// The Hive-style relative subpath (`key=value/…`) a file carrying `values` is
+/// placed under, given the partition-key column names in key order. Returns an
+/// empty string when there are no keys (an unpartitioned file lives directly
+/// under the table directory).
+///
+/// A `None` value (SQL NULL) uses DuckDB's `__HIVE_DEFAULT_PARTITION__` sentinel,
+/// matching official DuckLake's on-disk layout. The catalog
+/// (`ducklake_file_partition_value`) is the authoritative source for pruning, so
+/// this path is for human readability and interop only — values are sanitized for
+/// the filesystem without affecting correctness, and a sanitization collision
+/// between two distinct values is harmless (files carry distinct UUID names and
+/// distinct catalog values).
+pub(crate) fn hive_subpath(key_names: &[String], values: &[Option<String>]) -> String {
+    let mut rel = String::new();
+    for (i, value) in values.iter().enumerate() {
+        let name = key_names.get(i).map(String::as_str).unwrap_or("key");
+        let encoded = match value {
+            Some(v) => sanitize_partition_path(v),
+            None => "__HIVE_DEFAULT_PARTITION__".to_string(),
+        };
+        if rel.is_empty() {
+            rel = format!("{name}={encoded}");
+        } else {
+            rel = format!("{rel}/{name}={encoded}");
+        }
+    }
+    rel
+}
+
+/// Sanitize a partition value for use in a Hive-style directory name — see
+/// [`hive_subpath`] for why a lossy mapping is safe here.
+fn sanitize_partition_path(value: &str) -> String {
+    value
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | ':') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// One partition group of a partitioned write: the per-key partition values every
+/// row in the group shares (`values[i]` for partition key `i`, `None` == SQL NULL),
+/// and the row batches for that partition.
+pub type PartitionGroup = (Vec<Option<String>>, Vec<arrow::record_batch::RecordBatch>);
+
+/// Apply a partition transform to a whole column array: identity returns the
+/// column unchanged; the temporal transforms return an `Int32` calendar component
+/// (year/month/day/hour) via Arrow's `date_part`. Only producible transforms are
+/// valid here — [`PartitionWriteSpec::resolve`] rejects `bucket`/unknown up front.
+fn transform_array(
+    transform: &PartitionTransform,
+    array: &arrow::array::ArrayRef,
+) -> crate::Result<arrow::array::ArrayRef> {
+    use arrow::compute::{DatePart, date_part};
+    let part = match transform {
+        PartitionTransform::Identity => return Ok(std::sync::Arc::clone(array)),
+        PartitionTransform::Year => DatePart::Year,
+        PartitionTransform::Month => DatePart::Month,
+        PartitionTransform::Day => DatePart::Day,
+        PartitionTransform::Hour => DatePart::Hour,
+        other => {
+            return Err(crate::DuckLakeError::Unsupported(format!(
+                "partitioned write with transform '{}' is not supported",
+                other.to_catalog_string()
+            )));
+        },
+    };
+    Ok(date_part(array, part)?)
+}
+
+/// Split rows into groups keyed by the tuple of transformed, DuckDB-canonical
+/// partition values — one group per distinct key. Returns `(values, batches)` per
+/// group, where `values[i]` is the encoded value for partition key `i` (`None` for
+/// SQL NULL). Rows sharing a key land in the same group regardless of which input
+/// batch they came from.
+///
+/// `output_schema` is the schema the returned batches carry (the table's clean data
+/// columns); `batches` must already match it positionally.
+pub(crate) fn split_batches_by_partition(
+    output_schema: &arrow::datatypes::SchemaRef,
+    batches: &[arrow::record_batch::RecordBatch],
+    spec: &PartitionWriteSpec,
+) -> crate::Result<Vec<PartitionGroup>> {
+    use arrow::array::{ArrayRef, RecordBatch, UInt32Array};
+    use arrow::compute::{concat_batches, take};
+    use std::collections::HashMap;
+
+    if batches.is_empty() {
+        return Ok(Vec::new());
+    }
+    let input_schema = batches[0].schema();
+    let combined = concat_batches(&input_schema, batches)?;
+    let num_rows = combined.num_rows();
+    if num_rows == 0 {
+        return Ok(Vec::new());
+    }
+
+    // Transform each partition-key column once for the whole dataset.
+    let mut transformed: Vec<ArrayRef> = Vec::with_capacity(spec.keys.len());
+    for key in &spec.keys {
+        transformed.push(transform_array(
+            &key.transform,
+            combined.column(key.input_index),
+        )?);
+    }
+
+    // Group row indices by the encoded partition-value tuple.
+    let mut groups: HashMap<Vec<Option<String>>, Vec<u32>> = HashMap::new();
+    for row in 0..num_rows {
+        let mut values: Vec<Option<String>> = Vec::with_capacity(spec.keys.len());
+        for array in &transformed {
+            let scalar = ScalarValue::try_from_array(array, row)?;
+            // `encode_scalar` returns `None` for BOTH a genuine SQL NULL and a
+            // non-null value of a type it cannot encode. Those must not be
+            // conflated: silently mapping an unencodable non-null value to `None`
+            // would group every distinct such value into one file with a NULL
+            // partition value (data corruption). A NULL is a legitimate partition
+            // value; an unencodable non-null value is a hard error.
+            let encoded = if scalar.is_null() {
+                None
+            } else {
+                match crate::stats_encode::encode_scalar(&scalar) {
+                    Some(encoded) => Some(encoded),
+                    None => {
+                        return Err(crate::DuckLakeError::Unsupported(format!(
+                            "partitioned write: partition-key value of type {} cannot be \
+                             encoded; partitioning by this column type is not supported",
+                            array.data_type()
+                        )));
+                    },
+                }
+            };
+            values.push(encoded);
+        }
+        groups.entry(values).or_default().push(row as u32);
+    }
+
+    // Materialize one batch per group via `take` (output uses the clean schema).
+    let mut result = Vec::with_capacity(groups.len());
+    for (values, indices) in groups {
+        let index_array = UInt32Array::from(indices);
+        let columns = combined
+            .columns()
+            .iter()
+            .map(|c| take(c, &index_array, None))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        let batch = RecordBatch::try_new(output_schema.clone(), columns)?;
+        result.push((values, vec![batch]));
+    }
+    Ok(result)
+}
+
 /// One column of a partition spec: which table column, and how it is transformed.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PartitionSpecColumn {
@@ -240,6 +484,160 @@ impl PartitionSpec {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow::array::{ArrayRef, RecordBatch, StringArray};
+    use arrow::datatypes::{Field, Schema, SchemaRef};
+    use std::sync::Arc;
+
+    fn identity_region_spec() -> PartitionWriteSpec {
+        PartitionWriteSpec {
+            partition_id: 1,
+            keys: vec![PartitionWriteKey {
+                input_index: 0,
+                name: "region".to_string(),
+                transform: PartitionTransform::Identity,
+            }],
+        }
+    }
+
+    #[test]
+    fn split_groups_by_identity_and_keeps_null_partition() {
+        let schema: SchemaRef = Arc::new(Schema::new(vec![Field::new(
+            "region",
+            DataType::Utf8,
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(StringArray::from(vec![Some("us"), None, Some("us")])) as ArrayRef],
+        )
+        .unwrap();
+        let groups = split_batches_by_partition(
+            &schema,
+            std::slice::from_ref(&batch),
+            &identity_region_spec(),
+        )
+        .unwrap();
+        // "us" (2 rows) and a legitimate NULL partition (1 row).
+        assert_eq!(groups.len(), 2);
+        let total: usize = groups
+            .iter()
+            .flat_map(|(_, b)| b)
+            .map(|b| b.num_rows())
+            .sum();
+        assert_eq!(total, 3);
+        let mut values: Vec<Option<String>> = groups.iter().map(|(v, _)| v[0].clone()).collect();
+        values.sort();
+        assert_eq!(values, vec![None, Some("us".to_string())]);
+    }
+
+    #[test]
+    fn split_errors_on_unencodable_non_null_value_instead_of_corrupting() {
+        let schema: SchemaRef = Arc::new(Schema::new(vec![Field::new(
+            "region",
+            DataType::Utf8,
+            true,
+        )]));
+        // A NUL byte makes the value unencodable (encode_scalar returns None) but it
+        // is NOT null — it must error, not silently collapse into a NULL partition
+        // and commingle with genuinely-null rows.
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(StringArray::from(vec![Some("a\u{0}b")])) as ArrayRef],
+        )
+        .unwrap();
+        let err = split_batches_by_partition(
+            &schema,
+            std::slice::from_ref(&batch),
+            &identity_region_spec(),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().to_lowercase().contains("encode"),
+            "expected an encode error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn hive_subpath_encodes_keys_values_and_nulls() {
+        let keys = vec!["region".to_string(), "day".to_string()];
+        assert_eq!(
+            hive_subpath(&keys, &[Some("us".into()), Some("3".into())]),
+            "region=us/day=3"
+        );
+        // A NULL partition value uses DuckDB's sentinel directory name.
+        assert_eq!(
+            hive_subpath(&keys, &[None, Some("3".into())]),
+            "region=__HIVE_DEFAULT_PARTITION__/day=3"
+        );
+        // Path separators in a value can never escape the partition directory.
+        assert_eq!(
+            hive_subpath(&keys[..1], &[Some("a/../b".into())]),
+            "region=a_.._b"
+        );
+        // No keys: the file lives directly under the table directory.
+        assert_eq!(hive_subpath(&[], &[]), "");
+    }
+
+    #[test]
+    fn resolve_maps_column_ids_to_write_schema_indices() {
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("region", DataType::Utf8, true),
+        ]);
+        let spec = PartitionSpec {
+            partition_id: 7,
+            columns: vec![PartitionSpecColumn {
+                partition_key_index: 0,
+                column_id: 20,
+                transform: PartitionTransform::Identity,
+            }],
+            prune_safe: true,
+        };
+        // column_ids[i] is the catalog id of schema field i, so column_id 20 is
+        // field 1 ("region") — not key index 0.
+        let resolved = PartitionWriteSpec::resolve(&spec, &[10, 20], &schema).unwrap();
+        assert_eq!(resolved.partition_id, 7);
+        assert_eq!(resolved.keys.len(), 1);
+        assert_eq!(resolved.keys[0].input_index, 1);
+        assert_eq!(resolved.keys[0].name, "region");
+        assert_eq!(resolved.key_names(), vec!["region".to_string()]);
+    }
+
+    #[test]
+    fn resolve_rejects_non_producible_transform() {
+        let schema = Schema::new(vec![Field::new("id", DataType::Int64, false)]);
+        let spec = PartitionSpec {
+            partition_id: 1,
+            columns: vec![PartitionSpecColumn {
+                partition_key_index: 0,
+                column_id: 10,
+                transform: PartitionTransform::Bucket(8),
+            }],
+            prune_safe: true,
+        };
+        // `bucket` is readable but not producible: a partitioned write must fail
+        // rather than silently emit unpartitioned files the spec forbids.
+        let err = PartitionWriteSpec::resolve(&spec, &[10], &schema).unwrap_err();
+        assert!(
+            err.to_string().contains("bucket(8)"),
+            "expected the transform in the error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_errors_when_partition_column_absent_from_write_schema() {
+        let schema = Schema::new(vec![Field::new("id", DataType::Int64, false)]);
+        let spec = PartitionSpec {
+            partition_id: 1,
+            columns: vec![PartitionSpecColumn {
+                partition_key_index: 0,
+                column_id: 99,
+                transform: PartitionTransform::Identity,
+            }],
+            prune_safe: true,
+        };
+        assert!(PartitionWriteSpec::resolve(&spec, &[10], &schema).is_err());
+    }
 
     #[test]
     fn parse_and_roundtrip() {

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -94,6 +94,43 @@ impl PartitionTransform {
         )
     }
 
+    /// Whether `value` is a well-formed partition value for this transform on a
+    /// column of `column_type`. A NULL value (`None`) is always well-formed — it is a
+    /// partition in its own right.
+    ///
+    /// Mirrors what official DuckLake checks before registering a partition value:
+    /// an `identity` value must cast to the column's type (`MapHiveColumn`), a
+    /// `bucket(N)` value must be an integer in `0..N`
+    /// (`IsValidTransformedHivePartitionValue`), and a temporal value must be the
+    /// integer calendar component. It cannot tell whether the FILE's rows actually
+    /// share the value — only the caller knows that.
+    pub(crate) fn value_is_well_formed(&self, value: Option<&str>, column_type: &DataType) -> bool {
+        let Some(value) = value else {
+            return true;
+        };
+        match self {
+            PartitionTransform::Identity => {
+                ScalarValue::try_from_string(value.to_string(), column_type).is_ok()
+            },
+            PartitionTransform::Year => value.trim().parse::<i64>().is_ok(),
+            PartitionTransform::Month => {
+                matches!(value.trim().parse::<i64>(), Ok(m) if (1..=12).contains(&m))
+            },
+            PartitionTransform::Day => {
+                matches!(value.trim().parse::<i64>(), Ok(d) if (1..=31).contains(&d))
+            },
+            PartitionTransform::Hour => {
+                matches!(value.trim().parse::<i64>(), Ok(h) if (0..=23).contains(&h))
+            },
+            PartitionTransform::Bucket(buckets) => {
+                matches!(value.trim().parse::<i64>(), Ok(b) if b >= 0 && b < i64::from(*buckets))
+            },
+            // An unrecognized transform's value domain is unknown; accept it rather
+            // than reject a value some other writer legitimately produced.
+            PartitionTransform::Unknown(_) => true,
+        }
+    }
+
     /// Derive a `(min, max)` **envelope** on the *source column* for a file whose
     /// partition value for this transform is `value`, as `ScalarValue`s of the source
     /// column's `data_type`. The envelope is guaranteed to satisfy `min <= every row
@@ -227,15 +264,36 @@ impl PartitionWriteSpec {
                         column.column_id
                     ))
                 })?;
-            let name = schema
-                .fields()
-                .get(index)
-                .map(|f| f.name().to_string())
-                .ok_or_else(|| {
-                    crate::DuckLakeError::Internal(format!(
-                        "partition column index {index} out of range for write schema"
-                    ))
-                })?;
+            let field = schema.fields().get(index).ok_or_else(|| {
+                crate::DuckLakeError::Internal(format!(
+                    "partition column index {index} out of range for write schema"
+                ))
+            })?;
+            let name = field.name().to_string();
+
+            // A temporal transform on a TIME-ZONE-AWARE timestamp cannot be computed
+            // portably: DuckDB evaluates `year(timestamptz)` in the session time
+            // zone, while we would compute it in UTC. Near a boundary the two
+            // disagree — `2023-01-01 00:30:00+00` is year 2023 to us and 2022 to a
+            // DuckDB session in `America/New_York` — so the value we record would be
+            // one DuckDB then prunes against under a different rule, dropping live
+            // rows. The read path already refuses to derive bounds for this case
+            // (see `year_bounds`); refuse to WRITE it too rather than commit a value
+            // whose meaning depends on who reads it.
+            if !matches!(column.transform, PartitionTransform::Identity)
+                && matches!(
+                    field.data_type(),
+                    arrow::datatypes::DataType::Timestamp(_, Some(_))
+                )
+            {
+                return Err(crate::DuckLakeError::Unsupported(format!(
+                    "partitioning by '{}' on the time-zone-aware column '{}' is not supported: \
+                     the transformed value depends on the reader's session time zone. Partition \
+                     by a time-zone-naive timestamp, or by a pre-computed column.",
+                    column.transform.to_catalog_string(),
+                    name
+                )));
+            }
             keys.push(PartitionWriteKey {
                 input_index: index,
                 name,
@@ -252,6 +310,53 @@ impl PartitionWriteSpec {
     /// [`hive_subpath`].
     pub(crate) fn key_names(&self) -> Vec<String> {
         self.keys.iter().map(|k| k.name.clone()).collect()
+    }
+
+    /// Validate one file's partition `values` (in key order) against this spec and
+    /// the write schema: one value per key, each well-formed for its transform and
+    /// column type (see [`PartitionTransform::value_is_well_formed`]).
+    ///
+    /// Values this crate derived itself are well-formed by construction; this guards
+    /// the paths that accept them from a caller
+    /// ([`crate::table_writer::DuckLakeTableWriter::write_partitioned`]), where a
+    /// wrong arity or an unparseable value would otherwise be persisted and then
+    /// used as an EXACT pruning bound — silently dropping rows from later reads.
+    pub(crate) fn validate_values(
+        &self,
+        schema: &arrow::datatypes::Schema,
+        values: &[Option<String>],
+    ) -> crate::Result<()> {
+        if values.len() != self.keys.len() {
+            return Err(crate::DuckLakeError::InvalidConfig(format!(
+                "partitioned write supplied {} value(s) for a spec with {} key(s)",
+                values.len(),
+                self.keys.len()
+            )));
+        }
+        for (key, value) in self.keys.iter().zip(values.iter()) {
+            let column_type = schema
+                .fields()
+                .get(key.input_index)
+                .map(|f| f.data_type())
+                .ok_or_else(|| {
+                    crate::DuckLakeError::Internal(format!(
+                        "partition key column index {} out of range for write schema",
+                        key.input_index
+                    ))
+                })?;
+            if !key
+                .transform
+                .value_is_well_formed(value.as_deref(), column_type)
+            {
+                return Err(crate::DuckLakeError::InvalidConfig(format!(
+                    "partition value {value:?} is not valid for key '{}' with transform '{}' on a \
+                     {column_type} column",
+                    key.name,
+                    key.transform.to_catalog_string()
+                )));
+            }
+        }
+        Ok(())
     }
 }
 
@@ -621,6 +726,50 @@ mod tests {
         assert!(
             err.to_string().contains("bucket(8)"),
             "expected the transform in the error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_rejects_temporal_transform_on_tz_aware_timestamp() {
+        let tz = DataType::Timestamp(arrow::datatypes::TimeUnit::Microsecond, Some("UTC".into()));
+        let schema = Schema::new(vec![Field::new("ts", tz, true)]);
+        let spec = |transform| PartitionSpec {
+            partition_id: 1,
+            columns: vec![PartitionSpecColumn {
+                partition_key_index: 0,
+                column_id: 10,
+                transform,
+            }],
+            prune_safe: true,
+        };
+        // A temporal transform's value depends on the reader's session time zone, so
+        // writing one would silently disagree with DuckDB near a boundary.
+        for transform in [
+            PartitionTransform::Year,
+            PartitionTransform::Month,
+            PartitionTransform::Day,
+            PartitionTransform::Hour,
+        ] {
+            let err =
+                PartitionWriteSpec::resolve(&spec(transform.clone()), &[10], &schema).unwrap_err();
+            assert!(
+                err.to_string().contains("time zone"),
+                "expected a time-zone error for {transform:?}, got: {err}"
+            );
+        }
+        // Identity is unaffected: the raw value is time-zone independent.
+        assert!(
+            PartitionWriteSpec::resolve(&spec(PartitionTransform::Identity), &[10], &schema)
+                .is_ok()
+        );
+        // A naive timestamp is fine for temporal transforms.
+        let naive = Schema::new(vec![Field::new(
+            "ts",
+            DataType::Timestamp(arrow::datatypes::TimeUnit::Microsecond, None),
+            true,
+        )]);
+        assert!(
+            PartitionWriteSpec::resolve(&spec(PartitionTransform::Year), &[10], &naive).is_ok()
         );
     }
 

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -98,12 +98,20 @@ impl PartitionTransform {
     /// column of `column_type`. A NULL value (`None`) is always well-formed — it is a
     /// partition in its own right.
     ///
-    /// Mirrors what official DuckLake checks before registering a partition value:
-    /// an `identity` value must cast to the column's type (`MapHiveColumn`), a
-    /// `bucket(N)` value must be an integer in `0..N`
-    /// (`IsValidTransformedHivePartitionValue`), and a temporal value must be the
-    /// integer calendar component. It cannot tell whether the FILE's rows actually
-    /// share the value — only the caller knows that.
+    /// Deliberately matches official DuckLake's checks exactly, no more:
+    ///
+    /// - `identity` — must cast to the column's type. Official casts the Hive value
+    ///   to the field type and errors when it will not (`MapHiveColumn`).
+    /// - `year`/`month`/`day`/`hour` — must parse as an integer, and nothing further.
+    ///   Official types these keys as `BIGINT` (not the source column type) and only
+    ///   casts (`MapPartitionColumns` via `GetPartitionKeyType`); it does NOT check
+    ///   that a month is 1..12 or an hour 0..23. Adding such a range check here would
+    ///   reject values official accepts, so it is left out on purpose.
+    /// - `bucket(N)` — must be an integer in `0..N`, the one range check official
+    ///   does make (`IsValidTransformedHivePartitionValue`).
+    ///
+    /// None of this can tell whether the FILE's rows actually share the value — only
+    /// the caller knows that, in official too.
     pub(crate) fn value_is_well_formed(&self, value: Option<&str>, column_type: &DataType) -> bool {
         let Some(value) = value else {
             return true;
@@ -112,16 +120,10 @@ impl PartitionTransform {
             PartitionTransform::Identity => {
                 ScalarValue::try_from_string(value.to_string(), column_type).is_ok()
             },
-            PartitionTransform::Year => value.trim().parse::<i64>().is_ok(),
-            PartitionTransform::Month => {
-                matches!(value.trim().parse::<i64>(), Ok(m) if (1..=12).contains(&m))
-            },
-            PartitionTransform::Day => {
-                matches!(value.trim().parse::<i64>(), Ok(d) if (1..=31).contains(&d))
-            },
-            PartitionTransform::Hour => {
-                matches!(value.trim().parse::<i64>(), Ok(h) if (0..=23).contains(&h))
-            },
+            PartitionTransform::Year
+            | PartitionTransform::Month
+            | PartitionTransform::Day
+            | PartitionTransform::Hour => value.trim().parse::<i64>().is_ok(),
             PartitionTransform::Bucket(buckets) => {
                 matches!(value.trim().parse::<i64>(), Ok(b) if b >= 0 && b < i64::from(*buckets))
             },
@@ -271,29 +273,15 @@ impl PartitionWriteSpec {
             })?;
             let name = field.name().to_string();
 
-            // A temporal transform on a TIME-ZONE-AWARE timestamp cannot be computed
-            // portably: DuckDB evaluates `year(timestamptz)` in the session time
-            // zone, while we would compute it in UTC. Near a boundary the two
-            // disagree — `2023-01-01 00:30:00+00` is year 2023 to us and 2022 to a
-            // DuckDB session in `America/New_York` — so the value we record would be
-            // one DuckDB then prunes against under a different rule, dropping live
-            // rows. The read path already refuses to derive bounds for this case
-            // (see `year_bounds`); refuse to WRITE it too rather than commit a value
-            // whose meaning depends on who reads it.
-            if !matches!(column.transform, PartitionTransform::Identity)
-                && matches!(
-                    field.data_type(),
-                    arrow::datatypes::DataType::Timestamp(_, Some(_))
-                )
-            {
-                return Err(crate::DuckLakeError::Unsupported(format!(
-                    "partitioning by '{}' on the time-zone-aware column '{}' is not supported: \
-                     the transformed value depends on the reader's session time zone. Partition \
-                     by a time-zone-naive timestamp, or by a pre-computed column.",
-                    column.transform.to_catalog_string(),
-                    name
-                )));
-            }
+            // Caveat, deliberately NOT an error: a temporal transform on a
+            // time-zone-aware timestamp is computed here in UTC, whereas DuckDB
+            // evaluates `year(timestamptz)` in the session time zone, so near a
+            // boundary the two produce different partition values for the same row.
+            // Official DuckLake permits this combination (it emits `year(col)` and
+            // lets the session decide), so rejecting it would refuse a table official
+            // accepts. Our read path is unaffected: `year_bounds` declines to derive
+            // an envelope for tz-aware timestamps, so we never prune on such a key —
+            // only a DuckDB reader applying its own session rule could mis-prune.
             keys.push(PartitionWriteKey {
                 input_index: index,
                 name,
@@ -730,47 +718,23 @@ mod tests {
     }
 
     #[test]
-    fn resolve_rejects_temporal_transform_on_tz_aware_timestamp() {
+    fn resolve_allows_temporal_transform_on_tz_aware_timestamp() {
+        // Official DuckLake permits `year(timestamptz)` — it emits `year(col)` and
+        // lets the session time zone decide the value — so we must not refuse it.
+        // The value we compute is UTC-based, which is a documented cross-engine
+        // caveat on `resolve`, not an error.
         let tz = DataType::Timestamp(arrow::datatypes::TimeUnit::Microsecond, Some("UTC".into()));
         let schema = Schema::new(vec![Field::new("ts", tz, true)]);
-        let spec = |transform| PartitionSpec {
+        let spec = PartitionSpec {
             partition_id: 1,
             columns: vec![PartitionSpecColumn {
                 partition_key_index: 0,
                 column_id: 10,
-                transform,
+                transform: PartitionTransform::Year,
             }],
             prune_safe: true,
         };
-        // A temporal transform's value depends on the reader's session time zone, so
-        // writing one would silently disagree with DuckDB near a boundary.
-        for transform in [
-            PartitionTransform::Year,
-            PartitionTransform::Month,
-            PartitionTransform::Day,
-            PartitionTransform::Hour,
-        ] {
-            let err =
-                PartitionWriteSpec::resolve(&spec(transform.clone()), &[10], &schema).unwrap_err();
-            assert!(
-                err.to_string().contains("time zone"),
-                "expected a time-zone error for {transform:?}, got: {err}"
-            );
-        }
-        // Identity is unaffected: the raw value is time-zone independent.
-        assert!(
-            PartitionWriteSpec::resolve(&spec(PartitionTransform::Identity), &[10], &schema)
-                .is_ok()
-        );
-        // A naive timestamp is fine for temporal transforms.
-        let naive = Schema::new(vec![Field::new(
-            "ts",
-            DataType::Timestamp(arrow::datatypes::TimeUnit::Microsecond, None),
-            true,
-        )]);
-        assert!(
-            PartitionWriteSpec::resolve(&spec(PartitionTransform::Year), &[10], &naive).is_ok()
-        );
+        assert!(PartitionWriteSpec::resolve(&spec, &[10], &schema).is_ok());
     }
 
     #[test]

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -426,7 +426,14 @@ fn transform_array(
 /// partition values — one group per distinct key. Returns `(values, batches)` per
 /// group, where `values[i]` is the encoded value for partition key `i` (`None` for
 /// SQL NULL). Rows sharing a key land in the same group regardless of which input
-/// batch they came from.
+/// batch they came from, and keep their relative order.
+///
+/// Each group holds ONE OUTPUT BATCH PER INPUT BATCH that contributed rows to it,
+/// rather than a single concatenated batch. This matters because the writer evaluates
+/// file rollover at batch boundaries: collapsing a group into one batch would leave
+/// `target_file_size` unenforceable within a partition, emitting one file of unbounded
+/// size however large the write. It also keeps peak memory to one input batch's worth
+/// of `take` output instead of a full copy of the input.
 ///
 /// `output_schema` is the schema the returned batches carry (the table's clean data
 /// columns); `batches` must already match it positionally.
@@ -436,72 +443,88 @@ pub(crate) fn split_batches_by_partition(
     spec: &PartitionWriteSpec,
 ) -> crate::Result<Vec<PartitionGroup>> {
     use arrow::array::{ArrayRef, RecordBatch, UInt32Array};
-    use arrow::compute::{concat_batches, take};
+    use arrow::compute::take;
     use std::collections::HashMap;
 
-    if batches.is_empty() {
-        return Ok(Vec::new());
-    }
-    let input_schema = batches[0].schema();
-    let combined = concat_batches(&input_schema, batches)?;
-    let num_rows = combined.num_rows();
-    if num_rows == 0 {
-        return Ok(Vec::new());
-    }
+    // Group index by partition values, so groups keep first-seen order across
+    // batches and every batch appends into the same group.
+    let mut order: Vec<Vec<Option<String>>> = Vec::new();
+    let mut groups: HashMap<Vec<Option<String>>, Vec<RecordBatch>> = HashMap::new();
 
-    // Transform each partition-key column once for the whole dataset.
-    let mut transformed: Vec<ArrayRef> = Vec::with_capacity(spec.keys.len());
-    for key in &spec.keys {
-        transformed.push(transform_array(
-            &key.transform,
-            combined.column(key.input_index),
-        )?);
-    }
-
-    // Group row indices by the encoded partition-value tuple.
-    let mut groups: HashMap<Vec<Option<String>>, Vec<u32>> = HashMap::new();
-    for row in 0..num_rows {
-        let mut values: Vec<Option<String>> = Vec::with_capacity(spec.keys.len());
-        for array in &transformed {
-            let scalar = ScalarValue::try_from_array(array, row)?;
-            // `encode_scalar` returns `None` for BOTH a genuine SQL NULL and a
-            // non-null value of a type it cannot encode. Those must not be
-            // conflated: silently mapping an unencodable non-null value to `None`
-            // would group every distinct such value into one file with a NULL
-            // partition value (data corruption). A NULL is a legitimate partition
-            // value; an unencodable non-null value is a hard error.
-            let encoded = if scalar.is_null() {
-                None
-            } else {
-                match crate::stats_encode::encode_scalar(&scalar) {
-                    Some(encoded) => Some(encoded),
-                    None => {
-                        return Err(crate::DuckLakeError::Unsupported(format!(
-                            "partitioned write: partition-key value of type {} cannot be \
-                             encoded; partitioning by this column type is not supported",
-                            array.data_type()
-                        )));
-                    },
-                }
-            };
-            values.push(encoded);
+    for batch in batches {
+        let num_rows = batch.num_rows();
+        if num_rows == 0 {
+            continue;
         }
-        groups.entry(values).or_default().push(row as u32);
+        // Transform each partition-key column once per batch.
+        let mut transformed: Vec<ArrayRef> = Vec::with_capacity(spec.keys.len());
+        for key in &spec.keys {
+            transformed.push(transform_array(
+                &key.transform,
+                batch.column(key.input_index),
+            )?);
+        }
+
+        // Row indices of this batch, bucketed by encoded partition-value tuple.
+        // Ascending within a bucket, so relative order is preserved.
+        let mut per_batch: HashMap<Vec<Option<String>>, Vec<u32>> = HashMap::new();
+        let mut per_batch_order: Vec<Vec<Option<String>>> = Vec::new();
+        for row in 0..num_rows {
+            let mut values: Vec<Option<String>> = Vec::with_capacity(spec.keys.len());
+            for array in &transformed {
+                let scalar = ScalarValue::try_from_array(array, row)?;
+                // `encode_scalar` returns `None` for BOTH a genuine SQL NULL and a
+                // non-null value of a type it cannot encode. Those must not be
+                // conflated: silently mapping an unencodable non-null value to `None`
+                // would group every distinct such value into one file with a NULL
+                // partition value (data corruption). A NULL is a legitimate partition
+                // value; an unencodable non-null value is a hard error.
+                let encoded = if scalar.is_null() {
+                    None
+                } else {
+                    match crate::stats_encode::encode_scalar(&scalar) {
+                        Some(encoded) => Some(encoded),
+                        None => {
+                            return Err(crate::DuckLakeError::Unsupported(format!(
+                                "partitioned write: partition-key value of type {} cannot be \
+                                 encoded; partitioning by this column type is not supported",
+                                array.data_type()
+                            )));
+                        },
+                    }
+                };
+                values.push(encoded);
+            }
+            if !per_batch.contains_key(&values) {
+                per_batch_order.push(values.clone());
+            }
+            per_batch.entry(values).or_default().push(row as u32);
+        }
+
+        // Materialize this batch's contribution to each group it touched.
+        for values in per_batch_order {
+            let indices = per_batch.remove(&values).unwrap_or_default();
+            if indices.is_empty() {
+                continue;
+            }
+            let index_array = UInt32Array::from(indices);
+            let columns = batch
+                .columns()
+                .iter()
+                .map(|c| take(c, &index_array, None))
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            let out = RecordBatch::try_new(output_schema.clone(), columns)?;
+            if !groups.contains_key(&values) {
+                order.push(values.clone());
+            }
+            groups.entry(values).or_default().push(out);
+        }
     }
 
-    // Materialize one batch per group via `take` (output uses the clean schema).
-    let mut result = Vec::with_capacity(groups.len());
-    for (values, indices) in groups {
-        let index_array = UInt32Array::from(indices);
-        let columns = combined
-            .columns()
-            .iter()
-            .map(|c| take(c, &index_array, None))
-            .collect::<std::result::Result<Vec<_>, _>>()?;
-        let batch = RecordBatch::try_new(output_schema.clone(), columns)?;
-        result.push((values, vec![batch]));
-    }
-    Ok(result)
+    Ok(order
+        .into_iter()
+        .filter_map(|values| groups.remove(&values).map(|batches| (values, batches)))
+        .collect())
 }
 
 /// One column of a partition spec: which table column, and how it is transformed.

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -221,6 +221,70 @@ impl SortSpec {
     }
 }
 
+/// Reorder rows by a table's sort order, returning ONE sorted batch.
+///
+/// `batches` may carry trailing columns beyond `data_schema` (a compaction output
+/// embeds the rowid, and for a partial file the per-row snapshot id); sort keys
+/// resolve to `data_schema` positions — the leading columns — so those trailing
+/// columns travel with their rows.
+///
+/// This is a **global** sort across all of `batches`, matching official DuckLake,
+/// which sorts a write by planting a blocking `PhysicalOrder` above the insert plan
+/// (`ducklake_insert.cpp`). That is what makes successive rolled files cover
+/// contiguous, non-overlapping value ranges — the property that lets a reader skip
+/// whole files. Sorting *within* a file would not achieve it: a file's min/max is
+/// the min/max of its rows regardless of their order, so only its row-group bounds
+/// would tighten.
+///
+/// Returns `batches` unchanged when there is no producible sort order, a key is not
+/// in the schema, or there are no rows — sort order affects statistics locality
+/// only, never correctness.
+#[cfg(feature = "write")]
+pub(crate) fn sort_batches_by_spec(
+    batches: Vec<arrow::record_batch::RecordBatch>,
+    data_schema: &arrow::datatypes::Schema,
+    sort_spec: Option<&SortSpec>,
+) -> crate::Result<Vec<arrow::record_batch::RecordBatch>> {
+    use arrow::array::{ArrayRef, RecordBatch};
+    use std::sync::Arc;
+
+    let Some(keys) = sort_spec.and_then(|spec| spec.producible_columns()) else {
+        return Ok(batches);
+    };
+    if keys.is_empty() || batches.iter().all(|b| b.num_rows() == 0) {
+        return Ok(batches);
+    }
+    let mut resolved = Vec::with_capacity(keys.len());
+    for (name, direction, null_order) in &keys {
+        let Ok(index) = data_schema.index_of(name) else {
+            return Ok(batches);
+        };
+        resolved.push((
+            index,
+            arrow::compute::SortOptions {
+                descending: matches!(direction, SortDirection::Desc),
+                nulls_first: null_order.nulls_first(),
+            },
+        ));
+    }
+    let full_schema = batches[0].schema();
+    let combined = arrow::compute::concat_batches(&full_schema, &batches)?;
+    let sort_columns: Vec<arrow::compute::SortColumn> = resolved
+        .iter()
+        .map(|(index, options)| arrow::compute::SortColumn {
+            values: Arc::clone(combined.column(*index)),
+            options: Some(*options),
+        })
+        .collect();
+    let indices = arrow::compute::lexsort_to_indices(&sort_columns, None)?;
+    let sorted_columns = combined
+        .columns()
+        .iter()
+        .map(|c| arrow::compute::take(c, &indices, None))
+        .collect::<std::result::Result<Vec<ArrayRef>, _>>()?;
+    Ok(vec![RecordBatch::try_new(full_schema, sorted_columns)?])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -189,8 +189,14 @@ impl SortSpec {
     /// The producible sort keys as `(column_name, direction, null_order)`, in order,
     /// or `None` if any key is not a bare column (see [`SortSpec::is_producible`]).
     pub fn producible_columns(&self) -> Option<Vec<(String, SortDirection, NullOrder)>> {
+        // Skip fields whose dialect is not `duckdb`, matching official DuckLake, which
+        // `continue`s past them when building the sort expression
+        // (`ducklake_sort_data.cpp`). Their expression is written in some other
+        // engine's dialect, so evaluating it here would sort by something official
+        // ignores entirely.
         self.fields
             .iter()
+            .filter(|f| f.dialect.eq_ignore_ascii_case("duckdb"))
             .map(|f| f.column_candidate().map(|c| (c, f.direction, f.null_order)))
             .collect()
     }

--- a/src/table.rs
+++ b/src/table.rs
@@ -2122,6 +2122,17 @@ impl DuckLakeTable {
         self.provider.get_sort_spec(self.table_id, head)
     }
 
+    /// The table's partition spec live at the CURRENT catalog head (not the
+    /// snapshot this provider is pinned to) — the generation any write committing
+    /// now must agree with. Mirrors [`Self::live_sort_spec`]; the pinned
+    /// `self.partition_spec` remains the one used for read pruning, which is
+    /// snapshot-bound.
+    #[cfg(feature = "write")]
+    pub(crate) fn live_partition_spec(&self) -> crate::Result<Option<PartitionSpec>> {
+        let head = self.provider.get_current_snapshot()?;
+        self.provider.get_partition_spec(self.table_id, head)
+    }
+
     /// The live columns' catalog `column_id`s in `column_order` — the parquet
     /// field-ids a compaction output must bake in so its data columns map back
     /// to the catalog on read.
@@ -2731,34 +2742,15 @@ impl TableProvider for DuckLakeTable {
         let partition = match live_spec.as_ref() {
             None => None,
             Some(spec) => {
-                let mut keys = Vec::with_capacity(spec.columns.len());
-                for column in &spec.columns {
-                    if !column.transform.is_producible() {
-                        return Err(DataFusionError::NotImplemented(format!(
-                            "INSERT into a table partitioned by '{}' is not supported",
-                            column.transform.to_catalog_string()
-                        )));
-                    }
-                    let index = self
-                        .columns
-                        .iter()
-                        .position(|c| c.column_id == column.column_id)
-                        .ok_or_else(|| {
-                            DataFusionError::Internal(format!(
-                                "partition column_id {} not found in table schema",
-                                column.column_id
-                            ))
-                        })?;
-                    keys.push(crate::insert_exec::PartitionWriteKey {
-                        input_index: index,
-                        name: self.physical_schema.field(index).name().to_string(),
-                        transform: column.transform.clone(),
-                    });
-                }
-                Some(crate::insert_exec::PartitionWriteSpec {
-                    partition_id: spec.partition_id,
-                    keys,
-                })
+                let column_ids: Vec<i64> = self.columns.iter().map(|c| c.column_id).collect();
+                Some(
+                    crate::partition::PartitionWriteSpec::resolve(
+                        spec,
+                        &column_ids,
+                        self.physical_schema.as_ref(),
+                    )
+                    .map_err(|e| DataFusionError::External(Box::new(e)))?,
+                )
             },
         };
 

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -1074,15 +1074,18 @@ impl DuckLakeTableWriter {
     }
 
     /// Write `batches` into ONE OR MORE parquet files under `table_key` (data
-    /// columns with catalog field-ids, no embedded rowid), rolling over to a new
-    /// file whenever the current file's estimated encoded size reaches
-    /// `target_file_size`. `rel_prefix`, when set, is a Hive-style subpath (a
-    /// partition group) each file is placed under. Rollover is checked at batch
-    /// boundaries, so a file always holds a whole number of batches — preserving
-    /// any input ordering *across* files (file N's rows all precede file N+1's).
+    /// columns with catalog field-ids, no embedded rowid), rolling over to a new file
+    /// whenever the current file reaches `target_file_size`. `rel_prefix`, when set, is
+    /// a Hive-style subpath (a partition group) each file is placed under.
+    ///
+    /// Rollover mechanics live in [`RollingFileWriter`], shared with the streaming
+    /// session's per-partition sink so the two cannot drift. This path differs only in
+    /// its upload policy: having `await` available, it uploads each file as soon as it
+    /// rolls, so at most one staged file occupies local disk at a time.
+    ///
     /// Returns one [`DataFileInfo`] per file (relative catalog path set, stats and
-    /// footer harvested); empty rows produce no file. A write smaller than
-    /// `target_file_size` yields exactly one file.
+    /// footer harvested); empty rows produce no file, and a write below
+    /// `target_file_size` yields exactly one.
     async fn write_rolled_files(
         &self,
         table_key: &str,
@@ -1091,133 +1094,38 @@ impl DuckLakeTableWriter {
         column_ids: &[i64],
         batches: &[RecordBatch],
     ) -> Result<Vec<DataFileInfo>> {
+        let mut roller = RollingFileWriter::new(
+            table_key.to_string(),
+            rel_prefix.map(str::to_string),
+            schema_with_ids,
+            column_ids.len(),
+            self.build_writer_props(),
+            self.target_file_size,
+        );
         let mut files: Vec<DataFileInfo> = Vec::new();
-        // In-progress file (None between files / before the first row).
-        let mut writer: Option<ArrowWriter<std::io::BufWriter<std::fs::File>>> = None;
-        let mut temp: Option<NamedTempFile> = None;
-        let mut catalog_path = String::new();
-        let mut object_path = ObjectPath::from("");
-        let mut row_count: i64 = 0;
-        let mut nan_flags: Vec<Option<bool>> = Vec::new();
-
         for batch in batches {
-            if batch.num_rows() == 0 {
-                continue;
-            }
-            if writer.is_none() {
-                let file_name = format!("{}.parquet", Uuid::new_v4());
-                catalog_path = match rel_prefix {
-                    Some(prefix) if !prefix.is_empty() => format!("{prefix}/{file_name}"),
-                    _ => file_name.clone(),
-                };
-                let object_path_str = join_paths(table_key, &catalog_path)?;
-                object_path = ObjectPath::from(object_path_str.trim_start_matches('/'));
-                let temp_file = NamedTempFile::new()?;
-                let staging = std::io::BufWriter::new(temp_file.reopen()?);
-                writer = Some(ArrowWriter::try_new(
-                    staging,
-                    schema_with_ids.clone(),
-                    Some(self.build_writer_props()),
-                )?);
-                temp = Some(temp_file);
-                row_count = 0;
-                nan_flags = Vec::new();
-            }
-
-            let batch_with_ids =
-                RecordBatch::try_new(schema_with_ids.clone(), batch.columns().to_vec())?;
-            crate::stats_collect::accumulate_nan_flags(
-                &mut nan_flags,
-                &batch_with_ids,
-                column_ids.len(),
-            );
-            let active = writer.as_mut().unwrap();
-            active.write(&batch_with_ids)?;
-            row_count += batch.num_rows() as i64;
-
-            // Roll over at the batch boundary once the estimated encoded size
-            // (finished row groups + the in-progress one) reaches the target.
-            if active.bytes_written() + active.in_progress_size() >= self.target_file_size {
-                let info = finalize_and_upload_file(
-                    writer.take().unwrap(),
-                    temp.take().unwrap(),
-                    &self.object_store,
-                    &object_path,
-                    &catalog_path,
-                    column_ids,
-                    row_count,
-                    &nan_flags,
-                )
-                .await?;
-                files.push(info);
+            if let Some(staged) = roller.write(batch)? {
+                files.push(upload_staged_file(staged, &self.object_store, column_ids).await?);
             }
         }
-
-        // Finalize the trailing (or only) file.
-        if let Some(active) = writer.take() {
-            let info = finalize_and_upload_file(
-                active,
-                temp.take().unwrap(),
-                &self.object_store,
-                &object_path,
-                &catalog_path,
-                column_ids,
-                row_count,
-                &nan_flags,
-            )
-            .await?;
-            files.push(info);
+        if let Some(staged) = roller.finish()? {
+            files.push(upload_staged_file(staged, &self.object_store, column_ids).await?);
         }
-
         Ok(files)
     }
 }
 
-/// Finalize the parquet footer of a staged file, stream it to object storage, and
-/// harvest per-column stats — returning the [`DataFileInfo`] for the catalog
-/// commit (relative `catalog_path`). Shared by every multi-file write path.
-#[allow(clippy::too_many_arguments)]
-async fn finalize_and_upload_file(
-    writer: ArrowWriter<std::io::BufWriter<std::fs::File>>,
-    temp: NamedTempFile,
-    object_store: &Arc<dyn ObjectStore>,
-    object_path: &ObjectPath,
-    catalog_path: &str,
-    column_ids: &[i64],
-    row_count: i64,
-    nan_flags: &[Option<bool>],
-) -> Result<DataFileInfo> {
-    let staged = writer.into_inner()?;
-    let mut file = staged
-        .into_inner()
-        .map_err(|e| crate::error::DuckLakeError::Io(e.into_error()))?;
-    let file_size = file.metadata()?.len() as i64;
-    let footer_size = read_footer_size(&mut file)?;
-
-    let local = tokio::fs::File::open(temp.path()).await?;
-    let mut reader = tokio::io::BufReader::new(local);
-    let mut upload = ObjectBufWriter::new(Arc::clone(object_store), object_path.clone());
-    if let Err(e) = stream_to_upload(&mut reader, &mut upload).await {
-        let _ = upload.abort().await;
-        return Err(e.into());
-    }
-
-    let column_stats =
-        crate::stats_collect::collect_column_stats(temp.path(), column_ids, row_count, nan_flags);
-
-    Ok(DataFileInfo::new(catalog_path, file_size, row_count)
-        .with_footer_size(footer_size)
-        .with_column_stats(column_stats))
-}
-
 /// Split `batches` back into slices of `lengths` rows, in order.
 ///
-/// A global sort returns one concatenated batch; rollover and partition splitting
-/// both work per batch, so the single batch is re-sliced to the caller's original
-/// boundaries. `RecordBatch::slice` is a zero-copy view, so this costs no data
-/// movement. Returns the input untouched when it already matches `lengths` (no sort
-/// was applied) or when the totals disagree, so a mismatch degrades to "write what we
-/// have" rather than dropping or duplicating rows.
+/// A global sort returns one concatenated batch, but rollover is evaluated per batch,
+/// so handing that single batch to a [`RollingFileWriter`] would emit one file of
+/// unbounded size — losing rollover exactly where a sort order makes it most valuable.
+/// `RecordBatch::slice` is a zero-copy view, so restoring the caller's boundaries costs
+/// no data movement.
+///
+/// Returns the input untouched when it already matches `lengths` (no sort was applied)
+/// or when the totals disagree, so a mismatch degrades to "write what we have" rather
+/// than dropping or duplicating rows.
 fn reslice_to_lengths(batches: Vec<RecordBatch>, lengths: &[usize]) -> Vec<RecordBatch> {
     let total: usize = lengths.iter().sum();
     if batches.len() != 1 || batches[0].num_rows() != total || lengths.len() <= 1 {
@@ -1236,52 +1144,27 @@ fn reslice_to_lengths(batches: Vec<RecordBatch>, lengths: &[usize]) -> Vec<Recor
     out
 }
 
-/// How a streaming write session handles a partitioned target.
-#[derive(Debug, Clone, Copy)]
-enum StreamPartitionMode {
-    /// Split rows across one file per partition (a [`PartitionSink`]).
-    Split,
-    /// Refuse: this entry point writes to a single file the caller chose (a custom
-    /// path, or a file carrying embedded row lineage), which cannot also satisfy a
-    /// partition spec. Errors with the entry point named, rather than letting the
-    /// commit fail later with a partition-fence conflict that reads as a concurrent
-    /// DDL change.
-    Reject {
-        entry_point: &'static str,
-    },
-}
-
-/// One parquet file a [`PartitionSink`] is currently writing rows into.
+/// One parquet file being written to local staging.
 #[derive(Debug)]
-struct OpenPartitionFile {
-    /// The partition values every row in this file shares, in key order.
-    values: Vec<Option<String>>,
+struct OpenFile {
     writer: ArrowWriter<std::io::BufWriter<std::fs::File>>,
     temp: NamedTempFile,
-    /// Path relative to the table directory (includes the Hive subpath).
+    /// Path relative to the table directory (includes any Hive subpath).
     catalog_path: String,
     object_path: ObjectPath,
     row_count: i64,
     nan_flags: Vec<Option<bool>>,
 }
 
-/// A parquet file whose footer is written and whose staging file is complete, but
-/// which has not been uploaded yet.
+/// A finished parquet whose footer is written and whose staging file is complete on
+/// disk, awaiting upload.
 ///
-/// A streaming session finalizes files as it goes (on rollover, or when evicting to
-/// respect the open-file cap) but uploads them all in `finish`. Finalizing is
-/// synchronous, which is what lets [`TableWriteSession::write_batch`] stay
-/// synchronous; uploading is async and belongs to the one `finish` await point.
-///
-/// Holds a [`TempPath`], not a `NamedTempFile`: the staged file is not touched again
-/// until upload, so keeping its descriptor open would make the session's open-fd
-/// count grow with the TOTAL number of files written rather than staying bounded by
-/// `max_open` — a high-cardinality partition key would exhaust descriptors even
-/// though only `max_open` writers are live. `TempPath` keeps the file on disk (and
-/// still deletes it on drop) with no descriptor held.
+/// Holds a [`tempfile::TempPath`], not a `NamedTempFile`: nothing touches the file
+/// again until upload, so keeping a descriptor open would make a writer's open-fd count
+/// grow with the TOTAL number of files it produced rather than staying bounded.
+/// `TempPath` keeps the file on disk (still deleted on drop) with no descriptor held.
 #[derive(Debug)]
-struct StagedPartitionFile {
-    values: Vec<Option<String>>,
+struct StagedFile {
     temp: tempfile::TempPath,
     catalog_path: String,
     object_path: ObjectPath,
@@ -1289,99 +1172,104 @@ struct StagedPartitionFile {
     nan_flags: Vec<Option<bool>>,
 }
 
-/// Routes a streaming write's rows into one parquet file per partition.
+/// Writes batches into a sequence of parquet files, starting a new one whenever the
+/// current file reaches `target_file_size`.
 ///
-/// Mirrors DuckDB's partitioned COPY sink (which is how official DuckLake writes a
-/// partitioned table): keep a writer open per partition seen, roll a file over at
-/// `target_file_size`, and finalize the least-recently-opened file when the number
-/// of open files would exceed `max_open`. All files produced are committed in ONE
-/// snapshot, so a partitioned streaming write is as atomic as an unpartitioned one.
+/// The single home for rollover, used by both write paths — the buffered
+/// [`DuckLakeTableWriter::write_rolled_files`] and the streaming session's
+/// per-partition sink — so the check cannot be applied in one place and forgotten in
+/// the other. It was forgotten once already: a partitioned write left
+/// `target_file_size` unenforceable within a partition.
+///
+/// Deliberately synchronous, and deliberately does NOT upload: `write` returns the
+/// finished [`StagedFile`] whenever a roll happened and leaves the upload policy to the
+/// caller. That is what lets the streaming session keep
+/// [`TableWriteSession::write_batch`] synchronous (it defers uploads to `finish`) while
+/// the buffered path uploads eagerly to bound local disk use.
 #[derive(Debug)]
-struct PartitionSink {
-    spec: crate::partition::PartitionWriteSpec,
-    key_names: Vec<String>,
-    /// Object-store key prefix of the table directory; Hive subpaths hang off it.
+struct RollingFileWriter {
     table_key: String,
-    /// Field-id-tagged schema every written batch carries.
+    rel_prefix: Option<String>,
     schema_with_ids: SchemaRef,
-    column_ids: Vec<i64>,
+    /// Number of catalog data columns, for NaN-flag accumulation.
+    data_column_count: usize,
     props: WriterProperties,
     target_file_size: usize,
-    max_open: usize,
-    /// Open writers, oldest first (eviction takes from the front).
-    open: Vec<OpenPartitionFile>,
-    /// Finalized files awaiting upload at `finish`.
-    staged: Vec<StagedPartitionFile>,
+    open: Option<OpenFile>,
 }
 
-impl PartitionSink {
-    /// Split `batch` by partition and write each group to that partition's open
-    /// file, opening and rolling files as needed.
-    fn write_batch(&mut self, batch: &RecordBatch) -> Result<()> {
-        // Group by the transformed partition key. The group batches are built with
-        // the field-id-tagged schema, so they are ready to write as-is.
-        let groups = crate::partition::split_batches_by_partition(
-            &self.schema_with_ids,
-            std::slice::from_ref(batch),
-            &self.spec,
-        )?;
-        for (values, batches) in groups {
-            for group_batch in batches {
-                if group_batch.num_rows() == 0 {
-                    continue;
-                }
-                self.write_group_batch(&values, &group_batch)?;
-            }
+impl RollingFileWriter {
+    fn new(
+        table_key: String,
+        rel_prefix: Option<String>,
+        schema_with_ids: SchemaRef,
+        data_column_count: usize,
+        props: WriterProperties,
+        target_file_size: usize,
+    ) -> Self {
+        Self {
+            table_key,
+            rel_prefix,
+            schema_with_ids,
+            data_column_count,
+            props,
+            target_file_size,
+            open: None,
         }
-        Ok(())
     }
 
-    /// Append one partition's rows to that partition's open file (opening it, and
-    /// evicting another partition's file if at the cap), then roll the file over if
-    /// it has reached the target size.
-    fn write_group_batch(&mut self, values: &[Option<String>], batch: &RecordBatch) -> Result<()> {
-        let index = match self.open.iter().position(|f| f.values == values) {
-            Some(index) => index,
-            None => {
-                if self.open.len() >= self.max_open {
-                    // Evict the least-recently-opened file: finalize it locally so
-                    // it is complete on disk, and upload it at finish.
-                    let evicted = self.open.remove(0);
-                    let staged = finalize_open_file(evicted)?;
-                    self.staged.push(staged);
-                }
-                self.open.push(self.open_file(values.to_vec())?);
-                self.open.len() - 1
-            },
-        };
-
-        let file = &mut self.open[index];
+    /// Append `batch`, opening a file if none is in progress. Returns the finished
+    /// [`StagedFile`] when this batch pushed the current file to `target_file_size`
+    /// (rollover is evaluated at batch boundaries, so a file always holds a whole
+    /// number of batches and any input ordering is preserved *across* files).
+    ///
+    /// `batch` must carry the table's data columns positionally; the field-id-tagged
+    /// schema is re-imposed here.
+    fn write(&mut self, batch: &RecordBatch) -> Result<Option<StagedFile>> {
+        if batch.num_rows() == 0 {
+            return Ok(None);
+        }
+        if self.open.is_none() {
+            self.open = Some(self.open_file()?);
+        }
+        let batch_with_ids =
+            RecordBatch::try_new(self.schema_with_ids.clone(), batch.columns().to_vec())?;
+        let open = self.open.as_mut().expect("file opened above");
         crate::stats_collect::accumulate_nan_flags(
-            &mut file.nan_flags,
-            batch,
-            self.column_ids.len(),
+            &mut open.nan_flags,
+            &batch_with_ids,
+            self.data_column_count,
         );
-        file.writer.write(batch)?;
-        file.row_count += batch.num_rows() as i64;
+        open.writer.write(&batch_with_ids)?;
+        open.row_count += batch.num_rows() as i64;
 
-        // Roll over at the batch boundary once the estimated encoded size
-        // (finished row groups + the in-progress one) reaches the target.
-        if file.writer.bytes_written() + file.writer.in_progress_size() >= self.target_file_size {
-            let rolled = self.open.remove(index);
-            let staged = finalize_open_file(rolled)?;
-            self.staged.push(staged);
+        // Estimated encoded size = finished row groups + the in-progress one.
+        if open.writer.bytes_written() + open.writer.in_progress_size() >= self.target_file_size {
+            return Ok(Some(finalize_open_file(
+                self.open.take().expect("file open"),
+            )?));
         }
-        Ok(())
+        Ok(None)
     }
 
-    /// Open a new staging parquet for `values` under that partition's Hive subpath.
-    fn open_file(&self, values: Vec<Option<String>>) -> Result<OpenPartitionFile> {
-        let rel = crate::partition::hive_subpath(&self.key_names, &values);
+    /// Finish the trailing (or only) file, if any rows were written.
+    fn finish(&mut self) -> Result<Option<StagedFile>> {
+        match self.open.take() {
+            Some(open) => Ok(Some(finalize_open_file(open)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Whether a file is currently in progress (any rows written since the last roll).
+    fn has_open_file(&self) -> bool {
+        self.open.is_some()
+    }
+
+    fn open_file(&self) -> Result<OpenFile> {
         let file_name = format!("{}.parquet", Uuid::new_v4());
-        let catalog_path = if rel.is_empty() {
-            file_name
-        } else {
-            format!("{rel}/{file_name}")
+        let catalog_path = match self.rel_prefix.as_deref() {
+            Some(prefix) if !prefix.is_empty() => format!("{prefix}/{file_name}"),
+            _ => file_name,
         };
         let object_path_str = join_paths(&self.table_key, &catalog_path)?;
         let object_path = ObjectPath::from(object_path_str.trim_start_matches('/'));
@@ -1392,8 +1280,7 @@ impl PartitionSink {
             self.schema_with_ids.clone(),
             Some(self.props.clone()),
         )?;
-        Ok(OpenPartitionFile {
-            values,
+        Ok(OpenFile {
             writer,
             temp,
             catalog_path,
@@ -1402,45 +1289,18 @@ impl PartitionSink {
             nan_flags: Vec::new(),
         })
     }
-
-    /// Finalize every open file and upload all staged files, returning the
-    /// [`DataFileInfo`]s to commit — each stamped with its partition.
-    async fn into_file_infos(
-        mut self,
-        object_store: &Arc<dyn ObjectStore>,
-    ) -> Result<Vec<DataFileInfo>> {
-        for file in std::mem::take(&mut self.open) {
-            self.staged.push(finalize_open_file(file)?);
-        }
-        let mut infos = Vec::with_capacity(self.staged.len());
-        for staged in std::mem::take(&mut self.staged) {
-            let partition_values: Vec<(i32, Option<String>)> = staged
-                .values
-                .iter()
-                .enumerate()
-                .map(|(i, v)| (i as i32, v.clone()))
-                .collect();
-            let info = upload_staged_file(staged, object_store, &self.column_ids).await?;
-            infos.push(info.with_partition(self.spec.partition_id, partition_values));
-        }
-        Ok(infos)
-    }
 }
 
-/// Write the parquet footer of an open file and flush its staging file to disk,
-/// leaving it ready to upload. Synchronous, so the streaming write path needs no
-/// await.
-fn finalize_open_file(file: OpenPartitionFile) -> Result<StagedPartitionFile> {
+/// Write the parquet footer and flush the staging file to disk, releasing its
+/// descriptor. Synchronous, so a streaming write needs no await to roll a file.
+fn finalize_open_file(file: OpenFile) -> Result<StagedFile> {
     let staged = file.writer.into_inner()?;
     // `into_inner` flushes the buffered footer bytes to the OS file; dropping the
-    // returned handle closes that descriptor. Converting the NamedTempFile to a
-    // TempPath releases its descriptor too, leaving only the on-disk file (still
-    // deleted on drop) so staged files cost no descriptors while they wait.
+    // returned handle closes that descriptor.
     staged
         .into_inner()
         .map_err(|e| crate::error::DuckLakeError::Io(e.into_error()))?;
-    Ok(StagedPartitionFile {
-        values: file.values,
+    Ok(StagedFile {
         temp: file.temp.into_temp_path(),
         catalog_path: file.catalog_path,
         object_path: file.object_path,
@@ -1449,10 +1309,11 @@ fn finalize_open_file(file: OpenPartitionFile) -> Result<StagedPartitionFile> {
     })
 }
 
-/// Upload a finalized staging file and harvest its stats, returning the
-/// [`DataFileInfo`] to register (relative path; the caller stamps the partition).
+/// Upload a finished staging file and harvest its per-column stats, returning the
+/// [`DataFileInfo`] for the catalog commit (relative path; the caller stamps any
+/// partition). On failure the multipart upload is aborted so no partial object is left.
 async fn upload_staged_file(
-    staged: StagedPartitionFile,
+    staged: StagedFile,
     object_store: &Arc<dyn ObjectStore>,
     column_ids: &[i64],
 ) -> Result<DataFileInfo> {
@@ -1482,7 +1343,147 @@ async fn upload_staged_file(
     )
 }
 
-/// Streaming write session. Batches stream to a local staging file; the
+/// How a streaming write session handles a partitioned target.
+#[derive(Debug, Clone, Copy)]
+enum StreamPartitionMode {
+    /// Split rows across one file per partition (a [`PartitionSink`]).
+    Split,
+    /// Refuse: this entry point writes to a single file the caller chose (a custom
+    /// path, or a file carrying embedded row lineage), which cannot also satisfy a
+    /// partition spec. Errors with the entry point named, rather than letting the
+    /// commit fail later with a partition-fence conflict that reads as a concurrent
+    /// DDL change.
+    Reject {
+        entry_point: &'static str,
+    },
+}
+
+/// Routes a streaming write's rows into one parquet file per partition.
+///
+/// Mirrors DuckDB's partitioned COPY sink (which is how official DuckLake writes a
+/// partitioned table): keep a writer open per partition seen, roll at
+/// `target_file_size`, and finalize the least-recently-opened one when the number of
+/// open files would exceed `max_open`. All files produced are committed in ONE
+/// snapshot, so a partitioned streaming write is as atomic as an unpartitioned one.
+///
+/// Each partition's file sequence is a [`RollingFileWriter`] — the same rollover
+/// implementation the buffered path uses — so the two cannot drift. This sink differs
+/// only in upload policy: `write_batch` must stay synchronous, so rolled and evicted
+/// files are held as staged files on disk and uploaded together in `finish`.
+#[derive(Debug)]
+struct PartitionSink {
+    spec: crate::partition::PartitionWriteSpec,
+    key_names: Vec<String>,
+    /// Object-store key prefix of the table directory; Hive subpaths hang off it.
+    table_key: String,
+    /// Field-id-tagged schema every written batch carries.
+    schema_with_ids: SchemaRef,
+    column_ids: Vec<i64>,
+    props: WriterProperties,
+    target_file_size: usize,
+    max_open: usize,
+    /// One roller per partition with a file in progress, oldest first (eviction takes
+    /// from the front). Paired with the partition values its files carry.
+    open: Vec<(Vec<Option<String>>, RollingFileWriter)>,
+    /// Finished files awaiting upload at `finish`, with the partition each belongs to.
+    staged: Vec<(Vec<Option<String>>, StagedFile)>,
+}
+
+impl PartitionSink {
+    /// Split `batch` by partition and write each group to that partition's roller.
+    fn write_batch(&mut self, batch: &RecordBatch) -> Result<()> {
+        // The group batches are built with the field-id-tagged schema, so the roller
+        // re-imposing that schema is a no-op rather than a mismatch.
+        let groups = crate::partition::split_batches_by_partition(
+            &self.schema_with_ids,
+            std::slice::from_ref(batch),
+            &self.spec,
+        )?;
+        for (values, batches) in groups {
+            for group_batch in batches {
+                if group_batch.num_rows() == 0 {
+                    continue;
+                }
+                self.write_group_batch(&values, &group_batch)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Append one partition's rows to its roller, opening one (and evicting another
+    /// partition's file if already at `max_open`) when this partition has none.
+    fn write_group_batch(&mut self, values: &[Option<String>], batch: &RecordBatch) -> Result<()> {
+        let index = match self.open.iter().position(|(v, _)| v == values) {
+            Some(index) => index,
+            None => {
+                if self.open.len() >= self.max_open {
+                    // Evict the least-recently-opened partition: finish its file so it
+                    // is complete on disk, and upload it at `finish`. That partition
+                    // simply gets another file if more of its rows arrive.
+                    let (evicted_values, mut evicted) = self.open.remove(0);
+                    if let Some(staged) = evicted.finish()? {
+                        self.staged.push((evicted_values, staged));
+                    }
+                }
+                let rel = crate::partition::hive_subpath(&self.key_names, values);
+                self.open.push((
+                    values.to_vec(),
+                    RollingFileWriter::new(
+                        self.table_key.clone(),
+                        if rel.is_empty() {
+                            None
+                        } else {
+                            Some(rel)
+                        },
+                        self.schema_with_ids.clone(),
+                        self.column_ids.len(),
+                        self.props.clone(),
+                        self.target_file_size,
+                    ),
+                ));
+                self.open.len() - 1
+            },
+        };
+
+        let (partition_values, roller) = &mut self.open[index];
+        if let Some(staged) = roller.write(batch)? {
+            let partition_values = partition_values.clone();
+            self.staged.push((partition_values, staged));
+            // The roller rolled its file; drop it from `open` unless it already has a
+            // fresh one in progress, so the open-file cap counts real open files.
+            if !self.open[index].1.has_open_file() {
+                self.open.remove(index);
+            }
+        }
+        Ok(())
+    }
+
+    /// Finish every open file and upload all staged files, returning the
+    /// [`DataFileInfo`]s to commit — each stamped with its partition.
+    async fn into_file_infos(
+        mut self,
+        object_store: &Arc<dyn ObjectStore>,
+    ) -> Result<Vec<DataFileInfo>> {
+        for (values, mut roller) in std::mem::take(&mut self.open) {
+            if let Some(staged) = roller.finish()? {
+                self.staged.push((values, staged));
+            }
+        }
+        let mut infos = Vec::with_capacity(self.staged.len());
+        for (values, staged) in std::mem::take(&mut self.staged) {
+            let partition_values: Vec<(i32, Option<String>)> = values
+                .iter()
+                .enumerate()
+                .map(|(i, v)| (i as i32, v.clone()))
+                .collect();
+            let info = upload_staged_file(staged, object_store, &self.column_ids).await?;
+            infos.push(info.with_partition(self.spec.partition_id, partition_values));
+        }
+        Ok(infos)
+    }
+}
+
+/// Streaming write session./// Streaming write session. Batches stream to a local staging file; the
 /// finished parquet is uploaded in `finish()`. If the session is dropped
 /// without finishing, the staging file is removed and nothing is uploaded.
 #[derive(Debug)]

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -205,7 +205,7 @@ impl DuckLakeTableWriter {
     /// Begin a streaming write session.
     /// If mode is `WriteMode::Replace`, ends existing files.
     ///
-    /// **Layout-aware**: when the target table is partitioned, the session splits
+    /// **Partition-aware**: when the target table is partitioned, the session splits
     /// each batch by the transformed partition key and keeps one open parquet per
     /// partition (up to
     /// [`max_open_partitions`](Self::with_max_open_partitions), finalizing the
@@ -213,6 +213,20 @@ impl DuckLakeTableWriter {
     /// [`target_file_size`](Self::with_target_file_size). Every file produced is
     /// committed in ONE snapshot by [`TableWriteSession::finish`], so a partitioned
     /// streaming write stays as atomic as an unpartitioned one.
+    ///
+    /// **Sort order is the caller's responsibility here** — rows are written in
+    /// arrival order. Unlike [`Self::write_rows`], a streaming session cannot apply
+    /// the table's sort order itself: the useful sort is a GLOBAL one (official
+    /// DuckLake achieves it with a blocking `PhysicalOrder` above the insert plan),
+    /// and doing that here would mean buffering the entire write — the very thing
+    /// streaming exists to avoid, and unbounded across
+    /// `max_open_partitions` open files. Sorting only *within* each file would buy
+    /// nothing at the file level either, since a file's min/max is the min/max of its
+    /// rows however they are ordered; only its row-group bounds would tighten.
+    ///
+    /// So to get the file-skipping benefit of a sort order from this path, feed
+    /// batches already in sort order, or use [`Self::write_rows`] when the write fits
+    /// in memory. Writing unsorted costs pruning quality only, never correctness.
     pub fn begin_write(
         &self,
         schema_name: &str,
@@ -813,12 +827,20 @@ impl DuckLakeTableWriter {
     /// [`target_file_size`](Self::with_target_file_size)) and commit them in one
     /// snapshot via [`MetadataWriter::register_data_files`].
     ///
-    /// **Layout-aware**: the table's live partition spec is resolved here, so a
-    /// partitioned target splits `batches` into one Hive directory per partition and
-    /// stamps each file's `partition_id` + values — exactly as SQL `INSERT` does.
-    /// This is what keeps a direct caller (no SQL, no
+    /// **Layout-aware**: the table's live partition AND sort specs are resolved here,
+    /// so a partitioned target splits `batches` into one Hive directory per partition
+    /// with each file's `partition_id` + values stamped, and a sorted target has its
+    /// rows globally sorted before rolling — exactly as SQL `INSERT` does. This is
+    /// what keeps a direct caller (no SQL, no
     /// [`crate::metadata_provider::MetadataProvider`]) from writing files the
-    /// partition fence would reject.
+    /// partition fence would reject, or files whose ranges overlap when the table
+    /// declares a sort order.
+    ///
+    /// The sort is global across `batches`, mirroring official DuckLake's blocking
+    /// `PhysicalOrder` above the insert plan, so successive rolled files cover
+    /// contiguous, non-overlapping ranges. It therefore holds the whole write in
+    /// memory; the streaming [`Self::begin_write`] path cannot do this and leaves sort
+    /// order to the caller.
     ///
     /// The spec is read after the write transaction opens, which is the only view a
     /// caller without a `MetadataProvider` has. A spec change racing the commit is
@@ -896,6 +918,39 @@ impl DuckLakeTableWriter {
         } else {
             None
         };
+
+        // Lay the rows out in the table's sort order before splitting or rolling.
+        // This is a GLOBAL sort over the whole write, matching official DuckLake's
+        // blocking PhysicalOrder above the insert plan — that is what makes successive
+        // rolled files cover contiguous, non-overlapping ranges, so a reader can skip
+        // whole files. Splitting by partition afterwards preserves relative order
+        // within each partition, so every file it produces stays sorted.
+        //
+        // Skipped when the caller already arranged the rows (`!resolve_layout` — the
+        // SQL INSERT path, whose plan carries a SortExec for this same spec).
+        let sorted_owned: Vec<RecordBatch> = if resolve_layout {
+            let lengths: Vec<usize> = batches.iter().map(|b| b.num_rows()).collect();
+            let sorted = crate::sort::sort_batches_by_spec(
+                batches.to_vec(),
+                arrow_schema,
+                self.metadata.live_sort_spec(setup.table_id)?.as_ref(),
+            )?;
+            // The sort concatenates into ONE batch. Rollover is evaluated at batch
+            // boundaries, so handing that single batch onward would emit one file of
+            // unbounded size no matter how large the write — losing rollover exactly
+            // when a sort order makes it most valuable. Re-slice back into the
+            // caller's batch lengths (order-preserving, zero-copy) so rollover sees
+            // the same boundaries it would have without the sort.
+            reslice_to_lengths(sorted, &lengths)
+        } else {
+            Vec::new()
+        };
+        let batches: &[RecordBatch] = if resolve_layout {
+            &sorted_owned
+        } else {
+            batches
+        };
+
         let file_infos = match partition.as_ref() {
             Some(spec) => {
                 let output_schema: SchemaRef = Arc::new(arrow_schema.clone());
@@ -1153,6 +1208,32 @@ async fn finalize_and_upload_file(
     Ok(DataFileInfo::new(catalog_path, file_size, row_count)
         .with_footer_size(footer_size)
         .with_column_stats(column_stats))
+}
+
+/// Split `batches` back into slices of `lengths` rows, in order.
+///
+/// A global sort returns one concatenated batch; rollover and partition splitting
+/// both work per batch, so the single batch is re-sliced to the caller's original
+/// boundaries. `RecordBatch::slice` is a zero-copy view, so this costs no data
+/// movement. Returns the input untouched when it already matches `lengths` (no sort
+/// was applied) or when the totals disagree, so a mismatch degrades to "write what we
+/// have" rather than dropping or duplicating rows.
+fn reslice_to_lengths(batches: Vec<RecordBatch>, lengths: &[usize]) -> Vec<RecordBatch> {
+    let total: usize = lengths.iter().sum();
+    if batches.len() != 1 || batches[0].num_rows() != total || lengths.len() <= 1 {
+        return batches;
+    }
+    let combined = &batches[0];
+    let mut out = Vec::with_capacity(lengths.len());
+    let mut offset = 0usize;
+    for len in lengths {
+        if *len == 0 {
+            continue;
+        }
+        out.push(combined.slice(offset, *len));
+        offset += *len;
+    }
+    out
 }
 
 /// How a streaming write session handles a partitioned target.

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -28,6 +28,15 @@ use crate::table::delete_file_schema;
 // The partition-group shape is shared with the split logic in `partition`.
 pub use crate::partition::PartitionGroup;
 
+/// Default cap on parquet files a partitioned streaming write keeps open at once,
+/// matching DuckDB's `partition_write_max_open_files`. A streaming write cannot
+/// know how many partitions its rows will touch, so it holds one open writer per
+/// partition seen and, on reaching this cap, finalizes the least-recently-opened
+/// file to make room (that partition simply gets another file if more of its rows
+/// arrive). Without a cap, a high-cardinality partition key would exhaust file
+/// descriptors and memory.
+pub const DEFAULT_MAX_OPEN_PARTITIONS: usize = 100;
+
 /// Default target data file size: 512 MiB, matching official DuckLake's
 /// `target_file_size` default (`1 << 29`). A write rolls over to a new file once
 /// it reaches this size, so no single write can produce a file too large for
@@ -50,6 +59,9 @@ pub struct DuckLakeWriteOptions {
     /// Target data file size for rollover (approx encoded bytes); `None` leaves
     /// the writer default ([`DEFAULT_TARGET_FILE_SIZE`]).
     pub target_file_size: Option<usize>,
+    /// Max parquet files a partitioned streaming write keeps open at once; `None`
+    /// leaves the writer default ([`DEFAULT_MAX_OPEN_PARTITIONS`]).
+    pub max_open_partitions: Option<usize>,
 }
 
 /// High-level writer for DuckLake tables.
@@ -79,6 +91,10 @@ pub struct DuckLakeTableWriter {
     /// to [`DEFAULT_TARGET_FILE_SIZE`] (matching official DuckLake); override via
     /// [`DuckLakeTableWriter::with_target_file_size`].
     target_file_size: usize,
+    /// Max parquet files a partitioned streaming write keeps open concurrently.
+    /// Defaults to [`DEFAULT_MAX_OPEN_PARTITIONS`]; override via
+    /// [`DuckLakeTableWriter::with_max_open_partitions`].
+    max_open_partitions: usize,
 }
 
 impl DuckLakeTableWriter {
@@ -97,6 +113,7 @@ impl DuckLakeTableWriter {
             max_row_group_rows: None,
             max_row_group_bytes: None,
             target_file_size: DEFAULT_TARGET_FILE_SIZE,
+            max_open_partitions: DEFAULT_MAX_OPEN_PARTITIONS,
         })
     }
 
@@ -141,8 +158,16 @@ impl DuckLakeTableWriter {
         self.target_file_size
     }
 
+    /// Cap the number of parquet files a partitioned streaming write keeps open at
+    /// once. Defaults to [`DEFAULT_MAX_OPEN_PARTITIONS`]. Clamped to at least 1.
+    pub fn with_max_open_partitions(mut self, files: usize) -> Self {
+        self.max_open_partitions = files.max(1);
+        self
+    }
+
     /// Apply a [`DuckLakeWriteOptions`] set (compression, row-group caps, rollover
-    /// target). Each field overrides the corresponding setting only when present.
+    /// target, open-partition cap). Each field overrides the corresponding setting
+    /// only when present.
     pub fn with_options(mut self, options: &DuckLakeWriteOptions) -> Self {
         if let Some(compression) = options.compression {
             self.compression = compression;
@@ -155,6 +180,9 @@ impl DuckLakeTableWriter {
         }
         if let Some(bytes) = options.target_file_size {
             self.target_file_size = bytes;
+        }
+        if let Some(files) = options.max_open_partitions {
+            self.max_open_partitions = files.max(1);
         }
         self
     }
@@ -176,6 +204,15 @@ impl DuckLakeTableWriter {
 
     /// Begin a streaming write session.
     /// If mode is `WriteMode::Replace`, ends existing files.
+    ///
+    /// **Layout-aware**: when the target table is partitioned, the session splits
+    /// each batch by the transformed partition key and keeps one open parquet per
+    /// partition (up to
+    /// [`max_open_partitions`](Self::with_max_open_partitions), finalizing the
+    /// least-recently-opened file beyond that), rolling each over at
+    /// [`target_file_size`](Self::with_target_file_size). Every file produced is
+    /// committed in ONE snapshot by [`TableWriteSession::finish`], so a partitioned
+    /// streaming write stays as atomic as an unpartitioned one.
     pub fn begin_write(
         &self,
         schema_name: &str,
@@ -206,6 +243,7 @@ impl DuckLakeTableWriter {
             true,
             false,
             mode,
+            StreamPartitionMode::Split,
         )
     }
 
@@ -248,6 +286,9 @@ impl DuckLakeTableWriter {
             true,
             true,
             mode,
+            StreamPartitionMode::Reject {
+                entry_point: "begin_write_with_embedded_rowid",
+            },
         )
     }
 
@@ -272,6 +313,9 @@ impl DuckLakeTableWriter {
             false,
             false,
             mode,
+            StreamPartitionMode::Reject {
+                entry_point: "begin_write_to_path",
+            },
         )
     }
 
@@ -287,6 +331,7 @@ impl DuckLakeTableWriter {
         path_is_relative: bool,
         embed_rowid: bool,
         mode: WriteMode,
+        partition_mode: StreamPartitionMode,
     ) -> Result<TableWriteSession> {
         let columns = arrow_schema_to_column_defs(arrow_schema)?;
         let setup =
@@ -334,6 +379,46 @@ impl DuckLakeTableWriter {
         let staging = std::io::BufWriter::new(temp.reopen()?);
         let writer = ArrowWriter::try_new(staging, schema_with_ids.clone(), Some(props))?;
 
+        // A partitioned target routes rows through a per-partition sink. The
+        // single-file writer above is still created: with zero rows the sink
+        // produces no file, and a Replace then needs that 0-row marker to retire the
+        // prior generation.
+        let partition_sink =
+            match self.resolve_partition(setup.table_id, &setup.column_ids, arrow_schema)? {
+                None => None,
+                Some(spec) => match partition_mode {
+                    StreamPartitionMode::Reject {
+                        entry_point,
+                    } => {
+                        return Err(crate::error::DuckLakeError::Unsupported(format!(
+                            "{entry_point} does not support a partitioned table: it writes to one \
+                         caller-determined file, but the table's partition spec requires rows \
+                         to be split across one file per partition"
+                        )));
+                    },
+                    StreamPartitionMode::Split => {
+                        let scoped_base = match self.metadata.catalog_id() {
+                            Some(id) => join_paths(&self.base_key_path, &format!("cat_{id}"))?,
+                            None => self.base_key_path.clone(),
+                        };
+                        let table_key =
+                            join_paths(&join_paths(&scoped_base, schema_name)?, table_name)?;
+                        Some(PartitionSink {
+                            key_names: spec.key_names(),
+                            spec,
+                            table_key,
+                            schema_with_ids: schema_with_ids.clone(),
+                            column_ids: setup.column_ids.clone(),
+                            props: self.build_writer_props(),
+                            target_file_size: self.target_file_size,
+                            max_open: self.max_open_partitions,
+                            open: Vec::new(),
+                            staged: Vec::new(),
+                        })
+                    },
+                },
+            };
+
         Ok(TableWriteSession {
             metadata: Arc::clone(&self.metadata),
             object_store: Arc::clone(&self.object_store),
@@ -353,6 +438,7 @@ impl DuckLakeTableWriter {
             mode,
             row_count: 0,
             nan_flags: Vec::new(),
+            partition_sink,
         })
     }
 
@@ -1001,6 +1087,240 @@ async fn finalize_and_upload_file(
         .with_column_stats(column_stats))
 }
 
+/// How a streaming write session handles a partitioned target.
+#[derive(Debug, Clone, Copy)]
+enum StreamPartitionMode {
+    /// Split rows across one file per partition (a [`PartitionSink`]).
+    Split,
+    /// Refuse: this entry point writes to a single file the caller chose (a custom
+    /// path, or a file carrying embedded row lineage), which cannot also satisfy a
+    /// partition spec. Errors with the entry point named, rather than letting the
+    /// commit fail later with a partition-fence conflict that reads as a concurrent
+    /// DDL change.
+    Reject {
+        entry_point: &'static str,
+    },
+}
+
+/// One parquet file a [`PartitionSink`] is currently writing rows into.
+#[derive(Debug)]
+struct OpenPartitionFile {
+    /// The partition values every row in this file shares, in key order.
+    values: Vec<Option<String>>,
+    writer: ArrowWriter<std::io::BufWriter<std::fs::File>>,
+    temp: NamedTempFile,
+    /// Path relative to the table directory (includes the Hive subpath).
+    catalog_path: String,
+    object_path: ObjectPath,
+    row_count: i64,
+    nan_flags: Vec<Option<bool>>,
+}
+
+/// A parquet file whose footer is written and whose staging file is complete, but
+/// which has not been uploaded yet.
+///
+/// A streaming session finalizes files as it goes (on rollover, or when evicting to
+/// respect the open-file cap) but uploads them all in `finish`. Finalizing is
+/// synchronous, which is what lets [`TableWriteSession::write_batch`] stay
+/// synchronous; uploading is async and belongs to the one `finish` await point.
+#[derive(Debug)]
+struct StagedPartitionFile {
+    values: Vec<Option<String>>,
+    temp: NamedTempFile,
+    catalog_path: String,
+    object_path: ObjectPath,
+    row_count: i64,
+    nan_flags: Vec<Option<bool>>,
+}
+
+/// Routes a streaming write's rows into one parquet file per partition.
+///
+/// Mirrors DuckDB's partitioned COPY sink (which is how official DuckLake writes a
+/// partitioned table): keep a writer open per partition seen, roll a file over at
+/// `target_file_size`, and finalize the least-recently-opened file when the number
+/// of open files would exceed `max_open`. All files produced are committed in ONE
+/// snapshot, so a partitioned streaming write is as atomic as an unpartitioned one.
+#[derive(Debug)]
+struct PartitionSink {
+    spec: crate::partition::PartitionWriteSpec,
+    key_names: Vec<String>,
+    /// Object-store key prefix of the table directory; Hive subpaths hang off it.
+    table_key: String,
+    /// Field-id-tagged schema every written batch carries.
+    schema_with_ids: SchemaRef,
+    column_ids: Vec<i64>,
+    props: WriterProperties,
+    target_file_size: usize,
+    max_open: usize,
+    /// Open writers, oldest first (eviction takes from the front).
+    open: Vec<OpenPartitionFile>,
+    /// Finalized files awaiting upload at `finish`.
+    staged: Vec<StagedPartitionFile>,
+}
+
+impl PartitionSink {
+    /// Split `batch` by partition and write each group to that partition's open
+    /// file, opening and rolling files as needed.
+    fn write_batch(&mut self, batch: &RecordBatch) -> Result<()> {
+        // Group by the transformed partition key. The group batches are built with
+        // the field-id-tagged schema, so they are ready to write as-is.
+        let groups = crate::partition::split_batches_by_partition(
+            &self.schema_with_ids,
+            std::slice::from_ref(batch),
+            &self.spec,
+        )?;
+        for (values, batches) in groups {
+            for group_batch in batches {
+                if group_batch.num_rows() == 0 {
+                    continue;
+                }
+                self.write_group_batch(&values, &group_batch)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Append one partition's rows to that partition's open file (opening it, and
+    /// evicting another partition's file if at the cap), then roll the file over if
+    /// it has reached the target size.
+    fn write_group_batch(&mut self, values: &[Option<String>], batch: &RecordBatch) -> Result<()> {
+        let index = match self.open.iter().position(|f| f.values == values) {
+            Some(index) => index,
+            None => {
+                if self.open.len() >= self.max_open {
+                    // Evict the least-recently-opened file: finalize it locally so
+                    // it is complete on disk, and upload it at finish.
+                    let evicted = self.open.remove(0);
+                    let staged = finalize_open_file(evicted)?;
+                    self.staged.push(staged);
+                }
+                self.open.push(self.open_file(values.to_vec())?);
+                self.open.len() - 1
+            },
+        };
+
+        let file = &mut self.open[index];
+        crate::stats_collect::accumulate_nan_flags(
+            &mut file.nan_flags,
+            batch,
+            self.column_ids.len(),
+        );
+        file.writer.write(batch)?;
+        file.row_count += batch.num_rows() as i64;
+
+        // Roll over at the batch boundary once the estimated encoded size
+        // (finished row groups + the in-progress one) reaches the target.
+        if file.writer.bytes_written() + file.writer.in_progress_size() >= self.target_file_size {
+            let rolled = self.open.remove(index);
+            let staged = finalize_open_file(rolled)?;
+            self.staged.push(staged);
+        }
+        Ok(())
+    }
+
+    /// Open a new staging parquet for `values` under that partition's Hive subpath.
+    fn open_file(&self, values: Vec<Option<String>>) -> Result<OpenPartitionFile> {
+        let rel = crate::partition::hive_subpath(&self.key_names, &values);
+        let file_name = format!("{}.parquet", Uuid::new_v4());
+        let catalog_path = if rel.is_empty() {
+            file_name
+        } else {
+            format!("{rel}/{file_name}")
+        };
+        let object_path_str = join_paths(&self.table_key, &catalog_path)?;
+        let object_path = ObjectPath::from(object_path_str.trim_start_matches('/'));
+        let temp = NamedTempFile::new()?;
+        let staging = std::io::BufWriter::new(temp.reopen()?);
+        let writer = ArrowWriter::try_new(
+            staging,
+            self.schema_with_ids.clone(),
+            Some(self.props.clone()),
+        )?;
+        Ok(OpenPartitionFile {
+            values,
+            writer,
+            temp,
+            catalog_path,
+            object_path,
+            row_count: 0,
+            nan_flags: Vec::new(),
+        })
+    }
+
+    /// Finalize every open file and upload all staged files, returning the
+    /// [`DataFileInfo`]s to commit — each stamped with its partition.
+    async fn into_file_infos(
+        mut self,
+        object_store: &Arc<dyn ObjectStore>,
+    ) -> Result<Vec<DataFileInfo>> {
+        for file in std::mem::take(&mut self.open) {
+            self.staged.push(finalize_open_file(file)?);
+        }
+        let mut infos = Vec::with_capacity(self.staged.len());
+        for staged in std::mem::take(&mut self.staged) {
+            let partition_values: Vec<(i32, Option<String>)> = staged
+                .values
+                .iter()
+                .enumerate()
+                .map(|(i, v)| (i as i32, v.clone()))
+                .collect();
+            let info = upload_staged_file(staged, object_store, &self.column_ids).await?;
+            infos.push(info.with_partition(self.spec.partition_id, partition_values));
+        }
+        Ok(infos)
+    }
+}
+
+/// Write the parquet footer of an open file and flush its staging file to disk,
+/// leaving it ready to upload. Synchronous, so the streaming write path needs no
+/// await.
+fn finalize_open_file(file: OpenPartitionFile) -> Result<StagedPartitionFile> {
+    let staged = file.writer.into_inner()?;
+    staged
+        .into_inner()
+        .map_err(|e| crate::error::DuckLakeError::Io(e.into_error()))?;
+    Ok(StagedPartitionFile {
+        values: file.values,
+        temp: file.temp,
+        catalog_path: file.catalog_path,
+        object_path: file.object_path,
+        row_count: file.row_count,
+        nan_flags: file.nan_flags,
+    })
+}
+
+/// Upload a finalized staging file and harvest its stats, returning the
+/// [`DataFileInfo`] to register (relative path; the caller stamps the partition).
+async fn upload_staged_file(
+    staged: StagedPartitionFile,
+    object_store: &Arc<dyn ObjectStore>,
+    column_ids: &[i64],
+) -> Result<DataFileInfo> {
+    let mut file = std::fs::File::open(staged.temp.path())?;
+    let file_size = file.metadata()?.len() as i64;
+    let footer_size = read_footer_size(&mut file)?;
+
+    let local = tokio::fs::File::open(staged.temp.path()).await?;
+    let mut reader = tokio::io::BufReader::new(local);
+    let mut upload = ObjectBufWriter::new(Arc::clone(object_store), staged.object_path.clone());
+    if let Err(e) = stream_to_upload(&mut reader, &mut upload).await {
+        let _ = upload.abort().await;
+        return Err(e.into());
+    }
+
+    let column_stats = crate::stats_collect::collect_column_stats(
+        staged.temp.path(),
+        column_ids,
+        staged.row_count,
+        &staged.nan_flags,
+    );
+    Ok(
+        DataFileInfo::new(&staged.catalog_path, file_size, staged.row_count)
+            .with_footer_size(footer_size)
+            .with_column_stats(column_stats),
+    )
+}
+
 /// Streaming write session. Batches stream to a local staging file; the
 /// finished parquet is uploaded in `finish()`. If the session is dropped
 /// without finishing, the staging file is removed and nothing is uploaded.
@@ -1047,10 +1367,25 @@ pub struct TableWriteSession {
     /// Parquet footer carries no NaN flag). One entry per catalog data column;
     /// `None` for non-float columns. Fed into `collect_column_stats` at finish.
     nan_flags: Vec<Option<bool>>,
+    /// Set when the target table is partitioned: batches are routed here, one file
+    /// per partition, and `writer`/`temp` above stay `None`. `finish` then commits
+    /// every file the sink produced in a single snapshot.
+    partition_sink: Option<PartitionSink>,
 }
 
 impl TableWriteSession {
     pub fn write_batch(&mut self, batch: &RecordBatch) -> Result<()> {
+        if self.partition_sink.is_some() {
+            self.validate_batch_schema(batch)?;
+            let rows = batch.num_rows() as i64;
+            // `is_some` checked above.
+            self.partition_sink
+                .as_mut()
+                .expect("partition sink present")
+                .write_batch(batch)?;
+            self.row_count += rows;
+            return Ok(());
+        }
         if self.writer.is_none() {
             return Err(crate::error::DuckLakeError::Internal(
                 "Writer already closed".to_string(),
@@ -1111,12 +1446,52 @@ impl TableWriteSession {
         self.snapshot_id
     }
 
-    /// Returns the object path that will be written to
+    /// The object path this session writes to.
+    ///
+    /// For a partitioned session there is no single output file (one file per
+    /// partition, plus rollovers), so this returns the table directory the partition
+    /// subpaths hang off.
     pub fn file_path(&self) -> &str {
         self.object_path.as_ref()
     }
 
     pub async fn finish(mut self) -> Result<WriteResult> {
+        // Partitioned: commit every file the sink produced in ONE snapshot, so a
+        // partitioned streaming write is as atomic as an unpartitioned one.
+        if let Some(sink) = self.partition_sink.take() {
+            let file_infos = sink.into_file_infos(&self.object_store).await?;
+            if file_infos.is_empty() {
+                // No rows reached any partition. Fall through to the single-file
+                // path, which registers the 0-row marker that carries a Replace
+                // truncation (and is exempt from the partition fence).
+                return self.finish_single_file().await;
+            }
+            let records_written: i64 = file_infos.iter().map(|f| f.record_count).sum();
+            let committed = self.metadata.register_data_files(
+                self.table_id,
+                &self.schema_name,
+                &self.table_name,
+                self.snapshot_id,
+                &file_infos,
+                self.mode,
+                self.base_snapshot_id,
+                &self.columns,
+                &self.column_ids,
+            )?;
+            return Ok(WriteResult {
+                snapshot_id: committed.snapshot_id,
+                table_id: committed.table_id,
+                schema_id: committed.schema_id,
+                files_written: file_infos.len(),
+                records_written,
+            });
+        }
+        self.finish_single_file().await
+    }
+
+    /// Commit this session's single staged file (the unpartitioned path, and the
+    /// 0-row truncate marker of a partitioned Replace).
+    async fn finish_single_file(mut self) -> Result<WriteResult> {
         let file_info = self.upload_staged().await?;
         // register_data_file returns the ids actually committed (snapshot id
         // assigned at commit; real schema/table ids, which may differ from the
@@ -1152,6 +1527,14 @@ impl TableWriteSession {
         // Reject an unsupported combination before uploading the staged parquet,
         // so a misuse leaves no orphan object in storage.
         validate_delete_entries(self.mode, deletes)?;
+        if self.partition_sink.is_some() {
+            return Err(crate::error::DuckLakeError::Unsupported(
+                "an update/upsert on a partitioned table is not supported yet: the new row \
+                 versions span one file per partition, and the atomic append+delete commit \
+                 currently registers a single data file"
+                    .to_string(),
+            ));
+        }
         let file_info = self.upload_staged().await?;
         let committed = self.metadata.register_data_file_with_deletes(
             self.table_id,

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -826,7 +826,7 @@ impl DuckLakeTableWriter {
     ///
     /// Callers that DID make a layout decision earlier (the SQL `INSERT` path, which
     /// resolves the spec at plan time and pre-splits) must use
-    /// [`Self::write_rows_unpartitioned_as_planned`] instead, so a spec that went
+    /// `write_rows_unpartitioned_as_planned` instead, so a spec that went
     /// live in between surfaces as a conflict rather than being silently applied to a
     /// write planned without it.
     ///
@@ -866,7 +866,7 @@ impl DuckLakeTableWriter {
     }
 
     /// Shared body of [`Self::write_rows`] and
-    /// [`Self::write_rows_unpartitioned_as_planned`]. `resolve_layout` selects
+    /// `write_rows_unpartitioned_as_planned`. `resolve_layout` selects
     /// whether the table's live partition spec drives the layout, or the caller's
     /// earlier "unpartitioned" determination stands (and the fence adjudicates).
     async fn write_rows_inner(

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -25,10 +25,8 @@ use crate::path_resolver::join_paths;
 use crate::row_id::{embedded_rowid_field, embedded_snapshot_id_field};
 use crate::table::delete_file_schema;
 
-/// One partition group for a partitioned write: the per-key partition values
-/// every row in the group shares (`values[i]` for partition key `i`, `None` ==
-/// SQL NULL), and the row batches for that partition.
-pub type PartitionGroup = (Vec<Option<String>>, Vec<RecordBatch>);
+// The partition-group shape is shared with the split logic in `partition`.
+pub use crate::partition::PartitionGroup;
 
 /// Default target data file size: 512 MiB, matching official DuckLake's
 /// `target_file_size` default (`1 << 29`). A write rolls over to a new file once
@@ -499,6 +497,7 @@ impl DuckLakeTableWriter {
     /// and — when `embed_snapshot_id` — a further trailing `Int64` snapshot-id
     /// column. Streams to a local staging file and multipart-uploads it, so peak
     /// memory stays bounded regardless of file size.
+    #[allow(clippy::too_many_arguments)]
     pub async fn write_compacted_file(
         &self,
         schema_name: &str,
@@ -507,13 +506,22 @@ impl DuckLakeTableWriter {
         data_column_ids: &[i64],
         batches: &[RecordBatch],
         embed_snapshot_id: bool,
+        partition_subpath: Option<&str>,
     ) -> Result<DataFileInfo> {
         let scoped_base = match self.metadata.catalog_id() {
             Some(id) => join_paths(&self.base_key_path, &format!("cat_{id}"))?,
             None => self.base_key_path.clone(),
         };
         let table_key = join_paths(&join_paths(&scoped_base, schema_name)?, table_name)?;
-        let file_name = format!("{}.parquet", Uuid::new_v4());
+        // A compacted file of a partitioned table lands in its partition's Hive
+        // directory, like every other write of that partition; the returned
+        // `DataFileInfo.path` is relative to the table dir either way.
+        let file_name = match partition_subpath {
+            Some(prefix) if !prefix.is_empty() => {
+                format!("{prefix}/{}.parquet", Uuid::new_v4())
+            },
+            _ => format!("{}.parquet", Uuid::new_v4()),
+        };
         let object_path_str = join_paths(&table_key, &file_name)?;
         let object_path = ObjectPath::from(object_path_str.trim_start_matches('/'));
 
@@ -642,22 +650,9 @@ impl DuckLakeTableWriter {
         let mut file_infos: Vec<DataFileInfo> = Vec::with_capacity(groups.len());
         let mut records_written: i64 = 0;
         for (values, batches) in &groups {
-            // Readable Hive-style relative subpath (catalog is authoritative, so
-            // the encoded value is sanitized for the filesystem without affecting
-            // correctness). Files land under the table dir, registered relative.
-            let mut rel = String::new();
-            for (i, value) in values.iter().enumerate() {
-                let name = key_names.get(i).map(String::as_str).unwrap_or("key");
-                let encoded = match value {
-                    Some(v) => sanitize_partition_path(v),
-                    None => "__HIVE_DEFAULT_PARTITION__".to_string(),
-                };
-                rel = if rel.is_empty() {
-                    format!("{name}={encoded}")
-                } else {
-                    format!("{rel}/{name}={encoded}")
-                };
-            }
+            // Readable Hive-style relative subpath; files land under the table dir
+            // and are registered relative to it.
+            let rel = crate::partition::hive_subpath(key_names, values);
             // A group may roll over into several files (each a contiguous slice of
             // the group's rows); every file shares this group's partition values.
             let rel_prefix = if rel.is_empty() {
@@ -912,24 +907,6 @@ async fn finalize_and_upload_file(
     Ok(DataFileInfo::new(catalog_path, file_size, row_count)
         .with_footer_size(footer_size)
         .with_column_stats(column_stats))
-}
-
-/// Sanitize a partition value for use in a Hive-style directory name. The catalog
-/// (`ducklake_file_partition_value`) is the authoritative source for pruning, so
-/// this only needs to yield a stable, filesystem-safe segment; collisions between
-/// distinct values are harmless (files carry distinct UUID names and distinct
-/// catalog values).
-fn sanitize_partition_path(value: &str) -> String {
-    value
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | ':') {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect()
 }
 
 /// Streaming write session. Batches stream to a local staging file; the

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -357,35 +357,47 @@ impl DuckLakeTableWriter {
     }
 
     /// Write batches to a table, replacing any existing data.
+    ///
+    /// Goes through [`Self::write_rows`], so a partitioned target is split into one
+    /// file per partition and large inputs roll over by
+    /// [`target_file_size`](Self::with_target_file_size).
     pub async fn write_table(
         &self,
         schema_name: &str,
         table_name: &str,
         batches: &[RecordBatch],
     ) -> Result<WriteResult> {
-        if batches.is_empty() {
-            return Err(crate::error::DuckLakeError::InvalidConfig(
-                "No batches to write".to_string(),
-            ));
-        }
-
-        let arrow_schema = batches[0].schema();
-        let mut session =
-            self.begin_write(schema_name, table_name, &arrow_schema, WriteMode::Replace)?;
-
-        for batch in batches {
-            session.write_batch(batch)?;
-        }
-
-        session.finish().await
+        self.write_all(schema_name, table_name, batches, WriteMode::Replace)
+            .await
     }
 
     /// Write batches to a table, appending to existing data.
+    ///
+    /// Goes through [`Self::write_rows`], so a partitioned target is split into one
+    /// file per partition and large inputs roll over by
+    /// [`target_file_size`](Self::with_target_file_size).
     pub async fn append_table(
         &self,
         schema_name: &str,
         table_name: &str,
         batches: &[RecordBatch],
+    ) -> Result<WriteResult> {
+        self.write_all(schema_name, table_name, batches, WriteMode::Append)
+            .await
+    }
+
+    /// Shared body of [`Self::write_table`] / [`Self::append_table`].
+    ///
+    /// A row-bearing input goes through the layout-aware [`Self::write_rows`]. An
+    /// input of only empty batches keeps the single-file session path: `write_rows`
+    /// produces no file at all, which for `Replace` would skip the truncation of the
+    /// prior generation, whereas the session registers the 0-row file that carries it.
+    async fn write_all(
+        &self,
+        schema_name: &str,
+        table_name: &str,
+        batches: &[RecordBatch],
+        mode: WriteMode,
     ) -> Result<WriteResult> {
         if batches.is_empty() {
             return Err(crate::error::DuckLakeError::InvalidConfig(
@@ -394,13 +406,17 @@ impl DuckLakeTableWriter {
         }
 
         let arrow_schema = batches[0].schema();
-        let mut session =
-            self.begin_write(schema_name, table_name, &arrow_schema, WriteMode::Append)?;
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        if total_rows > 0 {
+            return self
+                .write_rows(schema_name, table_name, &arrow_schema, mode, batches)
+                .await;
+        }
 
+        let mut session = self.begin_write(schema_name, table_name, &arrow_schema, mode)?;
         for batch in batches {
             session.write_batch(batch)?;
         }
-
         session.finish().await
     }
 
@@ -647,39 +663,17 @@ impl DuckLakeTableWriter {
         };
         let table_key = join_paths(&join_paths(&scoped_base, schema_name)?, table_name)?;
 
-        let mut file_infos: Vec<DataFileInfo> = Vec::with_capacity(groups.len());
-        let mut records_written: i64 = 0;
-        for (values, batches) in &groups {
-            // Readable Hive-style relative subpath; files land under the table dir
-            // and are registered relative to it.
-            let rel = crate::partition::hive_subpath(key_names, values);
-            // A group may roll over into several files (each a contiguous slice of
-            // the group's rows); every file shares this group's partition values.
-            let rel_prefix = if rel.is_empty() {
-                None
-            } else {
-                Some(rel.as_str())
-            };
-            let group_files = self
-                .write_rolled_files(
-                    &table_key,
-                    rel_prefix,
-                    schema_with_ids.clone(),
-                    &setup.column_ids,
-                    batches,
-                )
-                .await?;
-            let partition_values: Vec<(i32, Option<String>)> = values
-                .iter()
-                .enumerate()
-                .map(|(i, v)| (i as i32, v.clone()))
-                .collect();
-            for info in group_files {
-                let info = info.with_partition(partition_id, partition_values.clone());
-                records_written += info.record_count;
-                file_infos.push(info);
-            }
-        }
+        let file_infos = self
+            .write_partition_groups(
+                &table_key,
+                schema_with_ids,
+                &setup.column_ids,
+                partition_id,
+                key_names,
+                &groups,
+            )
+            .await?;
+        let records_written: i64 = file_infos.iter().map(|f| f.record_count).sum();
 
         if file_infos.is_empty() {
             return Err(crate::error::DuckLakeError::InvalidConfig(
@@ -708,12 +702,24 @@ impl DuckLakeTableWriter {
         })
     }
 
-    /// Write `batches` to an unpartitioned table as ONE OR MORE data files
-    /// (rolling over by [`target_file_size`](Self::with_target_file_size)) and
-    /// commit them in one snapshot via [`MetadataWriter::register_data_files`].
-    /// Used by the insert path; `batches` must hold
-    /// at least one row (the caller keeps the single-file session path for empty
-    /// Replace truncation). `arrow_schema` is the table's data columns (no rowid).
+    /// Write `batches` to a table as ONE OR MORE data files (rolling over by
+    /// [`target_file_size`](Self::with_target_file_size)) and commit them in one
+    /// snapshot via [`MetadataWriter::register_data_files`].
+    ///
+    /// **Layout-aware**: the table's live partition spec is resolved here, so a
+    /// partitioned target splits `batches` into one Hive directory per partition and
+    /// stamps each file's `partition_id` + values — exactly as SQL `INSERT` does.
+    /// This is what keeps a direct caller (no SQL, no
+    /// [`crate::metadata_provider::MetadataProvider`]) from writing files the
+    /// partition fence would reject.
+    ///
+    /// The spec is read after the write transaction opens, so it reflects the table
+    /// as of this write rather than as of some earlier planning step; a spec change
+    /// racing the commit is still caught by the fence.
+    ///
+    /// `batches` must hold at least one row (the caller keeps the single-file session
+    /// path for empty Replace truncation). `arrow_schema` is the table's data columns
+    /// (no rowid).
     pub async fn write_rows(
         &self,
         schema_name: &str,
@@ -735,15 +741,33 @@ impl DuckLakeTableWriter {
         };
         let table_key = join_paths(&join_paths(&scoped_base, schema_name)?, table_name)?;
 
-        let file_infos = self
-            .write_rolled_files(
-                &table_key,
-                None,
-                schema_with_ids,
-                &setup.column_ids,
-                batches,
-            )
-            .await?;
+        let partition = self.resolve_partition(setup.table_id, &setup.column_ids, arrow_schema)?;
+        let file_infos = match partition.as_ref() {
+            Some(spec) => {
+                let output_schema: SchemaRef = Arc::new(arrow_schema.clone());
+                let groups =
+                    crate::partition::split_batches_by_partition(&output_schema, batches, spec)?;
+                self.write_partition_groups(
+                    &table_key,
+                    schema_with_ids,
+                    &setup.column_ids,
+                    spec.partition_id,
+                    &spec.key_names(),
+                    &groups,
+                )
+                .await?
+            },
+            None => {
+                self.write_rolled_files(
+                    &table_key,
+                    None,
+                    schema_with_ids,
+                    &setup.column_ids,
+                    batches,
+                )
+                .await?
+            },
+        };
         if file_infos.is_empty() {
             return Err(crate::error::DuckLakeError::InvalidConfig(
                 "write_rows: input produced no rows".to_string(),
@@ -770,6 +794,74 @@ impl DuckLakeTableWriter {
             files_written: file_infos.len(),
             records_written,
         })
+    }
+
+    /// Resolve the table's live partition spec against the columns this write is
+    /// about to produce, or `None` when the table is unpartitioned.
+    ///
+    /// `column_ids[i]` is the catalog id of `arrow_schema` field `i` (the pairing
+    /// `begin_write_transaction` returns). Errors on a spec this crate cannot
+    /// produce (`bucket`/unknown) rather than writing files that violate it.
+    fn resolve_partition(
+        &self,
+        table_id: i64,
+        column_ids: &[i64],
+        arrow_schema: &Schema,
+    ) -> Result<Option<crate::partition::PartitionWriteSpec>> {
+        match self.metadata.live_partition_spec(table_id)? {
+            None => Ok(None),
+            Some(spec) => Ok(Some(crate::partition::PartitionWriteSpec::resolve(
+                &spec,
+                column_ids,
+                arrow_schema,
+            )?)),
+        }
+    }
+
+    /// Write each partition group to its own Hive directory under `table_key`,
+    /// stamping `partition_id` and the group's values on every file produced.
+    ///
+    /// A group may roll over into several files (each a contiguous slice of the
+    /// group's rows); all of them share that group's partition values, so the
+    /// catalog records one partition per file as the spec requires.
+    async fn write_partition_groups(
+        &self,
+        table_key: &str,
+        schema_with_ids: SchemaRef,
+        column_ids: &[i64],
+        partition_id: i64,
+        key_names: &[String],
+        groups: &[PartitionGroup],
+    ) -> Result<Vec<DataFileInfo>> {
+        let mut file_infos: Vec<DataFileInfo> = Vec::with_capacity(groups.len());
+        for (values, batches) in groups {
+            // Readable Hive-style relative subpath; files land under the table dir
+            // and are registered relative to it.
+            let rel = crate::partition::hive_subpath(key_names, values);
+            let rel_prefix = if rel.is_empty() {
+                None
+            } else {
+                Some(rel.as_str())
+            };
+            let group_files = self
+                .write_rolled_files(
+                    table_key,
+                    rel_prefix,
+                    schema_with_ids.clone(),
+                    column_ids,
+                    batches,
+                )
+                .await?;
+            let partition_values: Vec<(i32, Option<String>)> = values
+                .iter()
+                .enumerate()
+                .map(|(i, v)| (i as i32, v.clone()))
+                .collect();
+            for info in group_files {
+                file_infos.push(info.with_partition(partition_id, partition_values.clone()));
+            }
+        }
+        Ok(file_infos)
     }
 
     /// Write `batches` into ONE OR MORE parquet files under `table_key` (data

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -749,6 +749,27 @@ impl DuckLakeTableWriter {
         };
         let table_key = join_paths(&join_paths(&scoped_base, schema_name)?, table_name)?;
 
+        // Validate the caller's assignment against the live spec BEFORE writing
+        // anything, so a bad one costs no uploads. A wrong arity or an unparseable
+        // value would otherwise be persisted and then used as an exact pruning
+        // bound, silently dropping rows from later reads. (Whether each group's rows
+        // really carry its values is the caller's assertion — as in official
+        // DuckLake's add_data_files, that cannot be checked without reading data.)
+        if let Some(spec) =
+            self.resolve_partition(setup.table_id, &setup.column_ids, arrow_schema)?
+        {
+            if spec.partition_id != partition_id {
+                return Err(crate::error::DuckLakeError::Conflict(format!(
+                    "write_partitioned targets partition spec {partition_id} but the table's live \
+                     generation is {}; re-resolve the spec and retry",
+                    spec.partition_id
+                )));
+            }
+            for (values, _) in &groups {
+                spec.validate_values(arrow_schema, values)?;
+            }
+        }
+
         let file_infos = self
             .write_partition_groups(
                 &table_key,
@@ -1123,10 +1144,17 @@ struct OpenPartitionFile {
 /// respect the open-file cap) but uploads them all in `finish`. Finalizing is
 /// synchronous, which is what lets [`TableWriteSession::write_batch`] stay
 /// synchronous; uploading is async and belongs to the one `finish` await point.
+///
+/// Holds a [`TempPath`], not a `NamedTempFile`: the staged file is not touched again
+/// until upload, so keeping its descriptor open would make the session's open-fd
+/// count grow with the TOTAL number of files written rather than staying bounded by
+/// `max_open` — a high-cardinality partition key would exhaust descriptors even
+/// though only `max_open` writers are live. `TempPath` keeps the file on disk (and
+/// still deletes it on drop) with no descriptor held.
 #[derive(Debug)]
 struct StagedPartitionFile {
     values: Vec<Option<String>>,
-    temp: NamedTempFile,
+    temp: tempfile::TempPath,
     catalog_path: String,
     object_path: ObjectPath,
     row_count: i64,
@@ -1276,12 +1304,16 @@ impl PartitionSink {
 /// await.
 fn finalize_open_file(file: OpenPartitionFile) -> Result<StagedPartitionFile> {
     let staged = file.writer.into_inner()?;
+    // `into_inner` flushes the buffered footer bytes to the OS file; dropping the
+    // returned handle closes that descriptor. Converting the NamedTempFile to a
+    // TempPath releases its descriptor too, leaving only the on-disk file (still
+    // deleted on drop) so staged files cost no descriptors while they wait.
     staged
         .into_inner()
         .map_err(|e| crate::error::DuckLakeError::Io(e.into_error()))?;
     Ok(StagedPartitionFile {
         values: file.values,
-        temp: file.temp,
+        temp: file.temp.into_temp_path(),
         catalog_path: file.catalog_path,
         object_path: file.object_path,
         row_count: file.row_count,
@@ -1296,11 +1328,12 @@ async fn upload_staged_file(
     object_store: &Arc<dyn ObjectStore>,
     column_ids: &[i64],
 ) -> Result<DataFileInfo> {
-    let mut file = std::fs::File::open(staged.temp.path())?;
+    // Reopen the staged file (its descriptor was released at finalize time).
+    let mut file = std::fs::File::open(&staged.temp)?;
     let file_size = file.metadata()?.len() as i64;
     let footer_size = read_footer_size(&mut file)?;
 
-    let local = tokio::fs::File::open(staged.temp.path()).await?;
+    let local = tokio::fs::File::open(&staged.temp).await?;
     let mut reader = tokio::io::BufReader::new(local);
     let mut upload = ObjectBufWriter::new(Arc::clone(object_store), staged.object_path.clone());
     if let Err(e) = stream_to_upload(&mut reader, &mut upload).await {
@@ -1309,7 +1342,7 @@ async fn upload_staged_file(
     }
 
     let column_stats = crate::stats_collect::collect_column_stats(
-        staged.temp.path(),
+        &staged.temp,
         column_ids,
         staged.row_count,
         &staged.nan_flags,

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -820,9 +820,15 @@ impl DuckLakeTableWriter {
     /// [`crate::metadata_provider::MetadataProvider`]) from writing files the
     /// partition fence would reject.
     ///
-    /// The spec is read after the write transaction opens, so it reflects the table
-    /// as of this write rather than as of some earlier planning step; a spec change
-    /// racing the commit is still caught by the fence.
+    /// The spec is read after the write transaction opens, which is the only view a
+    /// caller without a `MetadataProvider` has. A spec change racing the commit is
+    /// still caught by the fence.
+    ///
+    /// Callers that DID make a layout decision earlier (the SQL `INSERT` path, which
+    /// resolves the spec at plan time and pre-splits) must use
+    /// [`Self::write_rows_unpartitioned_as_planned`] instead, so a spec that went
+    /// live in between surfaces as a conflict rather than being silently applied to a
+    /// write planned without it.
     ///
     /// `batches` must hold at least one row (the caller keeps the single-file session
     /// path for empty Replace truncation). `arrow_schema` is the table's data columns
@@ -834,6 +840,43 @@ impl DuckLakeTableWriter {
         arrow_schema: &Schema,
         mode: WriteMode,
         batches: &[RecordBatch],
+    ) -> Result<WriteResult> {
+        self.write_rows_inner(schema_name, table_name, arrow_schema, mode, batches, true)
+            .await
+    }
+
+    /// Write `batches` as UNPARTITIONED because the caller already established that
+    /// the target has no partition spec.
+    ///
+    /// Used by the SQL `INSERT` path, which resolves the spec at plan time. If a
+    /// `SET PARTITIONED BY` went live between planning and this commit, the partition
+    /// fence rejects with a conflict and the caller retries against the new spec —
+    /// deliberately, rather than re-laying-out the rows under a spec the plan never
+    /// saw.
+    pub(crate) async fn write_rows_unpartitioned_as_planned(
+        &self,
+        schema_name: &str,
+        table_name: &str,
+        arrow_schema: &Schema,
+        mode: WriteMode,
+        batches: &[RecordBatch],
+    ) -> Result<WriteResult> {
+        self.write_rows_inner(schema_name, table_name, arrow_schema, mode, batches, false)
+            .await
+    }
+
+    /// Shared body of [`Self::write_rows`] and
+    /// [`Self::write_rows_unpartitioned_as_planned`]. `resolve_layout` selects
+    /// whether the table's live partition spec drives the layout, or the caller's
+    /// earlier "unpartitioned" determination stands (and the fence adjudicates).
+    async fn write_rows_inner(
+        &self,
+        schema_name: &str,
+        table_name: &str,
+        arrow_schema: &Schema,
+        mode: WriteMode,
+        batches: &[RecordBatch],
+        resolve_layout: bool,
     ) -> Result<WriteResult> {
         let columns = arrow_schema_to_column_defs(arrow_schema)?;
         let setup =
@@ -848,7 +891,11 @@ impl DuckLakeTableWriter {
         };
         let table_key = join_paths(&join_paths(&scoped_base, schema_name)?, table_name)?;
 
-        let partition = self.resolve_partition(setup.table_id, &setup.column_ids, arrow_schema)?;
+        let partition = if resolve_layout {
+            self.resolve_partition(setup.table_id, &setup.column_ids, arrow_schema)?
+        } else {
+            None
+        };
         let file_infos = match partition.as_ref() {
             Some(spec) => {
                 let output_schema: SchemaRef = Arc::new(arrow_schema.clone());

--- a/tests/compaction_sqlite_tests.rs
+++ b/tests/compaction_sqlite_tests.rs
@@ -213,6 +213,121 @@ async fn run_rewrite(temp: &TempDir, opts: RewriteOptions) -> CompactionResult {
     .await
 }
 
+/// Compaction of a PARTITIONED table must merge only within a partition and carry
+/// each output's partition assignment over from its sources — official DuckLake
+/// groups merge candidates by (schema_version, partition_id, partition_values).
+/// Merging across partitions would produce a file belonging to no single partition:
+/// unprunable, and unrepresentable in `ducklake_file_partition_value`.
+#[tokio::test(flavor = "multi_thread")]
+async fn merge_only_within_a_partition_and_preserves_assignment() {
+    use datafusion_ducklake::partition::PartitionTransform;
+    use datafusion_ducklake::{ColumnDef, MetadataWriter, WriteMode};
+
+    let temp = TempDir::new().unwrap();
+    // Create `main.t(id, val)` and partition it by `val` before writing any data.
+    let writer = Arc::new(make_writer(&temp).await);
+    let cols = vec![
+        ColumnDef::from_arrow("id", &DataType::Int32, false).unwrap(),
+        ColumnDef::from_arrow("val", &DataType::Int32, false).unwrap(),
+    ];
+    let table_id = {
+        let s = writer
+            .begin_write_transaction("main", "t", &cols, WriteMode::Replace)
+            .unwrap();
+        writer
+            .publish_snapshot(
+                s.table_id,
+                "main",
+                "t",
+                s.snapshot_id,
+                WriteMode::Replace,
+                s.base_snapshot_id,
+                &cols,
+                &s.column_ids,
+            )
+            .unwrap();
+        writer
+            .set_partition_spec(
+                s.table_id,
+                &[("val".to_string(), PartitionTransform::Identity)],
+            )
+            .unwrap();
+        s.table_id
+    };
+
+    // Four small appends: two rows in partition val=1, two in val=2. Each append is
+    // its own snapshot, and each writes one file per partition it touches.
+    for id in [1, 2] {
+        append(&temp, vec![id, id + 10], vec![1, 2]).await;
+    }
+
+    let p = pool(&temp).await;
+    let live_before = scalar_i64(
+        &p,
+        "SELECT COUNT(*) FROM ducklake_data_file WHERE end_snapshot IS NULL",
+    )
+    .await;
+    assert_eq!(live_before, 4, "two appends x two partitions = four files");
+
+    // Merge with a target large enough to bin everything that is legal to bin.
+    let result = run_merge(
+        &temp,
+        MergeOptions {
+            target_file_size: 1 << 30,
+            max_merged_files: 1024,
+            min_file_size: 0,
+        },
+    )
+    .await;
+    assert!(result.did_work(), "the small files must be compacted");
+
+    // Two outputs (one per partition), never one merged across both.
+    let live_after: Vec<(Option<i64>, Option<String>)> = sqlx::query(
+        "SELECT df.partition_id, fpv.partition_value
+         FROM ducklake_data_file AS df
+         LEFT JOIN ducklake_file_partition_value AS fpv
+           ON fpv.data_file_id = df.data_file_id
+         WHERE df.table_id = ? AND df.end_snapshot IS NULL
+         ORDER BY fpv.partition_value",
+    )
+    .bind(table_id)
+    .fetch_all(&p)
+    .await
+    .unwrap()
+    .into_iter()
+    .map(|r| {
+        (
+            r.try_get::<Option<i64>, _>(0).unwrap(),
+            r.try_get::<Option<String>, _>(1).unwrap(),
+        )
+    })
+    .collect();
+
+    assert_eq!(
+        live_after.len(),
+        2,
+        "one merged file per partition, not one across partitions: {live_after:?}"
+    );
+    let values: Vec<Option<String>> = live_after.iter().map(|(_, v)| v.clone()).collect();
+    assert_eq!(
+        values,
+        vec![Some("1".to_string()), Some("2".to_string())],
+        "each merged file keeps its partition value"
+    );
+    for (partition_id, _) in &live_after {
+        assert!(
+            partition_id.is_some(),
+            "a merged file of a partitioned table must keep its partition_id"
+        );
+    }
+
+    // And the rows survive intact, still prunable by the partition column.
+    assert_eq!(
+        read_rows(&temp).await,
+        vec![(1, 1), (2, 1), (11, 2), (12, 2)]
+    );
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn merge_harvests_output_stats_and_removes_source_stats() {
     // Compaction must record fresh per-file column stats for the merged output

--- a/tests/compaction_sqlite_tests.rs
+++ b/tests/compaction_sqlite_tests.rs
@@ -328,6 +328,112 @@ async fn merge_only_within_a_partition_and_preserves_assignment() {
     );
 }
 
+/// A delete-driven rewrite of a PARTITIONED table must carry the source file's
+/// partition assignment onto the rewritten output. The output holds a subset of one
+/// file's rows, so it belongs to exactly that file's partition — official takes the
+/// partition from `source_files[0]` on this path too. Without this the rewrite would
+/// silently strip the assignment and the rows would stop being prunable.
+#[tokio::test(flavor = "multi_thread")]
+async fn rewrite_preserves_partition_assignment() {
+    use datafusion_ducklake::partition::PartitionTransform;
+    use datafusion_ducklake::{ColumnDef, MetadataWriter, WriteMode};
+
+    let temp = TempDir::new().unwrap();
+    let writer = Arc::new(make_writer(&temp).await);
+    let cols = vec![
+        ColumnDef::from_arrow("id", &DataType::Int32, false).unwrap(),
+        ColumnDef::from_arrow("val", &DataType::Int32, false).unwrap(),
+    ];
+    let table_id = {
+        let s = writer
+            .begin_write_transaction("main", "t", &cols, WriteMode::Replace)
+            .unwrap();
+        writer
+            .publish_snapshot(
+                s.table_id,
+                "main",
+                "t",
+                s.snapshot_id,
+                WriteMode::Replace,
+                s.base_snapshot_id,
+                &cols,
+                &s.column_ids,
+            )
+            .unwrap();
+        writer
+            .set_partition_spec(
+                s.table_id,
+                &[("val".to_string(), PartitionTransform::Identity)],
+            )
+            .unwrap();
+        s.table_id
+    };
+
+    // One partition (val=1) holding 10 rows, so the rewrite has a single source.
+    append(&temp, (1..=10).collect(), vec![1; 10]).await;
+    let p = pool(&temp).await;
+    let live_spec_id = scalar_i64(
+        &p,
+        "SELECT partition_id FROM ducklake_partition_info WHERE end_snapshot IS NULL",
+    )
+    .await;
+
+    // Delete 8 of 10 rows, then rewrite past the 0.5 threshold.
+    {
+        let w = SqliteMetadataWriter::new(&db_url(&temp)).await.unwrap();
+        let provider = SqliteMetadataProvider::new(&db_url(&temp)).await.unwrap();
+        let catalog = DuckLakeCatalog::with_writer(Arc::new(provider), Arc::new(w)).unwrap();
+        let ctx = SessionContext::new();
+        ctx.register_catalog("ducklake", Arc::new(catalog));
+        ctx.sql("DELETE FROM ducklake.main.t WHERE id <= 8")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+    }
+    let result = run_rewrite(
+        &temp,
+        RewriteOptions {
+            delete_threshold: 0.5,
+        },
+    )
+    .await;
+    assert_eq!(result.files_created, 1, "the live rows are rewritten");
+
+    // The rewritten file keeps the partition it came from.
+    let (partition_id, value): (Option<i64>, Option<String>) = sqlx::query(
+        "SELECT df.partition_id, fpv.partition_value
+         FROM ducklake_data_file AS df
+         LEFT JOIN ducklake_file_partition_value AS fpv
+           ON fpv.data_file_id = df.data_file_id
+         WHERE df.table_id = ? AND df.end_snapshot IS NULL
+           AND df.begin_snapshot = (SELECT MAX(snapshot_id) FROM ducklake_snapshot)",
+    )
+    .bind(table_id)
+    .fetch_one(&p)
+    .await
+    .map(|r| {
+        (
+            r.try_get::<Option<i64>, _>(0).unwrap(),
+            r.try_get::<Option<String>, _>(1).unwrap(),
+        )
+    })
+    .unwrap();
+    assert_eq!(
+        partition_id,
+        Some(live_spec_id),
+        "the rewritten file must keep its partition_id"
+    );
+    assert_eq!(
+        value,
+        Some("1".to_string()),
+        "the rewritten file must keep its partition value"
+    );
+    // And the surviving rows read back.
+    assert_eq!(read_rows(&temp).await, vec![(9, 1), (10, 1)]);
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn merge_harvests_output_stats_and_removes_source_stats() {
     // Compaction must record fresh per-file column stats for the merged output

--- a/tests/multicatalog_postgres_tests.rs
+++ b/tests/multicatalog_postgres_tests.rs
@@ -4689,6 +4689,17 @@ async fn register_existing_data_file_persists_partition_assignment() {
         "must not blame a concurrent DDL change that did not happen, got: {msg}"
     );
 
+    // A 0-row promote is refused too. The shared fence exempts empty files for the
+    // sake of the empty-Replace truncate marker, but promote has no such marker, and
+    // official's AddFileToTable applies its key-count check with no row-count
+    // exception — so exempting it here would accept a file official rejects.
+    let empty = DataFileInfo::new("f5.parquet", 0, 0);
+    assert!(
+        w.register_existing_data_file("public", "orders", &cols(), &ids, &empty, WriteMode::Append)
+            .is_err(),
+        "a 0-row promote with no partition must be refused on a partitioned table"
+    );
+
     // A value count that disagrees with the live spec is refused too.
     let wrong_arity = DataFileInfo::new("f4.parquet", 256, 1).with_partition(
         spec.partition_id,

--- a/tests/multicatalog_postgres_tests.rs
+++ b/tests/multicatalog_postgres_tests.rs
@@ -4586,6 +4586,114 @@ async fn register_existing_data_file_adopts_column_ids() {
     );
 }
 
+/// Promoting a byte-copied parquet into a PARTITIONED table persists the caller's
+/// partition assignment, so the file is prunable exactly like one this crate wrote.
+/// Nothing is rewritten, so the values can only be carried, never derived.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn register_existing_data_file_persists_partition_assignment() {
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+    use datafusion_ducklake::partition::PartitionTransform;
+
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat = mgr.create_catalog("pg_promote_part").await.unwrap();
+    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+        .await
+        .unwrap();
+    w.set_data_path("/data").unwrap();
+
+    let ids = vec![100_i64, 200_i64];
+    // Create the table first (unpartitioned), then partition it by `name`.
+    let out = w
+        .register_existing_data_file(
+            "public",
+            "orders",
+            &cols(),
+            &ids,
+            &DataFileInfo::new("f1.parquet", 1024, 3),
+            WriteMode::Replace,
+        )
+        .unwrap();
+    w.set_partition_spec(
+        out.table_id,
+        &[("name".to_string(), PartitionTransform::Identity)],
+    )
+    .unwrap();
+    let spec = w.live_partition_spec(out.table_id).unwrap().unwrap();
+
+    // Promote a single-partition file, declaring the partition it holds.
+    let promoted = DataFileInfo::new("name=us/f2.parquet", 512, 2)
+        .with_partition(spec.partition_id, vec![(0, Some("us".to_string()))]);
+    w.register_existing_data_file("public", "orders", &cols(), &ids, &promoted, WriteMode::Append)
+        .unwrap();
+
+    let (file_partition_id, value): (Option<i64>, Option<String>) = sqlx::query(
+        "SELECT df.partition_id, fpv.partition_value
+         FROM ducklake_data_file AS df
+         LEFT JOIN ducklake_file_partition_value AS fpv
+           ON fpv.data_file_id = df.data_file_id
+         WHERE df.table_id = $1 AND df.path = 'name=us/f2.parquet'",
+    )
+    .bind(out.table_id)
+    .fetch_one(&pool)
+    .await
+    .map(|r| {
+        (
+            r.try_get::<Option<i64>, _>(0).unwrap(),
+            r.try_get::<Option<String>, _>(1).unwrap(),
+        )
+    })
+    .unwrap();
+    assert_eq!(
+        file_partition_id,
+        Some(spec.partition_id),
+        "a promoted file must carry the live partition generation"
+    );
+    assert_eq!(
+        value,
+        Some("us".to_string()),
+        "a promoted file must carry its partition value so it stays prunable"
+    );
+
+    // An unpartitioned promote into a now-partitioned table is refused: such a file
+    // cannot satisfy the spec, and silently accepting it would make the table's
+    // partition layout a lie.
+    let unpartitioned = DataFileInfo::new("f3.parquet", 256, 1);
+    let err = w
+        .register_existing_data_file(
+            "public",
+            "orders",
+            &cols(),
+            &ids,
+            &unpartitioned,
+            WriteMode::Append,
+        )
+        .unwrap_err();
+    assert!(
+        matches!(err, datafusion_ducklake::DuckLakeError::Conflict(_)),
+        "expected a partition-fence conflict, got: {err}"
+    );
+
+    // A value count that disagrees with the live spec is refused too.
+    let wrong_arity = DataFileInfo::new("f4.parquet", 256, 1).with_partition(
+        spec.partition_id,
+        vec![(0, Some("us".to_string())), (1, Some("2024".to_string()))],
+    );
+    assert!(
+        w.register_existing_data_file(
+            "public",
+            "orders",
+            &cols(),
+            &ids,
+            &wrong_arity,
+            WriteMode::Append,
+        )
+        .is_err(),
+        "two values for a one-key spec must be rejected"
+    );
+}
+
 /// `column_ids` must be 1:1 with `columns`; a mismatch is rejected before any
 /// write (otherwise `finalize_snapshot`'s zip would silently drop columns).
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/multicatalog_postgres_tests.rs
+++ b/tests/multicatalog_postgres_tests.rs
@@ -4625,8 +4625,15 @@ async fn register_existing_data_file_persists_partition_assignment() {
     // Promote a single-partition file, declaring the partition it holds.
     let promoted = DataFileInfo::new("name=us/f2.parquet", 512, 2)
         .with_partition(spec.partition_id, vec![(0, Some("us".to_string()))]);
-    w.register_existing_data_file("public", "orders", &cols(), &ids, &promoted, WriteMode::Append)
-        .unwrap();
+    w.register_existing_data_file(
+        "public",
+        "orders",
+        &cols(),
+        &ids,
+        &promoted,
+        WriteMode::Append,
+    )
+    .unwrap();
 
     let (file_partition_id, value): (Option<i64>, Option<String>) = sqlx::query(
         "SELECT df.partition_id, fpv.partition_value

--- a/tests/multicatalog_postgres_tests.rs
+++ b/tests/multicatalog_postgres_tests.rs
@@ -4663,9 +4663,11 @@ async fn register_existing_data_file_persists_partition_assignment() {
         "a promoted file must carry its partition value so it stays prunable"
     );
 
-    // An unpartitioned promote into a now-partitioned table is refused: such a file
+    // An unpartitioned promote into a partitioned table is refused: such a file
     // cannot satisfy the spec, and silently accepting it would make the table's
-    // partition layout a lie.
+    // partition layout a lie. The error must name the actual fix — nothing raced
+    // here, so the fence's "concurrent SET PARTITIONED BY / retry" wording would send
+    // the caller chasing a problem that does not exist.
     let unpartitioned = DataFileInfo::new("f3.parquet", 256, 1);
     let err = w
         .register_existing_data_file(
@@ -4677,9 +4679,14 @@ async fn register_existing_data_file_persists_partition_assignment() {
             WriteMode::Append,
         )
         .unwrap_err();
+    let msg = err.to_string();
     assert!(
-        matches!(err, datafusion_ducklake::DuckLakeError::Conflict(_)),
-        "expected a partition-fence conflict, got: {err}"
+        msg.contains("with_partition"),
+        "the error must tell the caller to declare the file's partition, got: {msg}"
+    );
+    assert!(
+        !msg.contains("concurrent"),
+        "must not blame a concurrent DDL change that did not happen, got: {msg}"
     );
 
     // A value count that disagrees with the live spec is refused too.

--- a/tests/partition_write_tests.rs
+++ b/tests/partition_write_tests.rs
@@ -106,6 +106,172 @@ const INSERT_SQL: &str = "INSERT INTO ducklake.main.events \
         (3, 'eu', TIMESTAMP '2023-03-10 08:00:00'), \
         (4, 'eu', TIMESTAMP '2024-11-05 18:00:00')) AS t(id, region, ts)";
 
+/// Four `events` rows spanning 4 partitions — (us,2023), (us,2024), (eu,2023),
+/// (eu,2024) — as separate batches, so a streaming session sees each partition
+/// across more than one `write_batch` call.
+fn events_batches() -> Vec<arrow::record_batch::RecordBatch> {
+    use arrow::array::{ArrayRef, Int32Array, RecordBatch, TimestampMicrosecondArray};
+    use arrow::datatypes::{Field, Schema};
+
+    let ts_type = DataType::Timestamp(TimeUnit::Microsecond, None);
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("region", DataType::Utf8, true),
+        Field::new("ts", ts_type, true),
+    ]));
+    // 2023-01-15T10:00:00Z and 2024-06-20T12:00:00Z in micros.
+    let y2023: i64 = 1_673_776_800_000_000;
+    let y2024: i64 = 1_718_884_800_000_000;
+    let rows: [(&[i32], &[&str], &[i64]); 2] =
+        [(&[1, 2], &["us", "us"], &[y2023, y2024]), (&[3, 4], &["eu", "eu"], &[y2023, y2024])];
+    rows.iter()
+        .map(|(ids, regions, times)| {
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(Int32Array::from(ids.to_vec())) as ArrayRef,
+                    Arc::new(arrow::array::StringArray::from(regions.to_vec())) as ArrayRef,
+                    Arc::new(TimestampMicrosecondArray::from(times.to_vec())) as ArrayRef,
+                ],
+            )
+            .unwrap()
+        })
+        .collect()
+}
+
+/// The streaming session (`begin_write` + `write_batch` + `finish`) — the entry
+/// point an embedding engine uses for ingest, with no SQL and no MetadataProvider —
+/// must split rows across one file per partition and commit them in ONE snapshot.
+#[tokio::test(flavor = "multi_thread")]
+async fn streaming_session_splits_rows_across_partitions() {
+    use datafusion_ducklake::table_writer::DuckLakeTableWriter;
+
+    let env = setup().await;
+    let writer = SqliteMetadataWriter::new_with_init(&env.conn_str)
+        .await
+        .unwrap();
+    let object_store: Arc<dyn object_store::ObjectStore> =
+        Arc::new(object_store::local::LocalFileSystem::new());
+    let table_writer = DuckLakeTableWriter::new(Arc::new(writer), object_store).unwrap();
+
+    let batches = events_batches();
+    let arrow_schema = batches[0].schema();
+    let mut session = table_writer
+        .begin_write("main", "events", arrow_schema.as_ref(), WriteMode::Append)
+        .unwrap();
+    for batch in &batches {
+        session.write_batch(batch).unwrap();
+    }
+    let result = session.finish().await.unwrap();
+
+    // One file per (region, year) partition, all in a single snapshot.
+    assert_eq!(result.records_written, 4);
+    assert_eq!(
+        result.files_written, 4,
+        "a streaming write must produce one file per partition"
+    );
+
+    let provider = SqliteMetadataProvider::new(&env.conn_str).await.unwrap();
+    let snap = provider.get_current_snapshot().unwrap();
+    let live = provider
+        .get_partition_spec(env.table_id, snap)
+        .unwrap()
+        .unwrap();
+    let page = provider
+        .get_table_file_metadata_page(env.table_id, snap, None, 4096)
+        .unwrap();
+    assert_eq!(page.len(), 4);
+    let mut seen: Vec<Vec<Option<String>>> = Vec::new();
+    for meta in &page {
+        assert_eq!(
+            meta.file.partition_id,
+            Some(live.partition_id),
+            "every streamed file must carry the live partition generation"
+        );
+        let mut values = meta.file.partition_values.clone();
+        values.sort_by_key(|(index, _)| *index);
+        seen.push(values.into_iter().map(|(_, v)| v).collect());
+        // The Hive directory mirrors the partition values.
+        assert!(
+            meta.file.file.path.contains("region="),
+            "partitioned file must live under a Hive path, got {}",
+            meta.file.file.path
+        );
+    }
+    seen.sort();
+    assert_eq!(
+        seen,
+        vec![
+            vec![Some("eu".to_string()), Some("2023".to_string())],
+            vec![Some("eu".to_string()), Some("2024".to_string())],
+            vec![Some("us".to_string()), Some("2023".to_string())],
+            vec![Some("us".to_string()), Some("2024".to_string())],
+        ]
+    );
+
+    // The rows read back intact through the partitioned layout.
+    let ctx = read_ctx(&env.conn_str).await;
+    let rows = ctx
+        .sql("SELECT count(*) FROM ducklake.main.events WHERE region = 'us'")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let count = rows[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<arrow::array::Int64Array>()
+        .unwrap()
+        .value(0);
+    assert_eq!(count, 2);
+}
+
+/// With the open-file cap at 1, a streaming write touching 4 partitions must still
+/// land every row: the sink finalizes the open file to make room and re-opens a
+/// partition later if more of its rows arrive.
+#[tokio::test(flavor = "multi_thread")]
+async fn streaming_session_respects_open_partition_cap() {
+    use datafusion_ducklake::table_writer::DuckLakeTableWriter;
+
+    let env = setup().await;
+    let writer = SqliteMetadataWriter::new_with_init(&env.conn_str)
+        .await
+        .unwrap();
+    let object_store: Arc<dyn object_store::ObjectStore> =
+        Arc::new(object_store::local::LocalFileSystem::new());
+    let table_writer = DuckLakeTableWriter::new(Arc::new(writer), object_store)
+        .unwrap()
+        .with_max_open_partitions(1);
+
+    let batches = events_batches();
+    let arrow_schema = batches[0].schema();
+    let mut session = table_writer
+        .begin_write("main", "events", arrow_schema.as_ref(), WriteMode::Append)
+        .unwrap();
+    for batch in &batches {
+        session.write_batch(batch).unwrap();
+    }
+    let result = session.finish().await.unwrap();
+    assert_eq!(result.records_written, 4, "eviction must not drop rows");
+
+    let ctx = read_ctx(&env.conn_str).await;
+    let rows = ctx
+        .sql("SELECT count(*) FROM ducklake.main.events")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let count = rows[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<arrow::array::Int64Array>()
+        .unwrap()
+        .value(0);
+    assert_eq!(count, 4, "every row must be readable after eviction");
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn partitioned_insert_writes_one_file_per_partition() {
     let env = setup().await;

--- a/tests/partition_write_tests.rs
+++ b/tests/partition_write_tests.rs
@@ -272,6 +272,77 @@ async fn streaming_session_respects_open_partition_cap() {
     assert_eq!(count, 4, "every row must be readable after eviction");
 }
 
+/// The write entry points that target ONE caller-determined file cannot satisfy a
+/// partition spec that needs one file per partition. They must refuse a partitioned
+/// table with a typed error naming the entry point — never fall through and commit a
+/// file with no partition, which would make the table's layout a lie and silently
+/// break pruning. These are the documented gaps; this test exists so that closing one
+/// is a deliberate act rather than an accident.
+#[tokio::test(flavor = "multi_thread")]
+async fn single_file_entry_points_refuse_a_partitioned_table() {
+    use datafusion_ducklake::table_writer::DuckLakeTableWriter;
+
+    let env = setup().await; // partitioned by (region, year(ts))
+    let writer = SqliteMetadataWriter::new_with_init(&env.conn_str)
+        .await
+        .unwrap();
+    let object_store: Arc<dyn object_store::ObjectStore> =
+        Arc::new(object_store::local::LocalFileSystem::new());
+    let table_writer = DuckLakeTableWriter::new(Arc::new(writer), object_store).unwrap();
+    let batches = events_batches();
+    let arrow_schema = batches[0].schema();
+
+    // Embedded-rowid session (the UPDATE row-rewrite path).
+    let err = table_writer
+        .begin_write_with_embedded_rowid("main", "events", arrow_schema.as_ref(), WriteMode::Append)
+        .expect_err("embedded-rowid write must refuse a partitioned table");
+    assert!(
+        err.to_string().contains("begin_write_with_embedded_rowid"),
+        "the error must name the entry point, got: {err}"
+    );
+
+    // Custom-path session.
+    let err = table_writer
+        .begin_write_to_path(
+            "main",
+            "events",
+            arrow_schema.as_ref(),
+            "/tmp/some-dir",
+            "f.parquet".to_string(),
+            WriteMode::Append,
+        )
+        .expect_err("custom-path write must refuse a partitioned table");
+    assert!(
+        err.to_string().contains("begin_write_to_path"),
+        "the error must name the entry point, got: {err}"
+    );
+
+    // Atomic append+delete (the upsert commit) on a partitioned session.
+    let mut session = table_writer
+        .begin_write("main", "events", arrow_schema.as_ref(), WriteMode::Append)
+        .unwrap();
+    session.write_batch(&batches[0]).unwrap();
+    let err = session
+        .finish_with_deletes(&[])
+        .await
+        .expect_err("append+delete must refuse a partitioned table");
+    assert!(
+        err.to_string().contains("partitioned table"),
+        "the error must say why, got: {err}"
+    );
+
+    // Nothing was committed by any of the three.
+    let provider = SqliteMetadataProvider::new(&env.conn_str).await.unwrap();
+    let snap = provider.get_current_snapshot().unwrap();
+    assert!(
+        provider
+            .get_table_file_metadata_page(env.table_id, snap, None, 4096)
+            .unwrap()
+            .is_empty(),
+        "a refused write must commit no data files"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn partitioned_insert_writes_one_file_per_partition() {
     let env = setup().await;

--- a/tests/partition_write_tests.rs
+++ b/tests/partition_write_tests.rs
@@ -272,6 +272,101 @@ async fn streaming_session_respects_open_partition_cap() {
     assert_eq!(count, 4, "every row must be readable after eviction");
 }
 
+/// A partitioned write must still respect `target_file_size` WITHIN each partition.
+///
+/// Rollover is evaluated at batch boundaries, so if the partition splitter collapsed
+/// each group into one batch the writer would emit a single file per partition of
+/// unbounded size — `target_file_size` silently unenforceable exactly on the tables
+/// most likely to be large. DuckLake merges but never splits, so such a file could
+/// never be broken up afterwards either.
+#[tokio::test(flavor = "multi_thread")]
+async fn partitioned_write_rolls_within_each_partition() {
+    use arrow::array::{ArrayRef, Int32Array, RecordBatch, TimestampMicrosecondArray};
+    use arrow::datatypes::{Field, Schema};
+    use datafusion_ducklake::table_writer::DuckLakeTableWriter;
+
+    let env = setup().await; // partitioned by (region, year(ts))
+    let ts_type = DataType::Timestamp(TimeUnit::Microsecond, None);
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("region", DataType::Utf8, true),
+        Field::new("ts", ts_type, true),
+    ]));
+    // Many batches, ALL in the same (us, 2023) partition, so the only way to end up
+    // with more than one file is rollover firing inside that partition.
+    let y2023: i64 = 1_673_776_800_000_000;
+    let batches: Vec<RecordBatch> = (0..40)
+        .map(|b| {
+            let ids: Vec<i32> = (b * 100..(b + 1) * 100).collect();
+            let n = ids.len();
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(Int32Array::from(ids)) as ArrayRef,
+                    Arc::new(arrow::array::StringArray::from(vec!["us"; n])) as ArrayRef,
+                    Arc::new(TimestampMicrosecondArray::from(vec![y2023; n])) as ArrayRef,
+                ],
+            )
+            .unwrap()
+        })
+        .collect();
+
+    let writer = SqliteMetadataWriter::new_with_init(&env.conn_str)
+        .await
+        .unwrap();
+    let object_store: Arc<dyn object_store::ObjectStore> =
+        Arc::new(object_store::local::LocalFileSystem::new());
+    let table_writer = DuckLakeTableWriter::new(Arc::new(writer), object_store)
+        .unwrap()
+        .with_target_file_size(8 * 1024);
+
+    let result = table_writer
+        .append_table("main", "events", &batches)
+        .await
+        .unwrap();
+    assert_eq!(result.records_written, 4000);
+    assert!(
+        result.files_written > 1,
+        "a single partition exceeding target_file_size must roll into several files, got {}",
+        result.files_written
+    );
+
+    // Every file still carries that one partition, and the rows all read back.
+    let provider = SqliteMetadataProvider::new(&env.conn_str).await.unwrap();
+    let snap = provider.get_current_snapshot().unwrap();
+    let page = provider
+        .get_table_file_metadata_page(env.table_id, snap, None, 4096)
+        .unwrap();
+    assert_eq!(page.len(), result.files_written);
+    for meta in &page {
+        let mut values = meta.file.partition_values.clone();
+        values.sort_by_key(|(index, _)| *index);
+        let values: Vec<Option<String>> = values.into_iter().map(|(_, v)| v).collect();
+        assert_eq!(
+            values,
+            vec![Some("us".to_string()), Some("2023".to_string())],
+            "every rolled file belongs to the same partition"
+        );
+    }
+    let ctx = read_ctx(&env.conn_str).await;
+    let rows = ctx
+        .sql("SELECT count(*) FROM ducklake.main.events")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(
+        rows[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .unwrap()
+            .value(0),
+        4000
+    );
+}
+
 /// The write entry points that target ONE caller-determined file cannot satisfy a
 /// partition spec that needs one file per partition. They must refuse a partitioned
 /// table with a typed error naming the entry point — never fall through and commit a

--- a/tests/partition_write_tests.rs
+++ b/tests/partition_write_tests.rs
@@ -537,11 +537,16 @@ async fn concurrent_reset_during_insert_conflicts() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn concurrent_set_during_unpartitioned_insert_conflicts() {
+async fn concurrent_set_during_unpartitioned_insert_partitions_at_write_time() {
     // Inverse P1: an unpartitioned INSERT plan captured while the table had NO spec,
     // then a concurrent SET PARTITIONED BY makes it partitioned before the plan
-    // commits. The commit must abort — never leave a partition_id-less file in a
-    // now-partitioned table.
+    // commits.
+    //
+    // The write resolves the live spec inside the write transaction (not at plan
+    // time), so the stale plan lays its rows out per the NEW spec and commits — no
+    // partition_id-less file ever reaches a partitioned table, and the caller needs
+    // no retry. The commit fence still backs this for a spec change that lands after
+    // the resolve.
     let (conn_str, table_id, _temp) = create_events_table_no_spec().await;
     let (ctx, _catalog) = writable_catalog(&conn_str).await;
     // Build the plan now: table is unpartitioned → partition = None.
@@ -563,24 +568,33 @@ async fn concurrent_set_during_unpartitioned_insert_conflicts() {
         )
         .unwrap();
     }
-    // Executing the stale unpartitioned plan must hit the singular-commit fence.
-    let result = datafusion::physical_plan::collect(plan, ctx.task_ctx()).await;
-    let err = result.expect_err("unpartitioned insert into a now-partitioned table must conflict");
-    let msg = err.to_string().to_lowercase();
-    assert!(
-        msg.contains("partition spec") || msg.contains("concurrent"),
-        "expected a partition-spec conflict, got: {err}"
-    );
-    // Nothing committed.
+    datafusion::physical_plan::collect(plan, ctx.task_ctx())
+        .await
+        .expect("the stale plan must partition at write time, not conflict");
+
+    // Every committed file carries the now-live partition generation and a value.
     let provider = SqliteMetadataProvider::new(&conn_str).await.unwrap();
     let snap = provider.get_current_snapshot().unwrap();
+    let live_spec = provider
+        .get_partition_spec(table_id, snap)
+        .unwrap()
+        .expect("table is partitioned");
     let page = provider
         .get_table_file_metadata_page(table_id, snap, None, 4096)
         .unwrap();
-    assert!(
-        page.is_empty(),
-        "a conflicting unpartitioned insert must not commit any data files"
-    );
+    assert!(!page.is_empty(), "the insert must commit data files");
+    for meta in &page {
+        assert_eq!(
+            meta.file.partition_id,
+            Some(live_spec.partition_id),
+            "every committed file must carry the live partition generation"
+        );
+        assert_eq!(
+            meta.file.partition_values.len(),
+            1,
+            "every committed file must carry a value for the single partition key"
+        );
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/partition_write_tests.rs
+++ b/tests/partition_write_tests.rs
@@ -703,19 +703,15 @@ async fn concurrent_reset_during_insert_conflicts() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn concurrent_set_during_unpartitioned_insert_partitions_at_write_time() {
+async fn concurrent_set_during_unpartitioned_insert_conflicts() {
     // Inverse P1: an unpartitioned INSERT plan captured while the table had NO spec,
     // then a concurrent SET PARTITIONED BY makes it partitioned before the plan
-    // commits.
-    //
-    // The write resolves the live spec inside the write transaction (not at plan
-    // time), so the stale plan lays its rows out per the NEW spec and commits — no
-    // partition_id-less file ever reaches a partitioned table, and the caller needs
-    // no retry. The commit fence still backs this for a spec change that lands after
-    // the resolve.
+    // commits. The commit must abort — never leave a partition_id-less file in a
+    // now-partitioned table, and never silently re-lay-out the rows under a spec the
+    // plan never saw. The caller re-plans against the new spec and retries.
     let (conn_str, table_id, _temp) = create_events_table_no_spec().await;
     let (ctx, _catalog) = writable_catalog(&conn_str).await;
-    // Build the plan now: table is unpartitioned → partition = None.
+    // Build the plan now: table is unpartitioned -> partition = None.
     let plan = ctx
         .sql(INSERT_SQL)
         .await
@@ -734,33 +730,24 @@ async fn concurrent_set_during_unpartitioned_insert_partitions_at_write_time() {
         )
         .unwrap();
     }
-    datafusion::physical_plan::collect(plan, ctx.task_ctx())
-        .await
-        .expect("the stale plan must partition at write time, not conflict");
-
-    // Every committed file carries the now-live partition generation and a value.
+    // Executing the stale unpartitioned plan must hit the singular-commit fence.
+    let result = datafusion::physical_plan::collect(plan, ctx.task_ctx()).await;
+    let err = result.expect_err("unpartitioned insert into a now-partitioned table must conflict");
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("partition spec") || msg.contains("concurrent"),
+        "expected a partition-spec conflict, got: {err}"
+    );
+    // Nothing committed.
     let provider = SqliteMetadataProvider::new(&conn_str).await.unwrap();
     let snap = provider.get_current_snapshot().unwrap();
-    let live_spec = provider
-        .get_partition_spec(table_id, snap)
-        .unwrap()
-        .expect("table is partitioned");
     let page = provider
         .get_table_file_metadata_page(table_id, snap, None, 4096)
         .unwrap();
-    assert!(!page.is_empty(), "the insert must commit data files");
-    for meta in &page {
-        assert_eq!(
-            meta.file.partition_id,
-            Some(live_spec.partition_id),
-            "every committed file must carry the live partition generation"
-        );
-        assert_eq!(
-            meta.file.partition_values.len(),
-            1,
-            "every committed file must carry a value for the single partition key"
-        );
-    }
+    assert!(
+        page.is_empty(),
+        "a conflicting unpartitioned insert must not commit any data files"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/postgres_metadata_provider_test.rs
+++ b/tests/postgres_metadata_provider_test.rs
@@ -1078,7 +1078,8 @@ async fn migrate_fixture_to_current_schema(pool: &PgPool) -> anyhow::Result<()> 
              ADD COLUMN IF NOT EXISTS row_id_start BIGINT,
              ADD COLUMN IF NOT EXISTS begin_snapshot BIGINT NOT NULL DEFAULT 1,
              ADD COLUMN IF NOT EXISTS end_snapshot BIGINT,
-             ADD COLUMN IF NOT EXISTS partial_max BIGINT",
+             ADD COLUMN IF NOT EXISTS partial_max BIGINT,
+             ADD COLUMN IF NOT EXISTS partition_id BIGINT",
     )
     .execute(pool)
     .await?;

--- a/tests/sorted_write_tests.rs
+++ b/tests/sorted_write_tests.rs
@@ -148,6 +148,113 @@ async fn live_file_count(conn_str: &str, table_id: i64) -> usize {
         .len()
 }
 
+/// The low-level bulk write (`write_rows`, and so `write_table`/`append_table`) must
+/// apply the table's sort order itself. It has no plan to carry a `SortExec`, so
+/// without this a caller outside SQL gets rolled files whose ranges OVERLAP — the
+/// files exist but no range filter can skip any of them, silently losing the entire
+/// point of `SET SORTED BY`.
+///
+/// Asserts the file-level property that matters: each rolled file's `val` range is
+/// disjoint from every other's. A per-file sort could not achieve this (a file's
+/// min/max does not depend on row order) — only a global sort before rolling can.
+#[tokio::test(flavor = "multi_thread")]
+async fn low_level_bulk_write_sorts_and_yields_non_overlapping_files() {
+    use datafusion_ducklake::table_writer::DuckLakeTableWriter;
+
+    let env = setup().await;
+    let dl = ddl_catalog(&env.conn_str).await;
+    let ddl_ctx = read_ctx(&env.conn_str).await;
+    execute_ducklake_sql(
+        &ddl_ctx,
+        &dl,
+        "ALTER TABLE ducklake.main.events SET SORTED BY (val)",
+    )
+    .await
+    .unwrap();
+
+    // Shuffled input, fed as many small batches so rollover produces several files.
+    let n = 4000i32;
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("val", DataType::Int32, true),
+    ]));
+    let batches: Vec<RecordBatch> = (0..n)
+        .step_by(200)
+        .map(|start| {
+            let ids: Vec<i32> = (start..(start + 200).min(n)).collect();
+            let vals: Vec<i32> = ids
+                .iter()
+                .map(|i| ((*i as i64 * 7919) % n as i64) as i32)
+                .collect();
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![Arc::new(Int32Array::from(ids)), Arc::new(Int32Array::from(vals))],
+            )
+            .unwrap()
+        })
+        .collect();
+
+    let writer = SqliteMetadataWriter::new_with_init(&env.conn_str)
+        .await
+        .unwrap();
+    let object_store: Arc<dyn object_store::ObjectStore> =
+        Arc::new(object_store::local::LocalFileSystem::new());
+    let table_writer = DuckLakeTableWriter::new(Arc::new(writer), object_store)
+        .unwrap()
+        // Small target so this write rolls into several files.
+        .with_target_file_size(8 * 1024);
+    let result = table_writer
+        .append_table("main", "events", &batches)
+        .await
+        .unwrap();
+    assert_eq!(result.records_written, n as i64);
+    assert!(
+        result.files_written > 1,
+        "the write must roll into several files for this to be meaningful, got {}",
+        result.files_written
+    );
+
+    // Every file's [min, max] on the sort key must be disjoint from every other's.
+    let provider = SqliteMetadataProvider::new(&env.conn_str).await.unwrap();
+    let snapshot = provider.get_current_snapshot().unwrap();
+    let page = provider
+        .get_table_file_metadata_page(env.table_id, snapshot, None, 4096)
+        .unwrap();
+    let val_column_id = 2i64; // events(id, val) -> column_ids 1, 2
+    let mut ranges: Vec<(i64, i64)> = page
+        .iter()
+        .map(|meta| {
+            let stat = meta
+                .column_statistics
+                .iter()
+                .find(|s| s.column_id == val_column_id)
+                .expect("val stats present");
+            (
+                stat.min_value.as_deref().unwrap().parse::<i64>().unwrap(),
+                stat.max_value.as_deref().unwrap().parse::<i64>().unwrap(),
+            )
+        })
+        .collect();
+    ranges.sort();
+    for pair in ranges.windows(2) {
+        assert!(
+            pair[0].1 < pair[1].0,
+            "file ranges must not overlap after a sorted bulk write: {:?} then {:?}",
+            pair[0],
+            pair[1]
+        );
+    }
+
+    // And a range filter therefore skips files.
+    let ctx = read_ctx(&env.conn_str).await;
+    let scanned = files_scanned(&ctx, "SELECT id FROM ducklake.main.events WHERE val < 100").await;
+    assert!(
+        scanned < ranges.len(),
+        "a range filter must prune files: scanned {scanned} of {}",
+        ranges.len()
+    );
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn set_and_reset_sorted_by_persists_in_catalog() {
     let env = setup().await;


### PR DESCRIPTION
Partition handling was only correct on the SQL `INSERT` path. Every other write path either
ignored the table's partition spec or was broken by it, so a declared spec could not survive
normal use: compaction stripped it, the low-level writer entry points could not write to a
partitioned table at all, and registering an already-written file silently discarded it.

This brings those paths to parity with official DuckLake, following its behaviour at each step
rather than inventing rules.

## What was wrong

| Path | Before |
|---|---|
| `merge_adjacent_files` | binned candidates by schema version alone, so it merged **across** partitions, and stamped no `partition_id`/values on outputs |
| `rewrite_data_files` | same — the rewritten file lost the partition of the file it replaced |
| `write_rows` / `write_table` / `append_table` | consulted no spec, so they could only produce unpartitioned files, which the commit fence then rejects |
| `begin_write` (streaming) | wrote every row to one file; on a partitioned table the commit failed with an error blaming a concurrent `SET/RESET PARTITIONED BY` that had not happened |
| `register_existing_data_file` | never wrote `ducklake_data_file.partition_id` and inserted no `ducklake_file_partition_value` rows, so a caller's `with_partition` was **silently dropped**; also skipped the fence |
| `register_data_file_with_deletes` | skipped the fence |
| `get_table_files_for_select` | projected no `partition_id` and loaded no per-file values, so compaction saw every file as unpartitioned |
| `split_batches_by_partition` | collapsed each partition into ONE batch, and rollover is evaluated per batch — so `target_file_size` was unenforceable *within* a partition and a partitioned write emitted one file of unbounded size |
| File rollover | implemented **twice** — once for the buffered path, once inline in the streaming sink — which is how the row above went unnoticed |

## What it does now

- **Compaction** groups candidates by `(schema_version, partition_id, partition_values)` and carries
  the group's partition onto each output, matching `ducklake_compaction_functions.cpp:238-245,350,519`.
  A retired generation is inherited deliberately: those rows really do have that generation's layout,
  so preserving it keeps them prunable.
- **`rewrite_data_files`** inherits the partition of the single file it rewrites.
- **The low-level entry points** resolve the live spec themselves — a caller with no
  `MetadataProvider` has no other way to learn it — split rows per partition, and stamp each file.
  New `MetadataWriter::live_partition_spec` on all four backends.
- **The streaming session** keeps one open parquet per partition, rolls at `target_file_size`, and
  finalizes the least-recently-opened file past `max_open_partitions` (default 100). This mirrors
  DuckDB's partitioned COPY sink — `active_partitioned_writes` capped by
  `partition_write_max_open_files` (`physical_copy_to_file.cpp:54,76,172`), which is how DuckLake
  writes partitioned tables (`ducklake_insert.cpp:581,715`). Files are finalized synchronously and
  uploaded together in `finish`, so `write_batch` stays synchronous and all files land in ONE snapshot.
- **Promote** persists the caller's assignment and validates it against the live spec — arity, key
  indices exactly `0..n-1` once each, `bucket(N)` range, and that an `identity` value casts to the key
  column's type. Mirrors `AddFileToTable` (`ducklake_add_data_files.cpp:1271-1308`),
  `IsValidTransformedHivePartitionValue`, and `MapHiveColumn`. Promoting into a partitioned table
  without an assignment is refused as an input error naming the fix, matching official's
  `InvalidInputException` — not the fence's concurrency wording, which would misdescribe it.
- **The fence** now covers every commit entry point.
- **Rollover has one implementation.** `RollingFileWriter` is the single home for it, driven by both
  the buffered path and the streaming sink, so the check cannot be applied in one and forgotten in the
  other. The paths differ only in *upload policy*, which is what the API expresses: `write` returns the
  finished staged file whenever a roll happened and leaves the upload to the caller — the buffered path
  uploads immediately (at most one staged file on local disk), the streaming sink defers to `finish`
  (which is what keeps `write_batch` synchronous). A partitioned write now respects `target_file_size`
  within each partition.
- **Sort order on the bulk path.** `write_rows` (and so `write_table`/`append_table`) resolves the
  table's live sort spec — new `MetadataWriter::live_sort_spec` on all four backends — and sorts
  **globally** before splitting or rolling, matching DuckLake's blocking `PhysicalOrder` above the
  insert plan (`ducklake_insert.cpp`). That is the part that matters: it makes successive rolled files
  cover contiguous, non-overlapping ranges, which is what lets a reader skip whole files. The sorted
  batch is re-sliced back to the caller's batch boundaries, because rollover is evaluated per batch and
  one concatenated batch would otherwise emit a single file of unbounded size.

Nothing is rewritten on promote, so a partition assignment can only be *carried*, not derived: the
caller asserts the file holds rows of one partition. Official assumes the same, taking values from the
file's Hive path and validating only their shape — never the contents. The trait docs spell out the
contract.

## Deliberately not in scope

- **Partitioned `UPDATE` / upsert (#214).** The atomic append+delete commit registers a single data file, but
  the new row versions span one per partition. Needs a `register_data_files_with_deletes`.
  `finish_with_deletes` refuses a partitioned table with a typed error until then.
- **`begin_write_with_embedded_rowid` / `begin_write_to_path`** write to one caller-determined file,
  which cannot satisfy a spec needing N. Both refuse, naming the entry point.
- **Orphaned objects on a fence rejection (#215).** A partitioned write uploads before committing, so a
  rejected commit leaves the objects behind. Pre-existing in kind (the single-file path has always
  uploaded before registering); this makes it N files instead of 1. DuckLake's orphan cleanup reclaims
  them. Official deletes eagerly on rollback, so this is a real follow-up.
- **Sort order on the *streaming* session.** The bulk path now sorts (below), but `begin_write`
  cannot: the useful sort is global, so doing it there would mean buffering the whole write — what
  streaming exists to avoid — and unbounded across `max_open_partitions` open files. Sorting only
  *within* each file would achieve nothing at the file level anyway, since a file's min/max is the
  min/max of its rows however they are ordered. Documented as caller-arranged on the API.
- **Sort keys that are expressions** (e.g. `(a + b) DESC`). DuckLake binds arbitrary sort expressions;
  this crate handles bare column keys only — the documented v1 limitation from the sort feature, not a
  regression here. It fails closed: an expression key leaves rows unsorted rather than mis-sorted.
- **Two transform-value parity gaps (#212).** Temporal transforms are computed in UTC while
  DuckDB uses the session time zone, and promoted temporal values are validated more strictly than
  DuckLake's cast. Both are currently unreachable; #212 explains what makes the first one urgent later.

## Behaviour changes

- `write_table` / `append_table` now roll files by `target_file_size` and partition, since they route
  through `write_rows`. An all-empty input keeps the single-file path, which is what carries a
  `Replace` truncation.
- A partitioned write now rolls files within a partition instead of emitting one file per partition of
  unbounded size. Files on such a table will be smaller and more numerous than before — the intended
  behaviour, and DuckLake merges but never splits, so oversized files could not have been fixed later.
- A sort field whose `dialect` is not `duckdb` is now skipped rather than sorted on, matching official,
  which `continue`s past such fields (`ducklake_sort_data.cpp`). Affects compaction too, which went
  through the same helper.
- A promoted 0-row file with no partition assignment is now refused on a partitioned table. The shared
  fence exempts empty files for the empty-`Replace` truncate marker; promote has no such marker, and
  official applies its check with no row-count exception.

## Tests

- compaction merges only within a partition and preserves the assignment; the rewrite path likewise
- streaming splits across partitions in one snapshot, and loses no rows when the open-file cap forces
  eviction
- promote persists the assignment, and refuses a missing one, a wrong arity, and a 0-row file
- the three single-file entry points refuse a partitioned table, committing nothing
- a `SET PARTITIONED BY` racing a planned `INSERT` still conflicts (the write is never silently
  re-laid-out under a spec its plan did not see)
- a sorted bulk write produces files whose ranges are disjoint, and a range filter prunes them
- a single oversized partition rolls into several files, each still carrying that partition
- unit coverage for the resolver, Hive path building, and every validation rule

Full suite green on SQLite and PostgreSQL; `cargo fmt` and `clippy --all-targets` clean.
