### PR TITLE
chore(ci): add CODEOWNERS for core maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Code owners for datafusion-ducklake.
+#
+# Owners are auto-requested for review on every pull request, and the
+# `main-review` ruleset requires an approval from one of them before a PR can
+# merge. Owners themselves bypass that requirement, so this gates contributions
+# from everyone else.
+#
+# Code owners must have write access to the repository, otherwise the entry is
+# silently ignored. A pull request is governed by the version of this file on
+# the base branch, not the version in the pull request.
+
+* @zfarrell @shefeek-jinnah @anoop-narang


### PR DESCRIPTION
Adds `.github/CODEOWNERS` assigning all paths to @zfarrell, @shefeek-jinnah, and @anoop-narang. This auto-requests review on incoming PRs and is a prerequisite for enabling `require_code_owner_review` on the `main-review` ruleset, which narrows the approval requirement from any of the 7 write-holders to one of the three core maintainers.