### PR TITLE
feat(write): roll data files on a streaming write, matching official

### DIFF
--- a/src/compaction.rs
+++ b/src/compaction.rs
@@ -208,6 +208,16 @@ pub(crate) fn sorted_rewrite_output(
             sort_spec.sort_id
         ))
     })?;
+    // No usable keys means "write unsorted", not an error. `producible_columns` filters
+    // out fields whose dialect is not `duckdb`, so a spec authored by another engine can
+    // legitimately leave nothing behind. Official DuckLake skips such fields and
+    // proceeds with whatever remains — an empty ORDER BY when that is all of them
+    // (`ducklake_compaction_functions.cpp`, `ducklake_insert.cpp`). Falling through to
+    // `LexOrdering::new` would instead fail a compaction that official completes; the
+    // SQL INSERT path already returns "no ordering" for this case.
+    if keys.is_empty() {
+        return Ok(input.execute(0, Arc::clone(&context))?);
+    }
 
     let mut expressions = Vec::with_capacity(keys.len());
     for (name, direction, null_order) in keys {

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -41,6 +41,12 @@ pub use crate::partition::PartitionGroup;
 /// descriptors and memory.
 pub const DEFAULT_MAX_OPEN_PARTITIONS: usize = 100;
 
+/// Floor on the target data file size, matching official DuckLake's
+/// `MINIMUM_WRITE_FILE_SIZE` (`ducklake_insert.cpp`), which clamps with
+/// `MaxValue<idx_t>(target_file_size, 4096)`. A smaller request would roll a new file
+/// per batch and produce a file per row group.
+pub const MINIMUM_TARGET_FILE_SIZE: usize = 4096;
+
 /// Default target data file size: 512 MiB, matching official DuckLake's
 /// `target_file_size` default (`1 << 29`). A write rolls over to a new file once
 /// it reaches this size, so no single write can produce a file too large for
@@ -152,7 +158,7 @@ impl DuckLakeTableWriter {
     /// holds a contiguous value range with a tight min/max, enabling file-level
     /// pruning. Defaults to [`DEFAULT_TARGET_FILE_SIZE`].
     pub fn with_target_file_size(mut self, bytes: usize) -> Self {
-        self.target_file_size = bytes;
+        self.target_file_size = bytes.max(MINIMUM_TARGET_FILE_SIZE);
         self
     }
 
@@ -231,6 +237,16 @@ impl DuckLakeTableWriter {
     /// So to get the file-skipping benefit of a sort order from this path, feed
     /// batches already in sort order, or use [`Self::write_rows`] when the write fits
     /// in memory. Writing unsorted costs pruning quality only, never correctness.
+    ///
+    /// **Rolls by default.** A new data file is started once the current one exceeds
+    /// [`target_file_size`](Self::with_target_file_size), and
+    /// [`TableWriteSession::finish`] commits them all in one snapshot. Official
+    /// DuckLake rotates on every write (`result.rotate = true` in
+    /// `ducklake_insert.cpp`), and a single unbounded file could never be reorganized
+    /// afterwards — DuckLake compaction merges but never splits.
+    ///
+    /// Use [`Self::begin_write_single_file`] when the session will be finished with
+    /// [`TableWriteSession::finish_with_deletes`], which commits exactly one data file.
     pub fn begin_write(
         &self,
         schema_name: &str,
@@ -262,6 +278,45 @@ impl DuckLakeTableWriter {
             false,
             mode,
             StreamPartitionMode::Split,
+            true,
+        )
+    }
+
+    /// Begin a streaming write session that writes ONE data file, however large the
+    /// input.
+    ///
+    /// For sessions finished with [`TableWriteSession::finish_with_deletes`]: that
+    /// commit registers exactly one appended data file, so a session that rolled into
+    /// several cannot use it. [`Self::begin_write`] rolls and is the right default for
+    /// everything else.
+    ///
+    /// A single file is not reorganizable later — DuckLake compaction merges but never
+    /// splits — so prefer [`Self::begin_write`] whenever the commit allows it.
+    pub fn begin_write_single_file(
+        &self,
+        schema_name: &str,
+        table_name: &str,
+        arrow_schema: &Schema,
+        mode: WriteMode,
+    ) -> Result<TableWriteSession> {
+        let scoped_base = match self.metadata.catalog_id() {
+            Some(id) => join_paths(&self.base_key_path, &format!("cat_{id}"))?,
+            None => self.base_key_path.clone(),
+        };
+        let table_key = join_paths(&join_paths(&scoped_base, schema_name)?, table_name)?;
+        let file_name = format!("{}.parquet", Uuid::new_v4());
+        self.begin_write_internal(
+            schema_name,
+            table_name,
+            arrow_schema,
+            table_key,
+            file_name.clone(),
+            file_name,
+            true,
+            false,
+            mode,
+            StreamPartitionMode::Split,
+            false,
         )
     }
 
@@ -306,6 +361,7 @@ impl DuckLakeTableWriter {
             true,
             mode,
             StreamPartitionMode::Split,
+            false,
         )
     }
 
@@ -333,6 +389,7 @@ impl DuckLakeTableWriter {
             StreamPartitionMode::Reject {
                 entry_point: "begin_write_to_path",
             },
+            false,
         )
     }
 
@@ -349,6 +406,7 @@ impl DuckLakeTableWriter {
         embed_rowid: bool,
         mode: WriteMode,
         partition_mode: StreamPartitionMode,
+        roll: bool,
     ) -> Result<TableWriteSession> {
         let columns = arrow_schema_to_column_defs(arrow_schema)?;
         let setup =
@@ -436,6 +494,28 @@ impl DuckLakeTableWriter {
                 },
             };
 
+        // A partitioned target already rolls inside its per-partition sink, so a
+        // second roller would be redundant (and would double-write).
+        let roller = if roll && partition_sink.is_none() {
+            let scoped_base = match self.metadata.catalog_id() {
+                Some(id) => join_paths(&self.base_key_path, &format!("cat_{id}"))?,
+                None => self.base_key_path.clone(),
+            };
+            let table_key = join_paths(&join_paths(&scoped_base, schema_name)?, table_name)?;
+            Some(RollingFileWriter::new(
+                table_key,
+                None,
+                schema_with_ids.clone(),
+                setup.column_ids.len(),
+                self.build_writer_props(),
+                self.target_file_size,
+                // Keep `TableWriteSession::file_path` accurate for the first file.
+                Some(catalog_path.clone()),
+            ))
+        } else {
+            None
+        };
+
         Ok(TableWriteSession {
             metadata: Arc::clone(&self.metadata),
             object_store: Arc::clone(&self.object_store),
@@ -456,6 +536,8 @@ impl DuckLakeTableWriter {
             row_count: 0,
             nan_flags: Vec::new(),
             partition_sink,
+            roller,
+            rolled: Vec::new(),
         })
     }
 
@@ -1145,6 +1227,7 @@ impl DuckLakeTableWriter {
             column_ids.len(),
             self.build_writer_props(),
             self.target_file_size,
+            None,
         );
         let mut files: Vec<DataFileInfo> = Vec::new();
         for batch in batches {
@@ -1240,6 +1323,14 @@ struct RollingFileWriter {
     props: WriterProperties,
     target_file_size: usize,
     open: Option<OpenFile>,
+    /// Catalog path to use for the FIRST file instead of minting a fresh name.
+    ///
+    /// A streaming session pre-computes its output path at `begin_write` and exposes it
+    /// through [`TableWriteSession::file_path`]. Handing that path to the roller keeps
+    /// that accessor accurate for the first (and, for a write below
+    /// `target_file_size`, only) file, so rolling does not silently change what an
+    /// existing caller observes. Taken on first use.
+    first_catalog_path: Option<String>,
 }
 
 impl RollingFileWriter {
@@ -1250,8 +1341,10 @@ impl RollingFileWriter {
         data_column_count: usize,
         props: WriterProperties,
         target_file_size: usize,
+        first_catalog_path: Option<String>,
     ) -> Self {
         Self {
+            first_catalog_path,
             table_key,
             rel_prefix,
             schema_with_ids,
@@ -1288,7 +1381,10 @@ impl RollingFileWriter {
         open.row_count += batch.num_rows() as i64;
 
         // Estimated encoded size = finished row groups + the in-progress one.
-        if open.writer.bytes_written() + open.writer.in_progress_size() >= self.target_file_size {
+        // Strictly greater, matching official's parquet rotate predicate
+        // (`FileSize() > file_size_bytes`), so a write landing exactly on the target
+        // stays in one file.
+        if open.writer.bytes_written() + open.writer.in_progress_size() > self.target_file_size {
             return Ok(Some(finalize_open_file(
                 self.open.take().expect("file open"),
             )?));
@@ -1309,11 +1405,16 @@ impl RollingFileWriter {
         self.open.is_some()
     }
 
-    fn open_file(&self) -> Result<OpenFile> {
-        let file_name = format!("{}.parquet", Uuid::new_v4());
-        let catalog_path = match self.rel_prefix.as_deref() {
-            Some(prefix) if !prefix.is_empty() => format!("{prefix}/{file_name}"),
-            _ => file_name,
+    fn open_file(&mut self) -> Result<OpenFile> {
+        let catalog_path = match self.first_catalog_path.take() {
+            Some(path) => path,
+            None => {
+                let file_name = format!("{}.parquet", Uuid::new_v4());
+                match self.rel_prefix.as_deref() {
+                    Some(prefix) if !prefix.is_empty() => format!("{prefix}/{file_name}"),
+                    _ => file_name,
+                }
+            },
         };
         let object_path_str = join_paths(&self.table_key, &catalog_path)?;
         let object_path = ObjectPath::from(object_path_str.trim_start_matches('/'));
@@ -1483,6 +1584,7 @@ impl PartitionSink {
                         self.column_ids.len(),
                         self.props.clone(),
                         self.target_file_size,
+                        None,
                     ),
                 ));
                 self.open.len() - 1
@@ -1586,14 +1688,32 @@ pub struct TableWriteSession {
     /// per partition, and `writer`/`temp` above stay `None`. `finish` then commits
     /// every file the sink produced in a single snapshot.
     partition_sink: Option<PartitionSink>,
+    /// Set unless the session is single-file (see
+    /// [`DuckLakeTableWriter::begin_write_single_file`]): batches are routed
+    /// through this instead of the single `writer` above, starting a new file each
+    /// time one reaches `target_file_size`, and `finish` commits them all in one
+    /// snapshot. `None` for a single-file session.
+    roller: Option<RollingFileWriter>,
+    /// Files the roller has finished, awaiting upload at `finish`.
+    rolled: Vec<StagedFile>,
 }
 
 impl TableWriteSession {
     pub fn write_batch(&mut self, batch: &RecordBatch) -> Result<()> {
-        // Partitioned target: validate up front so the shared borrow of `self` that
-        // `validate_batch_schema` takes is released before the sink is borrowed mutably.
-        if self.partition_sink.is_some() {
+        // Rolling or partitioned target: validate up front so the shared borrow of
+        // `self` that `validate_batch_schema` takes is released before the roller or
+        // sink is borrowed mutably.
+        if self.roller.is_some() || self.partition_sink.is_some() {
             self.validate_batch_schema(batch)?;
+        }
+        if let Some(roller) = &mut self.roller {
+            let rows = batch.num_rows() as i64;
+            // `roller` and `rolled` are distinct fields, so both can be borrowed here.
+            if let Some(staged) = roller.write(batch)? {
+                self.rolled.push(staged);
+            }
+            self.row_count += rows;
+            return Ok(());
         }
         if let Some(sink) = &mut self.partition_sink {
             let rows = batch.num_rows() as i64;
@@ -1671,6 +1791,43 @@ impl TableWriteSession {
     }
 
     pub async fn finish(mut self) -> Result<WriteResult> {
+        // Rolling: finish the in-progress file, upload every file this session
+        // produced, and commit them in ONE snapshot.
+        if let Some(mut roller) = self.roller.take() {
+            if let Some(staged) = roller.finish()? {
+                self.rolled.push(staged);
+            }
+            let mut file_infos = Vec::with_capacity(self.rolled.len());
+            for staged in std::mem::take(&mut self.rolled) {
+                file_infos
+                    .push(upload_staged_file(staged, &self.object_store, &self.column_ids).await?);
+            }
+            if file_infos.is_empty() {
+                // No rows arrived. Fall through to the single-file path, which
+                // registers the 0-row marker a Replace needs to retire the prior
+                // generation.
+                return self.finish_single_file().await;
+            }
+            let records_written: i64 = file_infos.iter().map(|f| f.record_count).sum();
+            let committed = self.metadata.register_data_files(
+                self.table_id,
+                &self.schema_name,
+                &self.table_name,
+                self.snapshot_id,
+                &file_infos,
+                self.mode,
+                self.base_snapshot_id,
+                &self.columns,
+                &self.column_ids,
+            )?;
+            return Ok(WriteResult {
+                snapshot_id: committed.snapshot_id,
+                table_id: committed.table_id,
+                schema_id: committed.schema_id,
+                files_written: file_infos.len(),
+                records_written,
+            });
+        }
         // Partitioned: commit every file the sink produced in ONE snapshot, so a
         // partitioned streaming write is as atomic as an unpartitioned one.
         if let Some(sink) = self.partition_sink.take() {
@@ -1742,21 +1899,45 @@ impl TableWriteSession {
         // Reject an unsupported combination before uploading the staged parquet,
         // so a misuse leaves no orphan object in storage.
         validate_delete_entries(self.mode, deletes)?;
-        let file_info = match self.partition_sink.take() {
-            Some(sink) => {
-                let file_count = sink.pending_file_count();
-                if file_count != 1 {
+        // A rolling or partitioned session may have produced several files, but this
+        // commit registers exactly one. Both cases therefore COUNT their files before
+        // uploading anything, so a rejected write leaves no orphan object.
+        let file_info = if let Some(sink) = self.partition_sink.take() {
+            let file_count = sink.pending_file_count();
+            if file_count != 1 {
+                return Err(crate::error::DuckLakeError::Unsupported(format!(
+                    "an atomic append+delete commit accepts one appended data file, but the \
+                     partitioned write produced {file_count}"
+                )));
+            }
+            sink.into_file_infos(&self.object_store)
+                .await?
+                .pop()
+                .expect("one pending partition file")
+        } else if let Some(mut roller) = self.roller.take() {
+            // `finish` writes the parquet footer locally; nothing is uploaded yet.
+            if let Some(staged) = roller.finish()? {
+                self.rolled.push(staged);
+            }
+            match self.rolled.len() {
+                // No rows arrived. Fall through to the single-file path, whose 0-row
+                // marker is what carries a Replace truncation (and is exempt from the
+                // partition fence) — same behaviour as a non-rolling session.
+                0 => self.upload_staged().await?,
+                1 => {
+                    let staged = self.rolled.pop().expect("one staged file");
+                    upload_staged_file(staged, &self.object_store, &self.column_ids).await?
+                },
+                file_count => {
                     return Err(crate::error::DuckLakeError::Unsupported(format!(
                         "an atomic append+delete commit accepts one appended data file, but the \
-                         partitioned write produced {file_count}"
+                         write rolled into {file_count}. Open the session with \
+                         begin_write_single_file, which never rolls."
                     )));
-                }
-                sink.into_file_infos(&self.object_store)
-                    .await?
-                    .pop()
-                    .expect("one pending partition file")
-            },
-            None => self.upload_staged().await?,
+                },
+            }
+        } else {
+            self.upload_staged().await?
         };
         let committed = self.metadata.register_data_file_with_deletes(
             self.table_id,

--- a/tests/compaction_sqlite_tests.rs
+++ b/tests/compaction_sqlite_tests.rs
@@ -250,6 +250,65 @@ async fn run_rewrite(temp: &TempDir, opts: RewriteOptions) -> CompactionResult {
     .await
 }
 
+/// A sort spec whose fields are ALL from a foreign dialect must compact unsorted, not
+/// fail.
+///
+/// `producible_columns` filters out any field whose dialect is not `duckdb`, so such a
+/// spec leaves no usable keys. Official DuckLake skips those fields and proceeds with
+/// whatever remains — nothing, here — so compaction completes and simply writes
+/// unsorted. Erroring instead would fail on a catalog official compacts fine.
+#[tokio::test(flavor = "multi_thread")]
+async fn compaction_ignores_a_foreign_dialect_sort_spec() {
+    use datafusion_ducklake::sort::{NullOrder, SortDirection, SortField};
+
+    let temp = TempDir::new().unwrap();
+    seed(&temp, vec![1, 2], vec![10, 20]).await;
+    append(&temp, vec![3, 4], vec![30, 40]).await;
+
+    let p = pool(&temp).await;
+    let table_id = scalar_i64(
+        &p,
+        "SELECT table_id FROM ducklake_table WHERE table_name = 't'",
+    )
+    .await;
+
+    // A sort field in another engine's dialect: readable, but not executable here.
+    let foreign = SortField {
+        sort_key_index: 0,
+        expression: "val".to_string(),
+        dialect: "spark".to_string(),
+        direction: SortDirection::Asc,
+        null_order: NullOrder::NullsLast,
+    };
+    SqliteMetadataWriter::new(&db_url(&temp))
+        .await
+        .unwrap()
+        .set_sort_spec(table_id, &[foreign])
+        .unwrap();
+
+    // Sanity: a duckdb-dialect spec on the same table is executable, so the fixture is
+    // exercising the dialect filter rather than some unrelated rejection.
+    let _ = SortField::column(0, "val", SortDirection::Asc, NullOrder::NullsLast);
+
+    let result = run_merge(
+        &temp,
+        MergeOptions {
+            target_file_size: 1 << 30,
+            max_merged_files: 1024,
+            min_file_size: 0,
+        },
+    )
+    .await;
+    assert!(
+        result.did_work(),
+        "compaction must complete despite an unexecutable sort spec"
+    );
+    assert_eq!(
+        read_rows(&temp).await,
+        vec![(1, 10), (2, 20), (3, 30), (4, 40)]
+    );
+}
+
 /// Compaction of a PARTITIONED table must merge only within a partition and carry
 /// each output's partition assignment over from its sources — official DuckLake
 /// groups merge candidates by (schema_version, partition_id, partition_values).

--- a/tests/sorted_write_tests.rs
+++ b/tests/sorted_write_tests.rs
@@ -157,6 +157,171 @@ async fn live_file_count(conn_str: &str, table_id: i64) -> usize {
 /// Asserts the file-level property that matters: each rolled file's `val` range is
 /// disjoint from every other's. A per-file sort could not achieve this (a file's
 /// min/max does not depend on row order) — only a global sort before rolling can.
+/// `begin_write` must produce SEVERAL files for a load larger than
+/// `target_file_size`, and `begin_write_single_file` must produce exactly one.
+///
+/// Rolling is the default because official DuckLake rotates on every write
+/// (`result.rotate = true`), and because DuckLake compaction merges but never splits —
+/// so a file written oversized can never be reorganized afterwards.
+#[tokio::test(flavor = "multi_thread")]
+async fn begin_write_rolls_by_default_and_single_file_opts_out() {
+    use datafusion_ducklake::table_writer::DuckLakeTableWriter;
+
+    let env = setup().await;
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("val", DataType::Int32, true),
+    ]));
+    // Many batches, comfortably past an 8 KiB target once encoded.
+    let batches: Vec<RecordBatch> = (0..40)
+        .map(|b| {
+            let ids: Vec<i32> = (b * 200..(b + 1) * 200).collect();
+            let vals = ids.clone();
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![Arc::new(Int32Array::from(ids)), Arc::new(Int32Array::from(vals))],
+            )
+            .unwrap()
+        })
+        .collect();
+
+    let object_store: Arc<dyn object_store::ObjectStore> =
+        Arc::new(object_store::local::LocalFileSystem::new());
+    let writer_for = |()| async {
+        let w = SqliteMetadataWriter::new_with_init(&env.conn_str)
+            .await
+            .unwrap();
+        DuckLakeTableWriter::new(Arc::new(w), object_store.clone())
+            .unwrap()
+            .with_target_file_size(8 * 1024)
+    };
+
+    // Default: rolls.
+    let table_writer = writer_for(()).await;
+    let mut session = table_writer
+        .begin_write("main", "events", schema.as_ref(), WriteMode::Replace)
+        .unwrap();
+    for batch in &batches {
+        session.write_batch(batch).unwrap();
+    }
+    let rolled = session.finish().await.unwrap();
+    assert_eq!(rolled.records_written, 8000);
+    assert!(
+        rolled.files_written > 1,
+        "begin_write must roll a load past target_file_size, got {} file(s)",
+        rolled.files_written
+    );
+
+    // Every row still readable through the catalog.
+    let ctx = read_ctx(&env.conn_str).await;
+    let rows = ctx
+        .sql("SELECT count(*) FROM ducklake.main.events")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(
+        rows[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .unwrap()
+            .value(0),
+        8000
+    );
+
+    // Opt out: exactly one file, however large the input.
+    let table_writer = writer_for(()).await;
+    let mut session = table_writer
+        .begin_write_single_file("main", "events", schema.as_ref(), WriteMode::Replace)
+        .unwrap();
+    for batch in &batches {
+        session.write_batch(batch).unwrap();
+    }
+    let single = session.finish().await.unwrap();
+    assert_eq!(
+        single.files_written, 1,
+        "begin_write_single_file must never roll"
+    );
+}
+
+/// `finish_with_deletes` accepts a session that produced exactly ONE file, and
+/// refuses one that rolled into several — the same rule the partitioned sink follows,
+/// because that commit registers a single appended data file.
+///
+/// The count is taken before any upload, so a refused write leaves no orphan object.
+#[tokio::test(flavor = "multi_thread")]
+async fn rolling_session_with_deletes_allows_one_file_and_refuses_several() {
+    use datafusion_ducklake::table_writer::DuckLakeTableWriter;
+
+    let env = setup().await;
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("val", DataType::Int32, true),
+    ]));
+    let object_store: Arc<dyn object_store::ObjectStore> =
+        Arc::new(object_store::local::LocalFileSystem::new());
+    // One small batch stays within one file -> the commit is accepted.
+    let small = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3])),
+            Arc::new(Int32Array::from(vec![10, 20, 30])),
+        ],
+    )
+    .unwrap();
+    let writer = {
+        let w = SqliteMetadataWriter::new_with_init(&env.conn_str)
+            .await
+            .unwrap();
+        DuckLakeTableWriter::new(Arc::new(w), object_store.clone())
+            .unwrap()
+            .with_target_file_size(512 * 1024)
+    };
+    let mut session = writer
+        .begin_write("main", "events", schema.as_ref(), WriteMode::Append)
+        .unwrap();
+    session.write_batch(&small).unwrap();
+    let result = session.finish_with_deletes(&[]).await.unwrap();
+    assert_eq!(result.records_written, 3);
+    assert_eq!(result.files_written, 1);
+
+    // A load that rolls past the target produces several files -> refused, naming the
+    // count and the single-file alternative.
+    let batches: Vec<RecordBatch> = (0..40)
+        .map(|b| {
+            let ids: Vec<i32> = (b * 200..(b + 1) * 200).collect();
+            let vals = ids.clone();
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![Arc::new(Int32Array::from(ids)), Arc::new(Int32Array::from(vals))],
+            )
+            .unwrap()
+        })
+        .collect();
+    let writer = {
+        let w = SqliteMetadataWriter::new_with_init(&env.conn_str)
+            .await
+            .unwrap();
+        DuckLakeTableWriter::new(Arc::new(w), object_store.clone())
+            .unwrap()
+            .with_target_file_size(8 * 1024)
+    };
+    let mut session = writer
+        .begin_write("main", "events", schema.as_ref(), WriteMode::Append)
+        .unwrap();
+    for batch in &batches {
+        session.write_batch(batch).unwrap();
+    }
+    let err = session.finish_with_deletes(&[]).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("one appended data file") && msg.contains("begin_write"),
+        "the error must state the rule and the alternative, got: {msg}"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn low_level_bulk_write_sorts_and_yields_non_overlapping_files() {
     use datafusion_ducklake::table_writer::DuckLakeTableWriter;


### PR DESCRIPTION
A streaming write session wrote **one** data file however large the input. A multi-GB load became a
multi-GB parquet — and DuckLake compaction merges but never splits, so such a file can never be
reorganized afterwards. It stays oversized permanently.

Official DuckLake rotates on **every** write — `result.rotate = true` in `ducklake_insert.cpp` — so
not rolling was the divergence.

## What changes

`begin_write` now starts a new data file once the current one exceeds `target_file_size` (512 MiB
default, matching official) and `finish()` commits them all in ONE snapshot.

- Reuses `RollingFileWriter`, so rollover still has a single implementation shared with the buffered
  path and the per-partition sink.
- Peak memory unchanged: batches stream to a local staging file as they arrive.
- A partitioned target already rolls inside its per-partition sink; no second roller is created.

## Opting out

`begin_write_single_file` writes exactly one file. It exists for sessions finished with
`finish_with_deletes`, which registers exactly one appended data file — a session that rolled into
several cannot use it. Callers pairing a write with deletes use that entry point; everything else gets
rolling by default.

`finish_with_deletes` counts files **before** uploading and accepts exactly one, mirroring the
partitioned sink from #223, so a rejection leaves no orphan object. A zero-file session falls through
to the 0-row marker that carries a `Replace` truncation, matching the non-rolling path.

## Two threshold details brought in line with official

- **Clamp**: `target_file_size` is floored at 4096, matching `MINIMUM_WRITE_FILE_SIZE` —
  `MaxValue<idx_t>(target_file_size, 4096)` in `ducklake_insert.cpp`. A smaller request would roll a
  file per row group.
- **Comparison**: rollover triggers on *strictly greater* than the target, matching the parquet rotate
  predicate `FileSize() > file_size_bytes`, so a write landing exactly on the target stays in one file.

## Compatibility

`TableWriteSession::file_path()` keeps its meaning. The session pre-computes its output path at
`begin_write` and hands it to the roller for the first file, so a caller observing that accessor sees
the same object it always did — covered by `concurrent_write_tests`.

`begin_write_to_path` and `begin_write_with_embedded_rowid` remain single-file: both write to one
caller-determined file by definition.

## Tests

- `begin_write` rolls a load past `target_file_size` into several files, every row still readable
  through the catalog, while `begin_write_single_file` yields exactly one
- `finish_with_deletes` accepts a session that produced one file and refuses one that rolled into
  several, with the error naming the single-file entry point

Full suite green on SQLite and PostgreSQL (52 binaries, container tests included); `cargo fmt`,
`clippy --all-features --all-targets`, and `cargo doc -D warnings` clean.


## Also folded in: an unexecutable sort spec no longer fails compaction

Second commit, unrelated to rolling, kept here to save a round-trip.

`producible_columns` drops sort fields whose dialect is not `duckdb`, so a spec written by another
engine can leave no usable keys. The rewrite path then passed an empty key list to `LexOrdering::new`
and failed with `sort order is empty`, aborting `merge_adjacent_files`, `rewrite_data_files`, and SQL
`UPDATE` on a catalog official DuckLake compacts without complaint. Official skips non-`duckdb` fields
and proceeds with whatever remains — nothing, when that is all of them. The SQL INSERT path in this
crate already returned "no ordering" for the same input, so the two paths simply disagreed.

Now an empty key list means "write unsorted". Test sets `dialect = 'spark'` on a sort field and asserts
compaction completes with the rows intact; it fails with `sort order is empty` without the fix.
