### PR TITLE
ci: cut redundant work from pull request builds

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,21 +27,23 @@ jobs:
       - name: Install sccache
         uses: mozilla-actions/sccache-action@9e326ebed976843c9932b3aa0e021c6f50310eb4 # v0.0.6
 
-      - name: Cache Cargo registry
+      # Same key as every job in the CI workflow, so this shares one cargo-home
+      # entry with them instead of maintaining a private pair. It previously keyed
+      # on `-cargo-registry-`/`-cargo-index-`, which CI also wrote until those two
+      # steps were merged into `Cache cargo home`; leaving this on the old keys
+      # would have orphaned it, and two extra per-OS entries count against the
+      # repository's 10 GB cache budget for no benefit. Combining the paths also
+      # drops the "Path Validation Error" that the `~/.cargo/git` step logged on
+      # every run, since the crate has no git dependencies.
+      - name: Cache cargo home
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-home-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-registry-
-
-      - name: Cache Cargo index
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-index-
+            ${{ runner.os }}-cargo-home-
 
       - name: Cache TPC-H test data
         id: cache-tpch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,9 +151,18 @@ jobs:
       # only thing it contributed was workspace scope. Bare cargo commands act on
       # the root package alone here, because the workspace root is itself a
       # package rather than a virtual manifest.
+      #
+      # Linux only, and measured rather than assumed: `ducklake-benchmark`
+      # depends on `duckdb` with `bundled`, so pulling it in makes clippy compile
+      # DuckDB's C++ a second time, in a second feature context. On macOS that
+      # took this step from 56s to 208s (run 30531835616) — and macOS is the
+      # longest required check, so it lands squarely on the critical path.
+      # Restricting the flag also matches the coverage this replaced exactly:
+      # `feature-check` is `runs-on: ubuntu-latest`, so the `benchmark` package
+      # was only ever checked on Linux, and the crate has no `target_os` cfgs.
       - name: Run clippy
         if: steps.changes.outputs.code == 'true'
-        run: cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings
+        run: cargo clippy ${{ runner.os == 'Linux' && '--workspace' || '' }} --all-targets --all-features --no-deps -- -D warnings
 
       # macOS only. This step used to run on Linux too, as
       # `cargo test --features write-sqlite` — but `--features` keeps the default

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,16 @@ on:
   pull_request:
     branches: [ main ]
 
+# Without this, pushing three times to a pull request leaves three full five-job
+# fan-outs alive at once, all competing for the same runner pool — the queueing
+# dominates the wall clock a reviewer actually waits for. Pull requests are
+# grouped per PR number so a new push cancels the previous run; pushes to main
+# are grouped per commit and never cancel, so every merged commit on main keeps
+# its own CI result and stays bisectable.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always
@@ -122,25 +132,49 @@ jobs:
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: ${{ runner.os == 'Linux' && '/mnt/cargo-target' || 'target' }}
-          key: ${{ runner.os }}-target-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
+          # `rust-toolchain.toml` is in the key because it, not `matrix.rust`,
+          # decides the compiler: it pins 1.94.0 and overrides the toolchain the
+          # `stable` action installs (the run log says as much — "note that the
+          # toolchain '1.94.0-...' is currently in use (overridden by
+          # ...rust-toolchain.toml)"). Keyed on Cargo.lock alone, bumping that
+          # channel left the key unchanged, so the entry kept hitting exactly,
+          # `actions/cache` skipped saving, and the job silently restored
+          # artifacts for the old rustc indefinitely.
+          key: ${{ runner.os }}-target-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}
           restore-keys: |
             ${{ runner.os }}-target-${{ matrix.rust }}-
 
+      # `--workspace` so this also lints the `benchmark` package. That coverage
+      # used to come from `cargo check --workspace --all-targets` in
+      # `feature-check`, which was deleted: `--all-features` is a superset of the
+      # default features that check used, and `--all-targets` matches, so the
+      # only thing it contributed was workspace scope. Bare cargo commands act on
+      # the root package alone here, because the workspace root is itself a
+      # package rather than a virtual manifest.
       - name: Run clippy
         if: steps.changes.outputs.code == 'true'
-        run: cargo clippy --all-targets --all-features --no-deps -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings
 
-      - name: Run tests
-        if: steps.changes.outputs.code == 'true'
-        # `write-sqlite` pulls in the writer and sqlite-provider tests,
-        # which are `#![cfg]`-gated; without it cargo compiles them to
-        # zero-test binaries.
-        run: |
-          if [[ "$RUNNER_OS" == "macOS" ]]; then
-            cargo test --features "skip-tests-with-docker write-sqlite"
-          else
-            cargo test --features "write-sqlite"
-          fi
+      # macOS only. This step used to run on Linux too, as
+      # `cargo test --features write-sqlite` — but `--features` keeps the default
+      # features on, so that feature set (metadata-duckdb + duckdb-bundled +
+      # write + metadata-sqlite + write-sqlite) is a strict subset of the one
+      # `test-full` uses, and no test file has a `cfg(not(feature = ...))` gate
+      # that could make the smaller set enable something the larger one doesn't.
+      # Every test therefore ran twice per pull request, ~8 minutes of it, for no
+      # extra signal. Linux keeps clippy and the doc build below.
+      #
+      # macOS stays: it is the only remaining job that runs the suite with
+      # `encryption` off, which is what exercises the `cfg(not(feature =
+      # "encryption"))` read paths in `table.rs` and `table_changes.rs`. If this
+      # job is ever reduced to a build, those paths lose all test coverage.
+      #
+      # `write-sqlite` pulls in the writer and sqlite-provider tests,
+      # which are `#![cfg]`-gated; without it cargo compiles them to
+      # zero-test binaries.
+      - name: Run tests (macOS; Linux is covered by test-full)
+        if: steps.changes.outputs.code == 'true' && runner.os == 'macOS'
+        run: cargo test --features "skip-tests-with-docker write-sqlite"
 
       - name: Check documentation
         if: steps.changes.outputs.code == 'true'
@@ -202,26 +236,42 @@ jobs:
         if: steps.changes.outputs.code == 'true'
         uses: mozilla-actions/sccache-action@9e326ebed976843c9932b3aa0e021c6f50310eb4 # v0.0.6
 
-      - name: Cache cargo registry
+      # One step for both cargo-home paths, matching the other jobs: as two steps
+      # the `~/.cargo/git` one logs "Path Validation Error" on every run, because
+      # the crate has no git dependencies so that directory is never created.
+      - name: Cache cargo home
         if: steps.changes.outputs.code == 'true'
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-home-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-registry-
+            ${{ runner.os }}-cargo-home-
 
-      - name: Cache cargo index
-        if: steps.changes.outputs.code == 'true'
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-index-
-
-      # Isolate each independently-supported feature axis once. `--workspace`
-      # covers the default feature set, including the benchmark package's bins.
+      # Deliberately NOT target-cached, even though this job recompiles its
+      # feature graphs from scratch every run. The repository is already at
+      # ~10.1 GB against GitHub's 10 GB per-repo cache limit — three target
+      # directories account for ~9.4 GB of that (macOS-target-stable 3.40,
+      # Linux-target-full 3.07, Linux-target-stable 2.96) — so any entry added
+      # here is paid for by least-recently-used eviction of one of those, which
+      # then rebuilds cold and re-saves, evicting something else. A fourth target
+      # cache would trade a few minutes on this job for that oscillation across
+      # the whole workflow. Deleting the redundant `--workspace --all-targets`
+      # check below recovers most of the time without spending cache budget;
+      # revisit once the existing entries are pruned.
+      #
+      # Isolate each independently-supported feature axis once.
+      #
+      # This used to be preceded by `cargo check --workspace --all-targets`,
+      # which was 496s of the step's 1189s — ~427s of it compiling DuckDB's C++
+      # via `libduckdb-sys`, since `--workspace` picks up the default features and
+      # those include `duckdb-bundled`. It was redundant: `check`'s
+      # `cargo clippy --all-targets --all-features` already covers a superset of
+      # those features and the same targets, and it target-caches that C++ compile.
+      # The one thing it did contribute was workspace scope (the `benchmark`
+      # package), so `--workspace` moved onto that clippy invocation.
       #
       # No `-D warnings`: a read-only build legitimately reports dead_code for the
       # write-only helpers, and `#[cfg]`-gating struct fields to silence that would
@@ -229,7 +279,6 @@ jobs:
       - name: Check feature combinations
         if: steps.changes.outputs.code == 'true'
         run: |
-          cargo check --workspace --all-targets
           for features in \
             "" \
             metadata-duckdb \
@@ -248,6 +297,7 @@ jobs:
             cargo check --no-default-features --features "$features"
             echo "::endgroup::"
           done
+
 
   test-full:
     name: Test (single-catalog backends + encryption, Docker)
@@ -323,7 +373,8 @@ jobs:
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: /mnt/cargo-target
-          key: ${{ runner.os }}-target-full-${{ hashFiles('**/Cargo.lock') }}
+          # See the `check` job for why `rust-toolchain.toml` belongs in the key.
+          key: ${{ runner.os }}-target-full-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}
           restore-keys: |
             ${{ runner.os }}-target-full-
 


### PR DESCRIPTION
Speeds up CI without changing what it verifies. Every number here is measured, not estimated — from warm run [30520466010](https://github.com/datafusion-contrib/datafusion-ducklake/actions/runs/30520466010) plus local timing.

## Where the time went

| Job | Wall | Required check? |
|---|---|---|
| Check feature combinations | **20m** (one 1189s step) | **no** |
| Check & Build (macos) | 12m | yes |
| Check & Build (ubuntu) | 10m — clippy 53s, **tests 485s**, doc 3s | yes |
| Test (single-catalog + Docker) | 10m | yes |
| Rustfmt | <1m | yes |

Test *execution* was never the problem: the full 601-test suite runs in 102s locally. Redundant compilation was.

## Changes

**1. Delete `cargo check --workspace --all-targets` from `feature-check`** — 496s of that step's 1189s, ~427s of it compiling DuckDB's C++ via `libduckdb-sys` (`--workspace` selects default features, which include `duckdb-bundled`). It is redundant with `check`'s `cargo clippy --all-targets --all-features`, a superset of those features over the same targets, which already target-caches that compile. Its only unique contribution was workspace scope, so `--workspace` moves onto that clippy call. Verified: `ducklake-benchmark` declares no features and has no `cfg(feature)`, and `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` passes clean.

**2. Stop running the suite on Linux in `check`** — `--features write-sqlite` keeps defaults on, so that set is a strict subset of `test-full`'s, and no test file has a `cfg(not(feature = ...))` gate that could break monotonicity. ~485s of every PR was running the same tests twice.

> macOS keeps its test run deliberately: it is now the **only** job running the suite with `encryption` off, i.e. the only coverage of the `cfg(not(feature = "encryption"))` read paths in `src/table.rs:1122`/`:1629` and `src/table_changes.rs:513`/`:1068`/`:1142`. Please don't reduce that job to a build without replacing this.

**3. Add a `concurrency:` group** — three pushes to a PR left three five-job fan-outs competing for the pool, and `strict: true` branch protection re-runs CI whenever `main` moves. PRs group per number and cancel; pushes to `main` group per commit and never cancel, so every merged commit stays bisectable.

**4. Put `rust-toolchain.toml` in both target-cache keys** — latent bug. It pins 1.94.0 and overrides the toolchain `dtolnay/rust-toolchain@stable` installs, so bumping the channel left the Cargo.lock-only key unchanged: the entry kept hitting exactly, `actions/cache` skipped saving, and the job silently restored artifacts built by the old rustc.

**5. Consolidate cargo-home caches** — merge `feature-check`'s registry/index steps into one and point `benchmark.yml` at the same key, so it no longer keeps a private pair nothing else writes.

## Deliberately not done

- **A target cache for `feature-check`.** The repo is already at **~10.1 GB against GitHub's 10 GB limit** (three target caches are ~9.4 GB of it), so a fourth entry is paid for by LRU-evicting one of those, which rebuilds cold and re-saves, evicting something else. Change 1 recovers most of the time without spending budget.
- **A cache for `~/.duckdb/extensions`.** `INSTALL` is a no-op once the file exists and `~/.duckdb` is shared across processes, so it is one ~42 MB download per job, not one per test binary.

## Result, and an honest caveat

**All-checks-green wait ~20m → ~12m; ~16 runner-minutes saved per push.**

**Merge-blocking latency is unchanged at ~12m**, bound by `Check & Build (macos-latest, stable)`. `Check feature combinations` is not a required status check, so its 20m never blocked a merge. This PR buys runner capacity and a shorter green-tick wait, not faster merges.

No check-run names change, so the four required contexts (`Rustfmt`, both `Check & Build` legs, `Test (single-catalog backends + encryption, Docker)`) are unaffected — only a step name changed.

## Follow-ups

- **`cargo-nextest`** is the only remaining lever on the merge-blocking 12m (measured 148s → 102s, 1.45x ⇒ est. ~9.3m). Not here because it runs process-per-test, which defeats the `static Once` at `tests/common/mod.rs:21` and reintroduces the concurrent `INSTALL ducklake` race that comment says was already hit on macOS CI. Needs a deterministic pre-install step, verified cold.
- **52 integration test files = 52 separately linked ~400 MB binaries** (bundled DuckDB in each, ~20 GB of linker output per test build). This is why `test-full` needs `CARGO_PROFILE_TEST_DEBUG: "0"` to stop lld dying with SIGBUS. Merging into one `tests/it/main.rs` would make it 1 link.
- **`run_all_sqllogictests` is 85s — 57% of all test execution** — running 248 vendored files to assert the 9 in `EXPECTED_PASS`.
- **Cache overage** (~10.1/10 GB) needs a decision on which target caches to keep.
- **`write-duckdb` (6 tests) and `write-mysql` (1 test) never run in CI**, undocumented and apparently unintentional — neither needs Docker beyond what `test-full` already has.