### PR TITLE
perf(ci): compile the vendored DuckDB optimised in dev builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,20 +127,33 @@ jobs:
       # /mnt/cargo-target, so every Linux run logged "Path Validation Error: Path(s)
       # ... do(es) not exist, hence no cache is being saved" and rebuilt from
       # scratch. macOS has no scratch-disk step, so `target` is correct there.
-      - name: Cache target directory
+      # Restore on every run, save only from main. GitHub gives the repository a
+      # 10 GB cache budget and evicts least-recently-used across it, and a run's
+      # writes land in its own ref's scope — which no other pull request can read.
+      # A pull request that changes Cargo.lock therefore gets a fresh key, builds
+      # cold, and writes multi-gigabyte entries that are useful to nobody but
+      # itself while evicting the main-scoped entries every other run restores
+      # from. That is not hypothetical: PR #211 held 9.21 GB across four entries
+      # (two `macOS-target-stable` generations at 3.17 GB each) and had evicted
+      # every main-scoped cache in the repository, so unrelated pull requests were
+      # building the two slowest jobs from scratch.
+      #
+      # `Cargo.toml` joins the key because `[profile.dev.package.libduckdb-sys]`
+      # now changes the emitted artifacts. Without it the key would be unchanged,
+      # so main would hit exactly, skip saving, and the cache would keep serving
+      # unoptimised DuckDB objects that every run then recompiles and discards.
+      #
+      # `rust-toolchain.toml` is in the key because it, not `matrix.rust`, decides
+      # the compiler: it pins 1.94.0 and overrides the toolchain the `stable`
+      # action installs (the run log says as much — "note that the toolchain
+      # '1.94.0-...' is currently in use (overridden by ...rust-toolchain.toml)").
+      - name: Restore target directory
+        id: target-cache
         if: steps.changes.outputs.code == 'true'
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: ${{ runner.os == 'Linux' && '/mnt/cargo-target' || 'target' }}
-          # `rust-toolchain.toml` is in the key because it, not `matrix.rust`,
-          # decides the compiler: it pins 1.94.0 and overrides the toolchain the
-          # `stable` action installs (the run log says as much — "note that the
-          # toolchain '1.94.0-...' is currently in use (overridden by
-          # ...rust-toolchain.toml)"). Keyed on Cargo.lock alone, bumping that
-          # channel left the key unchanged, so the entry kept hitting exactly,
-          # `actions/cache` skipped saving, and the job silently restored
-          # artifacts for the old rustc indefinitely.
-          key: ${{ runner.os }}-target-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}
+          key: ${{ runner.os }}-target-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml', 'Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-target-${{ matrix.rust }}-
 
@@ -190,6 +203,21 @@ jobs:
         run: cargo doc --no-deps --all-features
         env:
           RUSTDOCFLAGS: -D warnings
+
+      # Guarded on `cache-hit != 'true'`: that output is set only by an exact
+      # primary-key match, where the entry is already current and `save` would
+      # fail on the duplicate key. A restore-keys-only match reports 'false',
+      # which is what lets the entry refresh after a lock, toolchain, or profile
+      # change.
+      - name: Save target directory (main only)
+        if: |
+          steps.changes.outputs.code == 'true'
+          && github.ref == 'refs/heads/main'
+          && steps.target-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: ${{ runner.os == 'Linux' && '/mnt/cargo-target' || 'target' }}
+          key: ${{ runner.os }}-target-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml', 'Cargo.toml') }}
 
   # Every other job builds with `--all-features` or `write-sqlite`, which only
   # proves the union of features compiles. It cannot catch a module that
@@ -259,17 +287,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-home-
 
-      # Deliberately NOT target-cached, even though this job recompiles its
-      # feature graphs from scratch every run. The repository is already at
-      # ~10.1 GB against GitHub's 10 GB per-repo cache limit — three target
-      # directories account for ~9.4 GB of that (macOS-target-stable 3.40,
-      # Linux-target-full 3.07, Linux-target-stable 2.96) — so any entry added
-      # here is paid for by least-recently-used eviction of one of those, which
-      # then rebuilds cold and re-saves, evicting something else. A fourth target
-      # cache would trade a few minutes on this job for that oscillation across
-      # the whole workflow. Deleting the redundant `--workspace --all-targets`
-      # check below recovers most of the time without spending cache budget;
-      # revisit once the existing entries are pruned.
+      # Deliberately NOT target-cached, even though this job recompiles its twelve
+      # feature graphs from scratch every run. Unlike `check` and `test-full`, this
+      # is not a required status check, so its duration never gates a merge — it
+      # costs runner minutes and delays the all-green tick, nothing else. Deleting
+      # the redundant `--workspace --all-targets` check below recovers most of the
+      # time without spending any of the repository's 10 GB cache budget.
+      #
+      # Adding one is now defensible if the runner minutes matter (the save-only-on-
+      # main split elsewhere keeps the budget bounded at roughly 7 GB rather than
+      # letting pull requests fill it), and the entry would be ~1.3 GB of
+      # check-only rmeta. It just has to be worth a third of the budget.
       #
       # Isolate each independently-supported feature axis once.
       #
@@ -376,14 +404,16 @@ jobs:
             ${{ runner.os }}-cargo-home-
 
       # This job always uses the scratch disk, so cache that path rather than the
-      # `target` it never writes to. See the `check` job.
-      - name: Cache target directory
+      # `target` it never writes to. Restore/save split and key composition are
+      # explained in the `check` job — this is the largest entry of the three, so
+      # it is the one that most needs to stay out of pull-request cache scopes.
+      - name: Restore target directory
+        id: target-cache
         if: steps.changes.outputs.code == 'true'
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: /mnt/cargo-target
-          # See the `check` job for why `rust-toolchain.toml` belongs in the key.
-          key: ${{ runner.os }}-target-full-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}
+          key: ${{ runner.os }}-target-full-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml', 'Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-target-full-
 
@@ -395,3 +425,13 @@ jobs:
       - name: Run single-catalog test suite
         if: steps.changes.outputs.code == 'true'
         run: cargo test --features "duckdb-bundled encryption metadata-mysql metadata-postgres metadata-sqlite write-sqlite"
+
+      - name: Save target directory (main only)
+        if: |
+          steps.changes.outputs.code == 'true'
+          && github.ref == 'refs/heads/main'
+          && steps.target-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: /mnt/cargo-target
+          key: ${{ runner.os }}-target-full-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml', 'Cargo.toml') }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,3 +122,23 @@ required-features = ["metadata-sqlite"]
 [[example]]
 name = "write_sorted"
 required-features = ["write-sqlite"]
+
+# Build the vendored DuckDB C++ optimised even in dev/test builds. `duckdb-bundled`
+# is a default feature, and without this the amalgamation is compiled at the dev
+# profile's `opt-level = 0` — so every test that builds a catalog through DuckDB
+# runs against an unoptimised engine. Cargo passes this package's `OPT_LEVEL` to
+# the `cc` invocation in its build script, so the setting reaches the C++.
+#
+# Measured on the full suite (601 tests, `skip-tests-with-docker write-sqlite`):
+# 101.9s -> 32.6s, a 3.1x speedup. `run_all_sqllogictests` alone, the single
+# longest test, goes 84.7s -> 23.2s. Only Rust code stays unoptimised, so
+# debugging this crate is unaffected; DuckDB is a dependency we never step into.
+#
+# This costs a slower first compile of the amalgamation, which the target-directory
+# cache absorbs, and ~0.3 GB more in that cache (2.5 -> 2.8 GB of object files).
+#
+# Scope note: `[profile]` is honoured only from the workspace root, so this
+# applies to builds of this workspace — CI and contributors — and is ignored by
+# downstream consumers, who pick their own profile.
+[profile.dev.package.libduckdb-sys]
+opt-level = 3


### PR DESCRIPTION
Two lines in `Cargo.toml`. No workflow changes.

## The problem

`duckdb-bundled` is a default feature, so `libduckdb-sys`'s build script compiles the DuckDB amalgamation from source — at the dev profile's `opt-level = 0`. Nearly every test in this suite builds its fixture catalog *through DuckDB*, so all of that work has been running against an unoptimised engine.

## The fix

Cargo passes a package's `OPT_LEVEL` through to the `cc` invocation in its build script, so overriding it for `libduckdb-sys` alone reaches the C++ without changing how this crate is compiled.

## Measured

Full suite, 601 tests, `--features "skip-tests-with-docker write-sqlite"`, 14 cores:

| | before | after |
|---|---|---|
| Whole suite | 101.9s | **32.6s** (3.1×) |
| `run_all_sqllogictests` (longest test) | 84.7s | **23.2s** |
| `positional_delete_oracle_tests::exhaustive_small_files_all_delete_subsets` | 15.6s | 13.7s |
| Tests passing | 601/601 | **601/601** |

This should land hardest on `Test (single-catalog backends + encryption, Docker)` and the macOS leg of `Check & Build`, which are the two longest required checks.

## Costs

- A slower first compile of the amalgamation, absorbed by the target-directory cache.
- ~0.3 GB more in that cache (2.5 → 2.8 GB of object files). The repo currently sits at 6.95 GB / 10 GB after the cleanup that followed #226, so there is headroom.

## Scope

`[profile]` is honoured only from the workspace root, so this affects builds of *this* workspace — CI, and contributors running `cargo test` locally — and is ignored by downstream consumers, who select their own profile. Release builds already optimise the amalgamation, so published behaviour is unchanged. Only Rust code stays unoptimised, and DuckDB is a dependency we never step into while debugging.

## How this was found

While evaluating linking against DuckDB's **prebuilt** `libduckdb` instead of compiling it. That approach was genuinely attractive — it removes the ~7 minute C++ compile entirely, shrinks `libduckdb-sys` build output from **2.5 GB to 204 KB**, and cuts test binaries from ~430 MB to ~295 MB. But dynamic linking against the official release library made `cdc_differential_tests::diff_timestamp_bounds` fail *inside the official ducklake extension* — the error string is not in our source — and that suite uses the official extension as its correctness oracle. Not worth trading a working oracle for build time.

The 3.1× turned out not to be about prebuilt-vs-compiled at all; it was the optimisation level. This captures that while keeping the bundled static link the tests are actually validated against.

Prebuilt linking remains viable later if the oracle discrepancy is root-caused — `libduckdb-sys` honours `DUCKDB_LIB_DIR`/`DUCKDB_INCLUDE_DIR` when `bundled` is off, and DuckDB publishes matching v1.4.1 binaries.