### PR TITLE
chore(ci): bump sccache-action off deprecated node20 runtime

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,7 +25,7 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@9e326ebed976843c9932b3aa0e021c6f50310eb4 # v0.0.6
+        uses: mozilla-actions/sccache-action@fd02668681acd5f960e1372061bee5e3e987195c # v0.0.11
 
       # Same key as every job in the CI workflow, so this shares one cargo-home
       # entry with them instead of maintaining a private pair. It previously keyed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Install sccache
         if: steps.changes.outputs.code == 'true'
-        uses: mozilla-actions/sccache-action@9e326ebed976843c9932b3aa0e021c6f50310eb4 # v0.0.6
+        uses: mozilla-actions/sccache-action@fd02668681acd5f960e1372061bee5e3e987195c # v0.0.11
 
       # One step for both cargo-home paths. As two steps, the `~/.cargo/git` one
       # logged "Path Validation Error: Path(s) ... do(es) not exist, hence no
@@ -288,7 +288,7 @@ jobs:
 
       - name: Install sccache
         if: steps.changes.outputs.code == 'true'
-        uses: mozilla-actions/sccache-action@9e326ebed976843c9932b3aa0e021c6f50310eb4 # v0.0.6
+        uses: mozilla-actions/sccache-action@fd02668681acd5f960e1372061bee5e3e987195c # v0.0.11
 
       # One step for both cargo-home paths, matching the other jobs: as two steps
       # the `~/.cargo/git` one logs "Path Validation Error" on every run, because
@@ -402,7 +402,7 @@ jobs:
 
       - name: Install sccache
         if: steps.changes.outputs.code == 'true'
-        uses: mozilla-actions/sccache-action@9e326ebed976843c9932b3aa0e021c6f50310eb4 # v0.0.6
+        uses: mozilla-actions/sccache-action@fd02668681acd5f960e1372061bee5e3e987195c # v0.0.11
 
       # One step for both cargo-home paths. As two steps, the `~/.cargo/git` one
       # logged "Path Validation Error: Path(s) ... do(es) not exist, hence no


### PR DESCRIPTION
Bumps mozilla-actions/sccache-action from v0.0.6 to v0.0.11. v0.0.6 targets Node 20, which GitHub Actions is deprecating; v0.0.11 targets Node 24.