### PR TITLE
Restore table data in a new DuckLake snapshot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,9 @@ The codebase follows a layered architecture with clear separation of concerns:
 3. **Write Layer** (feature-gated, `write` / `write-sqlite` / `write-postgres`)
    - `MetadataWriter` trait (`metadata_writer.rs`) defines catalog mutations; implemented by `SqliteMetadataWriter` (`metadata_writer_sqlite.rs`), `PostgresSingleCatalogMetadataWriter` (`metadata_writer_postgres_single.rs`, standard spec layout), and `PostgresMetadataWriter` (`metadata_writer_postgres.rs`, multi-catalog layout)
    - `DuckLakeTableWriter` / `TableWriteSession` (`table_writer.rs`): write Arrow batches to Parquet with configurable compression and row-group sizing
+   - `DuckLakeTableWriter::restore_table_data_to_snapshot`: copy historical
+     data/delete objects to fresh paths, then commit the restored metadata
+     generation atomically through the backend's optional plan/commit capability
    - `DuckLakeInsertExec` (`insert_exec.rs`): DataFusion execution plan backing `INSERT INTO` / `CREATE TABLE AS SELECT`. Declares `required_input_distribution() == SinglePartition` so multi-partition inputs are coalesced before writing (guards against silently dropping rows; see `tests/it/insert_partitioning_tests.rs`)
    - A catalog becomes writable via `DuckLakeCatalog::with_writer(provider, writer)`
    - `maintenance.rs`: expire snapshots, clean up superseded files, reclaim orphaned files (Rust API, not SQL DDL)

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -118,6 +118,7 @@ the read backend: `--no-default-features --features metadata-duckdb` (requires
 | SQL-queryable `information_schema`                      |   ✅   |
 | Table functions (`ducklake_snapshots()`, `ducklake_table_info()`, `ducklake_list_files()`, `ducklake_table_changes()`, `ducklake_table_deletions()`, `ducklake_table_insertions()`) | ✅ |
 | Maintenance: expire snapshots, cleanup superseded files, orphan-file reclamation | ✅ |
+| Table‑data restore in a new snapshot (SQLite and PostgreSQL via `DuckLakeTableWriter`) | 🟧 |
 | Parquet Modular Encryption (PME) reads (feature `encryption`) | ✅ |
 | Configurable writer output (compression, row-group sizing) | ✅  |
 | Table partitioning — read + file pruning (all backends); `identity` + `year`/`month`/`day`/`hour` transforms (`bucket(N)` tolerated, not pruned) | ✅ |
@@ -127,6 +128,29 @@ the read backend: `--no-default-features --features metadata-duckdb` (requires
 
 Maintenance and `DROP TABLE` are driven through the Rust API (`maintenance` module and
 `MetadataWriter`), not SQL DDL.
+
+## Table data restore
+
+`DuckLakeTableWriter::restore_table_data_to_snapshot` restores one table's
+data state from an earlier snapshot without changing its schema. SQLite and
+PostgreSQL support it; DuckDB and MySQL return `Unsupported` through the
+optional metadata‑backend capability.
+
+Restore copies every source data and positional‑delete Parquet object to a
+fresh sibling path before committing the new metadata snapshot. Existing
+snapshots keep their original file paths, and snapshot expiration can delete
+retired source objects without affecting the restored live rows. Copy‑phase
+failures remove completed copies when possible. Once the metadata commit
+starts, an error can have an ambiguous commit outcome, so its copies remain as
+safe orphan candidates rather than risking deletion of committed live objects.
+`delete_orphaned_files` can reclaim any unreferenced copies.
+
+The commit rejects a stale catalog head, schema changes found in either the
+schema‑version ledger or the table's column generations, and partial data or
+delete files. SQLite also rejects a restore when inlined rows are visible at
+the source snapshot or current head because restoring those rows requires more
+than data‑file metadata changes. Partial files embed per‑row snapshot windows
+and require a physical rewrite rather than a metadata‑only restore.
 
 ---
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,8 +136,9 @@ pub use insert_exec::DuckLakeInsertExec;
 #[cfg(feature = "write")]
 pub use metadata_writer::{
     ColumnDef, ColumnStat, CommitIds, CompactionOutputFile, CompactionSourceFile, DataFileInfo,
-    DeleteFileEntry, DeleteFileInfo, MetadataWriter, SnapshotCommitMetadata, SourceRetirement,
-    WriteMode, WriteResult, WriteSetupResult,
+    DeleteFileEntry, DeleteFileInfo, MetadataWriter, RestoreResult, SnapshotCommitMetadata,
+    SourceRetirement, TableRestoreCommit, TableRestoreFile, TableRestoreFileKind,
+    TableRestoreOptions, TableRestorePlan, WriteMode, WriteResult, WriteSetupResult,
 };
 #[cfg(feature = "write-duckdb")]
 pub use metadata_writer_duckdb::DuckdbMetadataWriter;

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -3,9 +3,12 @@
 //! This module provides the `MetadataWriter` trait for writing metadata to DuckLake catalogs,
 //! along with helper types for column definitions and data file registration.
 
+use std::collections::BTreeSet;
+
 use crate::types::{arrow_to_ducklake_type, ducklake_to_arrow_type};
 use crate::{DuckLakeError, Result};
 use arrow::datatypes::DataType;
+use uuid::Uuid;
 
 /// Maximum allowed length for catalog entity names (schemas, tables, columns).
 pub const MAX_NAME_LENGTH: usize = 1024;
@@ -142,6 +145,21 @@ impl SnapshotCommitMetadata {
             ));
         }
         Ok(())
+    }
+}
+
+pub(crate) fn restored_table_data_changes(
+    table_id: i64,
+    retired_data: bool,
+    restored_data: bool,
+) -> String {
+    match (retired_data, restored_data) {
+        (true, true) => {
+            format!("deleted_from_table:{table_id},inserted_into_table:{table_id}")
+        },
+        (true, false) => format!("deleted_from_table:{table_id}"),
+        (false, true) => format!("inserted_into_table:{table_id}"),
+        (false, false) => String::new(),
     }
 }
 
@@ -675,6 +693,221 @@ pub struct WriteResult {
     pub records_written: i64,
 }
 
+/// Result of restoring one table's data to an earlier snapshot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RestoreResult {
+    /// New catalog snapshot containing the restored table state.
+    pub snapshot_id: i64,
+    /// Number of data-file metadata rows re-referenced by the restored state.
+    pub data_files_restored: usize,
+    /// Number of delete-file metadata rows re-referenced by the restored state.
+    pub delete_files_restored: usize,
+}
+
+/// Kind of object copied for a table-data restore.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TableRestoreFileKind {
+    /// A Parquet data file.
+    Data,
+    /// A Parquet positional-delete file.
+    Delete,
+}
+
+/// One physical object copied before a table-data restore commits its metadata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TableRestoreFile {
+    /// Whether this is a data or positional-delete file.
+    pub kind: TableRestoreFileKind,
+    /// Catalog identifier of the source data or delete file.
+    pub source_file_id: i64,
+    /// Source object path, resolved through the schema and table path hierarchy.
+    pub source_object_path: String,
+    /// Whether `source_object_path` is relative to the catalog `data_path`.
+    pub source_object_path_is_relative: bool,
+    /// Fresh path stored on the restored catalog row.
+    pub restored_catalog_path: String,
+    /// Whether `restored_catalog_path` is relative to the table path.
+    pub restored_catalog_path_is_relative: bool,
+    /// Fresh object path, resolved through the schema and table path hierarchy.
+    pub restored_object_path: String,
+    /// Whether `restored_object_path` is relative to the catalog `data_path`.
+    pub restored_object_path_is_relative: bool,
+}
+
+/// Physical-copy plan for restoring one table's data in a new snapshot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TableRestorePlan {
+    /// Table whose data state will be restored.
+    pub table_id: i64,
+    /// Snapshot whose table data state will be copied.
+    pub source_snapshot_id: i64,
+    /// Catalog head that must still be current when the plan commits.
+    pub expected_base_snapshot_id: i64,
+    /// Data and positional-delete objects to copy before the metadata commit.
+    pub files: Vec<TableRestoreFile>,
+}
+
+/// Proof that a table-restore plan's physical copies completed.
+///
+/// This value can only be created by [`crate::table_writer::DuckLakeTableWriter`].
+/// Metadata backends receive it after the writer has copied every planned object.
+#[derive(Debug)]
+pub struct TableRestoreCommit {
+    pub(crate) plan: TableRestorePlan,
+}
+
+impl TableRestoreCommit {
+    pub(crate) fn new(plan: TableRestorePlan) -> Self {
+        Self {
+            plan,
+        }
+    }
+
+    /// Return the copied physical-object plan to commit.
+    pub fn plan(&self) -> &TableRestorePlan {
+        &self.plan
+    }
+}
+
+pub(crate) fn table_restore_file(
+    kind: TableRestoreFileKind,
+    source_file_id: i64,
+    expected_base_snapshot_id: i64,
+    catalog_path: String,
+    catalog_path_is_relative: bool,
+    object_path: String,
+    object_path_is_relative: bool,
+) -> Result<TableRestoreFile> {
+    let kind_name = match kind {
+        TableRestoreFileKind::Data => "data",
+        TableRestoreFileKind::Delete => "delete",
+    };
+    let suffix = format!(
+        "{expected_base_snapshot_id}-{kind_name}-{source_file_id}-{}",
+        Uuid::new_v4()
+    );
+    let restored_catalog_path = restored_sibling_path(&catalog_path, &suffix)?;
+    let object_prefix = object_path.strip_suffix(&catalog_path).ok_or_else(|| {
+        DuckLakeError::InvalidConfig(format!(
+            "resolved restore path '{object_path}' does not end with catalog path '{catalog_path}'"
+        ))
+    })?;
+    let restored_object_path = format!("{object_prefix}{restored_catalog_path}");
+    Ok(TableRestoreFile {
+        kind,
+        source_file_id,
+        source_object_path: object_path,
+        source_object_path_is_relative: object_path_is_relative,
+        restored_catalog_path,
+        restored_catalog_path_is_relative: catalog_path_is_relative,
+        restored_object_path,
+        restored_object_path_is_relative: object_path_is_relative,
+    })
+}
+
+pub(crate) fn validate_table_restore_plan(plan: &TableRestorePlan) -> Result<()> {
+    let mut restored_paths = BTreeSet::new();
+    for file in &plan.files {
+        if file.source_object_path == file.restored_object_path
+            && file.source_object_path_is_relative == file.restored_object_path_is_relative
+        {
+            return Err(DuckLakeError::InvalidConfig(format!(
+                "restore plan reuses source object path '{}'",
+                file.source_object_path
+            )));
+        }
+        if !restored_paths.insert((
+            file.restored_object_path.as_str(),
+            file.restored_object_path_is_relative,
+        )) {
+            return Err(DuckLakeError::InvalidConfig(format!(
+                "restore plan repeats destination object path '{}'",
+                file.restored_object_path
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn restored_sibling_path(path: &str, suffix: &str) -> Result<String> {
+    let (directory, name) = path
+        .rsplit_once('/')
+        .map_or(("", path), |(dir, name)| (dir, name));
+    if name.is_empty() {
+        return Err(DuckLakeError::InvalidConfig(format!(
+            "cannot restore object from path '{path}' without a file name"
+        )));
+    }
+    let restored_name = name.rsplit_once('.').map_or_else(
+        || format!("{name}.restore-{suffix}"),
+        |(stem, extension)| format!("{stem}.restore-{suffix}.{extension}"),
+    );
+    if directory.is_empty() {
+        Ok(restored_name)
+    } else {
+        Ok(format!("{directory}/{restored_name}"))
+    }
+}
+
+/// Optional snapshot-change metadata for restoring table data.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TableRestoreOptions {
+    commit_metadata: SnapshotCommitMetadata,
+}
+
+impl TableRestoreOptions {
+    /// Creates restore options without snapshot-change metadata.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            commit_metadata: SnapshotCommitMetadata::new(),
+        }
+    }
+
+    /// Sets the snapshot author.
+    #[must_use]
+    pub fn with_author(mut self, author: impl Into<String>) -> Self {
+        self.commit_metadata = self.commit_metadata.with_author(author);
+        self
+    }
+
+    /// Sets the snapshot commit message.
+    #[must_use]
+    pub fn with_message(mut self, message: impl Into<String>) -> Self {
+        self.commit_metadata = self.commit_metadata.with_message(message);
+        self
+    }
+
+    /// Sets opaque snapshot extra information.
+    #[must_use]
+    pub fn with_extra_info(mut self, extra_info: impl Into<String>) -> Self {
+        self.commit_metadata = self.commit_metadata.with_extra_info(extra_info);
+        self
+    }
+
+    /// Returns the snapshot author.
+    #[must_use]
+    pub fn author(&self) -> Option<&str> {
+        self.commit_metadata.author()
+    }
+
+    /// Returns the snapshot commit message.
+    #[must_use]
+    pub fn message(&self) -> Option<&str> {
+        self.commit_metadata.message()
+    }
+
+    /// Returns the snapshot extra information.
+    #[must_use]
+    pub fn extra_info(&self) -> Option<&str> {
+        self.commit_metadata.extra_info()
+    }
+
+    pub(crate) fn commit_metadata(&self) -> &SnapshotCommitMetadata {
+        &self.commit_metadata
+    }
+}
+
 /// The ids actually committed by `register_data_file` / `publish_snapshot`.
 ///
 /// On multicatalog Postgres all metadata is written at the commit point, so the
@@ -722,6 +955,37 @@ pub struct WriteSetupResult {
 pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
     /// Create a new snapshot and return its ID.
     fn create_snapshot(&self) -> Result<i64>;
+
+    /// Plan physical object copies for restoring one table's data state.
+    ///
+    /// The default keeps external metadata backends source-compatible while making restore an
+    /// explicit optional capability.
+    fn plan_table_data_restore(
+        &self,
+        _table_id: i64,
+        _source_snapshot_id: i64,
+        _expected_base_snapshot_id: i64,
+    ) -> Result<TableRestorePlan> {
+        Err(DuckLakeError::Unsupported(
+            "table data restore is not supported on this metadata backend".to_string(),
+        ))
+    }
+
+    /// Atomically commit a prepared table-data restore after its objects are copied.
+    ///
+    /// Implementations must allocate fresh data/delete-file identifiers, preserve row lineage,
+    /// retire the current file generation, and abort if the catalog head differs from the plan's
+    /// expected base. They must revalidate schema and partial-file constraints in the commit
+    /// transaction so a failed restore leaves no metadata changes.
+    fn commit_table_data_restore(
+        &self,
+        _commit: &TableRestoreCommit,
+        _options: &TableRestoreOptions,
+    ) -> Result<RestoreResult> {
+        Err(DuckLakeError::Unsupported(
+            "table data restore is not supported on this metadata backend".to_string(),
+        ))
+    }
 
     /// Get or create a schema, returning `(schema_id, was_created)`.
     fn get_or_create_schema(

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -14,8 +14,10 @@ use crate::error::{TypeChangeOperation, TypeChangeWriteMode};
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
     ColumnDef, ColumnStat, CommitIds, DataFileInfo, DeleteFileEntry, DeleteFileInfo,
-    MetadataWriter, SnapshotCommitMetadata, WriteMode, WriteSetupResult, columns_differ,
-    table_write_changes, validate_delete_entries, validate_name,
+    MetadataWriter, RestoreResult, SnapshotCommitMetadata, TableRestoreCommit,
+    TableRestoreFileKind, TableRestoreOptions, TableRestorePlan, WriteMode, WriteSetupResult,
+    columns_differ, restored_table_data_changes, table_restore_file, table_write_changes,
+    validate_delete_entries, validate_name, validate_table_restore_plan,
 };
 use crate::partition::PartitionTransform;
 use sqlx::AssertSqlSafe;
@@ -655,6 +657,54 @@ END";
 const COMPACTION_REL_FLAG: &str =
     "(df.path_is_relative AND t.path_is_relative AND s.path_is_relative)";
 
+async fn reject_restore_path_collisions(
+    catalog_id: i64,
+    plan: &TableRestorePlan,
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+) -> Result<()> {
+    for file in &plan.files {
+        let collision: bool = sqlx::query_scalar(AssertSqlSafe(format!(
+            "SELECT EXISTS(
+                 SELECT 1 FROM (
+                     SELECT {COMPACTION_RESOLVED_PATH} AS object_path,
+                            {COMPACTION_REL_FLAG} AS object_path_is_relative
+                     FROM ducklake_data_file df
+                     JOIN ducklake_table t ON t.table_id = df.table_id
+                     JOIN ducklake_schema s ON s.schema_id = t.schema_id
+                     JOIN ducklake_catalog_schema_map csm
+                       ON csm.schema_id = s.schema_id AND csm.catalog_id = $1
+                     UNION ALL
+                     SELECT {COMPACTION_RESOLVED_PATH} AS object_path,
+                            {COMPACTION_REL_FLAG} AS object_path_is_relative
+                     FROM ducklake_delete_file df
+                     JOIN ducklake_table t ON t.table_id = df.table_id
+                     JOIN ducklake_schema s ON s.schema_id = t.schema_id
+                     JOIN ducklake_catalog_schema_map csm
+                       ON csm.schema_id = s.schema_id AND csm.catalog_id = $1
+                     UNION ALL
+                     SELECT path AS object_path,
+                            path_is_relative AS object_path_is_relative
+                     FROM ducklake_files_scheduled_for_deletion
+                     WHERE catalog_id = $1
+                 ) paths
+                 WHERE object_path = $2 AND object_path_is_relative = $3
+             )"
+        )))
+        .bind(catalog_id)
+        .bind(&file.restored_object_path)
+        .bind(file.restored_object_path_is_relative)
+        .fetch_one(&mut **tx)
+        .await?;
+        if collision {
+            return Err(crate::DuckLakeError::Conflict(format!(
+                "restore destination path '{}' is already cataloged or scheduled for deletion",
+                file.restored_object_path
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Insert `(id, resolved_path, rel)` rows (as produced by
 /// [`COMPACTION_RESOLVED_PATH`] / [`COMPACTION_REL_FLAG`]) into
 /// `ducklake_files_scheduled_for_deletion`, scoped to `catalog_id`. Mirrors the
@@ -1248,6 +1298,533 @@ impl MetadataWriter for PostgresMetadataWriter {
                 .await?;
             tx.commit().await?;
             Ok(snapshot_id)
+        })
+    }
+
+    fn plan_table_data_restore(
+        &self,
+        table_id: i64,
+        source_snapshot_id: i64,
+        expected_base_snapshot_id: i64,
+    ) -> Result<TableRestorePlan> {
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            assert_table_in_catalog(self.catalog_id, table_id, &mut tx).await?;
+            let base_snapshot_id: i64 = sqlx::query_scalar(
+                "SELECT s.snapshot_id
+                 FROM ducklake_snapshot s
+                 JOIN ducklake_catalog_snapshot_map m ON m.snapshot_id = s.snapshot_id
+                 WHERE m.catalog_id = $1
+                 ORDER BY s.snapshot_id DESC LIMIT 1",
+            )
+            .bind(self.catalog_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            if base_snapshot_id != expected_base_snapshot_id {
+                return Err(crate::DuckLakeError::Conflict(format!(
+                    "catalog head changed from snapshot {expected_base_snapshot_id} to \
+                     {base_snapshot_id} before table restore"
+                )));
+            }
+            if source_snapshot_id < 0 || source_snapshot_id >= expected_base_snapshot_id {
+                return Err(crate::DuckLakeError::InvalidConfig(format!(
+                    "restore source snapshot {source_snapshot_id} must precede catalog head \
+                     {expected_base_snapshot_id}"
+                )));
+            }
+            let source_exists: bool = sqlx::query_scalar(
+                "SELECT EXISTS(
+                    SELECT 1 FROM ducklake_catalog_snapshot_map
+                    WHERE catalog_id = $1 AND snapshot_id = $2
+                 )",
+            )
+            .bind(self.catalog_id)
+            .bind(source_snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            if !source_exists {
+                return Err(crate::DuckLakeError::InvalidConfig(format!(
+                    "restore source snapshot {source_snapshot_id} does not belong to catalog {}",
+                    self.catalog_id
+                )));
+            }
+            let table_visible_at_source: bool = sqlx::query_scalar(
+                "SELECT EXISTS(
+                    SELECT 1 FROM ducklake_table
+                    WHERE table_id = $1 AND begin_snapshot <= $2
+                      AND (end_snapshot IS NULL OR $2 < end_snapshot)
+                 )",
+            )
+            .bind(table_id)
+            .bind(source_snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            if !table_visible_at_source {
+                return Err(crate::DuckLakeError::InvalidConfig(format!(
+                    "table {table_id} is not visible at snapshot {source_snapshot_id}"
+                )));
+            }
+            let table_visible_at_base: bool = sqlx::query_scalar(
+                "SELECT EXISTS(
+                    SELECT 1 FROM ducklake_table
+                    WHERE table_id = $1 AND begin_snapshot <= $2
+                      AND (end_snapshot IS NULL OR $2 < end_snapshot)
+                 )",
+            )
+            .bind(table_id)
+            .bind(expected_base_snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            if !table_visible_at_base {
+                return Err(crate::DuckLakeError::Unsupported(format!(
+                    "cannot restore data for table {table_id} because it is not visible at the \
+                     current catalog head"
+                )));
+            }
+            let schema_changed_after_source: bool = sqlx::query_scalar(
+                "SELECT EXISTS(
+                    SELECT 1 FROM ducklake_schema_versions
+                    WHERE table_id = $1 AND begin_snapshot > $2 AND begin_snapshot <= $3
+                    UNION ALL
+                    SELECT 1 FROM ducklake_column
+                    WHERE table_id = $1 AND (
+                        (begin_snapshot > $2 AND begin_snapshot <= $3) OR
+                        (end_snapshot > $2 AND end_snapshot <= $3)
+                    )
+                 )",
+            )
+            .bind(table_id)
+            .bind(source_snapshot_id)
+            .bind(expected_base_snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            if schema_changed_after_source {
+                return Err(crate::DuckLakeError::Unsupported(format!(
+                    "cannot restore data for table {table_id} from snapshot {source_snapshot_id} \
+                     because its schema changed afterward"
+                )));
+            }
+
+            let source_files = sqlx::query(AssertSqlSafe(format!(
+                "SELECT df.data_file_id, df.path, df.path_is_relative,
+                        {COMPACTION_RESOLVED_PATH} AS object_path,
+                        {COMPACTION_REL_FLAG} AS object_path_is_relative, df.partial_max
+                 FROM ducklake_data_file df
+                 JOIN ducklake_table t ON t.table_id = df.table_id
+                 JOIN ducklake_schema s ON s.schema_id = t.schema_id
+                 WHERE df.table_id = $1 AND df.begin_snapshot <= $2
+                   AND (df.end_snapshot IS NULL OR $2 < df.end_snapshot)
+                 ORDER BY df.data_file_id"
+            )))
+            .bind(table_id)
+            .bind(source_snapshot_id)
+            .fetch_all(&mut *tx)
+            .await?;
+            let mut files = Vec::with_capacity(source_files.len());
+            for source in source_files {
+                if source.try_get::<Option<i64>, _>("partial_max")?.is_some() {
+                    return Err(crate::DuckLakeError::Unsupported(format!(
+                        "cannot restore data for table {table_id} from snapshot \
+                         {source_snapshot_id} because it contains a partial data file"
+                    )));
+                }
+                files.push(table_restore_file(
+                    TableRestoreFileKind::Data,
+                    source.try_get("data_file_id")?,
+                    expected_base_snapshot_id,
+                    source.try_get("path")?,
+                    source.try_get("path_is_relative")?,
+                    source.try_get("object_path")?,
+                    source.try_get("object_path_is_relative")?,
+                )?);
+            }
+            let source_deletes = sqlx::query(AssertSqlSafe(format!(
+                "SELECT df.delete_file_id, df.path, df.path_is_relative,
+                        {COMPACTION_RESOLVED_PATH} AS object_path,
+                        {COMPACTION_REL_FLAG} AS object_path_is_relative, df.partial_max
+                 FROM ducklake_delete_file df
+                 JOIN ducklake_data_file data ON data.data_file_id = df.data_file_id
+                 JOIN ducklake_table t ON t.table_id = df.table_id
+                 JOIN ducklake_schema s ON s.schema_id = t.schema_id
+                 WHERE df.table_id = $1 AND data.begin_snapshot <= $2
+                   AND (data.end_snapshot IS NULL OR $2 < data.end_snapshot)
+                   AND df.begin_snapshot <= $2
+                   AND (df.end_snapshot IS NULL OR $2 < df.end_snapshot)
+                 ORDER BY df.delete_file_id"
+            )))
+            .bind(table_id)
+            .bind(source_snapshot_id)
+            .fetch_all(&mut *tx)
+            .await?;
+            files.reserve(source_deletes.len());
+            for source in source_deletes {
+                if source.try_get::<Option<i64>, _>("partial_max")?.is_some() {
+                    return Err(crate::DuckLakeError::Unsupported(format!(
+                        "cannot restore data for table {table_id} from snapshot \
+                         {source_snapshot_id} because it contains a partial delete file"
+                    )));
+                }
+                files.push(table_restore_file(
+                    TableRestoreFileKind::Delete,
+                    source.try_get("delete_file_id")?,
+                    expected_base_snapshot_id,
+                    source.try_get("path")?,
+                    source.try_get("path_is_relative")?,
+                    source.try_get("object_path")?,
+                    source.try_get("object_path_is_relative")?,
+                )?);
+            }
+            let plan = TableRestorePlan {
+                table_id,
+                source_snapshot_id,
+                expected_base_snapshot_id,
+                files,
+            };
+            validate_table_restore_plan(&plan)?;
+            reject_restore_path_collisions(self.catalog_id, &plan, &mut tx).await?;
+            tx.commit().await?;
+            Ok(plan)
+        })
+    }
+
+    fn commit_table_data_restore(
+        &self,
+        commit: &TableRestoreCommit,
+        options: &TableRestoreOptions,
+    ) -> Result<RestoreResult> {
+        let plan = commit.plan();
+        block_on(async {
+            validate_table_restore_plan(plan)?;
+            let table_id = plan.table_id;
+            let source_snapshot_id = plan.source_snapshot_id;
+            let expected_base_snapshot_id = plan.expected_base_snapshot_id;
+            let mut tx = self.pool.begin().await?;
+            lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
+            assert_table_in_catalog(self.catalog_id, table_id, &mut tx).await?;
+
+            let base = sqlx::query(
+                "SELECT s.snapshot_id, s.schema_version
+                 FROM ducklake_snapshot s
+                 JOIN ducklake_catalog_snapshot_map m ON m.snapshot_id = s.snapshot_id
+                 WHERE m.catalog_id = $1
+                 ORDER BY s.snapshot_id DESC LIMIT 1",
+            )
+            .bind(self.catalog_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            let base_snapshot_id: i64 = base.try_get("snapshot_id")?;
+            let schema_version: i64 = base.try_get("schema_version")?;
+            if base_snapshot_id != expected_base_snapshot_id {
+                return Err(crate::DuckLakeError::Conflict(format!(
+                    "catalog head changed from snapshot {expected_base_snapshot_id} to \
+                     {base_snapshot_id} before table restore"
+                )));
+            }
+            if source_snapshot_id < 0 || source_snapshot_id >= expected_base_snapshot_id {
+                return Err(crate::DuckLakeError::InvalidConfig(format!(
+                    "restore source snapshot {source_snapshot_id} must precede catalog head \
+                     {expected_base_snapshot_id}"
+                )));
+            }
+            let source_exists: bool = sqlx::query_scalar(
+                "SELECT EXISTS(
+                    SELECT 1 FROM ducklake_catalog_snapshot_map
+                    WHERE catalog_id = $1 AND snapshot_id = $2
+                 )",
+            )
+            .bind(self.catalog_id)
+            .bind(source_snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            if !source_exists {
+                return Err(crate::DuckLakeError::InvalidConfig(format!(
+                    "restore source snapshot {source_snapshot_id} does not belong to catalog {}",
+                    self.catalog_id
+                )));
+            }
+            let table_visible_at_source: bool = sqlx::query_scalar(
+                "SELECT EXISTS(
+                    SELECT 1 FROM ducklake_table
+                    WHERE table_id = $1 AND begin_snapshot <= $2
+                      AND (end_snapshot IS NULL OR $2 < end_snapshot)
+                 )",
+            )
+            .bind(table_id)
+            .bind(source_snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            if !table_visible_at_source {
+                return Err(crate::DuckLakeError::InvalidConfig(format!(
+                    "table {table_id} is not visible at snapshot {source_snapshot_id}"
+                )));
+            }
+            let table_visible_at_base: bool = sqlx::query_scalar(
+                "SELECT EXISTS(
+                    SELECT 1 FROM ducklake_table
+                    WHERE table_id = $1 AND begin_snapshot <= $2
+                      AND (end_snapshot IS NULL OR $2 < end_snapshot)
+                 )",
+            )
+            .bind(table_id)
+            .bind(expected_base_snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            if !table_visible_at_base {
+                return Err(crate::DuckLakeError::Unsupported(format!(
+                    "cannot restore data for table {table_id} because it is not visible at the \
+                     current catalog head"
+                )));
+            }
+            let schema_changed_after_source: bool = sqlx::query_scalar(
+                "SELECT EXISTS(
+                    SELECT 1 FROM ducklake_schema_versions
+                    WHERE table_id = $1 AND begin_snapshot > $2 AND begin_snapshot <= $3
+                    UNION ALL
+                    SELECT 1 FROM ducklake_column
+                    WHERE table_id = $1 AND (
+                        (begin_snapshot > $2 AND begin_snapshot <= $3) OR
+                        (end_snapshot > $2 AND end_snapshot <= $3)
+                    )
+                 )",
+            )
+            .bind(table_id)
+            .bind(source_snapshot_id)
+            .bind(expected_base_snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            if schema_changed_after_source {
+                return Err(crate::DuckLakeError::Unsupported(format!(
+                    "cannot restore data for table {table_id} from snapshot {source_snapshot_id} \
+                     because its schema changed afterward"
+                )));
+            }
+            reject_restore_path_collisions(self.catalog_id, plan, &mut tx).await?;
+
+            let source_files = sqlx::query(
+                "SELECT data_file_id, path, path_is_relative, file_size_bytes, footer_size,
+                        encryption_key, record_count, row_id_start, mapping_id, partial_max,
+                        partition_id
+                 FROM ducklake_data_file
+                 WHERE table_id = $1 AND begin_snapshot <= $2
+                   AND (end_snapshot IS NULL OR $2 < end_snapshot)
+                 ORDER BY data_file_id",
+            )
+            .bind(table_id)
+            .bind(source_snapshot_id)
+            .fetch_all(&mut *tx)
+            .await?;
+            for source in &source_files {
+                if source.try_get::<Option<i64>, _>("partial_max")?.is_some() {
+                    return Err(crate::DuckLakeError::Unsupported(format!(
+                        "cannot restore data for table {table_id} from snapshot \
+                         {source_snapshot_id} because it contains a partial data file"
+                    )));
+                }
+            }
+            let planned_data_files = plan
+                .files
+                .iter()
+                .filter(|file| file.kind == TableRestoreFileKind::Data)
+                .count();
+            if planned_data_files != source_files.len() {
+                return Err(crate::DuckLakeError::InvalidConfig(
+                    "restore plan data files no longer match the source snapshot".to_string(),
+                ));
+            }
+            let retired_data_files: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM ducklake_data_file
+                 WHERE table_id = $1 AND end_snapshot IS NULL",
+            )
+            .bind(table_id)
+            .fetch_one(&mut *tx)
+            .await?;
+
+            let snapshot_id: i64 = sqlx::query_scalar(
+                "INSERT INTO ducklake_snapshot (snapshot_time, schema_version)
+                 VALUES (NOW(), $1) RETURNING snapshot_id",
+            )
+            .bind(schema_version)
+            .fetch_one(&mut *tx)
+            .await?;
+
+            sqlx::query(
+                "UPDATE ducklake_delete_file SET end_snapshot = $1
+                 WHERE table_id = $2 AND end_snapshot IS NULL",
+            )
+            .bind(snapshot_id)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            sqlx::query(
+                "UPDATE ducklake_data_file SET end_snapshot = $1
+                 WHERE table_id = $2 AND end_snapshot IS NULL",
+            )
+            .bind(snapshot_id)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+
+            let mut delete_files_restored = 0;
+            for source in &source_files {
+                let source_data_file_id: i64 = source.try_get("data_file_id")?;
+                let restored_data = plan
+                    .files
+                    .iter()
+                    .find(|file| {
+                        file.kind == TableRestoreFileKind::Data
+                            && file.source_file_id == source_data_file_id
+                    })
+                    .ok_or_else(|| {
+                        crate::DuckLakeError::InvalidConfig(format!(
+                            "restore plan is missing data file {source_data_file_id}"
+                        ))
+                    })?;
+                let data_file_id: i64 = sqlx::query_scalar(
+                    "INSERT INTO ducklake_data_file
+                         (table_id, path, path_is_relative, file_size_bytes, footer_size,
+                          encryption_key, record_count, row_id_start, mapping_id, begin_snapshot,
+                          end_snapshot, partial_max, partition_id)
+                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NULL, $11, $12)
+                     RETURNING data_file_id",
+                )
+                .bind(table_id)
+                .bind(&restored_data.restored_catalog_path)
+                .bind(restored_data.restored_catalog_path_is_relative)
+                .bind(source.try_get::<i64, _>("file_size_bytes")?)
+                .bind(source.try_get::<Option<i64>, _>("footer_size")?)
+                .bind(source.try_get::<Option<String>, _>("encryption_key")?)
+                .bind(source.try_get::<Option<i64>, _>("record_count")?)
+                .bind(source.try_get::<Option<i64>, _>("row_id_start")?)
+                .bind(source.try_get::<Option<i64>, _>("mapping_id")?)
+                .bind(snapshot_id)
+                .bind(source.try_get::<Option<i64>, _>("partial_max")?)
+                .bind(source.try_get::<Option<i64>, _>("partition_id")?)
+                .fetch_one(&mut *tx)
+                .await?;
+                sqlx::query(
+                    "INSERT INTO ducklake_file_column_stats
+                         (data_file_id, table_id, column_id, column_size_bytes, value_count,
+                          null_count, min_value, max_value, contains_nan, extra_stats)
+                     SELECT $1, table_id, column_id, column_size_bytes, value_count,
+                            null_count, min_value, max_value, contains_nan, extra_stats
+                     FROM ducklake_file_column_stats WHERE data_file_id = $2",
+                )
+                .bind(data_file_id)
+                .bind(source_data_file_id)
+                .execute(&mut *tx)
+                .await?;
+                sqlx::query(
+                    "INSERT INTO ducklake_file_partition_value
+                         (data_file_id, table_id, partition_key_index, partition_value)
+                     SELECT $1, table_id, partition_key_index, partition_value
+                     FROM ducklake_file_partition_value WHERE data_file_id = $2",
+                )
+                .bind(data_file_id)
+                .bind(source_data_file_id)
+                .execute(&mut *tx)
+                .await?;
+
+                let source_delete = sqlx::query(
+                    "SELECT delete_file_id, path, path_is_relative, file_size_bytes, footer_size,
+                            encryption_key, delete_count, partial_max
+                     FROM ducklake_delete_file
+                     WHERE data_file_id = $1 AND begin_snapshot <= $2
+                       AND (end_snapshot IS NULL OR $2 < end_snapshot)
+                     ORDER BY begin_snapshot DESC LIMIT 1",
+                )
+                .bind(source_data_file_id)
+                .bind(source_snapshot_id)
+                .fetch_optional(&mut *tx)
+                .await?;
+                if let Some(delete) = source_delete {
+                    let source_delete_file_id: i64 = delete.try_get("delete_file_id")?;
+                    if delete.try_get::<Option<i64>, _>("partial_max")?.is_some() {
+                        return Err(crate::DuckLakeError::Unsupported(format!(
+                            "cannot restore data for table {table_id} from snapshot \
+                            {source_snapshot_id} because it contains a partial delete file"
+                        )));
+                    }
+                    let restored_delete = plan
+                        .files
+                        .iter()
+                        .find(|file| {
+                            file.kind == TableRestoreFileKind::Delete
+                                && file.source_file_id == source_delete_file_id
+                        })
+                        .ok_or_else(|| {
+                            crate::DuckLakeError::InvalidConfig(format!(
+                                "restore plan is missing delete file {source_delete_file_id}"
+                            ))
+                        })?;
+                    sqlx::query(
+                        "INSERT INTO ducklake_delete_file
+                             (data_file_id, table_id, path, path_is_relative, file_size_bytes,
+                              footer_size, encryption_key, delete_count, begin_snapshot,
+                              end_snapshot, partial_max)
+                         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NULL, $10)",
+                    )
+                    .bind(data_file_id)
+                    .bind(table_id)
+                    .bind(&restored_delete.restored_catalog_path)
+                    .bind(restored_delete.restored_catalog_path_is_relative)
+                    .bind(delete.try_get::<i64, _>("file_size_bytes")?)
+                    .bind(delete.try_get::<Option<i64>, _>("footer_size")?)
+                    .bind(delete.try_get::<Option<String>, _>("encryption_key")?)
+                    .bind(delete.try_get::<Option<i64>, _>("delete_count")?)
+                    .bind(snapshot_id)
+                    .bind(delete.try_get::<Option<i64>, _>("partial_max")?)
+                    .execute(&mut *tx)
+                    .await?;
+                    delete_files_restored += 1;
+                }
+            }
+            let planned_delete_files = plan
+                .files
+                .iter()
+                .filter(|file| file.kind == TableRestoreFileKind::Delete)
+                .count();
+            if planned_delete_files != delete_files_restored {
+                return Err(crate::DuckLakeError::InvalidConfig(
+                    "restore plan delete files no longer match the source snapshot".to_string(),
+                ));
+            }
+
+            sqlx::query(
+                "UPDATE ducklake_table_stats
+                 SET record_count = (
+                         SELECT COALESCE(SUM(record_count), 0) FROM ducklake_data_file
+                         WHERE table_id = $1 AND end_snapshot IS NULL
+                     ),
+                     file_size_bytes = (
+                         SELECT COALESCE(SUM(file_size_bytes), 0) FROM ducklake_data_file
+                         WHERE table_id = $1 AND end_snapshot IS NULL
+                     )
+                 WHERE table_id = $1",
+            )
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            let (columns, column_ids) = live_columns_for_stats(table_id, &mut tx).await?;
+            recompute_table_column_stats(&mut tx, table_id, &columns, &column_ids).await?;
+            let changes_made = restored_table_data_changes(
+                table_id,
+                retired_data_files > 0,
+                !source_files.is_empty(),
+            );
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &changes_made,
+                options.commit_metadata(),
+            )
+            .await?;
+            advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
+            tx.commit().await?;
+            Ok(RestoreResult {
+                snapshot_id,
+                data_files_restored: source_files.len(),
+                delete_files_restored,
+            })
         })
     }
 

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -10,8 +10,10 @@ use crate::maintenance::{
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
     ColumnDef, ColumnStat, CommitIds, DataFileInfo, DeleteFileEntry, DeleteFileInfo,
-    MetadataWriter, SnapshotCommitMetadata, WriteMode, WriteSetupResult, columns_differ,
-    table_write_changes, validate_delete_entries, validate_name,
+    MetadataWriter, RestoreResult, SnapshotCommitMetadata, TableRestoreCommit,
+    TableRestoreFileKind, TableRestoreOptions, TableRestorePlan, WriteMode, WriteSetupResult,
+    columns_differ, restored_table_data_changes, table_restore_file, table_write_changes,
+    validate_delete_entries, validate_name, validate_table_restore_plan,
 };
 use crate::partition::PartitionTransform;
 use sqlx::AssertSqlSafe;
@@ -699,7 +701,48 @@ END";
 /// resolved path is relative to `data_path`), else 0 (the resolved path is absolute).
 const REL_FLAG: &str =
     "(CASE WHEN df.path_is_relative AND t.path_is_relative AND s.path_is_relative
-           THEN 1 ELSE 0 END)";
+      THEN 1 ELSE 0 END)";
+
+async fn reject_restore_path_collisions(
+    plan: &TableRestorePlan,
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+) -> Result<()> {
+    for file in &plan.files {
+        let collision: bool = sqlx::query_scalar(AssertSqlSafe(format!(
+            "SELECT EXISTS(
+                 SELECT 1 FROM (
+                     SELECT {RESOLVED_PATH} AS object_path,
+                            {REL_FLAG} AS object_path_is_relative
+                     FROM ducklake_data_file df
+                     JOIN ducklake_table t ON t.table_id = df.table_id
+                     JOIN ducklake_schema s ON s.schema_id = t.schema_id
+                     UNION ALL
+                     SELECT {RESOLVED_PATH} AS object_path,
+                            {REL_FLAG} AS object_path_is_relative
+                     FROM ducklake_delete_file df
+                     JOIN ducklake_table t ON t.table_id = df.table_id
+                     JOIN ducklake_schema s ON s.schema_id = t.schema_id
+                     UNION ALL
+                     SELECT path AS object_path,
+                            CAST(path_is_relative AS INTEGER) AS object_path_is_relative
+                     FROM ducklake_files_scheduled_for_deletion
+                 ) paths
+                 WHERE object_path = ? AND object_path_is_relative = ?
+             )"
+        )))
+        .bind(&file.restored_object_path)
+        .bind(i64::from(file.restored_object_path_is_relative))
+        .fetch_one(&mut **tx)
+        .await?;
+        if collision {
+            return Err(crate::DuckLakeError::Conflict(format!(
+                "restore destination path '{}' is already cataloged or scheduled for deletion",
+                file.restored_object_path
+            )));
+        }
+    }
+    Ok(())
+}
 
 /// Map `(snapshot_id, snapshot_time)` rows to [`ExpiredSnapshot`]s.
 fn rows_to_snapshots(rows: Vec<sqlx::sqlite::SqliteRow>) -> Result<Vec<ExpiredSnapshot>> {
@@ -1596,6 +1639,544 @@ impl MetadataWriter for SqliteMetadataWriter {
             let (snapshot_id, _schema_version) = insert_snapshot(&mut tx).await?;
             tx.commit().await?;
             Ok(snapshot_id)
+        })
+    }
+
+    fn plan_table_data_restore(
+        &self,
+        table_id: i64,
+        source_snapshot_id: i64,
+        expected_base_snapshot_id: i64,
+    ) -> Result<TableRestorePlan> {
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            let base_snapshot_id: i64 =
+                sqlx::query_scalar("SELECT COALESCE(MAX(snapshot_id), 0) FROM ducklake_snapshot")
+                    .fetch_one(&mut *tx)
+                    .await?;
+            if base_snapshot_id != expected_base_snapshot_id {
+                return Err(crate::DuckLakeError::Conflict(format!(
+                    "catalog head changed from snapshot {expected_base_snapshot_id} to \
+                     {base_snapshot_id} before table restore"
+                )));
+            }
+            if source_snapshot_id < 0 || source_snapshot_id >= expected_base_snapshot_id {
+                return Err(crate::DuckLakeError::InvalidConfig(format!(
+                    "restore source snapshot {source_snapshot_id} must precede catalog head \
+                     {expected_base_snapshot_id}"
+                )));
+            }
+            let source_exists: bool = sqlx::query_scalar(
+                "SELECT EXISTS(SELECT 1 FROM ducklake_snapshot WHERE snapshot_id = ?)",
+            )
+            .bind(source_snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            if !source_exists {
+                return Err(crate::DuckLakeError::InvalidConfig(format!(
+                    "restore source snapshot {source_snapshot_id} does not exist"
+                )));
+            }
+            let table_visible_at_source: bool = sqlx::query_scalar(
+                "SELECT EXISTS(
+                    SELECT 1 FROM ducklake_table
+                    WHERE table_id = ? AND begin_snapshot <= ?
+                      AND (end_snapshot IS NULL OR ? < end_snapshot)
+                 )",
+            )
+            .bind(table_id)
+            .bind(source_snapshot_id)
+            .bind(source_snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            if !table_visible_at_source {
+                return Err(crate::DuckLakeError::InvalidConfig(format!(
+                    "table {table_id} is not visible at snapshot {source_snapshot_id}"
+                )));
+            }
+            let table_visible_at_base: bool = sqlx::query_scalar(
+                "SELECT EXISTS(
+                    SELECT 1 FROM ducklake_table
+                    WHERE table_id = ? AND begin_snapshot <= ?
+                      AND (end_snapshot IS NULL OR ? < end_snapshot)
+                 )",
+            )
+            .bind(table_id)
+            .bind(expected_base_snapshot_id)
+            .bind(expected_base_snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            if !table_visible_at_base {
+                return Err(crate::DuckLakeError::Unsupported(format!(
+                    "cannot restore data for table {table_id} because it is not visible at the \
+                     current catalog head"
+                )));
+            }
+            let schema_changed_after_source: bool = sqlx::query_scalar(
+                "SELECT EXISTS(
+                    SELECT 1 FROM ducklake_schema_versions
+                    WHERE table_id = ? AND begin_snapshot > ? AND begin_snapshot <= ?
+                    UNION ALL
+                    SELECT 1 FROM ducklake_column
+                    WHERE table_id = ? AND (
+                        (begin_snapshot > ? AND begin_snapshot <= ?) OR
+                        (end_snapshot > ? AND end_snapshot <= ?)
+                    )
+                 )",
+            )
+            .bind(table_id)
+            .bind(source_snapshot_id)
+            .bind(expected_base_snapshot_id)
+            .bind(table_id)
+            .bind(source_snapshot_id)
+            .bind(expected_base_snapshot_id)
+            .bind(source_snapshot_id)
+            .bind(expected_base_snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            if schema_changed_after_source {
+                return Err(crate::DuckLakeError::Unsupported(format!(
+                    "cannot restore data for table {table_id} from snapshot {source_snapshot_id} \
+                    because its schema changed afterward"
+                )));
+            }
+            if has_inlined_table_data(
+                table_id,
+                source_snapshot_id,
+                expected_base_snapshot_id,
+                &mut tx,
+            )
+            .await?
+            {
+                return Err(crate::DuckLakeError::Unsupported(format!(
+                    "cannot restore data for table {table_id} while it has inlined rows"
+                )));
+            }
+
+            let source_files = sqlx::query(AssertSqlSafe(format!(
+                "SELECT df.data_file_id, df.path, df.path_is_relative,
+                        {RESOLVED_PATH} AS object_path, {REL_FLAG} AS object_path_is_relative,
+                        df.partial_max
+                 FROM ducklake_data_file df
+                 JOIN ducklake_table t ON t.table_id = df.table_id
+                 JOIN ducklake_schema s ON s.schema_id = t.schema_id
+                 WHERE df.table_id = ? AND df.begin_snapshot <= ?
+                   AND (df.end_snapshot IS NULL OR ? < df.end_snapshot)
+                 ORDER BY df.data_file_id"
+            )))
+            .bind(table_id)
+            .bind(source_snapshot_id)
+            .bind(source_snapshot_id)
+            .fetch_all(&mut *tx)
+            .await?;
+            let mut files = Vec::with_capacity(source_files.len());
+            for source in source_files {
+                if source.try_get::<Option<i64>, _>("partial_max")?.is_some() {
+                    return Err(crate::DuckLakeError::Unsupported(format!(
+                        "cannot restore data for table {table_id} from snapshot \
+                         {source_snapshot_id} because it contains a partial data file"
+                    )));
+                }
+                files.push(table_restore_file(
+                    TableRestoreFileKind::Data,
+                    source.try_get("data_file_id")?,
+                    expected_base_snapshot_id,
+                    source.try_get("path")?,
+                    source.try_get("path_is_relative")?,
+                    source.try_get("object_path")?,
+                    source.try_get::<i64, _>("object_path_is_relative")? != 0,
+                )?);
+            }
+            let source_deletes = sqlx::query(AssertSqlSafe(format!(
+                "SELECT df.delete_file_id, df.path, df.path_is_relative,
+                        {RESOLVED_PATH} AS object_path, {REL_FLAG} AS object_path_is_relative,
+                        df.partial_max
+                 FROM ducklake_delete_file df
+                 JOIN ducklake_data_file data ON data.data_file_id = df.data_file_id
+                 JOIN ducklake_table t ON t.table_id = df.table_id
+                 JOIN ducklake_schema s ON s.schema_id = t.schema_id
+                 WHERE df.table_id = ? AND data.begin_snapshot <= ?
+                   AND (data.end_snapshot IS NULL OR ? < data.end_snapshot)
+                   AND df.begin_snapshot <= ?
+                   AND (df.end_snapshot IS NULL OR ? < df.end_snapshot)
+                 ORDER BY df.delete_file_id"
+            )))
+            .bind(table_id)
+            .bind(source_snapshot_id)
+            .bind(source_snapshot_id)
+            .bind(source_snapshot_id)
+            .bind(source_snapshot_id)
+            .fetch_all(&mut *tx)
+            .await?;
+            files.reserve(source_deletes.len());
+            for source in source_deletes {
+                if source.try_get::<Option<i64>, _>("partial_max")?.is_some() {
+                    return Err(crate::DuckLakeError::Unsupported(format!(
+                        "cannot restore data for table {table_id} from snapshot \
+                         {source_snapshot_id} because it contains a partial delete file"
+                    )));
+                }
+                files.push(table_restore_file(
+                    TableRestoreFileKind::Delete,
+                    source.try_get("delete_file_id")?,
+                    expected_base_snapshot_id,
+                    source.try_get("path")?,
+                    source.try_get("path_is_relative")?,
+                    source.try_get("object_path")?,
+                    source.try_get::<i64, _>("object_path_is_relative")? != 0,
+                )?);
+            }
+            let plan = TableRestorePlan {
+                table_id,
+                source_snapshot_id,
+                expected_base_snapshot_id,
+                files,
+            };
+            validate_table_restore_plan(&plan)?;
+            reject_restore_path_collisions(&plan, &mut tx).await?;
+            tx.commit().await?;
+            Ok(plan)
+        })
+    }
+
+    fn commit_table_data_restore(
+        &self,
+        commit: &TableRestoreCommit,
+        options: &TableRestoreOptions,
+    ) -> Result<RestoreResult> {
+        let plan = commit.plan();
+        block_on(async {
+            validate_table_restore_plan(plan)?;
+            let table_id = plan.table_id;
+            let source_snapshot_id = plan.source_snapshot_id;
+            let expected_base_snapshot_id = plan.expected_base_snapshot_id;
+            let mut tx = self.pool.begin().await?;
+            let (snapshot_id, _schema_version) = insert_snapshot(&mut tx).await?;
+            let base_snapshot_id = snapshot_id - 1;
+            if base_snapshot_id != expected_base_snapshot_id {
+                return Err(crate::DuckLakeError::Conflict(format!(
+                    "catalog head changed from snapshot {expected_base_snapshot_id} to \
+                     {base_snapshot_id} before table restore"
+                )));
+            }
+            if source_snapshot_id < 0 || source_snapshot_id >= expected_base_snapshot_id {
+                return Err(crate::DuckLakeError::InvalidConfig(format!(
+                    "restore source snapshot {source_snapshot_id} must precede catalog head \
+                     {expected_base_snapshot_id}"
+                )));
+            }
+            let source_exists: bool = sqlx::query_scalar(
+                "SELECT EXISTS(
+                    SELECT 1 FROM ducklake_snapshot WHERE snapshot_id = ?
+                 )",
+            )
+            .bind(source_snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            if !source_exists {
+                return Err(crate::DuckLakeError::InvalidConfig(format!(
+                    "restore source snapshot {source_snapshot_id} does not exist"
+                )));
+            }
+            let table_visible_at_source: bool = sqlx::query_scalar(
+                "SELECT EXISTS(
+                    SELECT 1 FROM ducklake_table
+                    WHERE table_id = ? AND begin_snapshot <= ?
+                      AND (end_snapshot IS NULL OR ? < end_snapshot)
+                 )",
+            )
+            .bind(table_id)
+            .bind(source_snapshot_id)
+            .bind(source_snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            if !table_visible_at_source {
+                return Err(crate::DuckLakeError::InvalidConfig(format!(
+                    "table {table_id} is not visible at snapshot {source_snapshot_id}"
+                )));
+            }
+            let table_visible_at_base: bool = sqlx::query_scalar(
+                "SELECT EXISTS(
+                    SELECT 1 FROM ducklake_table
+                    WHERE table_id = ? AND begin_snapshot <= ?
+                      AND (end_snapshot IS NULL OR ? < end_snapshot)
+                 )",
+            )
+            .bind(table_id)
+            .bind(expected_base_snapshot_id)
+            .bind(expected_base_snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            if !table_visible_at_base {
+                return Err(crate::DuckLakeError::Unsupported(format!(
+                    "cannot restore data for table {table_id} because it is not visible at the \
+                     current catalog head"
+                )));
+            }
+            let schema_changed_after_source: bool = sqlx::query_scalar(
+                "SELECT EXISTS(
+                    SELECT 1 FROM ducklake_schema_versions
+                    WHERE table_id = ? AND begin_snapshot > ? AND begin_snapshot <= ?
+                    UNION ALL
+                    SELECT 1 FROM ducklake_column
+                    WHERE table_id = ? AND (
+                        (begin_snapshot > ? AND begin_snapshot <= ?) OR
+                        (end_snapshot > ? AND end_snapshot <= ?)
+                    )
+                 )",
+            )
+            .bind(table_id)
+            .bind(source_snapshot_id)
+            .bind(expected_base_snapshot_id)
+            .bind(table_id)
+            .bind(source_snapshot_id)
+            .bind(expected_base_snapshot_id)
+            .bind(source_snapshot_id)
+            .bind(expected_base_snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            if schema_changed_after_source {
+                return Err(crate::DuckLakeError::Unsupported(format!(
+                    "cannot restore data for table {table_id} from snapshot {source_snapshot_id} \
+                    because its schema changed afterward"
+                )));
+            }
+            if has_inlined_table_data(
+                table_id,
+                source_snapshot_id,
+                expected_base_snapshot_id,
+                &mut tx,
+            )
+            .await?
+            {
+                return Err(crate::DuckLakeError::Unsupported(format!(
+                    "cannot restore data for table {table_id} while it has inlined rows"
+                )));
+            }
+            reject_restore_path_collisions(plan, &mut tx).await?;
+
+            let source_files = sqlx::query(
+                "SELECT data_file_id, path, path_is_relative, file_size_bytes, footer_size,
+                        encryption_key, record_count, row_id_start, mapping_id, partial_max,
+                        partition_id
+                 FROM ducklake_data_file
+                 WHERE table_id = ? AND begin_snapshot <= ?
+                   AND (end_snapshot IS NULL OR ? < end_snapshot)
+                 ORDER BY data_file_id",
+            )
+            .bind(table_id)
+            .bind(source_snapshot_id)
+            .bind(source_snapshot_id)
+            .fetch_all(&mut *tx)
+            .await?;
+            for source in &source_files {
+                if source.try_get::<Option<i64>, _>("partial_max")?.is_some() {
+                    return Err(crate::DuckLakeError::Unsupported(format!(
+                        "cannot restore data for table {table_id} from snapshot \
+                         {source_snapshot_id} because it contains a partial data file"
+                    )));
+                }
+            }
+            let planned_data_files = plan
+                .files
+                .iter()
+                .filter(|file| file.kind == TableRestoreFileKind::Data)
+                .count();
+            if planned_data_files != source_files.len() {
+                return Err(crate::DuckLakeError::InvalidConfig(
+                    "restore plan data files no longer match the source snapshot".to_string(),
+                ));
+            }
+            let retired_data_files: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM ducklake_data_file
+                 WHERE table_id = ? AND end_snapshot IS NULL",
+            )
+            .bind(table_id)
+            .fetch_one(&mut *tx)
+            .await?;
+
+            sqlx::query(
+                "UPDATE ducklake_delete_file SET end_snapshot = ?
+                 WHERE table_id = ? AND end_snapshot IS NULL",
+            )
+            .bind(snapshot_id)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            sqlx::query(
+                "UPDATE ducklake_data_file SET end_snapshot = ?
+                 WHERE table_id = ? AND end_snapshot IS NULL",
+            )
+            .bind(snapshot_id)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+
+            let mut delete_files_restored = 0;
+            for source in &source_files {
+                let source_data_file_id: i64 = source.try_get("data_file_id")?;
+                let restored_data = plan
+                    .files
+                    .iter()
+                    .find(|file| {
+                        file.kind == TableRestoreFileKind::Data
+                            && file.source_file_id == source_data_file_id
+                    })
+                    .ok_or_else(|| {
+                        crate::DuckLakeError::InvalidConfig(format!(
+                            "restore plan is missing data file {source_data_file_id}"
+                        ))
+                    })?;
+                sqlx::query(
+                    "INSERT INTO ducklake_data_file
+                         (table_id, path, path_is_relative, file_size_bytes, footer_size,
+                          encryption_key, record_count, row_id_start, mapping_id, begin_snapshot,
+                          end_snapshot, partial_max, partition_id)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)",
+                )
+                .bind(table_id)
+                .bind(&restored_data.restored_catalog_path)
+                .bind(restored_data.restored_catalog_path_is_relative)
+                .bind(source.try_get::<i64, _>("file_size_bytes")?)
+                .bind(source.try_get::<Option<i64>, _>("footer_size")?)
+                .bind(source.try_get::<Option<String>, _>("encryption_key")?)
+                .bind(source.try_get::<Option<i64>, _>("record_count")?)
+                .bind(source.try_get::<Option<i64>, _>("row_id_start")?)
+                .bind(source.try_get::<Option<i64>, _>("mapping_id")?)
+                .bind(snapshot_id)
+                .bind(source.try_get::<Option<i64>, _>("partial_max")?)
+                .bind(source.try_get::<Option<i64>, _>("partition_id")?)
+                .execute(&mut *tx)
+                .await?;
+                let data_file_id: i64 = sqlx::query_scalar("SELECT last_insert_rowid()")
+                    .fetch_one(&mut *tx)
+                    .await?;
+                sqlx::query(
+                    "INSERT INTO ducklake_file_column_stats
+                         (data_file_id, table_id, column_id, column_size_bytes, value_count,
+                          null_count, min_value, max_value, contains_nan, extra_stats)
+                     SELECT ?, table_id, column_id, column_size_bytes, value_count,
+                            null_count, min_value, max_value, contains_nan, extra_stats
+                     FROM ducklake_file_column_stats WHERE data_file_id = ?",
+                )
+                .bind(data_file_id)
+                .bind(source_data_file_id)
+                .execute(&mut *tx)
+                .await?;
+                sqlx::query(
+                    "INSERT INTO ducklake_file_partition_value
+                         (data_file_id, table_id, partition_key_index, partition_value)
+                     SELECT ?, table_id, partition_key_index, partition_value
+                     FROM ducklake_file_partition_value WHERE data_file_id = ?",
+                )
+                .bind(data_file_id)
+                .bind(source_data_file_id)
+                .execute(&mut *tx)
+                .await?;
+
+                let source_delete = sqlx::query(
+                    "SELECT delete_file_id, path, path_is_relative, file_size_bytes, footer_size,
+                            encryption_key, delete_count, partial_max
+                     FROM ducklake_delete_file
+                     WHERE data_file_id = ? AND begin_snapshot <= ?
+                       AND (end_snapshot IS NULL OR ? < end_snapshot)
+                     ORDER BY begin_snapshot DESC LIMIT 1",
+                )
+                .bind(source_data_file_id)
+                .bind(source_snapshot_id)
+                .bind(source_snapshot_id)
+                .fetch_optional(&mut *tx)
+                .await?;
+                if let Some(delete) = source_delete {
+                    let source_delete_file_id: i64 = delete.try_get("delete_file_id")?;
+                    if delete.try_get::<Option<i64>, _>("partial_max")?.is_some() {
+                        return Err(crate::DuckLakeError::Unsupported(format!(
+                            "cannot restore data for table {table_id} from snapshot \
+                            {source_snapshot_id} because it contains a partial delete file"
+                        )));
+                    }
+                    let restored_delete = plan
+                        .files
+                        .iter()
+                        .find(|file| {
+                            file.kind == TableRestoreFileKind::Delete
+                                && file.source_file_id == source_delete_file_id
+                        })
+                        .ok_or_else(|| {
+                            crate::DuckLakeError::InvalidConfig(format!(
+                                "restore plan is missing delete file {source_delete_file_id}"
+                            ))
+                        })?;
+                    sqlx::query(
+                        "INSERT INTO ducklake_delete_file
+                             (data_file_id, table_id, path, path_is_relative, file_size_bytes,
+                              footer_size, encryption_key, delete_count, begin_snapshot,
+                              end_snapshot, partial_max)
+                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)",
+                    )
+                    .bind(data_file_id)
+                    .bind(table_id)
+                    .bind(&restored_delete.restored_catalog_path)
+                    .bind(restored_delete.restored_catalog_path_is_relative)
+                    .bind(delete.try_get::<i64, _>("file_size_bytes")?)
+                    .bind(delete.try_get::<Option<i64>, _>("footer_size")?)
+                    .bind(delete.try_get::<Option<String>, _>("encryption_key")?)
+                    .bind(delete.try_get::<Option<i64>, _>("delete_count")?)
+                    .bind(snapshot_id)
+                    .bind(delete.try_get::<Option<i64>, _>("partial_max")?)
+                    .execute(&mut *tx)
+                    .await?;
+                    delete_files_restored += 1;
+                }
+            }
+            let planned_delete_files = plan
+                .files
+                .iter()
+                .filter(|file| file.kind == TableRestoreFileKind::Delete)
+                .count();
+            if planned_delete_files != delete_files_restored {
+                return Err(crate::DuckLakeError::InvalidConfig(
+                    "restore plan delete files no longer match the source snapshot".to_string(),
+                ));
+            }
+
+            sqlx::query(
+                "UPDATE ducklake_table_stats
+                 SET record_count = (
+                         SELECT COALESCE(SUM(record_count), 0) FROM ducklake_data_file
+                         WHERE table_id = ? AND end_snapshot IS NULL
+                     ),
+                     file_size_bytes = (
+                         SELECT COALESCE(SUM(file_size_bytes), 0) FROM ducklake_data_file
+                         WHERE table_id = ? AND end_snapshot IS NULL
+                     )
+                 WHERE table_id = ?",
+            )
+            .bind(table_id)
+            .bind(table_id)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            let (columns, column_ids) = live_columns_for_stats(table_id, &mut tx).await?;
+            recompute_table_column_stats(&mut tx, table_id, &columns, &column_ids).await?;
+            let changes_made = restored_table_data_changes(
+                table_id,
+                retired_data_files > 0,
+                !source_files.is_empty(),
+            );
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &changes_made,
+                options.commit_metadata(),
+            )
+            .await?;
+            tx.commit().await?;
+            Ok(RestoreResult {
+                snapshot_id,
+                data_files_restored: source_files.len(),
+                delete_files_restored,
+            })
         })
     }
 
@@ -3901,9 +4482,68 @@ impl MetadataWriter for SqliteMetadataWriter {
     }
 }
 
+async fn has_inlined_table_data(
+    table_id: i64,
+    source_snapshot_id: i64,
+    expected_base_snapshot_id: i64,
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+) -> Result<bool> {
+    let registry_exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+            SELECT 1 FROM sqlite_master
+            WHERE type = 'table' AND name = 'ducklake_inlined_data_tables'
+         )",
+    )
+    .fetch_one(&mut **tx)
+    .await?;
+    if !registry_exists {
+        return Ok(false);
+    }
+
+    let tables =
+        sqlx::query("SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?")
+            .bind(table_id)
+            .fetch_all(&mut **tx)
+            .await?;
+    for row in tables {
+        let table_name: String = row.try_get("table_name")?;
+        if !table_name.starts_with("ducklake_inlined_data_")
+            || !table_name
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_')
+        {
+            return Err(crate::DuckLakeError::InvalidConfig(format!(
+                "invalid inlined data table name '{table_name}'"
+            )));
+        }
+        let has_rows: bool = sqlx::query_scalar(AssertSqlSafe(format!(
+            "SELECT EXISTS(
+                SELECT 1 FROM {table_name}
+                WHERE (begin_snapshot <= ? AND (end_snapshot IS NULL OR ? < end_snapshot))
+                   OR (begin_snapshot <= ? AND (end_snapshot IS NULL OR ? < end_snapshot))
+             )"
+        )))
+        .bind(source_snapshot_id)
+        .bind(source_snapshot_id)
+        .bind(expected_base_snapshot_id)
+        .bind(expected_base_snapshot_id)
+        .fetch_one(&mut **tx)
+        .await?;
+        if has_rows {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::maintenance::cleanup_old_files_sqlite;
+    use crate::table_writer::DuckLakeTableWriter;
+    use object_store::ObjectStore;
+    use object_store::local::LocalFileSystem;
+    use std::sync::Arc;
     use tempfile::TempDir;
 
     async fn create_test_writer() -> (SqliteMetadataWriter, TempDir) {
@@ -4792,6 +5432,805 @@ mod tests {
                  inserted_into_table:{table_id}"
             ),
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_restore_keeps_changes_made_null() {
+        let (writer, temp) = create_test_writer().await;
+        let data_path = temp.path().join("data");
+        std::fs::create_dir_all(&data_path).unwrap();
+        writer.set_data_path(data_path.to_str().unwrap()).unwrap();
+        let source_snapshot_id = writer.create_snapshot().unwrap();
+        let (schema_id, _) = writer
+            .get_or_create_schema("main", None, source_snapshot_id)
+            .unwrap();
+        let (table_id, _) = writer
+            .get_or_create_table(schema_id, "events", None, source_snapshot_id)
+            .unwrap();
+        writer
+            .set_columns(
+                table_id,
+                &[ColumnDef::new("id", "int64", false).unwrap()],
+                source_snapshot_id,
+            )
+            .unwrap();
+        let base_snapshot_id = writer.create_snapshot().unwrap();
+        let writer = Arc::new(writer);
+        let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+        let table_writer = DuckLakeTableWriter::new(writer.clone(), store).unwrap();
+
+        let restored = table_writer
+            .restore_table_data_to_snapshot(
+                table_id,
+                source_snapshot_id,
+                base_snapshot_id,
+                &TableRestoreOptions::new()
+                    .with_author("Jane Doe")
+                    .with_message("Restore empty table")
+                    .with_extra_info("empty-source"),
+            )
+            .await
+            .unwrap();
+        let changes = sqlx::query_as::<
+            _,
+            (
+                Option<String>,
+                Option<String>,
+                Option<String>,
+                Option<String>,
+            ),
+        >(
+            "SELECT changes_made, author, commit_message, commit_extra_info
+             FROM ducklake_snapshot_changes WHERE snapshot_id = ?",
+        )
+        .bind(restored.snapshot_id)
+        .fetch_one(&writer.pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            restored,
+            RestoreResult {
+                snapshot_id: base_snapshot_id + 1,
+                data_files_restored: 0,
+                delete_files_restored: 0,
+            }
+        );
+        assert_eq!(
+            changes,
+            (
+                None,
+                Some("Jane Doe".to_string()),
+                Some("Restore empty table".to_string()),
+                Some("empty-source".to_string()),
+            )
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn restore_rechecks_unledgered_column_generations() {
+        let (writer, _temp) = create_test_writer().await;
+        let source_snapshot_id = writer.create_snapshot().unwrap();
+        let (schema_id, _) = writer
+            .get_or_create_schema("main", None, source_snapshot_id)
+            .unwrap();
+        let (table_id, _) = writer
+            .get_or_create_table(schema_id, "events", None, source_snapshot_id)
+            .unwrap();
+        writer
+            .set_columns(
+                table_id,
+                &[ColumnDef::new("id", "int64", true).unwrap()],
+                source_snapshot_id,
+            )
+            .unwrap();
+        let base_snapshot_id = writer.create_snapshot().unwrap();
+        let plan = writer
+            .plan_table_data_restore(table_id, source_snapshot_id, base_snapshot_id)
+            .unwrap();
+
+        writer
+            .set_columns(
+                table_id,
+                &[ColumnDef::new("id", "int64", false).unwrap()],
+                base_snapshot_id,
+            )
+            .unwrap();
+        let ledger_rows: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM ducklake_schema_versions
+             WHERE table_id = ? AND begin_snapshot > ?",
+        )
+        .bind(table_id)
+        .bind(source_snapshot_id)
+        .fetch_one(&writer.pool)
+        .await
+        .unwrap();
+        let commit = TableRestoreCommit::new(plan);
+        let commit_error = writer
+            .commit_table_data_restore(&commit, &TableRestoreOptions::new())
+            .expect_err("the commit must recheck unledgered column generations");
+        let plan_error = writer
+            .plan_table_data_restore(table_id, source_snapshot_id, base_snapshot_id)
+            .expect_err("the plan must reject unledgered column generations");
+        let head: i64 = sqlx::query_scalar("SELECT MAX(snapshot_id) FROM ducklake_snapshot")
+            .fetch_one(&writer.pool)
+            .await
+            .unwrap();
+
+        assert_eq!(ledger_rows, 0);
+        assert!(matches!(commit_error, crate::DuckLakeError::Unsupported(_)));
+        assert!(matches!(plan_error, crate::DuckLakeError::Unsupported(_)));
+        assert_eq!(head, base_snapshot_id);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn restore_rejects_inlined_rows_during_plan_and_commit() {
+        let (writer, _temp) = create_test_writer().await;
+        let source_snapshot_id = writer.create_snapshot().unwrap();
+        let (schema_id, _) = writer
+            .get_or_create_schema("main", None, source_snapshot_id)
+            .unwrap();
+        let (table_id, _) = writer
+            .get_or_create_table(schema_id, "events", None, source_snapshot_id)
+            .unwrap();
+        writer
+            .set_columns(
+                table_id,
+                &[ColumnDef::new("id", "int64", false).unwrap()],
+                source_snapshot_id,
+            )
+            .unwrap();
+        let base_snapshot_id = writer.create_snapshot().unwrap();
+        let plan = writer
+            .plan_table_data_restore(table_id, source_snapshot_id, base_snapshot_id)
+            .unwrap();
+        let inlined_table = format!("ducklake_inlined_data_{table_id}_1");
+        sqlx::query(
+            "CREATE TABLE ducklake_inlined_data_tables
+                 (table_id BIGINT, table_name VARCHAR, schema_version BIGINT)",
+        )
+        .execute(&writer.pool)
+        .await
+        .unwrap();
+        sqlx::query(AssertSqlSafe(format!(
+            "CREATE TABLE {inlined_table}
+                 (row_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT)"
+        )))
+        .execute(&writer.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO ducklake_inlined_data_tables
+                 (table_id, table_name, schema_version) VALUES (?, ?, 1)",
+        )
+        .bind(table_id)
+        .bind(&inlined_table)
+        .execute(&writer.pool)
+        .await
+        .unwrap();
+        sqlx::query(AssertSqlSafe(format!(
+            "INSERT INTO {inlined_table} (row_id, begin_snapshot, end_snapshot)
+             VALUES (1, ?, NULL)"
+        )))
+        .bind(source_snapshot_id)
+        .execute(&writer.pool)
+        .await
+        .unwrap();
+
+        let commit = TableRestoreCommit::new(plan);
+        let commit_error = writer
+            .commit_table_data_restore(&commit, &TableRestoreOptions::new())
+            .expect_err("the commit must recheck inlined rows");
+        let plan_error = writer
+            .plan_table_data_restore(table_id, source_snapshot_id, base_snapshot_id)
+            .expect_err("the plan must reject inlined rows");
+        let head: i64 = sqlx::query_scalar("SELECT MAX(snapshot_id) FROM ducklake_snapshot")
+            .fetch_one(&writer.pool)
+            .await
+            .unwrap();
+
+        assert!(matches!(commit_error, crate::DuckLakeError::Unsupported(_)));
+        assert!(matches!(plan_error, crate::DuckLakeError::Unsupported(_)));
+        assert_eq!(head, base_snapshot_id);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn scheduled_listing_keeps_referenced_paths() {
+        let (writer, _temp) = create_test_writer().await;
+        let setup = writer
+            .begin_write_transaction(
+                "main",
+                "events",
+                &[ColumnDef::new("id", "int64", false).unwrap()],
+                WriteMode::Replace,
+            )
+            .unwrap();
+        let committed = writer
+            .register_data_file(
+                setup.table_id,
+                "main",
+                "events",
+                setup.snapshot_id,
+                &DataFileInfo::new("data.parquet", 100, 10),
+                WriteMode::Replace,
+                setup.base_snapshot_id,
+                &[ColumnDef::new("id", "int64", false).unwrap()],
+                &setup.column_ids,
+            )
+            .unwrap();
+        let data_file_id: i64 = sqlx::query_scalar(
+            "SELECT data_file_id FROM ducklake_data_file
+             WHERE table_id = ? AND path = 'data.parquet'",
+        )
+        .bind(committed.table_id)
+        .fetch_one(&writer.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO ducklake_files_scheduled_for_deletion
+                 (data_file_id, path, path_is_relative)
+             VALUES (?, 'main/events/data.parquet', TRUE)",
+        )
+        .bind(data_file_id)
+        .execute(&writer.pool)
+        .await
+        .unwrap();
+
+        let scheduled = writer
+            .list_scheduled_for_deletion(&CleanupCriteria::All)
+            .unwrap();
+
+        assert_eq!(scheduled.len(), 1);
+        assert_eq!(scheduled[0].data_file_id, data_file_id);
+        assert_eq!(scheduled[0].path, "main/events/data.parquet");
+        assert!(scheduled[0].path_is_relative);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn restore_copies_source_files_and_cleanup_deletes_only_retired_paths() {
+        let (writer, temp) = create_test_writer().await;
+        let data_path = temp.path().join("data");
+        let table_path = data_path.join("main/users");
+        std::fs::create_dir_all(&table_path).unwrap();
+        std::fs::write(table_path.join("first.parquet"), b"first data").unwrap();
+        std::fs::write(table_path.join("first-deletes.parquet"), b"first deletes").unwrap();
+        std::fs::write(table_path.join("second.parquet"), b"second data").unwrap();
+        writer.set_data_path(data_path.to_str().unwrap()).unwrap();
+        let writer = Arc::new(writer);
+        let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+        let table_writer = DuckLakeTableWriter::new(writer.clone(), store.clone()).unwrap();
+        let columns = vec![ColumnDef::new("id", "int64", false).unwrap()];
+        let setup = writer
+            .begin_write_transaction("main", "users", &columns, WriteMode::Replace)
+            .unwrap();
+        let first_file = DataFileInfo::new("first.parquet", 100, 10)
+            .with_footer_size(17)
+            .with_column_stats(vec![ColumnStat {
+                column_id: setup.column_ids[0],
+                min_value: Some("1".to_string()),
+                max_value: Some("10".to_string()),
+                null_count: Some(0),
+                value_count: Some(10),
+                contains_nan: Some(false),
+                column_size_bytes: Some(80),
+            }]);
+        let first = writer
+            .register_data_file(
+                setup.table_id,
+                "main",
+                "users",
+                setup.snapshot_id,
+                &first_file,
+                WriteMode::Replace,
+                setup.base_snapshot_id,
+                &columns,
+                &setup.column_ids,
+            )
+            .unwrap();
+        let table_id = first.table_id;
+        let source_data_file_id: i64 = sqlx::query_scalar(
+            "SELECT data_file_id FROM ducklake_data_file
+             WHERE table_id = ? AND path = 'first.parquet'",
+        )
+        .bind(table_id)
+        .fetch_one(&writer.pool)
+        .await
+        .unwrap();
+        let partition_id = 1_i64;
+        sqlx::query(
+            "INSERT INTO ducklake_partition_info
+                 (partition_id, table_id, begin_snapshot, end_snapshot)
+             VALUES (?, ?, ?, NULL)",
+        )
+        .bind(partition_id)
+        .bind(table_id)
+        .bind(first.snapshot_id)
+        .execute(&writer.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO ducklake_partition_column
+                 (partition_id, table_id, partition_key_index, column_id, transform)
+             VALUES (?, ?, 0, ?, 'identity')",
+        )
+        .bind(partition_id)
+        .bind(table_id)
+        .bind(setup.column_ids[0])
+        .execute(&writer.pool)
+        .await
+        .unwrap();
+        sqlx::query("UPDATE ducklake_data_file SET partition_id = ? WHERE data_file_id = ?")
+            .bind(partition_id)
+            .bind(source_data_file_id)
+            .execute(&writer.pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO ducklake_file_partition_value
+                 (data_file_id, table_id, partition_key_index, partition_value)
+             VALUES (?, ?, 0, '1')",
+        )
+        .bind(source_data_file_id)
+        .bind(table_id)
+        .execute(&writer.pool)
+        .await
+        .unwrap();
+        let delete = writer
+            .set_delete_file(
+                table_id,
+                "main",
+                "users",
+                first.snapshot_id + 1,
+                source_data_file_id,
+                None,
+                first.snapshot_id,
+                &DeleteFileInfo::new("first-deletes.parquet", 20, 2).with_footer_size(7),
+            )
+            .unwrap();
+        let source_delete_file_id: i64 = sqlx::query_scalar(
+            "SELECT delete_file_id FROM ducklake_delete_file
+             WHERE data_file_id = ? AND end_snapshot IS NULL",
+        )
+        .bind(source_data_file_id)
+        .fetch_one(&writer.pool)
+        .await
+        .unwrap();
+        let second_setup = writer
+            .begin_write_transaction("main", "users", &columns, WriteMode::Append)
+            .unwrap();
+        let second = writer
+            .register_data_file(
+                table_id,
+                "main",
+                "users",
+                second_setup.snapshot_id,
+                &DataFileInfo::new("second.parquet", 200, 20)
+                    .with_partition(partition_id, vec![(0, Some("2".to_string()))]),
+                WriteMode::Append,
+                second_setup.base_snapshot_id,
+                &columns,
+                &second_setup.column_ids,
+            )
+            .unwrap();
+
+        let restored = table_writer
+            .restore_table_data_to_snapshot(
+                table_id,
+                delete.snapshot_id,
+                second.snapshot_id,
+                &TableRestoreOptions::new().with_message("datafusion restore"),
+            )
+            .await
+            .unwrap();
+        let live = sqlx::query(
+            "SELECT data_file_id, path, path_is_relative, file_size_bytes, footer_size,
+                    record_count, row_id_start, mapping_id, partial_max, partition_id
+             FROM ducklake_data_file
+             WHERE table_id = ? AND end_snapshot IS NULL",
+        )
+        .bind(table_id)
+        .fetch_all(&writer.pool)
+        .await
+        .unwrap();
+        let restored_data_file_id = live[0].try_get::<i64, _>("data_file_id").unwrap();
+        let restored_partition_values = sqlx::query_as::<_, (i64, Option<String>)>(
+            "SELECT partition_key_index, partition_value
+             FROM ducklake_file_partition_value WHERE data_file_id = ?
+             ORDER BY partition_key_index",
+        )
+        .bind(restored_data_file_id)
+        .fetch_all(&writer.pool)
+        .await
+        .unwrap();
+        let restored_data_path = live[0].try_get::<String, _>("path").unwrap();
+        let restored_delete = sqlx::query(
+            "SELECT delete_file_id, data_file_id, path, path_is_relative, file_size_bytes,
+                    footer_size, delete_count, partial_max
+             FROM ducklake_delete_file
+             WHERE table_id = ? AND end_snapshot IS NULL",
+        )
+        .bind(table_id)
+        .fetch_one(&writer.pool)
+        .await
+        .unwrap();
+        let restored_delete_path = restored_delete.try_get::<String, _>("path").unwrap();
+        let restored_stats = sqlx::query_as::<
+            _,
+            (
+                i64,
+                i64,
+                Option<i64>,
+                Option<i64>,
+                Option<String>,
+                Option<String>,
+                Option<bool>,
+                Option<String>,
+            ),
+        >(
+            "SELECT column_id, column_size_bytes, value_count, null_count, min_value,
+                    max_value, contains_nan, extra_stats
+             FROM ducklake_file_column_stats WHERE data_file_id = ?",
+        )
+        .bind(restored_data_file_id)
+        .fetch_all(&writer.pool)
+        .await
+        .unwrap();
+        let snapshot_change =
+            sqlx::query_as::<_, (String, Option<String>, Option<String>, Option<String>)>(
+                "SELECT changes_made, author, commit_message, commit_extra_info
+             FROM ducklake_snapshot_changes WHERE snapshot_id = ?",
+            )
+            .bind(restored.snapshot_id)
+            .fetch_one(&writer.pool)
+            .await
+            .unwrap();
+        let table_stats = sqlx::query_as::<_, (i64, i64, i64)>(
+            "SELECT record_count, next_row_id, file_size_bytes
+                 FROM ducklake_table_stats WHERE table_id = ?",
+        )
+        .bind(table_id)
+        .fetch_one(&writer.pool)
+        .await
+        .unwrap();
+
+        assert_eq!(restored.snapshot_id, second.snapshot_id + 1);
+        assert_eq!(restored.data_files_restored, 1);
+        assert_eq!(restored.delete_files_restored, 1);
+        assert_eq!(live.len(), 1);
+        assert!(
+            restored_data_file_id > source_data_file_id,
+            "restore must allocate a fresh data_file_id"
+        );
+        assert!(restored_data_path.starts_with(&format!(
+            "first.restore-{}-data-{source_data_file_id}-",
+            second.snapshot_id
+        )));
+        assert!(restored_data_path.ends_with(".parquet"));
+        assert_eq!(
+            (
+                live[0].try_get::<bool, _>("path_is_relative").unwrap(),
+                live[0].try_get::<i64, _>("file_size_bytes").unwrap(),
+                live[0].try_get::<Option<i64>, _>("footer_size").unwrap(),
+                live[0].try_get::<Option<i64>, _>("record_count").unwrap(),
+                live[0].try_get::<Option<i64>, _>("row_id_start").unwrap(),
+                live[0].try_get::<Option<i64>, _>("mapping_id").unwrap(),
+                live[0].try_get::<Option<i64>, _>("partial_max").unwrap(),
+                live[0].try_get::<Option<i64>, _>("partition_id").unwrap(),
+            ),
+            (
+                true,
+                100,
+                Some(17),
+                Some(10),
+                Some(0),
+                None,
+                None,
+                Some(partition_id),
+            ),
+        );
+        assert_eq!(restored_partition_values, vec![(0, Some("1".to_string()))]);
+        let restored_delete_file_id = restored_delete.try_get::<i64, _>("delete_file_id").unwrap();
+        assert!(
+            restored_delete_file_id > source_delete_file_id,
+            "restore must allocate a fresh delete_file_id"
+        );
+        assert!(restored_delete_path.starts_with(&format!(
+            "first-deletes.restore-{}-delete-{source_delete_file_id}-",
+            second.snapshot_id
+        )));
+        assert!(restored_delete_path.ends_with(".parquet"));
+        assert_eq!(
+            (
+                restored_delete.try_get::<i64, _>("data_file_id").unwrap(),
+                restored_delete
+                    .try_get::<bool, _>("path_is_relative")
+                    .unwrap(),
+                restored_delete
+                    .try_get::<i64, _>("file_size_bytes")
+                    .unwrap(),
+                restored_delete
+                    .try_get::<Option<i64>, _>("footer_size")
+                    .unwrap(),
+                restored_delete
+                    .try_get::<Option<i64>, _>("delete_count")
+                    .unwrap(),
+                restored_delete
+                    .try_get::<Option<i64>, _>("partial_max")
+                    .unwrap(),
+            ),
+            (restored_data_file_id, true, 20, Some(7), Some(2), None,),
+        );
+        assert_eq!(
+            restored_stats,
+            vec![(
+                setup.column_ids[0],
+                80,
+                Some(10),
+                Some(0),
+                Some("1".to_string()),
+                Some("10".to_string()),
+                Some(false),
+                None,
+            )],
+        );
+        assert_eq!(
+            snapshot_change,
+            (
+                format!("deleted_from_table:{table_id},inserted_into_table:{table_id}"),
+                None,
+                Some("datafusion restore".to_string()),
+                None,
+            ),
+        );
+        assert_eq!(table_stats, (10, 30, 100));
+        assert_eq!(
+            std::fs::read(table_path.join(&restored_data_path)).unwrap(),
+            b"first data"
+        );
+        assert_eq!(
+            std::fs::read(table_path.join(&restored_delete_path)).unwrap(),
+            b"first deletes"
+        );
+
+        writer
+            .expire_snapshots(ExpireCriteria::Versions(vec![
+                first.snapshot_id,
+                delete.snapshot_id,
+                second.snapshot_id,
+            ]))
+            .unwrap();
+        let scheduled = writer
+            .list_scheduled_for_deletion(&CleanupCriteria::All)
+            .unwrap();
+        let mut scheduled_paths = scheduled
+            .iter()
+            .map(|file| file.path.clone())
+            .collect::<Vec<_>>();
+        scheduled_paths.sort();
+        assert_eq!(
+            scheduled_paths,
+            vec![
+                "main/users/first-deletes.parquet".to_string(),
+                "main/users/first.parquet".to_string(),
+                "main/users/second.parquet".to_string(),
+            ],
+        );
+        cleanup_old_files_sqlite(writer.as_ref(), store, CleanupCriteria::All, false)
+            .await
+            .unwrap();
+        assert!(
+            writer
+                .list_scheduled_for_deletion(&CleanupCriteria::All)
+                .unwrap()
+                .is_empty()
+        );
+        assert!(!table_path.join("first.parquet").exists());
+        assert!(!table_path.join("first-deletes.parquet").exists());
+        assert!(!table_path.join("second.parquet").exists());
+        assert!(table_path.join(restored_data_path).exists());
+        assert!(table_path.join(restored_delete_path).exists());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn restore_rejects_partial_files_schema_changes_and_stale_heads_atomically() {
+        let (writer, temp) = create_test_writer().await;
+        let data_path = temp.path().join("data");
+        std::fs::create_dir_all(&data_path).unwrap();
+        writer.set_data_path(data_path.to_str().unwrap()).unwrap();
+        let writer = Arc::new(writer);
+        let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+        let table_writer = DuckLakeTableWriter::new(writer.clone(), store).unwrap();
+        let columns = vec![ColumnDef::new("id", "int32", true).unwrap()];
+        let first_setup = writer
+            .begin_write_transaction("main", "events", &columns, WriteMode::Replace)
+            .unwrap();
+        let first = writer
+            .register_data_file(
+                first_setup.table_id,
+                "main",
+                "events",
+                first_setup.snapshot_id,
+                &DataFileInfo::new("first.parquet", 100, 10),
+                WriteMode::Replace,
+                first_setup.base_snapshot_id,
+                &columns,
+                &first_setup.column_ids,
+            )
+            .unwrap();
+        let second_setup = writer
+            .begin_write_transaction("main", "events", &columns, WriteMode::Append)
+            .unwrap();
+        let second = writer
+            .register_data_file(
+                first.table_id,
+                "main",
+                "events",
+                second_setup.snapshot_id,
+                &DataFileInfo::new("second.parquet", 200, 20),
+                WriteMode::Append,
+                second_setup.base_snapshot_id,
+                &columns,
+                &second_setup.column_ids,
+            )
+            .unwrap();
+        sqlx::query(
+            "UPDATE ducklake_data_file SET partial_max = ?
+             WHERE table_id = ? AND path = 'first.parquet'",
+        )
+        .bind(first.snapshot_id)
+        .bind(first.table_id)
+        .execute(&writer.pool)
+        .await
+        .unwrap();
+
+        let partial_error = table_writer
+            .restore_table_data_to_snapshot(
+                first.table_id,
+                first.snapshot_id,
+                second.snapshot_id,
+                &TableRestoreOptions::new(),
+            )
+            .await
+            .expect_err("partial source files must require a physical rewrite");
+        let head_after_partial: i64 =
+            sqlx::query_scalar("SELECT MAX(snapshot_id) FROM ducklake_snapshot")
+                .fetch_one(&writer.pool)
+                .await
+                .unwrap();
+
+        assert!(
+            matches!(partial_error, crate::DuckLakeError::Unsupported(_)),
+            "expected Unsupported, got {partial_error:?}"
+        );
+        assert_eq!(head_after_partial, second.snapshot_id);
+
+        sqlx::query(
+            "UPDATE ducklake_data_file SET partial_max = NULL
+             WHERE table_id = ? AND path = 'first.parquet'",
+        )
+        .bind(first.table_id)
+        .execute(&writer.pool)
+        .await
+        .unwrap();
+        let tightened_columns = vec![ColumnDef::new("id", "int32", false).unwrap()];
+        let tightened_setup = writer
+            .begin_write_transaction("main", "events", &tightened_columns, WriteMode::Append)
+            .unwrap();
+        let tightened = writer
+            .register_data_file(
+                first.table_id,
+                "main",
+                "events",
+                tightened_setup.snapshot_id,
+                &DataFileInfo::new("tightened.parquet", 300, 30),
+                WriteMode::Append,
+                tightened_setup.base_snapshot_id,
+                &tightened_columns,
+                &tightened_setup.column_ids,
+            )
+            .unwrap();
+        let schema_error = table_writer
+            .restore_table_data_to_snapshot(
+                first.table_id,
+                first.snapshot_id,
+                tightened.snapshot_id,
+                &TableRestoreOptions::new(),
+            )
+            .await
+            .expect_err("metadata-only restore must not reinterpret an old schema");
+        let stale_error = table_writer
+            .restore_table_data_to_snapshot(
+                first.table_id,
+                first.snapshot_id,
+                second.snapshot_id,
+                &TableRestoreOptions::new(),
+            )
+            .await
+            .expect_err("a stale expected catalog head must conflict");
+        let head_after_rejections: i64 =
+            sqlx::query_scalar("SELECT MAX(snapshot_id) FROM ducklake_snapshot")
+                .fetch_one(&writer.pool)
+                .await
+                .unwrap();
+
+        assert!(
+            matches!(schema_error, crate::DuckLakeError::Unsupported(_)),
+            "expected Unsupported, got {schema_error:?}"
+        );
+        assert!(
+            matches!(stale_error, crate::DuckLakeError::Conflict(_)),
+            "expected Conflict, got {stale_error:?}"
+        );
+        assert_eq!(head_after_rejections, tightened.snapshot_id);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn restore_rejects_destination_path_collisions_atomically() {
+        let (writer, _temp) = create_test_writer().await;
+        let columns = vec![ColumnDef::new("id", "int32", false).unwrap()];
+        let first_setup = writer
+            .begin_write_transaction("main", "events", &columns, WriteMode::Replace)
+            .unwrap();
+        let first = writer
+            .register_data_file(
+                first_setup.table_id,
+                "main",
+                "events",
+                first_setup.snapshot_id,
+                &DataFileInfo::new("first.parquet", 100, 10),
+                WriteMode::Replace,
+                first_setup.base_snapshot_id,
+                &columns,
+                &first_setup.column_ids,
+            )
+            .unwrap();
+        let second_setup = writer
+            .begin_write_transaction("main", "events", &columns, WriteMode::Append)
+            .unwrap();
+        let second = writer
+            .register_data_file(
+                first.table_id,
+                "main",
+                "events",
+                second_setup.snapshot_id,
+                &DataFileInfo::new("second.parquet", 200, 20),
+                WriteMode::Append,
+                second_setup.base_snapshot_id,
+                &columns,
+                &second_setup.column_ids,
+            )
+            .unwrap();
+        let plan = writer
+            .plan_table_data_restore(first.table_id, first.snapshot_id, second.snapshot_id)
+            .unwrap();
+        let destination = plan.files[0].restored_object_path.clone();
+        let destination_is_relative = plan.files[0].restored_object_path_is_relative;
+        sqlx::query(
+            "INSERT INTO ducklake_files_scheduled_for_deletion
+                 (data_file_id, path, path_is_relative)
+             VALUES (?, ?, ?)",
+        )
+        .bind(-1_i64)
+        .bind(destination)
+        .bind(destination_is_relative)
+        .execute(&writer.pool)
+        .await
+        .unwrap();
+
+        let commit = TableRestoreCommit::new(plan);
+        let error = writer
+            .commit_table_data_restore(&commit, &TableRestoreOptions::new())
+            .expect_err("a cataloged or scheduled destination path must conflict");
+        let head: i64 = sqlx::query_scalar("SELECT MAX(snapshot_id) FROM ducklake_snapshot")
+            .fetch_one(&writer.pool)
+            .await
+            .unwrap();
+
+        assert!(
+            matches!(error, crate::DuckLakeError::Conflict(_)),
+            "expected Conflict, got {error:?}"
+        );
+        assert_eq!(head, second.snapshot_id);
     }
 
     /// Reserve the next snapshot id the way `begin_write_transaction` now does

--- a/src/path_resolver.rs
+++ b/src/path_resolver.rs
@@ -76,7 +76,7 @@ fn validate_no_path_traversal(path: &str) -> Result<()> {
 }
 
 /// Validate a path for both null bytes and path traversal
-fn validate_path(path: &str) -> Result<()> {
+pub(crate) fn validate_path(path: &str) -> Result<()> {
     validate_no_null_bytes(path)?;
     validate_no_path_traversal(path)?;
     Ok(())

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -10,9 +10,9 @@ use datafusion::error::DataFusionError;
 use datafusion::execution::SendableRecordBatchStream;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use futures::StreamExt;
-use object_store::ObjectStore;
 use object_store::buffered::BufWriter as ObjectBufWriter;
 use object_store::path::Path as ObjectPath;
+use object_store::{ObjectStore, ObjectStoreExt};
 use parquet::arrow::ArrowWriter;
 use parquet::basic::Compression;
 use parquet::file::properties::WriterProperties;
@@ -22,10 +22,11 @@ use uuid::Uuid;
 
 use crate::Result;
 use crate::metadata_writer::{
-    ColumnDef, DataFileInfo, DeleteFileEntry, DeleteFileInfo, MetadataWriter,
-    SnapshotCommitMetadata, WriteMode, WriteResult, validate_delete_entries,
+    ColumnDef, DataFileInfo, DeleteFileEntry, DeleteFileInfo, MetadataWriter, RestoreResult,
+    SnapshotCommitMetadata, TableRestoreCommit, TableRestoreOptions, WriteMode, WriteResult,
+    validate_delete_entries, validate_table_restore_plan,
 };
-use crate::path_resolver::join_paths;
+use crate::path_resolver::{join_paths, validate_path};
 use crate::row_id::{embedded_rowid_field, embedded_snapshot_id_field};
 use crate::table::delete_file_schema;
 
@@ -609,6 +610,62 @@ impl DuckLakeTableWriter {
     ) -> Result<WriteResult> {
         self.write_all(schema_name, table_name, batches, WriteMode::Append)
             .await
+    }
+
+    /// Restore one table's data state from an earlier snapshot in a new snapshot.
+    ///
+    /// Every source data and positional-delete object is copied to a fresh sibling path before
+    /// the metadata commit. This keeps physical cleanup path-safe: expiring a retired source row
+    /// can never delete an object referenced by the restored live row. The metadata commit
+    /// revalidates the catalog head, schema generation, and source file set atomically.
+    pub async fn restore_table_data_to_snapshot(
+        &self,
+        table_id: i64,
+        source_snapshot_id: i64,
+        expected_base_snapshot_id: i64,
+        options: &TableRestoreOptions,
+    ) -> Result<RestoreResult> {
+        let plan = self.metadata.plan_table_data_restore(
+            table_id,
+            source_snapshot_id,
+            expected_base_snapshot_id,
+        )?;
+        validate_table_restore_plan(&plan)?;
+        let mut copied = Vec::with_capacity(plan.files.len());
+        for file in &plan.files {
+            let source = self.table_restore_object_path(
+                &file.source_object_path,
+                file.source_object_path_is_relative,
+            )?;
+            let restored = self.table_restore_object_path(
+                &file.restored_object_path,
+                file.restored_object_path_is_relative,
+            )?;
+            if let Err(e) = self.object_store.copy(&source, &restored).await {
+                copied.push(restored);
+                self.remove_table_restore_objects(&copied).await;
+                return Err(e.into());
+            }
+            copied.push(restored);
+        }
+        let commit = TableRestoreCommit::new(plan);
+        self.metadata.commit_table_data_restore(&commit, options)
+    }
+
+    fn table_restore_object_path(&self, path: &str, path_is_relative: bool) -> Result<ObjectPath> {
+        validate_path(path)?;
+        let path = if path_is_relative {
+            join_paths(&self.base_key_path, path)?
+        } else {
+            path.to_string()
+        };
+        Ok(ObjectPath::from(path.trim_start_matches('/')))
+    }
+
+    async fn remove_table_restore_objects(&self, files: &[ObjectPath]) {
+        for file in files {
+            let _ = self.object_store.delete(file).await;
+        }
     }
 
     /// Shared body of [`Self::write_table`] / [`Self::append_table`].

--- a/tests/it/multicatalog_postgres_tests.rs
+++ b/tests/it/multicatalog_postgres_tests.rs
@@ -10,16 +10,21 @@
 //! - No orphan mapping rows after writes
 
 use datafusion_ducklake::metadata_writer::{
-    ColumnDef, DataFileInfo, MetadataWriter, SnapshotCommitMetadata, WriteMode,
+    ColumnDef, DataFileInfo, MetadataWriter, SnapshotCommitMetadata, TableRestoreOptions, WriteMode,
 };
 use datafusion_ducklake::{
-    DuckLakeError, DuckLakeTableWriter, MulticatalogManager, NullOrder, PartitionTransform,
-    PostgresMetadataWriter, SortDirection, SortField, TableWriteOptions, TypeChangeOperation,
-    TypeChangeWriteMode, initialize_multicatalog_schema,
+    DeleteFileInfo, DuckLakeError, DuckLakeTableWriter, MulticatalogManager, NullOrder,
+    PartitionTransform, PostgresMetadataWriter, SortDirection, SortField, TableWriteOptions,
+    TypeChangeOperation, TypeChangeWriteMode, initialize_multicatalog_schema,
+    maintenance::{CleanupCriteria, ExpireCriteria, cleanup_old_files_in_catalog},
 };
+use object_store::ObjectStore;
+use object_store::local::LocalFileSystem;
 use sqlx::AssertSqlSafe;
 use sqlx::Row;
 use sqlx::postgres::{PgPool, PgPoolOptions};
+use std::sync::Arc;
+use tempfile::TempDir;
 use testcontainers::ContainerAsync;
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::postgres::Postgres;
@@ -608,6 +613,309 @@ async fn postgres_sort_ddl_records_snapshot_changes() {
             .try_get(0)
             .unwrap();
     assert_eq!(end_snapshot, reset_snapshot);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn postgres_restore_copies_source_files_and_cleanup_deletes_only_retired_paths() {
+    let (pool, _container) = spin_up_postgres().await.unwrap();
+    let manager = MulticatalogManager::new(pool.clone());
+    let catalog_id = manager.create_catalog("restore").await.unwrap();
+    let writer = PostgresMetadataWriter::with_pool(pool.clone(), catalog_id)
+        .await
+        .unwrap();
+    let temp = TempDir::new().unwrap();
+    let data_path = temp.path().join("data");
+    let table_path = data_path.join(format!("cat_{catalog_id}/public/events"));
+    std::fs::create_dir_all(&table_path).unwrap();
+    std::fs::write(table_path.join("first.parquet"), b"first data").unwrap();
+    std::fs::write(table_path.join("first-deletes.parquet"), b"first deletes").unwrap();
+    std::fs::write(table_path.join("second.parquet"), b"second data").unwrap();
+    writer.set_data_path(data_path.to_str().unwrap()).unwrap();
+    let writer = Arc::new(writer);
+    let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+    let table_writer = DuckLakeTableWriter::new(writer.clone(), store.clone()).unwrap();
+    let columns = cols();
+    let first_setup = writer
+        .begin_write_transaction("public", "events", &columns, WriteMode::Replace)
+        .unwrap();
+    let first = writer
+        .register_data_file(
+            first_setup.table_id,
+            "public",
+            "events",
+            first_setup.snapshot_id,
+            &DataFileInfo::new("first.parquet", 100, 10).with_footer_size(17),
+            WriteMode::Replace,
+            first_setup.base_snapshot_id,
+            &columns,
+            &first_setup.column_ids,
+        )
+        .unwrap();
+    let source_data_file_id: i64 = sqlx::query_scalar(
+        "SELECT data_file_id FROM ducklake_data_file
+         WHERE table_id = $1 AND path = 'first.parquet'",
+    )
+    .bind(first.table_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let partition_id = 1_i64;
+    sqlx::query(
+        "INSERT INTO ducklake_partition_info
+             (partition_id, table_id, begin_snapshot, end_snapshot)
+         VALUES ($1, $2, $3, NULL)",
+    )
+    .bind(partition_id)
+    .bind(first.table_id)
+    .bind(first.snapshot_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO ducklake_partition_column
+             (partition_id, table_id, partition_key_index, column_id, transform)
+         VALUES ($1, $2, 0, $3, 'identity')",
+    )
+    .bind(partition_id)
+    .bind(first.table_id)
+    .bind(first_setup.column_ids[0])
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query("UPDATE ducklake_data_file SET partition_id = $1 WHERE data_file_id = $2")
+        .bind(partition_id)
+        .bind(source_data_file_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO ducklake_file_partition_value
+             (data_file_id, table_id, partition_key_index, partition_value)
+         VALUES ($1, $2, 0, '1')",
+    )
+    .bind(source_data_file_id)
+    .bind(first.table_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+    let delete = writer
+        .set_delete_file(
+            first.table_id,
+            "public",
+            "events",
+            first.snapshot_id + 1,
+            source_data_file_id,
+            None,
+            first.snapshot_id,
+            &DeleteFileInfo::new("first-deletes.parquet", 20, 2).with_footer_size(7),
+        )
+        .unwrap();
+    let source_delete_file_id: i64 = sqlx::query_scalar(
+        "SELECT delete_file_id FROM ducklake_delete_file
+         WHERE data_file_id = $1 AND end_snapshot IS NULL",
+    )
+    .bind(source_data_file_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let second_setup = writer
+        .begin_write_transaction("public", "events", &columns, WriteMode::Append)
+        .unwrap();
+    let second = writer
+        .register_data_file(
+            first.table_id,
+            "public",
+            "events",
+            second_setup.snapshot_id,
+            &DataFileInfo::new("second.parquet", 200, 20)
+                .with_partition(partition_id, vec![(0, Some("2".to_string()))]),
+            WriteMode::Append,
+            second_setup.base_snapshot_id,
+            &columns,
+            &second_setup.column_ids,
+        )
+        .unwrap();
+
+    let restored = table_writer
+        .restore_table_data_to_snapshot(
+            first.table_id,
+            delete.snapshot_id,
+            second.snapshot_id,
+            &TableRestoreOptions::new().with_message("datafusion restore"),
+        )
+        .await
+        .unwrap();
+    let live_data = sqlx::query(
+        "SELECT data_file_id, path, file_size_bytes, footer_size, record_count, row_id_start,
+                partition_id
+         FROM ducklake_data_file WHERE table_id = $1 AND end_snapshot IS NULL",
+    )
+    .bind(first.table_id)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    let restored_data_file_id = live_data[0].try_get::<i64, _>("data_file_id").unwrap();
+    let restored_partition_values = sqlx::query_as::<_, (i64, Option<String>)>(
+        "SELECT partition_key_index, partition_value
+         FROM ducklake_file_partition_value WHERE data_file_id = $1
+         ORDER BY partition_key_index",
+    )
+    .bind(restored_data_file_id)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    let restored_data_path = live_data[0].try_get::<String, _>("path").unwrap();
+    let live_delete = sqlx::query(
+        "SELECT delete_file_id, data_file_id, path, file_size_bytes, footer_size, delete_count
+         FROM ducklake_delete_file WHERE table_id = $1 AND end_snapshot IS NULL",
+    )
+    .bind(first.table_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let restored_delete_path = live_delete.try_get::<String, _>("path").unwrap();
+    let snapshot_change =
+        sqlx::query_as::<_, (String, Option<String>, Option<String>, Option<String>)>(
+            "SELECT changes_made, author, commit_message, commit_extra_info
+             FROM ducklake_snapshot_changes WHERE snapshot_id = $1",
+        )
+        .bind(restored.snapshot_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(current_head(&pool, catalog_id).await, restored.snapshot_id);
+    assert!(restored.snapshot_id > second.snapshot_id);
+    assert_eq!(restored.data_files_restored, 1);
+    assert_eq!(restored.delete_files_restored, 1);
+    assert_eq!(live_data.len(), 1);
+    assert!(restored_data_file_id > source_data_file_id);
+    assert!(restored_data_path.starts_with(&format!(
+        "first.restore-{}-data-{source_data_file_id}-",
+        second.snapshot_id
+    )));
+    assert!(restored_data_path.ends_with(".parquet"));
+    assert_eq!(
+        (
+            live_data[0].try_get::<i64, _>("file_size_bytes").unwrap(),
+            live_data[0]
+                .try_get::<Option<i64>, _>("footer_size")
+                .unwrap(),
+            live_data[0]
+                .try_get::<Option<i64>, _>("record_count")
+                .unwrap(),
+            live_data[0]
+                .try_get::<Option<i64>, _>("row_id_start")
+                .unwrap(),
+            live_data[0]
+                .try_get::<Option<i64>, _>("partition_id")
+                .unwrap(),
+        ),
+        (100, Some(17), Some(10), Some(0), Some(partition_id)),
+    );
+    assert_eq!(restored_partition_values, vec![(0, Some("1".to_string()))]);
+    let restored_delete_file_id = live_delete.try_get::<i64, _>("delete_file_id").unwrap();
+    assert!(restored_delete_file_id > source_delete_file_id);
+    assert!(restored_delete_path.starts_with(&format!(
+        "first-deletes.restore-{}-delete-{source_delete_file_id}-",
+        second.snapshot_id
+    )));
+    assert!(restored_delete_path.ends_with(".parquet"));
+    assert_eq!(
+        (
+            live_delete.try_get::<i64, _>("data_file_id").unwrap(),
+            live_delete.try_get::<i64, _>("file_size_bytes").unwrap(),
+            live_delete
+                .try_get::<Option<i64>, _>("footer_size")
+                .unwrap(),
+            live_delete
+                .try_get::<Option<i64>, _>("delete_count")
+                .unwrap(),
+        ),
+        (restored_data_file_id, 20, Some(7), Some(2)),
+    );
+    assert_eq!(
+        snapshot_change,
+        (
+            format!(
+                "deleted_from_table:{},inserted_into_table:{}",
+                first.table_id, first.table_id
+            ),
+            None,
+            Some("datafusion restore".to_string()),
+            None,
+        ),
+    );
+
+    let expired = manager
+        .expire_snapshots_in_catalog(
+            "restore",
+            ExpireCriteria::Versions(vec![
+                first.snapshot_id,
+                delete.snapshot_id,
+                second.snapshot_id,
+            ]),
+        )
+        .await
+        .unwrap();
+    let scheduled = sqlx::query_scalar::<_, String>(
+        "SELECT path FROM ducklake_files_scheduled_for_deletion WHERE catalog_id = $1
+         ORDER BY path",
+    )
+    .bind(catalog_id)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+
+    assert_eq!(
+        expired
+            .iter()
+            .map(|snapshot| snapshot.snapshot_id)
+            .collect::<Vec<_>>(),
+        vec![first.snapshot_id, delete.snapshot_id, second.snapshot_id],
+    );
+    assert_eq!(
+        scheduled,
+        vec![
+            format!("cat_{catalog_id}/public/events/first-deletes.parquet"),
+            format!("cat_{catalog_id}/public/events/first.parquet"),
+            format!("cat_{catalog_id}/public/events/second.parquet"),
+        ],
+    );
+
+    let mut cleanup =
+        cleanup_old_files_in_catalog(&manager, "restore", store, CleanupCriteria::All, false)
+            .await
+            .unwrap();
+    cleanup.sort();
+    assert_eq!(
+        cleanup,
+        vec![
+            table_path
+                .join("first-deletes.parquet")
+                .to_string_lossy()
+                .to_string(),
+            table_path
+                .join("first.parquet")
+                .to_string_lossy()
+                .to_string(),
+            table_path
+                .join("second.parquet")
+                .to_string_lossy()
+                .to_string(),
+        ],
+    );
+    let scheduled_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ducklake_files_scheduled_for_deletion WHERE catalog_id = $1",
+    )
+    .bind(catalog_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(scheduled_count, 0);
+    assert!(table_path.join(restored_data_path).exists());
+    assert!(table_path.join(restored_delete_path).exists());
 }
 
 /// #864: the postgres `set_delete_file` write — fenced, cumulative,


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD041 -->

### PR title

Restore table data in a new DuckLake snapshot

### Summary

Add a catalog‑generic operation that restores one table's data state from an earlier snapshot by
committing a new forward snapshot. The operation does not rewind the catalog head, reuse file
identifiers, reopen visibility intervals, or reinterpret files under a changed schema.

Every selected data and positional‑delete object is copied to a fresh UUID‑suffixed sibling path
before the metadata transaction starts. This preserves DuckLake's path‑based expiration and cleanup
semantics: retired source rows and live restored rows never own the same physical object.

```mermaid
flowchart LR
    Source["Historical snapshot"] --> Plan["Validate restore plan"]
    Plan --> Copy["Copy objects to fresh paths"]
    Copy --> Recheck["Lock and recheck catalog state"]
    Head["Expected catalog head"] --> Recheck
    Recheck --> Commit["Commit a new forward snapshot"]
```

### Contract

- Require the source snapshot to precede the expected catalog head.
- Require the table to be visible at both snapshots.
- Lock and recheck the catalog head, schema state, source file set, and destination paths before
  committing metadata.
- Detect schema changes through both `ducklake_schema_versions` and `ducklake_column` generation
  bounds. The second check covers older or library‑specific mutations that did not write a ledger
  row.
- Reject partial data and delete files because their embedded snapshot lineage needs a physical
  rewrite.
- Reject SQLite restores when inlined rows are visible at the source snapshot or current head.
- Store an empty restore's `changes_made` value as `NULL`, matching DuckLake aggregation and parsing
  semantics, while preserving optional author, message, and extra information.
- Leave unsupported metadata backends on the trait's explicit `Unsupported` default.

### Metadata and object safety

- Allocate one new monotonic snapshot and fresh data‑file and delete‑file identifiers.
- Preserve half‑open visibility through `begin_snapshot <= selected < end_snapshot`.
- Preserve file sizes, footer sizes, row ID starts, mappings, partitions, partition values, file
  statistics, and delete‑file relationships.
- Recompute live table and column statistics from the restored file set.
- Record standard `deleted_from_table` and `inserted_into_table` change tokens.
- Keep the existing scheduled‑deletion API unchanged. Restore safety comes from distinct physical
  paths, not a cleanup‑queue reference filter.
- Remove completed copies after a copy‑phase error. Once the metadata commit starts, retain copies
  after errors because the transaction outcome may be ambiguous; orphan cleanup can reclaim objects
  that no committed row references.
- Validate both relative and absolute catalog‑derived object paths before copy or deletion.

### Backend support

- SQLite single‑catalog metadata: supported, including explicit inlined‑row rejection.
- PostgreSQL multi‑catalog metadata: supported.
- DuckDB, MySQL, and PostgreSQL standard single‑catalog metadata: return `Unsupported` through the
  optional trait method.

### Branch

- Independent branch: `ducklake-snapshot-restore-pr`.
- Base: upstream `0ae7b7e`.
- Commit: `dab9c0a feat(write): restore table data in a new snapshot`.
- The branch is one commit ahead of upstream.
- The public API uses only DuckLake table, snapshot, file, and snapshot‑change concepts.

### Verification

- `cargo fmt --all -- --check`.
- Focused SQLite restore tests cover physical copies and cleanup, empty restore metadata,
  unledgered column generations, inlined rows, stale heads, partial files, and destination
  collisions.
- The scheduled‑deletion regression proves referenced paths remain visible to existing callers.
- The PostgreSQL integration restore target compiles with all features.
- Clippy runs across all targets and features with warnings denied.

### Deliberate follow‑ups

This change does not add restore support for inlined rows, rewrite positional‑delete Parquet payloads,
parallelize object copies, batch destination collision queries, or shorten repeated restore suffixes.
Those changes have separate compatibility and performance tradeoffs and are not required for the
safe metadata‑only restore contract implemented here.
