### PR TITLE
Support recursive DuckLake column types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Recursive `list`, `struct`, and `map` columns use standard `ducklake_column` parent links and
+  matching Parquet field IDs across reads, writes, schema evolution, rewrites, and compaction.
 - `PostgresSingleCatalogMetadataWriter` — writes the **standard, spec-compliant** single-catalog DuckLake layout on PostgreSQL (no `catalog_id` columns, no `ducklake_catalog*` map tables, unscoped relative paths), so Postgres catalogs are interchangeable with the SQLite/MySQL backends and DuckDB's `ducklake` extension. SQL `CREATE TABLE AS SELECT` works on this path, unlike the multicatalog writer (#165).
 - Atomic append+delete commits accept SEVERAL appended data files: `MetadataWriter::register_data_files_with_deletes` (and its conditional `_and_commit_metadata` sibling) register N data files plus M positional delete files in ONE snapshot — matching the reference implementation, where one transaction carries both the new data files and the new delete files. A keyed mutation (update/upsert) therefore works on a partitioned table and on a write that rolled past `target_file_size` (#214).
 - SQL `UPDATE` on a PARTITIONED table: each rewritten row is routed by its own post-assignment key values, so an assignment that changes a partition key moves the row to its new partition (calendar transforms included). A rewrite spanning several partitions writes one file per partition and commits them all — with the positional deletes — in one snapshot, preserving every row's `rowid` lineage. Rewritten rows adopt the table's live spec, so a table that adopted partitioning after data was written partitions its updated rows (#214).
@@ -16,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `TableWriteSession::finish_with_deletes` no longer refuses a session that produced more than one appended file; it commits them all in the snapshot that carries the deletes (#214).
+
+### Fixed
+- A write upgrades legacy single‑row `list<T>` metadata to recursive list and element rows without
+  changing the existing list column ID or invalidating historical snapshots.
+- Reads null‑fill fields added inside structs, including non‑nullable fields and structs nested in
+  lists, while preserving field‑ID‑based nested renames and drops.
 
 ## [0.6.0] - 2026-07-20
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -90,13 +90,13 @@ the read backend: `--no-default-features --features metadata-duckdb` (requires
 
 ## Type support
 
-| Category                         | Status | Notes                                          |
-|----------------------------------|:------:|------------------------------------------------|
-| Integers / floats / boolean      |   ✅   |                                                |
-| Strings / dates / timestamps     |   ✅   |                                                |
-| Decimal (precision & scale)      |   ✅   |                                                |
-| Geometry                         |   ✅   | Mapped to `Binary` (WKB)                        |
-| Complex / nested (list, struct, map) | 🟧 | Minimal support; many cases return errors      |
+| Category                              |  Status   | Notes                                                        |
+| ------------------------------------- | :-------: | ------------------------------------------------------------ |
+| Integers / floats / boolean           |    ✅     |                                                              |
+| Strings / dates / timestamps          |    ✅     |                                                              |
+| Decimal (precision & scale)           |    ✅     |                                                              |
+| Geometry                              |    ✅     | Mapped to `Binary` (WKB)                                     |
+| Complex / nested (list, struct, map)  | Supported | Recursive types and nullable‑field evolution; no pruning     |
 
 ---
 

--- a/src/column_rename.rs
+++ b/src/column_rename.rs
@@ -269,7 +269,7 @@ impl Stream for ColumnRenameStream {
                             .collect();
 
                         columns.and_then(|cols| {
-                            RecordBatch::try_new(Arc::clone(&self.output_schema), cols)
+                            record_batch_with_schema(Arc::clone(&self.output_schema), cols)
                                 .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
                         })
                     };
@@ -306,27 +306,113 @@ pub(crate) fn coerce_column(
     col: &arrow::array::ArrayRef,
     target: &arrow::datatypes::DataType,
 ) -> DataFusionResult<arrow::array::ArrayRef> {
-    use arrow::array::{Array, make_array};
+    use arrow::array::Array;
 
-    if col.data_type() == target {
+    let is_nested = matches!(
+        target,
+        arrow::datatypes::DataType::List(_)
+            | arrow::datatypes::DataType::LargeList(_)
+            | arrow::datatypes::DataType::FixedSizeList(_, _)
+            | arrow::datatypes::DataType::Map(_, _)
+            | arrow::datatypes::DataType::Struct(_)
+    );
+    if col.data_type() == target && !is_nested {
         return Ok(Arc::clone(col));
     }
 
-    let casted = arrow::compute::cast(col, target)
-        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-    if casted.data_type() == target {
+    let casted = if col.data_type() == target {
+        Arc::clone(col)
+    } else {
+        arrow::compute::cast(col, target)
+            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?
+    };
+    if casted.data_type() == target && !is_nested {
         return Ok(casted);
     }
 
-    // Same physical layout, only nested field metadata (e.g. list child name)
-    // differs. Rebuild the ArrayData with the target DataType.
-    let data = casted
-        .into_data()
-        .into_builder()
-        .data_type(target.clone())
-        .build()
-        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-    Ok(make_array(data))
+    array_with_data_type(&casted, target)
+        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+}
+
+pub(crate) fn array_with_data_type(
+    array: &arrow::array::ArrayRef,
+    data_type: &arrow::datatypes::DataType,
+) -> Result<arrow::array::ArrayRef, arrow::error::ArrowError> {
+    use arrow::array::{Array, ArrayData, make_array};
+    use arrow::datatypes::DataType;
+    use arrow::error::ArrowError;
+
+    fn rewrite(data: &ArrayData, data_type: &DataType) -> Result<ArrayData, ArrowError> {
+        let is_nested = matches!(
+            data_type,
+            DataType::List(_)
+                | DataType::LargeList(_)
+                | DataType::FixedSizeList(_, _)
+                | DataType::Map(_, _)
+                | DataType::Struct(_)
+        );
+        if data.data_type() == data_type && !is_nested {
+            return Ok(data.clone());
+        }
+        let child_types = match data_type {
+            DataType::List(field)
+            | DataType::LargeList(field)
+            | DataType::FixedSizeList(field, _)
+            | DataType::Map(field, _) => vec![field.data_type()],
+            DataType::Struct(fields) => fields.iter().map(|field| field.data_type()).collect(),
+            _ => {
+                return Err(ArrowError::InvalidArgumentError(format!(
+                    "cannot apply array type {:?} as {data_type:?}",
+                    data.data_type(),
+                )));
+            },
+        };
+        if child_types.len() != data.child_data().len() {
+            return Err(ArrowError::InvalidArgumentError(format!(
+                "array type {:?} has {} children, expected {} for {data_type:?}",
+                data.data_type(),
+                data.child_data().len(),
+                child_types.len(),
+            )));
+        }
+        let children = data
+            .child_data()
+            .iter()
+            .zip(child_types)
+            .map(|(child, child_type)| rewrite(child, child_type))
+            .collect::<Result<Vec<_>, _>>()?;
+        data.clone()
+            .into_builder()
+            .data_type(data_type.clone())
+            .child_data(children)
+            .build()
+    }
+
+    Ok(make_array(rewrite(&array.to_data(), data_type)?))
+}
+
+pub(crate) fn record_batch_with_schema(
+    schema: arrow::datatypes::SchemaRef,
+    columns: Vec<arrow::array::ArrayRef>,
+) -> Result<arrow::record_batch::RecordBatch, arrow::error::ArrowError> {
+    use arrow::datatypes::{Field, Schema};
+    use arrow::record_batch::RecordBatch;
+
+    let fields = schema
+        .fields()
+        .iter()
+        .zip(&columns)
+        .map(|(field, column)| {
+            Field::new(
+                field.name(),
+                column.data_type().clone(),
+                field.is_nullable(),
+            )
+            .with_metadata(field.metadata().clone())
+        })
+        .collect::<Vec<_>>();
+    let actual_schema = Arc::new(Schema::new_with_metadata(fields, schema.metadata().clone()));
+    RecordBatch::try_new(actual_schema, columns)?.with_schema(schema)
 }
 
 #[cfg(test)]
@@ -362,6 +448,42 @@ mod tests {
 
         // The stream should report the output schema
         assert_eq!(stream.schema().field(0).name(), "new_col");
+    }
+
+    #[test]
+    fn coerce_column_restamps_nested_field_metadata() {
+        use arrow::{
+            array::{ArrayRef, Int32Array, RecordBatch, StructArray},
+            datatypes::Fields,
+        };
+
+        let source_fields =
+            Fields::from(vec![Arc::new(Field::new("value", DataType::Int32, false))]);
+        let source: ArrayRef = Arc::new(StructArray::new(
+            source_fields,
+            vec![Arc::new(Int32Array::from(vec![1, 2]))],
+            None,
+        ));
+        let target_field = Arc::new(Field::new("value", DataType::Int32, false).with_metadata(
+            HashMap::from([("PARQUET:field_id".to_string(), "2".to_string())]),
+        ));
+        let target = DataType::Struct(Fields::from(vec![target_field]));
+
+        let coerced = coerce_column(&source, &target).unwrap();
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "nested",
+            target.clone(),
+            false,
+        )]));
+        let batch = RecordBatch::try_new(schema, vec![coerced]).unwrap();
+
+        let DataType::Struct(fields) = batch.column(0).data_type() else {
+            panic!("expected struct");
+        };
+        assert_eq!(
+            fields[0].metadata().get("PARQUET:field_id"),
+            Some(&"2".to_string())
+        );
     }
 
     #[test]

--- a/src/compaction.rs
+++ b/src/compaction.rs
@@ -32,7 +32,7 @@
 //! [`cleanup_old_files_sqlite`](crate::maintenance::cleanup_old_files_sqlite)
 //! reclaims them.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use arrow::array::{ArrayRef, Int64Array, RecordBatch};
@@ -44,6 +44,7 @@ use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::{LexOrdering, PhysicalSortExpr, expressions::Column};
 use datafusion::physical_plan::{ExecutionPlan, sorts::sort::SortExec};
 
+use crate::column_rename::ColumnRenameExec;
 use crate::metadata_provider::DuckLakeTableFile;
 use crate::metadata_writer::{CompactionOutputFile, CompactionSourceFile, SourceRetirement};
 use crate::partition::PartitionSpec;
@@ -236,7 +237,9 @@ pub(crate) fn sorted_rewrite_output(
     }
     let ordering = LexOrdering::new(expressions)
         .ok_or_else(|| DuckLakeError::Internal("sort order is empty".to_string()))?;
-    Ok(SortExec::new(ordering, input).execute(0, context)?)
+    let sorted: Arc<dyn ExecutionPlan> = Arc::new(SortExec::new(ordering, input));
+    let output = Arc::new(ColumnRenameExec::new(sorted, schema, HashMap::new()));
+    Ok(output.execute(0, context)?)
 }
 
 impl DuckLakeTable {
@@ -380,6 +383,7 @@ impl DuckLakeTable {
             .object_store(self.object_store_url().as_ref())?;
         let table_writer = DuckLakeTableWriter::new(Arc::clone(writer), object_store)?;
         let column_ids = self.column_ids();
+        let top_level_column_ids = self.top_level_column_ids();
         let physical_schema = self.physical_schema();
 
         // Apply the table's live sort order to each merged file (mirroring official
@@ -478,8 +482,11 @@ impl DuckLakeTable {
             // same `partition_id` + values in the catalog.
             let (partition_id, partition_values) = partition_key(bin[0]);
             let subpath = partition_id.map(|pid| {
-                let names =
-                    self.partition_path_names(live_partition_spec.as_ref(), pid, &column_ids);
+                let names = self.partition_path_names(
+                    live_partition_spec.as_ref(),
+                    pid,
+                    &top_level_column_ids,
+                );
                 crate::partition::hive_subpath(&names, &partition_values)
             });
             let file = table_writer
@@ -488,6 +495,7 @@ impl DuckLakeTable {
                     self.table_name(),
                     physical_schema.as_ref(),
                     &column_ids,
+                    &top_level_column_ids,
                     merged,
                     partial,
                     subpath.as_deref(),
@@ -559,6 +567,7 @@ impl DuckLakeTable {
             .object_store(self.object_store_url().as_ref())?;
         let table_writer = DuckLakeTableWriter::new(Arc::clone(writer), object_store)?;
         let column_ids = self.column_ids();
+        let top_level_column_ids = self.top_level_column_ids();
         let physical_schema = self.physical_schema();
 
         // Re-apply the table's live sort order to each rewritten file so its rows
@@ -620,8 +629,11 @@ impl DuckLakeTable {
                 // partition: inherit the identity and the Hive directory.
                 let (partition_id, partition_values) = partition_key(tf);
                 let subpath = partition_id.map(|pid| {
-                    let names =
-                        self.partition_path_names(live_partition_spec.as_ref(), pid, &column_ids);
+                    let names = self.partition_path_names(
+                        live_partition_spec.as_ref(),
+                        pid,
+                        &top_level_column_ids,
+                    );
                     crate::partition::hive_subpath(&names, &partition_values)
                 });
                 let file = table_writer
@@ -630,6 +642,7 @@ impl DuckLakeTable {
                         self.table_name(),
                         physical_schema.as_ref(),
                         &column_ids,
+                        &top_level_column_ids,
                         sorted,
                         false,
                         subpath.as_deref(),

--- a/src/metadata_provider.rs
+++ b/src/metadata_provider.rs
@@ -1,5 +1,8 @@
 use crate::Result;
-use std::collections::HashMap;
+use crate::types::{arrow_to_ducklake_type, ducklake_to_arrow_type};
+use arrow::datatypes::{DataType, Field};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 // SQL queries for DuckLake catalog tables
 // These queries are database-agnostic and work with DuckDB, SQLite, PostgreSQL, MySQL
@@ -498,7 +501,10 @@ pub struct FileWithTable {
     pub file: DuckLakeTableFile,
 }
 
-/// Column definition for a DuckLake table
+/// Column definition for a DuckLake table.
+///
+/// Built-in providers retain the reconstructed nested Arrow type and descendant
+/// IDs so reads and rewrites preserve the recursive catalog representation.
 #[derive(Debug, Clone)]
 pub struct DuckLakeTableColumn {
     /// Unique identifier for this column in the catalog
@@ -509,6 +515,8 @@ pub struct DuckLakeTableColumn {
     pub column_type: String,
     /// Whether this column allows NULL values
     pub is_nullable: bool,
+    pub(crate) data_type: Option<DataType>,
+    pub(crate) nested_column_ids: Vec<i64>,
 }
 
 impl DuckLakeTableColumn {
@@ -523,98 +531,229 @@ impl DuckLakeTableColumn {
             column_name,
             column_type,
             is_nullable,
+            data_type: None,
+            nested_column_ids: Vec::new(),
+        }
+    }
+
+    pub(crate) fn data_type(&self) -> Result<DataType> {
+        match &self.data_type {
+            Some(data_type) => Ok(data_type.clone()),
+            None => ducklake_to_arrow_type(&self.column_type),
         }
     }
 }
 
-/// Reconstruct list types from parent-child column rows.
-///
-/// DuckLake stores list columns as two rows in `ducklake_column`:
-/// - Parent row: `column_type = "list"`, `parent_column = NULL`
-/// - Child row:  `column_type = "<element_type>"`, `parent_column = <parent_column_id>`
-///
-/// This function rewrites the parent's `column_type` to `list<element_type>`
-/// and removes child rows from the result.
-///
-/// Only handles `list` parent types. Struct, map, etc. are left unchanged.
-pub fn reconstruct_list_columns(
+/// Reconstruct nested Arrow types from DuckLake's recursive column rows.
+pub fn reconstruct_columns(
     rows: Vec<(DuckLakeTableColumn, Option<i64>)>,
-) -> Vec<DuckLakeTableColumn> {
-    use std::collections::HashMap;
-
-    // Index: column_id -> position in rows
+) -> Result<Vec<DuckLakeTableColumn>> {
     let id_to_index: HashMap<i64, usize> = rows
         .iter()
         .enumerate()
-        .map(|(i, (col, _))| (col.column_id, i))
+        .map(|(index, (column, _))| (column.column_id, index))
         .collect();
-
-    // Separate into columns and parent_column arrays
-    let mut columns: Vec<DuckLakeTableColumn> = Vec::with_capacity(rows.len());
-    let mut parent_columns: Vec<Option<i64>> = Vec::with_capacity(rows.len());
-    for (col, parent) in rows {
-        columns.push(col);
-        parent_columns.push(parent);
+    if id_to_index.len() != rows.len() {
+        return Err(crate::DuckLakeError::InvalidConfig(
+            "DuckLake column metadata contains duplicate column ids".into(),
+        ));
     }
-
-    // Find children of list parents and rewrite parent types
-    let mut skip: std::collections::HashSet<usize> = std::collections::HashSet::new();
-    for (i, parent_id) in parent_columns.iter().enumerate() {
-        if let Some(pid) = parent_id
-            && let Some(&parent_idx) = id_to_index.get(pid)
-            && columns[parent_idx].column_type == "list"
-        {
-            columns[parent_idx].column_type = format!("list<{}>", columns[i].column_type);
-            skip.insert(i);
+    let mut children: HashMap<i64, Vec<usize>> = HashMap::new();
+    for (index, (_, parent_id)) in rows.iter().enumerate() {
+        if let Some(parent_id) = parent_id {
+            if !id_to_index.contains_key(parent_id) {
+                return Err(crate::DuckLakeError::InvalidConfig(format!(
+                    "Nested column {} references missing parent column {parent_id}",
+                    rows[index].0.column_id
+                )));
+            }
+            children.entry(*parent_id).or_default().push(index);
         }
     }
 
-    // Return only top-level columns (not children)
-    columns
-        .into_iter()
-        .enumerate()
-        .filter(|(i, _)| !skip.contains(i))
-        .map(|(_, col)| col)
-        .collect()
+    fn build_type(
+        index: usize,
+        rows: &[(DuckLakeTableColumn, Option<i64>)],
+        children: &HashMap<i64, Vec<usize>>,
+        visiting: &mut HashSet<i64>,
+    ) -> Result<DataType> {
+        let column = &rows[index].0;
+        if visiting.len() >= crate::types::MAX_NESTED_TYPE_DEPTH {
+            return Err(crate::DuckLakeError::InvalidConfig(format!(
+                "Nested column metadata exceeds maximum depth {}",
+                crate::types::MAX_NESTED_TYPE_DEPTH
+            )));
+        }
+        if !visiting.insert(column.column_id) {
+            return Err(crate::DuckLakeError::InvalidConfig(format!(
+                "Nested column cycle includes column {}",
+                column.column_id
+            )));
+        }
+        let child_indices = children
+            .get(&column.column_id)
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        let data_type = match column.column_type.to_ascii_lowercase().as_str() {
+            "list" => {
+                let [child_index] = child_indices else {
+                    return Err(crate::DuckLakeError::InvalidConfig(format!(
+                        "List column '{}' must have exactly one child",
+                        column.column_name
+                    )));
+                };
+                let child = &rows[*child_index].0;
+                DataType::List(Arc::new(Field::new(
+                    "item",
+                    build_type(*child_index, rows, children, visiting)?,
+                    child.is_nullable,
+                )))
+            },
+            "struct" => {
+                let fields = child_indices
+                    .iter()
+                    .map(|child_index| {
+                        let child = &rows[*child_index].0;
+                        Ok(Arc::new(Field::new(
+                            &child.column_name,
+                            build_type(*child_index, rows, children, visiting)?,
+                            child.is_nullable,
+                        )))
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                DataType::Struct(fields.into())
+            },
+            "map" => {
+                let [key_index, value_index] = child_indices else {
+                    return Err(crate::DuckLakeError::InvalidConfig(format!(
+                        "Map column '{}' must have key and value children",
+                        column.column_name
+                    )));
+                };
+                let key = &rows[*key_index].0;
+                let value = &rows[*value_index].0;
+                if key.column_name != "key" || value.column_name != "value" {
+                    return Err(crate::DuckLakeError::InvalidConfig(format!(
+                        "Map column '{}' children must be named key then value",
+                        column.column_name
+                    )));
+                }
+                let entries = DataType::Struct(
+                    vec![
+                        Arc::new(Field::new(
+                            "key",
+                            build_type(*key_index, rows, children, visiting)?,
+                            false,
+                        )),
+                        Arc::new(Field::new(
+                            "value",
+                            build_type(*value_index, rows, children, visiting)?,
+                            value.is_nullable,
+                        )),
+                    ]
+                    .into(),
+                );
+                DataType::Map(Arc::new(Field::new("entries", entries, false)), false)
+            },
+            _ if child_indices.is_empty() => ducklake_to_arrow_type(&column.column_type)?,
+            _ => {
+                return Err(crate::DuckLakeError::InvalidConfig(format!(
+                    "Non-nested column '{}' has child columns",
+                    column.column_name
+                )));
+            },
+        };
+        visiting.remove(&column.column_id);
+        Ok(data_type)
+    }
+
+    let mut result = Vec::new();
+    for (index, (column, parent_id)) in rows.iter().enumerate() {
+        if parent_id.is_some() {
+            continue;
+        }
+        let mut column = column.clone();
+        let data_type = build_type(index, &rows, &children, &mut HashSet::new())?;
+        column.column_type = reconstructed_column_type(&column.column_type, &data_type)?;
+        column.data_type = Some(data_type);
+        fn collect_ids(
+            column_id: i64,
+            rows: &[(DuckLakeTableColumn, Option<i64>)],
+            children: &HashMap<i64, Vec<usize>>,
+            ids: &mut Vec<i64>,
+        ) {
+            if let Some(child_indices) = children.get(&column_id) {
+                for child_index in child_indices {
+                    let child_id = rows[*child_index].0.column_id;
+                    ids.push(child_id);
+                    collect_ids(child_id, rows, children, ids);
+                }
+            }
+        }
+        collect_ids(
+            column.column_id,
+            &rows,
+            &children,
+            &mut column.nested_column_ids,
+        );
+        result.push(column);
+    }
+    let reconstructed_count = result
+        .iter()
+        .map(|column| 1 + column.nested_column_ids.len())
+        .sum::<usize>();
+    if reconstructed_count != rows.len() {
+        return Err(crate::DuckLakeError::InvalidConfig(
+            "DuckLake column metadata contains a parent cycle or unreachable nested column".into(),
+        ));
+    }
+    Ok(result)
 }
 
-/// Same as [`reconstruct_list_columns`] but for [`ColumnWithTable`] rows.
-pub fn reconstruct_list_columns_with_table(
+fn reconstructed_column_type(catalog_type: &str, data_type: &DataType) -> Result<String> {
+    let normalized = catalog_type.trim().to_ascii_lowercase();
+    let preserves_logical_name = matches!(data_type, DataType::Binary)
+        || matches!(data_type, DataType::Utf8View)
+            && !matches!(normalized.as_str(), "varchar" | "text" | "string");
+    if preserves_logical_name {
+        Ok(catalog_type.to_string())
+    } else {
+        arrow_to_ducklake_type(data_type)
+    }
+}
+
+/// Same as [`reconstruct_columns`] but for [`ColumnWithTable`] rows.
+pub fn reconstruct_columns_with_table(
     rows: Vec<(ColumnWithTable, Option<i64>)>,
-) -> Vec<ColumnWithTable> {
-    use std::collections::HashMap;
-
-    let id_to_index: HashMap<i64, usize> = rows
-        .iter()
-        .enumerate()
-        .map(|(i, (cwt, _))| (cwt.column.column_id, i))
-        .collect();
-
-    let mut entries: Vec<ColumnWithTable> = Vec::with_capacity(rows.len());
-    let mut parent_columns: Vec<Option<i64>> = Vec::with_capacity(rows.len());
-    for (cwt, parent) in rows {
-        entries.push(cwt);
-        parent_columns.push(parent);
-    }
-
-    let mut skip: std::collections::HashSet<usize> = std::collections::HashSet::new();
-    for (i, parent_id) in parent_columns.iter().enumerate() {
-        if let Some(pid) = parent_id
-            && let Some(&parent_idx) = id_to_index.get(pid)
-            && entries[parent_idx].column.column_type == "list"
-        {
-            entries[parent_idx].column.column_type =
-                format!("list<{}>", entries[i].column.column_type);
-            skip.insert(i);
+) -> Result<Vec<ColumnWithTable>> {
+    type ColumnRowsByTable = HashMap<(String, String), Vec<(DuckLakeTableColumn, Option<i64>)>>;
+    let mut grouped = ColumnRowsByTable::new();
+    let mut order = Vec::new();
+    for (entry, parent_id) in rows {
+        let key = (entry.schema_name, entry.table_name);
+        if !grouped.contains_key(&key) {
+            order.push(key.clone());
         }
+        grouped
+            .entry(key)
+            .or_default()
+            .push((entry.column, parent_id));
     }
 
-    entries
-        .into_iter()
-        .enumerate()
-        .filter(|(i, _)| !skip.contains(i))
-        .map(|(_, e)| e)
-        .collect()
+    let mut result = Vec::new();
+    for (schema_name, table_name) in order {
+        let columns = reconstruct_columns(
+            grouped
+                .remove(&(schema_name.clone(), table_name.clone()))
+                .unwrap_or_default(),
+        )?;
+        result.extend(columns.into_iter().map(|column| ColumnWithTable {
+            schema_name: schema_name.clone(),
+            table_name: table_name.clone(),
+            column,
+        }));
+    }
+    Ok(result)
 }
 
 /// Metadata for a data file or delete file in DuckLake
@@ -1099,7 +1238,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_reconstruct_list_columns_basic() {
+    fn test_reconstruct_columns_list() {
         let rows = vec![
             (
                 DuckLakeTableColumn::new(1, "id".into(), "int64".into(), false),
@@ -1115,7 +1254,7 @@ mod tests {
             ),
         ];
 
-        let result = reconstruct_list_columns(rows);
+        let result = reconstruct_columns(rows).unwrap();
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].column_name, "id");
         assert_eq!(result[0].column_type, "int64");
@@ -1124,7 +1263,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reconstruct_list_columns_no_lists() {
+    fn test_reconstruct_columns_scalars() {
         let rows = vec![
             (
                 DuckLakeTableColumn::new(1, "id".into(), "int64".into(), false),
@@ -1136,15 +1275,71 @@ mod tests {
             ),
         ];
 
-        let result = reconstruct_list_columns(rows);
+        let result = reconstruct_columns(rows).unwrap();
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].column_type, "int64");
         assert_eq!(result[1].column_type, "varchar");
     }
 
     #[test]
-    fn test_reconstruct_list_columns_struct_parent_unchanged() {
-        // Struct parents should NOT be rewritten — child stays in result
+    fn test_reconstruct_columns_preserves_scalar_catalog_names() {
+        let rows = vec![
+            (
+                DuckLakeTableColumn::new(1, "shape".into(), "geometry".into(), true),
+                None,
+            ),
+            (
+                DuckLakeTableColumn::new(2, "details".into(), "json".into(), true),
+                None,
+            ),
+            (
+                DuckLakeTableColumn::new(3, "at".into(), "timetz".into(), true),
+                None,
+            ),
+            (
+                DuckLakeTableColumn::new(4, "count".into(), "INT".into(), true),
+                None,
+            ),
+        ];
+
+        let result = reconstruct_columns(rows).unwrap();
+
+        assert_eq!(result[0].column_type, "geometry");
+        assert_eq!(result[1].column_type, "json");
+        assert_eq!(result[2].column_type, "timetz");
+        assert_eq!(result[3].column_type, "int32");
+    }
+
+    #[test]
+    fn test_reconstruct_columns_depth_is_bounded() {
+        let count = crate::types::MAX_NESTED_TYPE_DEPTH + 2;
+        let rows = (0..count)
+            .map(|index| {
+                let column_id = index as i64 + 1;
+                let column_type = if index + 1 == count {
+                    "int32"
+                } else {
+                    "struct"
+                };
+                (
+                    DuckLakeTableColumn::new(
+                        column_id,
+                        format!("field_{index}"),
+                        column_type.to_string(),
+                        true,
+                    ),
+                    (index > 0).then_some(column_id - 1),
+                )
+            })
+            .collect();
+
+        let error = reconstruct_columns(rows).unwrap_err();
+
+        assert!(error.to_string().contains("maximum depth"));
+    }
+
+    #[test]
+    fn test_reconstruct_columns_struct() {
         let rows = vec![
             (
                 DuckLakeTableColumn::new(1, "data".into(), "struct".into(), true),
@@ -1156,13 +1351,112 @@ mod tests {
             ),
         ];
 
-        let result = reconstruct_list_columns(rows);
-        assert_eq!(result.len(), 2); // both remain
-        assert_eq!(result[0].column_type, "struct"); // unchanged
+        let result = reconstruct_columns(rows).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].column_type, "struct<field_a:int32>");
+        assert_eq!(result[0].nested_column_ids, vec![2]);
     }
 
     #[test]
-    fn test_reconstruct_list_columns_multiple_lists() {
+    fn test_reconstruct_columns_arbitrary_nesting() {
+        let rows = vec![
+            (
+                DuckLakeTableColumn::new(1, "payload".into(), "struct".into(), false),
+                None,
+            ),
+            (
+                DuckLakeTableColumn::new(2, "levels".into(), "list".into(), false),
+                Some(1),
+            ),
+            (
+                DuckLakeTableColumn::new(3, "element".into(), "struct".into(), false),
+                Some(2),
+            ),
+            (
+                DuckLakeTableColumn::new(4, "price".into(), "decimal(38, 16)".into(), false),
+                Some(3),
+            ),
+            (
+                DuckLakeTableColumn::new(5, "attrs".into(), "map".into(), true),
+                Some(1),
+            ),
+            (
+                DuckLakeTableColumn::new(6, "key".into(), "varchar".into(), false),
+                Some(5),
+            ),
+            (
+                DuckLakeTableColumn::new(7, "value".into(), "list".into(), true),
+                Some(5),
+            ),
+            (
+                DuckLakeTableColumn::new(8, "element".into(), "int32".into(), true),
+                Some(7),
+            ),
+        ];
+
+        let result = reconstruct_columns(rows).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0].column_type,
+            "struct<levels:list<struct<price:decimal(38, 16)>>,attrs:map<varchar,list<int32>>>"
+        );
+        assert_eq!(result[0].nested_column_ids, vec![2, 3, 4, 5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn test_reconstruct_columns_rejects_invalid_map_children() {
+        let rows = vec![
+            (
+                DuckLakeTableColumn::new(1, "attrs".into(), "map".into(), true),
+                None,
+            ),
+            (
+                DuckLakeTableColumn::new(2, "value".into(), "int32".into(), true),
+                Some(1),
+            ),
+            (
+                DuckLakeTableColumn::new(3, "key".into(), "varchar".into(), false),
+                Some(1),
+            ),
+        ];
+
+        assert!(reconstruct_columns(rows).is_err());
+    }
+
+    #[test]
+    fn test_reconstruct_columns_rejects_duplicate_ids() {
+        let rows = vec![
+            (
+                DuckLakeTableColumn::new(1, "id".into(), "int64".into(), false),
+                None,
+            ),
+            (
+                DuckLakeTableColumn::new(1, "name".into(), "varchar".into(), true),
+                None,
+            ),
+        ];
+
+        assert!(reconstruct_columns(rows).is_err());
+    }
+
+    #[test]
+    fn test_reconstruct_columns_rejects_parent_cycle() {
+        let rows = vec![
+            (
+                DuckLakeTableColumn::new(1, "left".into(), "struct".into(), false),
+                Some(2),
+            ),
+            (
+                DuckLakeTableColumn::new(2, "right".into(), "struct".into(), false),
+                Some(1),
+            ),
+        ];
+
+        assert!(reconstruct_columns(rows).is_err());
+    }
+
+    #[test]
+    fn test_reconstruct_columns_multiple_lists() {
         let rows = vec![
             (
                 DuckLakeTableColumn::new(1, "tags".into(), "list".into(), true),
@@ -1182,14 +1476,14 @@ mod tests {
             ),
         ];
 
-        let result = reconstruct_list_columns(rows);
+        let result = reconstruct_columns(rows).unwrap();
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].column_type, "list<varchar>");
         assert_eq!(result[1].column_type, "list<float64>");
     }
 
     #[test]
-    fn test_reconstruct_list_columns_with_table_basic() {
+    fn test_reconstruct_columns_with_table_list() {
         let rows = vec![
             (
                 ColumnWithTable {
@@ -1209,7 +1503,7 @@ mod tests {
             ),
         ];
 
-        let result = reconstruct_list_columns_with_table(rows);
+        let result = reconstruct_columns_with_table(rows).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].column.column_type, "list<float64>");
     }

--- a/src/metadata_provider_duckdb.rs
+++ b/src/metadata_provider_duckdb.rs
@@ -9,8 +9,8 @@ use crate::metadata_provider::{
     SQL_GET_SCHEMA_BY_NAME, SQL_GET_SORT_SPEC, SQL_GET_TABLE_BY_NAME, SQL_GET_TABLE_COLUMN_STATS,
     SQL_GET_TABLE_COLUMNS, SQL_GET_TABLE_STATS, SQL_LIST_ALL_COLUMNS, SQL_LIST_ALL_FILES,
     SQL_LIST_ALL_TABLES, SQL_LIST_SCHEMAS, SQL_LIST_SNAPSHOTS, SQL_LIST_TABLES, SQL_TABLE_EXISTS,
-    SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, reconstruct_list_columns,
-    reconstruct_list_columns_with_table,
+    SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, reconstruct_columns,
+    reconstruct_columns_with_table,
 };
 use crate::partition::PartitionSpec;
 use crate::sort::SortSpec;
@@ -245,7 +245,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
             })?
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(reconstruct_list_columns(raw_columns))
+        reconstruct_columns(raw_columns)
     }
 
     fn get_table_files_for_select(
@@ -811,6 +811,8 @@ impl MetadataProvider for DuckdbMetadataProvider {
                         column_name: row.get(3)?,
                         column_type: row.get(4)?,
                         is_nullable: nulls_allowed.unwrap_or(true),
+                        data_type: None,
+                        nested_column_ids: Vec::new(),
                     };
                     Ok((
                         ColumnWithTable {
@@ -824,7 +826,7 @@ impl MetadataProvider for DuckdbMetadataProvider {
             )?
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(reconstruct_list_columns_with_table(raw_columns))
+        reconstruct_columns_with_table(raw_columns)
     }
 
     fn list_all_files(&self, snapshot_id: i64) -> crate::Result<Vec<FileWithTable>> {

--- a/src/metadata_provider_mysql.rs
+++ b/src/metadata_provider_mysql.rs
@@ -7,7 +7,7 @@ use crate::metadata_provider::{
     DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable,
     MetadataProvider, SQL_GET_FILE_PARTITION_VALUES, SQL_GET_PARTITION_SPEC, SQL_GET_SORT_SPEC,
     SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, block_on,
-    reconstruct_list_columns, reconstruct_list_columns_with_table,
+    reconstruct_columns, reconstruct_columns_with_table,
 };
 use crate::partition::PartitionSpec;
 use crate::sort::SortSpec;
@@ -297,12 +297,14 @@ impl MetadataProvider for MySqlMetadataProvider {
                             column_name: row.try_get(1)?,
                             column_type: row.try_get(2)?,
                             is_nullable: nulls_allowed.unwrap_or(true),
+                            data_type: None,
+                            nested_column_ids: Vec::new(),
                         },
                         parent_column,
                     ))
                 })
                 .collect();
-            Ok(reconstruct_list_columns(raw?))
+            reconstruct_columns(raw?)
         })
     }
 
@@ -936,6 +938,8 @@ impl MetadataProvider for MySqlMetadataProvider {
                         column_name: row.try_get(3)?,
                         column_type: row.try_get(4)?,
                         is_nullable: nulls_allowed.unwrap_or(true),
+                        data_type: None,
+                        nested_column_ids: Vec::new(),
                     };
                     Ok((
                         ColumnWithTable {
@@ -947,7 +951,7 @@ impl MetadataProvider for MySqlMetadataProvider {
                     ))
                 })
                 .collect();
-            Ok(reconstruct_list_columns_with_table(raw?))
+            reconstruct_columns_with_table(raw?)
         })
     }
 

--- a/src/metadata_provider_postgres.rs
+++ b/src/metadata_provider_postgres.rs
@@ -6,7 +6,7 @@ use crate::metadata_provider::{
     DuckLakeFileData, DuckLakeFileMetadata, DuckLakeStatistics, DuckLakeTableColumn,
     DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable,
     MetadataProvider, SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, block_on,
-    reconstruct_list_columns, reconstruct_list_columns_with_table,
+    reconstruct_columns, reconstruct_columns_with_table,
 };
 use crate::partition::PartitionSpec;
 use crate::sort::SortSpec;
@@ -340,12 +340,14 @@ impl MetadataProvider for PostgresMetadataProvider {
                             column_name: row.try_get(1)?,
                             column_type: row.try_get(2)?,
                             is_nullable: nulls_allowed.unwrap_or(true),
+                            data_type: None,
+                            nested_column_ids: Vec::new(),
                         },
                         parent_column,
                     ))
                 })
                 .collect();
-            Ok(reconstruct_list_columns(raw?))
+            reconstruct_columns(raw?)
         })
     }
 
@@ -1097,6 +1099,8 @@ impl MetadataProvider for PostgresMetadataProvider {
                         column_name: row.try_get(3)?,
                         column_type: row.try_get(4)?,
                         is_nullable: nulls_allowed.unwrap_or(true),
+                        data_type: None,
+                        nested_column_ids: Vec::new(),
                     };
                     Ok((
                         ColumnWithTable {
@@ -1108,7 +1112,7 @@ impl MetadataProvider for PostgresMetadataProvider {
                     ))
                 })
                 .collect();
-            Ok(reconstruct_list_columns_with_table(raw?))
+            reconstruct_columns_with_table(raw?)
         })
     }
 

--- a/src/metadata_provider_sqlite.rs
+++ b/src/metadata_provider_sqlite.rs
@@ -7,7 +7,7 @@ use crate::metadata_provider::{
     DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable,
     MetadataProvider, SQL_GET_FILE_PARTITION_VALUES, SQL_GET_PARTITION_SPEC, SQL_GET_SORT_SPEC,
     SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, block_on,
-    reconstruct_list_columns, reconstruct_list_columns_with_table,
+    reconstruct_columns, reconstruct_columns_with_table,
 };
 use crate::partition::PartitionSpec;
 use crate::sort::SortSpec;
@@ -419,12 +419,14 @@ impl MetadataProvider for SqliteMetadataProvider {
                             column_name: row.try_get(1)?,
                             column_type: row.try_get(2)?,
                             is_nullable: nulls_allowed.unwrap_or(true),
+                            data_type: None,
+                            nested_column_ids: Vec::new(),
                         },
                         parent_column,
                     ))
                 })
                 .collect();
-            Ok(reconstruct_list_columns(raw?))
+            reconstruct_columns(raw?)
         })
     }
 
@@ -1243,6 +1245,8 @@ impl MetadataProvider for SqliteMetadataProvider {
                         column_name: row.try_get(3)?,
                         column_type: row.try_get(4)?,
                         is_nullable: nulls_allowed.unwrap_or(true),
+                        data_type: None,
+                        nested_column_ids: Vec::new(),
                     };
                     Ok((
                         ColumnWithTable {
@@ -1254,7 +1258,7 @@ impl MetadataProvider for SqliteMetadataProvider {
                     ))
                 })
                 .collect();
-            Ok(reconstruct_list_columns_with_table(raw?))
+            reconstruct_columns_with_table(raw?)
         })
     }
 

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -6,6 +6,7 @@
 use crate::types::{arrow_to_ducklake_type, ducklake_to_arrow_type};
 use crate::{DuckLakeError, Result};
 use arrow::datatypes::DataType;
+use std::collections::{HashMap, HashSet};
 
 /// Maximum allowed length for catalog entity names (schemas, tables, columns).
 pub const MAX_NAME_LENGTH: usize = 1024;
@@ -157,6 +158,8 @@ pub struct ColumnDef {
     pub(crate) ducklake_type: String,
     /// Whether this column allows NULL values
     pub(crate) is_nullable: bool,
+    /// Arrow type retained so nested child names and nullability survive catalog flattening.
+    pub(crate) data_type: DataType,
 }
 
 impl ColumnDef {
@@ -189,11 +192,12 @@ impl ColumnDef {
         let ducklake_type = ducklake_type.into();
         // Validate the type string by attempting to convert it to an Arrow type.
         // We discard the result; we only care that the conversion succeeds.
-        ducklake_to_arrow_type(&ducklake_type)?;
+        let data_type = ducklake_to_arrow_type(&ducklake_type)?;
         Ok(Self {
             name,
             ducklake_type,
             is_nullable,
+            data_type,
         })
     }
 
@@ -216,8 +220,250 @@ impl ColumnDef {
             name,
             ducklake_type,
             is_nullable,
+            data_type: data_type.clone(),
         })
     }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CatalogColumnDef {
+    pub name: String,
+    pub ducklake_type: String,
+    pub logical_type: String,
+    pub is_nullable: bool,
+    pub parent_index: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ExistingCatalogColumn {
+    pub column_id: i64,
+    pub name: String,
+    pub ducklake_type: String,
+    pub parent_column: Option<i64>,
+}
+
+pub(crate) fn catalog_column_defs(columns: &[ColumnDef]) -> Result<Vec<CatalogColumnDef>> {
+    let mut result = Vec::new();
+    for column in columns {
+        append_column_def(
+            &column.name,
+            &column.data_type,
+            column.is_nullable,
+            None,
+            &mut result,
+        )?;
+    }
+    Ok(result)
+}
+
+fn append_column_def(
+    name: &str,
+    data_type: &DataType,
+    is_nullable: bool,
+    parent_index: Option<usize>,
+    result: &mut Vec<CatalogColumnDef>,
+) -> Result<()> {
+    let index = result.len();
+    result.push(CatalogColumnDef {
+        name: name.to_string(),
+        ducklake_type: catalog_type_name(data_type)?,
+        logical_type: arrow_to_ducklake_type(data_type)?,
+        is_nullable,
+        parent_index,
+    });
+    match data_type {
+        DataType::List(field) | DataType::LargeList(field) | DataType::FixedSizeList(field, _) => {
+            append_column_def(
+                "element",
+                field.data_type(),
+                field.is_nullable(),
+                Some(index),
+                result,
+            )
+        },
+        DataType::Struct(fields) => {
+            for field in fields {
+                append_column_def(
+                    field.name(),
+                    field.data_type(),
+                    field.is_nullable(),
+                    Some(index),
+                    result,
+                )?;
+            }
+            Ok(())
+        },
+        DataType::Map(entries, _) => {
+            let DataType::Struct(fields) = entries.data_type() else {
+                return Err(DuckLakeError::UnsupportedType(
+                    "Arrow map entries must be a struct".to_string(),
+                ));
+            };
+            let [key, value] = fields.as_ref() else {
+                return Err(DuckLakeError::UnsupportedType(
+                    "Arrow maps must have key and value fields".to_string(),
+                ));
+            };
+            append_column_def("key", key.data_type(), false, Some(index), result)?;
+            append_column_def(
+                "value",
+                value.data_type(),
+                value.is_nullable(),
+                Some(index),
+                result,
+            )
+        },
+        _ => Ok(()),
+    }
+}
+
+pub(crate) fn catalog_column_type_equal(existing_type: &str, proposed: &CatalogColumnDef) -> bool {
+    existing_type.eq_ignore_ascii_case(&proposed.ducklake_type)
+        || crate::types::types_equal_canonical(existing_type, &proposed.ducklake_type)
+        || catalog_column_type_requires_migration(existing_type, proposed)
+}
+
+pub(crate) fn catalog_column_type_requires_migration(
+    existing_type: &str,
+    proposed: &CatalogColumnDef,
+) -> bool {
+    proposed.ducklake_type == "list"
+        && existing_type
+            .trim()
+            .to_ascii_lowercase()
+            .starts_with("list<")
+        && crate::types::types_equal_canonical(existing_type, &proposed.logical_type)
+}
+
+fn catalog_type_name(data_type: &DataType) -> Result<String> {
+    match data_type {
+        DataType::List(_) | DataType::LargeList(_) | DataType::FixedSizeList(_, _) => {
+            Ok("list".to_string())
+        },
+        DataType::Struct(_) => Ok("struct".to_string()),
+        DataType::Map(_, _) => Ok("map".to_string()),
+        _ => arrow_to_ducklake_type(data_type),
+    }
+}
+
+pub(crate) fn top_level_column_ids(
+    columns: &[CatalogColumnDef],
+    field_ids: &[i64],
+) -> Result<Vec<i64>> {
+    if columns.len() != field_ids.len() {
+        return Err(DuckLakeError::Internal(format!(
+            "catalog column count {} does not match field id count {}",
+            columns.len(),
+            field_ids.len()
+        )));
+    }
+    Ok(columns
+        .iter()
+        .zip(field_ids)
+        .filter_map(|(column, field_id)| column.parent_index.is_none().then_some(*field_id))
+        .collect())
+}
+
+pub(crate) fn assign_column_ids(
+    proposed: &[CatalogColumnDef],
+    existing: &[ExistingCatalogColumn],
+    fresh_ids: &[i64],
+) -> Result<Vec<i64>> {
+    if proposed.len() != fresh_ids.len() {
+        return Err(DuckLakeError::Internal(format!(
+            "proposed column count {} does not match reserved id count {}",
+            proposed.len(),
+            fresh_ids.len()
+        )));
+    }
+    let mut existing_paths: HashMap<i64, Vec<String>> = HashMap::new();
+    let mut unresolved = existing.iter().collect::<Vec<_>>();
+    while !unresolved.is_empty() {
+        let before = unresolved.len();
+        unresolved.retain(|column| {
+            let parent_path = match column.parent_column {
+                Some(parent_id) => match existing_paths.get(&parent_id) {
+                    Some(path) => path.clone(),
+                    None => return true,
+                },
+                None => Vec::new(),
+            };
+            let mut path = parent_path;
+            path.push(column.name.clone());
+            existing_paths.insert(column.column_id, path);
+            false
+        });
+        if unresolved.len() == before {
+            return Err(DuckLakeError::InvalidConfig(
+                "Catalog contains an orphaned or cyclic nested column".to_string(),
+            ));
+        }
+    }
+    if existing_paths.len() != existing.len() {
+        return Err(DuckLakeError::InvalidConfig(
+            "Catalog contains duplicate column ids".to_string(),
+        ));
+    }
+    let mut existing_by_path = HashMap::new();
+    for column in existing {
+        let path = existing_paths
+            .get(&column.column_id)
+            .expect("every existing column path was resolved")
+            .clone();
+        if existing_by_path.insert(path, column.column_id).is_some() {
+            return Err(DuckLakeError::InvalidConfig(
+                "Catalog contains duplicate nested column paths".to_string(),
+            ));
+        }
+    }
+    let mut proposed_paths: Vec<Vec<String>> = Vec::with_capacity(proposed.len());
+    let mut proposed_path_set = HashSet::with_capacity(proposed.len());
+    for column in proposed {
+        let mut path = column
+            .parent_index
+            .map(|parent_index| proposed_paths[parent_index].clone())
+            .unwrap_or_default();
+        path.push(column.name.clone());
+        if !proposed_path_set.insert(path.clone()) {
+            return Err(DuckLakeError::InvalidConfig(
+                "Proposed schema contains duplicate nested column paths".to_string(),
+            ));
+        }
+        proposed_paths.push(path);
+    }
+    Ok(proposed_paths
+        .iter()
+        .zip(fresh_ids)
+        .map(|(path, fresh_id)| existing_by_path.get(path).copied().unwrap_or(*fresh_id))
+        .collect())
+}
+
+pub(crate) fn catalog_columns_differ(
+    existing: &[ExistingCatalogColumn],
+    existing_nullability: &[bool],
+    proposed: &[CatalogColumnDef],
+    field_ids: &[i64],
+) -> bool {
+    if existing.len() != proposed.len()
+        || existing.len() != existing_nullability.len()
+        || proposed.len() != field_ids.len()
+    {
+        return true;
+    }
+    existing
+        .iter()
+        .zip(existing_nullability)
+        .zip(proposed.iter().zip(field_ids))
+        .any(|((existing, existing_nullable), (proposed, field_id))| {
+            let parent_id = proposed.parent_index.map(|index| field_ids[index]);
+            let same_type = catalog_column_type_equal(&existing.ducklake_type, proposed)
+                || crate::types::is_promotable(&proposed.ducklake_type, &existing.ducklake_type);
+            existing.column_id != *field_id
+                || existing.name != proposed.name
+                || !same_type
+                || *existing_nullable != proposed.is_nullable
+                || existing.parent_column != parent_id
+        })
 }
 
 /// Whether `proposed` is a *schema change* relative to `existing` — i.e. whether a
@@ -237,8 +483,7 @@ impl ColumnDef {
 /// anything else is real DDL. (Not `types_compatible`, which would also accept
 /// committed-widens-to-staged and wrongly classify the race as DDL.)
 ///
-/// Shared by the SQLite and Postgres writers so the DDL/DML classification can't
-/// drift between backends.
+#[cfg(test)]
 pub(crate) fn columns_differ(existing: &[(String, String, bool)], proposed: &[ColumnDef]) -> bool {
     if existing.len() != proposed.len() {
         return true;
@@ -712,8 +957,10 @@ pub struct WriteSetupResult {
     pub schema_id: i64,
     /// Table ID (may be newly created)
     pub table_id: i64,
-    /// Column IDs in order
+    /// Top-level column IDs in Arrow schema order.
     pub column_ids: Vec<i64>,
+    /// Every typed field ID in DuckLake depth-first preorder.
+    pub field_ids: Vec<i64>,
 }
 
 /// Trait for writing metadata to DuckLake catalogs.
@@ -908,8 +1155,9 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
     /// for SQLite (so it may differ from `WriteSetupResult::snapshot_id` under
     /// concurrency), reserved at begin for Postgres.
     ///
-    /// `columns` / `column_ids` describe the snapshot's column generation (in
-    /// `column_order`, ids matching `WriteSetupResult::column_ids`). Backends
+    /// `columns` carries the top-level Arrow schema. `column_ids` carries every
+    /// typed node ID in depth-first `column_order`, matching
+    /// `WriteSetupResult::field_ids`. Backends
     /// that finalize columns in `begin_write_transaction` (multicatalog
     /// Postgres) ignore them; single-catalog backends (SQLite) defer the
     /// column generation to this commit and use them to insert the column rows.
@@ -1432,8 +1680,8 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
     /// resolve on read. Self-contained (no `begin_write_transaction`): creates
     /// the table/columns on first write, appends after.
     ///
-    /// `column_ids` must be non-empty and 1:1 with `columns` (`column_ids[i]` is
-    /// the id assigned to `columns[i]`, in column order); a mismatch is rejected
+    /// `column_ids` must be non-empty and 1:1 with the recursive catalog nodes
+    /// flattened from `columns`, in depth-first preorder. A mismatch is rejected
     /// with [`crate::DuckLakeError::InvalidConfig`]. Rowids are freshly assigned
     /// (the source `row_id_start` is not preserved), so indexes keyed on the
     /// source's rowids do not carry over.
@@ -1570,6 +1818,8 @@ pub trait MetadataWriter: Send + Sync + std::fmt::Debug {
 mod tests {
     use super::*;
     use crate::DuckLakeError;
+    use arrow::datatypes::Field;
+    use std::sync::Arc;
 
     fn promoted(values: Vec<(i32, Option<String>)>) -> DataFileInfo {
         DataFileInfo::new("f.parquet", 1024, 10).with_partition(7, values)
@@ -1815,6 +2065,156 @@ mod tests {
         assert_eq!(col.name, "id");
         assert_eq!(col.ducklake_type, "int64");
         assert!(!col.is_nullable);
+    }
+
+    #[test]
+    fn test_catalog_column_defs_use_depth_first_preorder() {
+        let levels = DataType::List(Arc::new(Field::new(
+            "item",
+            DataType::Struct(
+                vec![
+                    Arc::new(Field::new("price", DataType::Decimal128(38, 16), false)),
+                    Arc::new(Field::new(
+                        "tags",
+                        DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+                        true,
+                    )),
+                ]
+                .into(),
+            ),
+            false,
+        )));
+        let attrs = DataType::Map(
+            Arc::new(Field::new(
+                "entries",
+                DataType::Struct(
+                    vec![
+                        Arc::new(Field::new("key", DataType::Utf8, false)),
+                        Arc::new(Field::new(
+                            "value",
+                            DataType::Struct(
+                                vec![Arc::new(Field::new("active", DataType::Boolean, false))]
+                                    .into(),
+                            ),
+                            true,
+                        )),
+                    ]
+                    .into(),
+                ),
+                false,
+            )),
+            false,
+        );
+        let columns = vec![
+            ColumnDef::from_arrow("id", &DataType::Int32, false).unwrap(),
+            ColumnDef::from_arrow("levels", &levels, false).unwrap(),
+            ColumnDef::from_arrow("attrs", &attrs, true).unwrap(),
+        ];
+
+        let definitions = catalog_column_defs(&columns).unwrap();
+        let actual = definitions
+            .iter()
+            .map(|column| {
+                (
+                    column.name.as_str(),
+                    column.ducklake_type.as_str(),
+                    column.is_nullable,
+                    column.parent_index,
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            actual,
+            vec![
+                ("id", "int32", false, None),
+                ("levels", "list", false, None),
+                ("element", "struct", false, Some(1)),
+                ("price", "decimal(38, 16)", false, Some(2)),
+                ("tags", "list", true, Some(2)),
+                ("element", "varchar", true, Some(4)),
+                ("attrs", "map", true, None),
+                ("key", "varchar", false, Some(6)),
+                ("value", "struct", true, Some(6)),
+                ("active", "boolean", false, Some(8)),
+            ]
+        );
+        assert_eq!(
+            top_level_column_ids(&definitions, &[10, 11, 12, 13, 14, 15, 16, 17, 18, 19]).unwrap(),
+            vec![10, 11, 16]
+        );
+    }
+
+    #[test]
+    fn test_assign_column_ids_rejects_duplicate_paths() {
+        let columns = vec![
+            ColumnDef::from_arrow("value", &DataType::Int32, false).unwrap(),
+            ColumnDef::from_arrow("value", &DataType::Int64, false).unwrap(),
+        ];
+        let definitions = catalog_column_defs(&columns).unwrap();
+
+        assert!(assign_column_ids(&definitions, &[], &[10, 11]).is_err());
+    }
+
+    #[test]
+    fn catalog_type_name_returns_unsupported_scalar_error() {
+        let error =
+            catalog_type_name(&DataType::Duration(arrow::datatypes::TimeUnit::Second)).unwrap_err();
+
+        assert!(matches!(error, DuckLakeError::UnsupportedType(_)));
+    }
+
+    #[test]
+    fn test_catalog_columns_differ_accepts_nested_type_alias() {
+        let columns = vec![
+            ColumnDef::from_arrow(
+                "values",
+                &DataType::List(Arc::new(Field::new("item", DataType::Int64, true))),
+                false,
+            )
+            .unwrap(),
+        ];
+        let definitions = catalog_column_defs(&columns).unwrap();
+        let existing = vec![
+            ExistingCatalogColumn {
+                column_id: 10,
+                name: "values".into(),
+                ducklake_type: "list".into(),
+                parent_column: None,
+            },
+            ExistingCatalogColumn {
+                column_id: 11,
+                name: "element".into(),
+                ducklake_type: "bigint".into(),
+                parent_column: Some(10),
+            },
+        ];
+
+        assert!(!catalog_columns_differ(
+            &existing,
+            &[false, true],
+            &definitions,
+            &[10, 11],
+        ));
+    }
+
+    #[test]
+    fn legacy_list_type_matches_only_the_same_recursive_type() {
+        let columns = vec![
+            ColumnDef::from_arrow(
+                "values",
+                &DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+                true,
+            )
+            .unwrap(),
+        ];
+        let definitions = catalog_column_defs(&columns).unwrap();
+
+        assert!(catalog_column_type_equal("list<float32>", &definitions[0]));
+        assert!(catalog_column_type_requires_migration(
+            "list<float32>",
+            &definitions[0]
+        ));
+        assert!(!catalog_column_type_equal("list<int32>", &definitions[0]));
     }
 
     #[test]

--- a/src/metadata_writer_duckdb.rs
+++ b/src/metadata_writer_duckdb.rs
@@ -39,9 +39,11 @@
 use crate::Result;
 use crate::error::{TypeChangeOperation, TypeChangeWriteMode};
 use crate::metadata_writer::{
-    ColumnDef, ColumnStat, CommitIds, DataFileInfo, MetadataWriter, SnapshotCommitMetadata,
-    WriteMode, WriteSetupResult, columns_differ, quote_snapshot_name, quote_snapshot_table,
-    table_write_changes, validate_name,
+    ColumnDef, ColumnStat, CommitIds, DataFileInfo, ExistingCatalogColumn, MetadataWriter,
+    SnapshotCommitMetadata, WriteMode, WriteSetupResult, assign_column_ids, catalog_column_defs,
+    catalog_column_type_equal, catalog_column_type_requires_migration, catalog_columns_differ,
+    quote_snapshot_name, quote_snapshot_table, table_write_changes, top_level_column_ids,
+    validate_name,
 };
 use crate::partition::PartitionTransform;
 use duckdb::{Connection, OptionalExt, Transaction, params};
@@ -596,6 +598,8 @@ fn recompute_table_column_stats(
     column_ids: &[i64],
 ) -> Result<()> {
     use crate::stats_encode::{FileColumnStat, aggregate_global_column_stats};
+    let catalog_columns = catalog_column_defs(columns)?;
+    let column_ids = top_level_column_ids(&catalog_columns, column_ids)?;
 
     let live_file_count: i64 = tx.query_row(
         "SELECT COUNT(*) FROM ducklake_data_file WHERE table_id = ? AND end_snapshot IS NULL",
@@ -665,6 +669,14 @@ fn finalize_snapshot(
     base_snapshot: i64,
 ) -> Result<i64> {
     use std::collections::{HashMap, HashSet};
+    let proposed = catalog_column_defs(columns)?;
+    if proposed.len() != column_ids.len() {
+        return Err(crate::DuckLakeError::InvalidConfig(format!(
+            "column_ids has {} entries for {} catalog column nodes",
+            column_ids.len(),
+            proposed.len()
+        )));
+    }
 
     // Allocate the snapshot FIRST (carrying schema_version forward); corrected to
     // a DDL bump below once the commit is classified.
@@ -673,28 +685,56 @@ fn finalize_snapshot(
     // The table's live columns ordered by column_order. Collected into an owned
     // Vec so the prepared statement is dropped before we mutate the same
     // connection. An empty set means a brand-new table (its creating write is DDL).
-    let current: Vec<(String, String, i64, bool)> = {
+    let current: Vec<(i64, String, String, i64, bool, Option<i64>)> = {
         let mut stmt = tx.prepare(
-            "SELECT column_name, column_type, column_order, nulls_allowed
+            "SELECT column_id, column_name, column_type, column_order, nulls_allowed, parent_column
              FROM ducklake_column
              WHERE table_id = ? AND end_snapshot IS NULL
              ORDER BY column_order",
         )?;
         let mapped = stmt.query_map(params![table_id], |row| {
-            let name: String = row.get(0)?;
-            let ty: String = row.get(1)?;
-            let order: i64 = row.get(2)?;
-            let nullable: Option<bool> = row.get(3)?;
-            Ok((name, ty, order, nullable.unwrap_or(true)))
+            let column_id: i64 = row.get(0)?;
+            let name: String = row.get(1)?;
+            let ty: String = row.get(2)?;
+            let order: i64 = row.get(3)?;
+            let nullable: Option<bool> = row.get(4)?;
+            let parent_column: Option<i64> = row.get(5)?;
+            Ok((
+                column_id,
+                name,
+                ty,
+                order,
+                nullable.unwrap_or(true),
+                parent_column,
+            ))
         })?;
         mapped.collect::<std::result::Result<Vec<_>, duckdb::Error>>()?
     };
-
-    let existing: Vec<(String, String, bool)> = current
+    let existing_catalog_columns = current
         .iter()
-        .map(|(name, ty, _order, nullable)| (name.clone(), ty.clone(), *nullable))
-        .collect();
-    let is_ddl = existing.is_empty() || columns_differ(&existing, columns);
+        .map(|column| ExistingCatalogColumn {
+            column_id: column.0,
+            name: column.1.clone(),
+            ducklake_type: column.2.clone(),
+            parent_column: column.5,
+        })
+        .collect::<Vec<_>>();
+    let existing_nullability = current.iter().map(|column| column.4).collect::<Vec<_>>();
+    let committed_ids = assign_column_ids(&proposed, &existing_catalog_columns, column_ids)?;
+    if committed_ids != column_ids {
+        return Err(crate::DuckLakeError::Conflict(
+            "table columns were created concurrently with different field ids; retry the write"
+                .to_string(),
+        ));
+    }
+
+    let is_ddl = current.is_empty()
+        || catalog_columns_differ(
+            &existing_catalog_columns,
+            &existing_nullability,
+            &proposed,
+            column_ids,
+        );
     if is_ddl {
         // A DDL commit bumps schema_version (the insert only carried it forward).
         schema_version = bump_schema_version(tx, snapshot_id)?;
@@ -703,29 +743,54 @@ fn finalize_snapshot(
     // Reconcile the column generation SURGICALLY so each column keeps a stable
     // column_id (== parquet field_id): end only removed columns, insert only new
     // ones, and leave unchanged columns (and their ids) in place.
-    let new_names: HashSet<&str> = columns.iter().map(|c| c.name()).collect();
-    let mut current_by_name: HashMap<String, (i64, bool)> = HashMap::new();
-    for (name, _ty, order, nullable) in &current {
-        if !new_names.contains(name.as_str()) {
+    let proposed_ids = column_ids.iter().copied().collect::<HashSet<_>>();
+    let mut current_by_id: HashMap<i64, (i64, bool, String)> = HashMap::new();
+    for (column_id, _name, ty, order, nullable, _parent_id) in &current {
+        if !proposed_ids.contains(column_id) {
             tx.execute(
                 "UPDATE ducklake_column SET end_snapshot = ?
-                 WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL",
-                params![snapshot_id, table_id, name.as_str()],
+                 WHERE table_id = ? AND column_id = ? AND end_snapshot IS NULL",
+                params![snapshot_id, table_id, column_id],
             )?;
         }
-        current_by_name.insert(name.clone(), (*order, *nullable));
+        current_by_id.insert(*column_id, (*order, *nullable, ty.clone()));
     }
 
-    for (order, (col, column_id)) in columns.iter().zip(column_ids.iter()).enumerate() {
-        match current_by_name.get(col.name()) {
-            // Existing column kept: its id stays stable. Sync order/nullability
-            // only if they changed (type changes are rejected at begin).
-            Some(&(cur_order, cur_nullable)) => {
-                if cur_order != order as i64 || cur_nullable != col.is_nullable() {
+    for (order, (column, column_id)) in proposed.iter().zip(column_ids).enumerate() {
+        let parent_id = column.parent_index.map(|index| column_ids[index]);
+        match current_by_id.get(column_id) {
+            // Existing column kept: its id stays stable. Sync metadata only if it
+            // changed. A legacy list representation gets a snapshot-bounded row.
+            Some((cur_order, cur_nullable, cur_type)) => {
+                let migrate_type = catalog_column_type_requires_migration(cur_type, column);
+                if migrate_type {
                     tx.execute(
-                        "UPDATE ducklake_column SET column_order = ?, nulls_allowed = ?
-                         WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL",
-                        params![order as i64, col.is_nullable(), table_id, col.name()],
+                        "UPDATE ducklake_column SET end_snapshot = ?
+                         WHERE table_id = ? AND column_id = ? AND end_snapshot IS NULL",
+                        params![snapshot_id, table_id, column_id],
+                    )?;
+                    tx.execute(
+                        "INSERT INTO ducklake_column
+                             (column_id, table_id, column_name, column_type, column_order,
+                              nulls_allowed, parent_column, begin_snapshot)
+                         VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                        params![
+                            column_id,
+                            table_id,
+                            column.name.as_str(),
+                            column.ducklake_type.as_str(),
+                            order as i64,
+                            column.is_nullable,
+                            parent_id,
+                            snapshot_id
+                        ],
+                    )?;
+                } else if *cur_order != order as i64 || *cur_nullable != column.is_nullable {
+                    tx.execute(
+                        "UPDATE ducklake_column
+                         SET column_order = ?, nulls_allowed = ?
+                         WHERE table_id = ? AND column_id = ? AND end_snapshot IS NULL",
+                        params![order as i64, column.is_nullable, table_id, column_id],
                     )?;
                 }
             },
@@ -733,15 +798,17 @@ fn finalize_snapshot(
             None => {
                 tx.execute(
                     "INSERT INTO ducklake_column
-                         (column_id, table_id, column_name, column_type, column_order, nulls_allowed, begin_snapshot)
-                     VALUES (?, ?, ?, ?, ?, ?, ?)",
+                         (column_id, table_id, column_name, column_type, column_order,
+                          nulls_allowed, parent_column, begin_snapshot)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                     params![
                         column_id,
                         table_id,
-                        col.name(),
-                        col.ducklake_type(),
+                        column.name.as_str(),
+                        column.ducklake_type.as_str(),
                         order as i64,
-                        col.is_nullable(),
+                        column.is_nullable,
+                        parent_id,
                         snapshot_id
                     ],
                 )?;
@@ -888,26 +955,31 @@ impl MetadataWriter for DuckdbMetadataWriter {
 
         // Reserve a contiguous column_id block from the monotonic counter and
         // insert with explicit ids, keeping the allocator authoritative.
-        let n = columns.len() as i64;
+        let catalog_columns = catalog_column_defs(columns)?;
+        let n = catalog_columns.len() as i64;
         let last_column_id = reserve_ids(&tx, "next_column_id", n)?;
         let first_column_id = last_column_id - n + 1;
-        let mut column_ids = Vec::with_capacity(columns.len());
-        for (order, col) in columns.iter().enumerate() {
-            let column_id = first_column_id + order as i64;
+        let column_ids = (first_column_id..=last_column_id).collect::<Vec<_>>();
+        for (order, (column, column_id)) in
+            catalog_columns.iter().zip(column_ids.iter()).enumerate()
+        {
+            let parent_id = column.parent_index.map(|index| column_ids[index]);
             tx.execute(
-                "INSERT INTO ducklake_column (column_id, table_id, column_name, column_type, column_order, nulls_allowed, begin_snapshot)
-                 VALUES (?, ?, ?, ?, ?, ?, ?)",
+                "INSERT INTO ducklake_column
+                     (column_id, table_id, column_name, column_type, column_order,
+                      nulls_allowed, parent_column, begin_snapshot)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 params![
                     column_id,
                     table_id,
-                    col.name(),
-                    col.ducklake_type(),
+                    column.name.as_str(),
+                    column.ducklake_type.as_str(),
                     order as i64,
-                    col.is_nullable(),
+                    column.is_nullable,
+                    parent_id,
                     snapshot_id
                 ],
             )?;
-            column_ids.push(column_id);
         }
 
         let table_begin_snapshot: i64 = tx.query_row(
@@ -924,7 +996,7 @@ impl MetadataWriter for DuckdbMetadataWriter {
             )?;
         }
         tx.commit()?;
-        Ok(column_ids)
+        top_level_column_ids(&catalog_columns, &column_ids)
     }
 
     fn register_data_file(
@@ -1222,7 +1294,8 @@ impl MetadataWriter for DuckdbMetadataWriter {
             let column_id: i64 = tx
                 .query_row(
                     "SELECT column_id FROM ducklake_column
-                     WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL",
+                     WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL
+                       AND parent_column IS NULL",
                     params![table_id, name.as_str()],
                     |row| row.get(0),
                 )
@@ -1385,7 +1458,8 @@ impl MetadataWriter for DuckdbMetadataWriter {
             let exists: Option<i64> = tx
                 .query_row(
                     "SELECT column_id FROM ducklake_column
-                     WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL",
+                     WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL
+                       AND parent_column IS NULL",
                     params![table_id, column.as_str()],
                     |row| row.get(0),
                 )
@@ -1612,7 +1686,8 @@ impl MetadataWriter for DuckdbMetadataWriter {
         let tx = conn.transaction()?;
 
         // Reserve the column ids first. These match the staged parquet field ids.
-        let n = columns.len() as i64;
+        let catalog_columns = catalog_column_defs(columns)?;
+        let n = catalog_columns.len() as i64;
         let last_column_id = reserve_ids(&tx, "next_column_id", n)?;
         // Freshly reserved ids. Only a genuinely-new column consumes one below; an
         // existing column keeps its current id, so some may go unused (harmless
@@ -1675,9 +1750,9 @@ impl MetadataWriter for DuckdbMetadataWriter {
         // column's id (column_id == parquet field_id == a column's stable
         // identity). Collected into owned Vec so the statement drops before the
         // commit that follows.
-        let existing_rows: Vec<(String, String, bool, i64)> = {
+        let existing_rows: Vec<(String, String, i64, Option<i64>)> = {
             let mut stmt = tx.prepare(
-                "SELECT column_name, column_type, nulls_allowed, column_id
+                "SELECT column_name, column_type, column_id, parent_column
                  FROM ducklake_column
                  WHERE table_id = ? AND end_snapshot IS NULL
                  ORDER BY column_order",
@@ -1685,39 +1760,41 @@ impl MetadataWriter for DuckdbMetadataWriter {
             let mapped = stmt.query_map(params![table_id], |row| {
                 let name: String = row.get(0)?;
                 let col_type: String = row.get(1)?;
-                let nullable: Option<bool> = row.get(2)?;
-                let cid: i64 = row.get(3)?;
-                Ok((name, col_type, nullable.unwrap_or(true), cid))
+                let cid: i64 = row.get(2)?;
+                let parent_column: Option<i64> = row.get(3)?;
+                Ok((name, col_type, cid, parent_column))
             })?;
             mapped.collect::<std::result::Result<Vec<_>, duckdb::Error>>()?
         };
 
-        let mut existing_columns: Vec<(String, String, bool)> =
-            Vec::with_capacity(existing_rows.len());
-        let mut existing_ids: std::collections::HashMap<String, i64> =
-            std::collections::HashMap::new();
-        for (name, col_type, nullable, cid) in existing_rows {
-            existing_ids.insert(name.clone(), cid);
-            existing_columns.push((name, col_type, nullable));
+        let mut existing_catalog_columns = Vec::with_capacity(existing_rows.len());
+        for (name, ducklake_type, column_id, parent_column) in existing_rows {
+            existing_catalog_columns.push(ExistingCatalogColumn {
+                column_id,
+                name,
+                ducklake_type,
+                parent_column,
+            });
         }
+        let field_ids = assign_column_ids(&catalog_columns, &existing_catalog_columns, &fresh_ids)?;
 
         // Data-write policy: a data write — Replace OR Append — must NOT change a
         // column's type (that is schema evolution, which must go through
         // promote_column_type). Comparison is canonical (int64 ≡ bigint) so an
         // alias-only restatement is a no-op. Append additionally requires a
         // genuinely new column to be nullable. Mirrors the SQLite writer.
-        if !existing_columns.is_empty() {
+        if !existing_catalog_columns.is_empty() {
             use std::collections::HashMap;
-            let existing_map: HashMap<&str, (&str, bool)> = existing_columns
+            let existing_map: HashMap<i64, &ExistingCatalogColumn> = existing_catalog_columns
                 .iter()
-                .map(|(name, col_type, nullable)| (name.as_str(), (col_type.as_str(), *nullable)))
+                .map(|column| (column.column_id, column))
                 .collect();
 
-            for new_col in columns.iter() {
-                if let Some((existing_type, _existing_nullable)) = existing_map.get(new_col.name())
-                {
-                    if !crate::types::types_equal_canonical(existing_type, new_col.ducklake_type())
-                    {
+            for (new_column, column_id) in catalog_columns.iter().zip(&field_ids) {
+                if let Some(existing_column) = existing_map.get(column_id) {
+                    let same_type =
+                        catalog_column_type_equal(&existing_column.ducklake_type, new_column);
+                    if !same_type {
                         return Err(crate::error::DuckLakeError::UnsupportedTypeChange {
                             operation: TypeChangeOperation::DataWrite {
                                 mode: match mode {
@@ -1725,15 +1802,18 @@ impl MetadataWriter for DuckdbMetadataWriter {
                                     WriteMode::Append => TypeChangeWriteMode::Append,
                                 },
                             },
-                            column: new_col.name().to_string(),
-                            from: (*existing_type).to_string(),
-                            to: new_col.ducklake_type().to_string(),
+                            column: new_column.name.clone(),
+                            from: existing_column.ducklake_type.clone(),
+                            to: new_column.ducklake_type.clone(),
                         });
                     }
-                } else if mode == WriteMode::Append && !new_col.is_nullable() {
+                } else if mode == WriteMode::Append
+                    && new_column.parent_index.is_none()
+                    && !new_column.is_nullable
+                {
                     return Err(crate::error::DuckLakeError::InvalidConfig(format!(
                         "Schema evolution error: new column '{}' must be nullable. Adding non-nullable columns is not allowed.",
-                        new_col.name()
+                        new_column.name
                     )));
                 }
             }
@@ -1744,12 +1824,6 @@ impl MetadataWriter for DuckdbMetadataWriter {
         // These are baked into the staged parquet's field_id metadata, so they
         // must equal the ids finalize_snapshot commits. The column rows are
         // written at the commit point (not here).
-        let column_ids: Vec<i64> = columns
-            .iter()
-            .zip(fresh_ids.iter())
-            .map(|(col, &fresh)| existing_ids.get(col.name()).copied().unwrap_or(fresh))
-            .collect();
-
         // Only the idempotent get-or-create schema/table rows are committed here;
         // they carry begin_snapshot = the reserved id and stay invisible until the
         // snapshot publishes, since schema/table reads ARE snapshot-scoped.
@@ -1760,7 +1834,8 @@ impl MetadataWriter for DuckdbMetadataWriter {
             base_snapshot_id,
             schema_id,
             table_id,
-            column_ids,
+            column_ids: top_level_column_ids(&catalog_columns, &field_ids)?,
+            field_ids,
         })
     }
 }
@@ -1770,7 +1845,94 @@ mod tests {
     use super::*;
     use crate::DuckdbMetadataProvider;
     use crate::metadata_provider::MetadataProvider;
+    use arrow::datatypes::{DataType, Field};
+    use std::sync::Arc;
     use tempfile::TempDir;
+
+    #[test]
+    fn duckdb_writer_persists_recursive_columns() {
+        let temp = TempDir::new().unwrap();
+        let db_path = temp.path().join("nested.ducklake");
+        let writer = DuckdbMetadataWriter::new_with_init(db_path.to_str().unwrap()).unwrap();
+        let levels = DataType::List(Arc::new(Field::new(
+            "item",
+            DataType::Struct(
+                vec![
+                    Arc::new(Field::new("price", DataType::Decimal128(38, 16), false)),
+                    Arc::new(Field::new("count", DataType::UInt32, false)),
+                ]
+                .into(),
+            ),
+            false,
+        )));
+        let columns = vec![ColumnDef::from_arrow("bids", &levels, false).unwrap()];
+
+        let setup = writer
+            .begin_write_transaction("main", "depths", &columns, WriteMode::Replace)
+            .unwrap();
+        assert_eq!(setup.column_ids, vec![setup.field_ids[0]]);
+        assert_eq!(setup.field_ids.len(), 4);
+        writer
+            .register_data_file(
+                setup.table_id,
+                "main",
+                "depths",
+                setup.snapshot_id,
+                &DataFileInfo::new("depths.parquet", 1, 1),
+                WriteMode::Replace,
+                setup.base_snapshot_id,
+                &columns,
+                &setup.field_ids,
+            )
+            .unwrap();
+
+        let mut connection = writer.connection();
+        let transaction = connection.transaction().unwrap();
+        let mut statement = transaction
+            .prepare(
+                "SELECT column_id, column_name, column_type, parent_column
+                 FROM ducklake_column
+                 WHERE table_id = ? AND end_snapshot IS NULL
+                 ORDER BY column_order",
+            )
+            .unwrap();
+        let rows = statement
+            .query_map(params![setup.table_id], |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, Option<i64>>(3)?,
+                ))
+            })
+            .unwrap()
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                (setup.field_ids[0], "bids".into(), "list".into(), None),
+                (
+                    setup.field_ids[1],
+                    "element".into(),
+                    "struct".into(),
+                    Some(setup.field_ids[0]),
+                ),
+                (
+                    setup.field_ids[2],
+                    "price".into(),
+                    "decimal(38, 16)".into(),
+                    Some(setup.field_ids[1]),
+                ),
+                (
+                    setup.field_ids[3],
+                    "count".into(),
+                    "uint32".into(),
+                    Some(setup.field_ids[1]),
+                ),
+            ]
+        );
+    }
 
     /// End-to-end round trip: write a small table through the real write path
     /// (begin_write_transaction + register_data_file), then read every catalog

--- a/src/metadata_writer_mysql.rs
+++ b/src/metadata_writer_mysql.rs
@@ -34,9 +34,11 @@ use crate::Result;
 use crate::error::{TypeChangeOperation, TypeChangeWriteMode};
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
-    ColumnDef, ColumnStat, CommitIds, DataFileInfo, MetadataWriter, SnapshotCommitMetadata,
-    WriteMode, WriteSetupResult, columns_differ, quote_snapshot_name, quote_snapshot_table,
-    table_write_changes, validate_name,
+    ColumnDef, ColumnStat, CommitIds, DataFileInfo, ExistingCatalogColumn, MetadataWriter,
+    SnapshotCommitMetadata, WriteMode, WriteSetupResult, assign_column_ids, catalog_column_defs,
+    catalog_column_type_equal, catalog_column_type_requires_migration, catalog_columns_differ,
+    quote_snapshot_name, quote_snapshot_table, table_write_changes, top_level_column_ids,
+    validate_name,
 };
 use crate::partition::PartitionTransform;
 use sqlx::Row;
@@ -650,6 +652,8 @@ async fn recompute_table_column_stats(
     column_ids: &[i64],
 ) -> Result<()> {
     use crate::stats_encode::{FileColumnStat, aggregate_global_column_stats};
+    let catalog_columns = catalog_column_defs(columns)?;
+    let column_ids = top_level_column_ids(&catalog_columns, column_ids)?;
 
     let live_file_count: i64 = sqlx::query(
         "SELECT COUNT(*) FROM ducklake_data_file WHERE table_id = ? AND end_snapshot IS NULL",
@@ -728,8 +732,16 @@ async fn finalize_snapshot(
     // live columns ordered by `column_order`; an empty set means a brand-new table
     // (the creating write is DDL). Mirrors upstream `SchemaChangesMade()`.
     use std::collections::{HashMap, HashSet};
+    let proposed = catalog_column_defs(columns)?;
+    if proposed.len() != column_ids.len() {
+        return Err(crate::DuckLakeError::InvalidConfig(format!(
+            "column_ids has {} entries for {} catalog column nodes",
+            column_ids.len(),
+            proposed.len()
+        )));
+    }
     let current = sqlx::query(
-        "SELECT column_name, column_type, column_order, nulls_allowed
+        "SELECT column_id, column_name, column_type, column_order, nulls_allowed, parent_column
          FROM ducklake_column
          WHERE table_id = ? AND end_snapshot IS NULL
          ORDER BY column_order",
@@ -738,16 +750,40 @@ async fn finalize_snapshot(
     .fetch_all(&mut **tx)
     .await?;
 
-    let mut existing: Vec<(String, String, bool)> = Vec::with_capacity(current.len());
-    for row in &current {
-        let name: String = row.try_get("column_name")?;
-        let ty: String = row.try_get("column_type")?;
-        let nullable: bool = row
-            .try_get::<Option<bool>, _>("nulls_allowed")?
-            .unwrap_or(true);
-        existing.push((name, ty, nullable));
+    let existing_catalog_columns = current
+        .iter()
+        .map(|row| {
+            Ok::<_, sqlx::Error>(ExistingCatalogColumn {
+                column_id: row.try_get("column_id")?,
+                name: row.try_get("column_name")?,
+                ducklake_type: row.try_get("column_type")?,
+                parent_column: row.try_get("parent_column")?,
+            })
+        })
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    let existing_nullability = current
+        .iter()
+        .map(|row| {
+            Ok::<_, sqlx::Error>(
+                row.try_get::<Option<bool>, _>("nulls_allowed")?
+                    .unwrap_or(true),
+            )
+        })
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    let committed_ids = assign_column_ids(&proposed, &existing_catalog_columns, column_ids)?;
+    if committed_ids != column_ids {
+        return Err(crate::DuckLakeError::Conflict(
+            "table columns were created concurrently with different field ids; retry the write"
+                .to_string(),
+        ));
     }
-    let is_ddl = existing.is_empty() || columns_differ(&existing, columns);
+    let is_ddl = current.is_empty()
+        || catalog_columns_differ(
+            &existing_catalog_columns,
+            &existing_nullability,
+            &proposed,
+            column_ids,
+        );
     if is_ddl {
         // A DDL commit bumps the per-catalog schema_version (the insert above only
         // carried it forward). A pure data write keeps the carried value.
@@ -757,43 +793,70 @@ async fn finalize_snapshot(
     // Reconcile the column generation SURGICALLY so each column keeps a stable
     // column_id (== parquet field_id) across writes: end only removed columns,
     // insert only new ones, and leave unchanged columns (and their ids) in place.
-    let new_names: HashSet<&str> = columns.iter().map(|c| c.name()).collect();
-    let mut current_by_name: HashMap<String, (i64, bool)> = HashMap::new();
+    let proposed_ids = column_ids.iter().copied().collect::<HashSet<_>>();
+    let mut current_by_id: HashMap<i64, (i64, bool, String)> = HashMap::new();
     for row in &current {
-        let name: String = row.try_get("column_name")?;
+        let column_id: i64 = row.try_get("column_id")?;
         let order: i64 = row.try_get("column_order")?;
         let nullable: bool = row
             .try_get::<Option<bool>, _>("nulls_allowed")?
             .unwrap_or(true);
-        if !new_names.contains(name.as_str()) {
-            // Column dropped in the new schema: end its generation.
+        let ducklake_type: String = row.try_get("column_type")?;
+        if !proposed_ids.contains(&column_id) {
             sqlx::query(
                 "UPDATE ducklake_column SET end_snapshot = ?
-                 WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL",
+                 WHERE table_id = ? AND column_id = ? AND end_snapshot IS NULL",
             )
             .bind(snapshot_id)
             .bind(table_id)
-            .bind(&name)
+            .bind(column_id)
             .execute(&mut **tx)
             .await?;
         }
-        current_by_name.insert(name, (order, nullable));
+        current_by_id.insert(column_id, (order, nullable, ducklake_type));
     }
 
-    for (order, (col, column_id)) in columns.iter().zip(column_ids.iter()).enumerate() {
-        match current_by_name.get(col.name()) {
-            // Existing column kept: its id stays stable. Sync order/nullability
-            // only if they changed (type changes are rejected at begin).
-            Some(&(cur_order, cur_nullable)) => {
-                if cur_order != order as i64 || cur_nullable != col.is_nullable() {
+    for (order, (column, column_id)) in proposed.iter().zip(column_ids).enumerate() {
+        let parent_id = column.parent_index.map(|index| column_ids[index]);
+        match current_by_id.get(column_id) {
+            Some((cur_order, cur_nullable, cur_type)) => {
+                let migrate_type = catalog_column_type_requires_migration(cur_type, column);
+                if migrate_type {
                     sqlx::query(
-                        "UPDATE ducklake_column SET column_order = ?, nulls_allowed = ?
-                         WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL",
+                        "UPDATE ducklake_column SET end_snapshot = ?
+                         WHERE table_id = ? AND column_id = ? AND end_snapshot IS NULL",
+                    )
+                    .bind(snapshot_id)
+                    .bind(table_id)
+                    .bind(column_id)
+                    .execute(&mut **tx)
+                    .await?;
+                    sqlx::query(
+                        "INSERT INTO ducklake_column
+                             (column_id, table_id, column_name, column_type, column_order,
+                              nulls_allowed, parent_column, begin_snapshot)
+                         VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    )
+                    .bind(column_id)
+                    .bind(table_id)
+                    .bind(&column.name)
+                    .bind(&column.ducklake_type)
+                    .bind(order as i64)
+                    .bind(column.is_nullable)
+                    .bind(parent_id)
+                    .bind(snapshot_id)
+                    .execute(&mut **tx)
+                    .await?;
+                } else if *cur_order != order as i64 || *cur_nullable != column.is_nullable {
+                    sqlx::query(
+                        "UPDATE ducklake_column
+                         SET column_order = ?, nulls_allowed = ?
+                         WHERE table_id = ? AND column_id = ? AND end_snapshot IS NULL",
                     )
                     .bind(order as i64)
-                    .bind(col.is_nullable())
+                    .bind(column.is_nullable)
                     .bind(table_id)
-                    .bind(col.name())
+                    .bind(column_id)
                     .execute(&mut **tx)
                     .await?;
                 }
@@ -802,15 +865,17 @@ async fn finalize_snapshot(
             None => {
                 sqlx::query(
                     "INSERT INTO ducklake_column
-                         (column_id, table_id, column_name, column_type, column_order, nulls_allowed, begin_snapshot)
-                     VALUES (?, ?, ?, ?, ?, ?, ?)",
+                         (column_id, table_id, column_name, column_type, column_order,
+                          nulls_allowed, parent_column, begin_snapshot)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 )
                 .bind(column_id)
                 .bind(table_id)
-                .bind(col.name())
-                .bind(col.ducklake_type())
+                .bind(&column.name)
+                .bind(&column.ducklake_type)
                 .bind(order as i64)
-                .bind(col.is_nullable())
+                .bind(column.is_nullable)
+                .bind(parent_id)
                 .bind(snapshot_id)
                 .execute(&mut **tx)
                 .await?;
@@ -982,26 +1047,31 @@ impl MetadataWriter for MySqlMetadataWriter {
 
             // Reserve a contiguous column_id block from the monotonic counter and
             // insert with explicit ids, keeping the allocator authoritative.
-            let n = columns.len() as i64;
+            let catalog_columns = catalog_column_defs(columns)?;
+            let n = catalog_columns.len() as i64;
             let last_column_id = reserve_ids(&mut tx, "next_column_id", n).await?;
             let first_column_id = last_column_id - n + 1;
-            let mut column_ids = Vec::with_capacity(columns.len());
-            for (order, col) in columns.iter().enumerate() {
-                let column_id = first_column_id + order as i64;
+            let field_ids = (first_column_id..=last_column_id).collect::<Vec<_>>();
+            for (order, (column, column_id)) in
+                catalog_columns.iter().zip(field_ids.iter()).enumerate()
+            {
+                let parent_id = column.parent_index.map(|index| field_ids[index]);
                 sqlx::query(
-                    "INSERT INTO ducklake_column (column_id, table_id, column_name, column_type, column_order, nulls_allowed, begin_snapshot)
-                     VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    "INSERT INTO ducklake_column
+                         (column_id, table_id, column_name, column_type, column_order,
+                          nulls_allowed, parent_column, begin_snapshot)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 )
                 .bind(column_id)
                 .bind(table_id)
-                .bind(col.name())
-                .bind(col.ducklake_type())
+                .bind(&column.name)
+                .bind(&column.ducklake_type)
                 .bind(order as i64)
-                .bind(col.is_nullable())
+                .bind(column.is_nullable)
+                .bind(parent_id)
                 .bind(snapshot_id)
                 .execute(&mut *tx)
                 .await?;
-                column_ids.push(column_id);
             }
 
             let table_begin_snapshot: i64 =
@@ -1019,7 +1089,7 @@ impl MetadataWriter for MySqlMetadataWriter {
                 .await?;
             }
             tx.commit().await?;
-            Ok(column_ids)
+            top_level_column_ids(&catalog_columns, &field_ids)
         })
     }
 
@@ -1349,7 +1419,8 @@ impl MetadataWriter for MySqlMetadataWriter {
             for (name, _transform) in columns {
                 let column_id: i64 = sqlx::query_scalar(
                     "SELECT column_id FROM ducklake_column
-                     WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL",
+                     WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL
+                       AND parent_column IS NULL",
                 )
                 .bind(table_id)
                 .bind(name)
@@ -1534,7 +1605,8 @@ impl MetadataWriter for MySqlMetadataWriter {
                 })?;
                 let exists: Option<i64> = sqlx::query_scalar(
                     "SELECT column_id FROM ducklake_column
-                     WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL",
+                     WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL
+                       AND parent_column IS NULL",
                 )
                 .bind(table_id)
                 .bind(&column)
@@ -1834,7 +1906,8 @@ impl MetadataWriter for MySqlMetadataWriter {
 
             // Reserve the column ids first so the counter UPDATE takes the write
             // lock up front. These ids match the staged parquet field ids.
-            let n = columns.len() as i64;
+            let catalog_columns = catalog_column_defs(columns)?;
+            let n = catalog_columns.len() as i64;
             let last_column_id = reserve_ids(&mut tx, "next_column_id", n).await?;
             // Freshly reserved ids. Only a genuinely-new column actually consumes
             // one below; an existing column keeps its current id, so some of these
@@ -1910,7 +1983,7 @@ impl MetadataWriter for MySqlMetadataWriter {
             // unchanged column must keep its id, or files already written would
             // read back as NULL).
             let rows = sqlx::query(
-                "SELECT column_name, column_type, nulls_allowed, column_id
+                "SELECT column_name, column_type, column_id, parent_column
                  FROM ducklake_column
                  WHERE table_id = ? AND end_snapshot IS NULL
                  ORDER BY column_order",
@@ -1919,17 +1992,21 @@ impl MetadataWriter for MySqlMetadataWriter {
             .fetch_all(&mut *tx)
             .await?;
 
-            let mut existing_columns: Vec<(String, String, bool)> = Vec::with_capacity(rows.len());
-            let mut existing_ids: std::collections::HashMap<String, i64> =
-                std::collections::HashMap::new();
+            let mut existing_catalog_columns = Vec::with_capacity(rows.len());
             for row in rows {
                 let name: String = row.try_get(0)?;
-                let col_type: String = row.try_get(1)?;
-                let nullable: bool = row.try_get::<Option<bool>, _>(2)?.unwrap_or(true);
-                let cid: i64 = row.try_get(3)?;
-                existing_ids.insert(name.clone(), cid);
-                existing_columns.push((name, col_type, nullable));
+                let ducklake_type: String = row.try_get(1)?;
+                let column_id: i64 = row.try_get(2)?;
+                let parent_column: Option<i64> = row.try_get(3)?;
+                existing_catalog_columns.push(ExistingCatalogColumn {
+                    column_id,
+                    name,
+                    ducklake_type,
+                    parent_column,
+                });
             }
+            let field_ids =
+                assign_column_ids(&catalog_columns, &existing_catalog_columns, &fresh_ids)?;
 
             // Data-write policy (§5): a data write — Replace OR Append — must NOT
             // change a column's type (that is schema evolution and must go through
@@ -1937,24 +2014,19 @@ impl MetadataWriter for MySqlMetadataWriter {
             // comparison is canonical (`int64` ≡ `bigint`) so an alias-only
             // restatement is a no-op. Append additionally requires a genuinely new
             // column to be nullable.
-            if !existing_columns.is_empty() {
+            if !existing_catalog_columns.is_empty() {
                 use std::collections::HashMap;
 
-                let existing_map: HashMap<&str, (&str, bool)> = existing_columns
+                let existing_map: HashMap<i64, &ExistingCatalogColumn> = existing_catalog_columns
                     .iter()
-                    .map(|(name, col_type, nullable)| {
-                        (name.as_str(), (col_type.as_str(), *nullable))
-                    })
+                    .map(|column| (column.column_id, column))
                     .collect();
 
-                for new_col in columns.iter() {
-                    if let Some((existing_type, _existing_nullable)) =
-                        existing_map.get(new_col.name())
-                    {
-                        if !crate::types::types_equal_canonical(
-                            existing_type,
-                            new_col.ducklake_type(),
-                        ) {
+                for (new_column, column_id) in catalog_columns.iter().zip(&field_ids) {
+                    if let Some(existing_column) = existing_map.get(column_id) {
+                        let same_type =
+                            catalog_column_type_equal(&existing_column.ducklake_type, new_column);
+                        if !same_type {
                             return Err(crate::error::DuckLakeError::UnsupportedTypeChange {
                                 operation: TypeChangeOperation::DataWrite {
                                     mode: match mode {
@@ -1962,15 +2034,18 @@ impl MetadataWriter for MySqlMetadataWriter {
                                         WriteMode::Append => TypeChangeWriteMode::Append,
                                     },
                                 },
-                                column: new_col.name().to_string(),
-                                from: (*existing_type).to_string(),
-                                to: new_col.ducklake_type().to_string(),
+                                column: new_column.name.clone(),
+                                from: existing_column.ducklake_type.clone(),
+                                to: new_column.ducklake_type.clone(),
                             });
                         }
-                    } else if mode == WriteMode::Append && !new_col.is_nullable() {
+                    } else if mode == WriteMode::Append
+                        && new_column.parent_index.is_none()
+                        && !new_column.is_nullable
+                    {
                         return Err(crate::error::DuckLakeError::InvalidConfig(format!(
                             "Schema evolution error: new column '{}' must be nullable. Adding non-nullable columns is not allowed.",
-                            new_col.name()
+                            new_column.name
                         )));
                     }
                 }
@@ -1983,12 +2058,6 @@ impl MetadataWriter for MySqlMetadataWriter {
             // themselves are written at the commit point (not here): the read path
             // resolves columns by `end_snapshot IS NULL` only, so inserting at begin
             // would leak the new generation to concurrent reads.
-            let column_ids: Vec<i64> = columns
-                .iter()
-                .zip(fresh_ids.iter())
-                .map(|(col, &fresh)| existing_ids.get(col.name()).copied().unwrap_or(fresh))
-                .collect();
-
             // No snapshot row, no column rows, and no Replace retirement are written
             // here — all are deferred to the atomic commit so the head never
             // resolves to an incomplete snapshot. This TX commits only the
@@ -2002,7 +2071,8 @@ impl MetadataWriter for MySqlMetadataWriter {
                 base_snapshot_id,
                 schema_id,
                 table_id,
-                column_ids,
+                column_ids: top_level_column_ids(&catalog_columns, &field_ids)?,
+                field_ids,
             })
         })
     }

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -14,8 +14,10 @@ use crate::error::{TypeChangeOperation, TypeChangeWriteMode};
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
     ColumnDef, ColumnStat, CommitIds, DataFileInfo, DeleteFileEntry, DeleteFileInfo,
-    MetadataWriter, SnapshotCommitMetadata, WriteMode, WriteSetupResult, columns_differ,
-    table_write_changes, validate_delete_entries, validate_name,
+    ExistingCatalogColumn, MetadataWriter, SnapshotCommitMetadata, WriteMode, WriteSetupResult,
+    assign_column_ids, catalog_column_defs, catalog_column_type_equal,
+    catalog_column_type_requires_migration, catalog_columns_differ, table_write_changes,
+    top_level_column_ids, validate_delete_entries, validate_name,
 };
 use crate::partition::PartitionTransform;
 use sqlx::AssertSqlSafe;
@@ -780,7 +782,7 @@ async fn live_columns_for_stats(
     for row in sqlx::query(
         "SELECT column_id, column_name, column_type
          FROM ducklake_column
-         WHERE table_id = $1 AND end_snapshot IS NULL
+         WHERE table_id = $1 AND end_snapshot IS NULL AND parent_column IS NULL
          ORDER BY column_order",
     )
     .bind(table_id)
@@ -796,6 +798,8 @@ async fn live_columns_for_stats(
         // irrelevant here — recompute_table_column_stats only reads the type.
         columns.push(ColumnDef {
             name,
+            data_type: crate::types::ducklake_to_arrow_type(&ducklake_type)
+                .unwrap_or(arrow::datatypes::DataType::Null),
             ducklake_type,
             is_nullable: true,
         });
@@ -813,6 +817,8 @@ async fn recompute_table_column_stats(
     column_ids: &[i64],
 ) -> Result<()> {
     use crate::stats_encode::{FileColumnStat, aggregate_global_column_stats};
+    let catalog_columns = catalog_column_defs(columns)?;
+    let column_ids = top_level_column_ids(&catalog_columns, column_ids)?;
 
     let live_file_count: i64 = sqlx::query(
         "SELECT COUNT(*) FROM ducklake_data_file WHERE table_id = $1 AND end_snapshot IS NULL",
@@ -998,8 +1004,16 @@ async fn finalize_snapshot(
 
     // 6. Read the columns live AT COMMIT (under the lock) to classify DDL vs DML
     //    and drive the surgical column update below.
+    let proposed = catalog_column_defs(columns)?;
+    if proposed.len() != column_ids.len() {
+        return Err(crate::DuckLakeError::InvalidConfig(format!(
+            "column_ids has {} entries for {} catalog column nodes",
+            column_ids.len(),
+            proposed.len()
+        )));
+    }
     let existing_column_rows = sqlx::query(
-        "SELECT column_name, column_type, nulls_allowed, column_order, column_id
+        "SELECT column_name, column_type, nulls_allowed, column_order, column_id, parent_column
          FROM ducklake_column
          WHERE table_id = $1 AND end_snapshot IS NULL
          ORDER BY column_order",
@@ -1007,31 +1021,50 @@ async fn finalize_snapshot(
     .bind(table_id)
     .fetch_all(&mut **tx)
     .await?;
-    let existing_columns: Vec<(String, String, bool)> = existing_column_rows
+    let existing_catalog_columns = existing_column_rows
         .iter()
         .map(|row| {
-            let name: String = row.try_get(0)?;
-            let col_type: String = row.try_get(1)?;
-            let nullable: bool = row.try_get::<Option<bool>, _>(2)?.unwrap_or(true);
-            Ok::<_, sqlx::Error>((name, col_type, nullable))
+            Ok::<_, sqlx::Error>(ExistingCatalogColumn {
+                column_id: row.try_get(4)?,
+                name: row.try_get(0)?,
+                ducklake_type: row.try_get(1)?,
+                parent_column: row.try_get(5)?,
+            })
         })
-        .collect::<std::result::Result<_, _>>()?;
-    // name -> (column_id, column_order, nullable) for the surgical update. The
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    let existing_nullability = existing_column_rows
+        .iter()
+        .map(|row| Ok::<_, sqlx::Error>(row.try_get::<Option<bool>, _>(2)?.unwrap_or(true)))
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    let committed_ids = assign_column_ids(&proposed, &existing_catalog_columns, column_ids)?;
+    if committed_ids != column_ids {
+        return Err(crate::DuckLakeError::Conflict(
+            "table columns were created concurrently with different field ids; retry the write"
+                .to_string(),
+        ));
+    }
+    // column_id -> (column_order, nullable, type) for the surgical update. The
     // column_id is used to detect field-id drift: if the caller's staged parquet
     // baked a column_id (at begin) that no longer matches the committed column
     // (e.g. an Append whose table was created by a concurrent writer with
     // different ids), the file's field-ids would resolve to NULL — so we abort.
-    let mut current_by_name: std::collections::HashMap<String, (i64, i64, bool)> =
+    let mut current_by_id: std::collections::HashMap<i64, (i64, bool, String)> =
         std::collections::HashMap::new();
     for row in &existing_column_rows {
-        let name: String = row.try_get(0)?;
         let nullable: bool = row.try_get::<Option<bool>, _>(2)?.unwrap_or(true);
         let order: i64 = row.try_get(3)?;
         let id: i64 = row.try_get(4)?;
-        current_by_name.insert(name, (id, order, nullable));
+        let ducklake_type: String = row.try_get(1)?;
+        current_by_id.insert(id, (order, nullable, ducklake_type));
     }
 
-    let is_ddl = table_was_created || columns_differ(&existing_columns, columns);
+    let is_ddl = table_was_created
+        || catalog_columns_differ(
+            &existing_catalog_columns,
+            &existing_nullability,
+            &proposed,
+            column_ids,
+        );
 
     // No `< S` window: ids are commit-ordered, so MAX over mapped predecessors is
     // the immediately-preceding version. DDL bumps; DML carries forward (with a v1
@@ -1069,23 +1102,24 @@ async fn finalize_snapshot(
     //    not depend on a column re-mint — see the data-file/column scan above.)
     {
         use std::collections::HashSet;
-        let new_names: HashSet<&str> = columns.iter().map(|c| c.name.as_str()).collect();
-        for name in current_by_name.keys() {
-            if !new_names.contains(name.as_str()) {
+        let proposed_ids = column_ids.iter().copied().collect::<HashSet<_>>();
+        for column_id in current_by_id.keys() {
+            if !proposed_ids.contains(column_id) {
                 sqlx::query(
                     "UPDATE ducklake_column SET end_snapshot = $1
-                     WHERE table_id = $2 AND column_name = $3 AND end_snapshot IS NULL",
+                     WHERE table_id = $2 AND column_id = $3 AND end_snapshot IS NULL",
                 )
                 .bind(snapshot_id)
                 .bind(table_id)
-                .bind(name)
+                .bind(column_id)
                 .execute(&mut **tx)
                 .await?;
             }
         }
-        for (order, (col, column_id)) in columns.iter().zip(column_ids.iter()).enumerate() {
-            match current_by_name.get(&col.name) {
-                Some(&(cur_id, cur_order, cur_nullable)) => {
+        for (order, (column, column_id)) in proposed.iter().zip(column_ids).enumerate() {
+            let parent_id = column.parent_index.map(|index| column_ids[index]);
+            match current_by_id.get(column_id) {
+                Some((cur_order, cur_nullable, cur_type)) => {
                     // Field-id drift: the staged parquet baked `*column_id` for this
                     // column at begin, but the committed column now has a different
                     // id (a concurrent writer created the table/column with other
@@ -1094,23 +1128,44 @@ async fn finalize_snapshot(
                     // the caller retries against the now-committed schema. (Append
                     // is otherwise not conflict-checked; this guards correctness,
                     // not isolation.)
-                    if *column_id != cur_id {
-                        return Err(crate::DuckLakeError::Conflict(format!(
-                            "column '{}' of table {table_id} was created concurrently with a \
-                             different field id ({cur_id}, staged {column_id}); aborting to avoid \
-                             a NULL-filled read (retry the write)",
-                            col.name
-                        )));
-                    }
-                    if cur_order != order as i64 || cur_nullable != col.is_nullable {
+                    let migrate_type = catalog_column_type_requires_migration(cur_type, column);
+                    if migrate_type {
                         sqlx::query(
-                            "UPDATE ducklake_column SET column_order = $1, nulls_allowed = $2
-                             WHERE table_id = $3 AND column_name = $4 AND end_snapshot IS NULL",
+                            "UPDATE ducklake_column SET end_snapshot = $1
+                             WHERE table_id = $2 AND column_id = $3 AND end_snapshot IS NULL",
+                        )
+                        .bind(snapshot_id)
+                        .bind(table_id)
+                        .bind(column_id)
+                        .execute(&mut **tx)
+                        .await?;
+                        sqlx::query(
+                            "INSERT INTO ducklake_column
+                                 (column_id, table_id, column_name, column_type, column_order,
+                                  nulls_allowed, parent_column, begin_snapshot)
+                             OVERRIDING SYSTEM VALUE
+                             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+                        )
+                        .bind(column_id)
+                        .bind(table_id)
+                        .bind(&column.name)
+                        .bind(&column.ducklake_type)
+                        .bind(order as i64)
+                        .bind(column.is_nullable)
+                        .bind(parent_id)
+                        .bind(snapshot_id)
+                        .execute(&mut **tx)
+                        .await?;
+                    } else if *cur_order != order as i64 || *cur_nullable != column.is_nullable {
+                        sqlx::query(
+                            "UPDATE ducklake_column
+                             SET column_order = $1, nulls_allowed = $2
+                             WHERE table_id = $3 AND column_id = $4 AND end_snapshot IS NULL",
                         )
                         .bind(order as i64)
-                        .bind(col.is_nullable)
+                        .bind(column.is_nullable)
                         .bind(table_id)
-                        .bind(&col.name)
+                        .bind(column_id)
                         .execute(&mut **tx)
                         .await?;
                     }
@@ -1119,16 +1174,17 @@ async fn finalize_snapshot(
                     sqlx::query(
                         "INSERT INTO ducklake_column
                              (column_id, table_id, column_name, column_type, column_order,
-                              nulls_allowed, begin_snapshot)
+                              nulls_allowed, parent_column, begin_snapshot)
                          OVERRIDING SYSTEM VALUE
-                         VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
                     )
                     .bind(column_id)
                     .bind(table_id)
-                    .bind(&col.name)
-                    .bind(&col.ducklake_type)
+                    .bind(&column.name)
+                    .bind(&column.ducklake_type)
                     .bind(order as i64)
-                    .bind(col.is_nullable)
+                    .bind(column.is_nullable)
+                    .bind(parent_id)
                     .bind(snapshot_id)
                     .execute(&mut **tx)
                     .await?;
@@ -1271,9 +1327,10 @@ impl MetadataWriter for PostgresMetadataWriter {
 
             // Live version of the column.
             let row = sqlx::query(
-                "SELECT column_id, column_type, column_order, nulls_allowed
+                "SELECT column_id, column_type, column_order, nulls_allowed, parent_column
                  FROM ducklake_column
-                 WHERE table_id = $1 AND column_name = $2 AND end_snapshot IS NULL",
+                 WHERE table_id = $1 AND column_name = $2 AND end_snapshot IS NULL
+                   AND parent_column IS NULL",
             )
             .bind(table_id)
             .bind(column_name)
@@ -1290,6 +1347,7 @@ impl MetadataWriter for PostgresMetadataWriter {
             let nulls_allowed: bool = row
                 .try_get::<Option<bool>, _>("nulls_allowed")?
                 .unwrap_or(true);
+            let parent_column: Option<i64> = row.try_get("parent_column")?;
 
             // No-op / not-a-widening guards (canonical first so an alias-only
             // restatement is "no change", not attempted).
@@ -1373,9 +1431,9 @@ impl MetadataWriter for PostgresMetadataWriter {
             .await?;
             sqlx::query(
                 "INSERT INTO ducklake_column
-                     (column_id, table_id, column_name, column_type, column_order, nulls_allowed, begin_snapshot)
+                     (column_id, table_id, column_name, column_type, column_order, nulls_allowed, begin_snapshot, parent_column)
                  OVERRIDING SYSTEM VALUE
-                 VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
             )
             .bind(column_id)
             .bind(table_id)
@@ -1384,6 +1442,7 @@ impl MetadataWriter for PostgresMetadataWriter {
             .bind(column_order)
             .bind(nulls_allowed)
             .bind(snapshot_id)
+            .bind(parent_column)
             .execute(&mut *tx)
             .await?;
 
@@ -1547,17 +1606,22 @@ impl MetadataWriter for PostgresMetadataWriter {
             .execute(&mut *tx)
             .await?;
 
-            let mut column_ids = Vec::with_capacity(columns.len());
-            for (order, col) in columns.iter().enumerate() {
+            let catalog_columns = catalog_column_defs(columns)?;
+            let mut column_ids = Vec::with_capacity(catalog_columns.len());
+            for (order, column) in catalog_columns.iter().enumerate() {
+                let parent_id = column.parent_index.map(|index| column_ids[index]);
                 let row = sqlx::query(
-                    "INSERT INTO ducklake_column (table_id, column_name, column_type, column_order, nulls_allowed, begin_snapshot)
-                     VALUES ($1, $2, $3, $4, $5, $6) RETURNING column_id",
+                    "INSERT INTO ducklake_column
+                         (table_id, column_name, column_type, column_order, nulls_allowed,
+                          parent_column, begin_snapshot)
+                     VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING column_id",
                 )
                 .bind(table_id)
-                .bind(&col.name)
-                .bind(&col.ducklake_type)
+                .bind(&column.name)
+                .bind(&column.ducklake_type)
                 .bind(order as i64)
-                .bind(col.is_nullable)
+                .bind(column.is_nullable)
+                .bind(parent_id)
                 .bind(snapshot_id)
                 .fetch_one(&mut *tx)
                 .await?;
@@ -1574,7 +1638,7 @@ impl MetadataWriter for PostgresMetadataWriter {
                 .await?;
             }
             tx.commit().await?;
-            Ok(column_ids)
+            top_level_column_ids(&catalog_columns, &column_ids)
         })
     }
 
@@ -1935,7 +1999,8 @@ impl MetadataWriter for PostgresMetadataWriter {
             for (name, _transform) in columns {
                 let column_id: i64 = sqlx::query_scalar(
                     "SELECT column_id FROM ducklake_column
-                     WHERE table_id = $1 AND column_name = $2 AND end_snapshot IS NULL",
+                     WHERE table_id = $1 AND column_name = $2 AND end_snapshot IS NULL
+                       AND parent_column IS NULL",
                 )
                 .bind(table_id)
                 .bind(name)
@@ -2213,7 +2278,8 @@ impl MetadataWriter for PostgresMetadataWriter {
                 })?;
                 let exists: Option<i64> = sqlx::query_scalar(
                     "SELECT column_id FROM ducklake_column
-                     WHERE table_id = $1 AND column_name = $2 AND end_snapshot IS NULL",
+                     WHERE table_id = $1 AND column_name = $2 AND end_snapshot IS NULL
+                       AND parent_column IS NULL",
                 )
                 .bind(table_id)
                 .bind(&column)
@@ -2339,11 +2405,12 @@ impl MetadataWriter for PostgresMetadataWriter {
                 "register_existing_data_file requires at least one column".to_string(),
             ));
         }
-        if column_ids.len() != columns.len() {
+        let catalog_column_count = catalog_column_defs(columns)?.len();
+        if column_ids.len() != catalog_column_count {
             return Err(crate::DuckLakeError::InvalidConfig(format!(
-                "register_existing_data_file: column_ids (len {}) must be 1:1 with columns (len {})",
+                "register_existing_data_file: column_ids (len {}) must match catalog column nodes (len {})",
                 column_ids.len(),
-                columns.len()
+                catalog_column_count
             )));
         }
         block_on(async {
@@ -4052,7 +4119,7 @@ impl MetadataWriter for PostgresMetadataWriter {
             // keeps its column_id (== parquet field_id), so an already-written
             // file's field-ids stay valid.
             let rows = sqlx::query(
-                "SELECT column_name, column_type, nulls_allowed, column_id
+                "SELECT column_name, column_type, column_id, parent_column
                  FROM ducklake_column
                  WHERE table_id = $1 AND end_snapshot IS NULL
                  ORDER BY column_order",
@@ -4060,17 +4127,30 @@ impl MetadataWriter for PostgresMetadataWriter {
             .bind(table_id)
             .fetch_all(&mut *tx)
             .await?;
-            let mut existing_columns: Vec<(String, String, bool)> = Vec::with_capacity(rows.len());
-            let mut existing_ids: std::collections::HashMap<String, i64> =
-                std::collections::HashMap::new();
+            let mut existing_catalog_columns = Vec::with_capacity(rows.len());
             for row in rows {
                 let name: String = row.try_get(0)?;
-                let col_type: String = row.try_get(1)?;
-                let nullable: bool = row.try_get::<Option<bool>, _>(2)?.unwrap_or(true);
-                let cid: i64 = row.try_get(3)?;
-                existing_ids.insert(name.clone(), cid);
-                existing_columns.push((name, col_type, nullable));
+                let ducklake_type: String = row.try_get(1)?;
+                let column_id: i64 = row.try_get(2)?;
+                let parent_column: Option<i64> = row.try_get(3)?;
+                existing_catalog_columns.push(ExistingCatalogColumn {
+                    column_id,
+                    name,
+                    ducklake_type,
+                    parent_column,
+                });
             }
+
+            let catalog_columns = catalog_column_defs(columns)?;
+            let fresh_ids = reserve_ids(
+                "ducklake_column",
+                "column_id",
+                catalog_columns.len() as i64,
+                &mut tx,
+            )
+            .await?;
+            let field_ids =
+                assign_column_ids(&catalog_columns, &existing_catalog_columns, &fresh_ids)?;
 
             // Data-write policy (§5, same rules as the SQLite writer): a data write
             // — Replace OR Append — must NOT change a column's type. A type change is
@@ -4080,24 +4160,18 @@ impl MetadataWriter for PostgresMetadataWriter {
             // restatement is a no-op. Append additionally requires a genuinely new
             // column to be nullable (a Replace overwrites every row, so a new
             // non-nullable column is fine there).
-            if !existing_columns.is_empty() {
+            if !existing_catalog_columns.is_empty() {
                 use std::collections::HashMap;
-                let existing_map: HashMap<&str, (&str, bool)> = existing_columns
+                let existing_map: HashMap<i64, &ExistingCatalogColumn> = existing_catalog_columns
                     .iter()
-                    .map(|(name, col_type, nullable)| {
-                        (name.as_str(), (col_type.as_str(), *nullable))
-                    })
+                    .map(|column| (column.column_id, column))
                     .collect();
 
-                for new_col in columns.iter() {
-                    if let Some((existing_type, _)) = existing_map.get(new_col.name.as_str()) {
-                        // Same-name column: a (canonical) type change is rejected in BOTH
-                        // modes. Not `types_compatible` — that accepts widenings, the
-                        // silent acceptance we are closing.
-                        if !crate::types::types_equal_canonical(
-                            existing_type,
-                            &new_col.ducklake_type,
-                        ) {
+                for (new_column, column_id) in catalog_columns.iter().zip(&field_ids) {
+                    if let Some(existing_column) = existing_map.get(column_id) {
+                        let same_type =
+                            catalog_column_type_equal(&existing_column.ducklake_type, new_column);
+                        if !same_type {
                             return Err(crate::error::DuckLakeError::UnsupportedTypeChange {
                                 operation: TypeChangeOperation::DataWrite {
                                     mode: match mode {
@@ -4105,15 +4179,18 @@ impl MetadataWriter for PostgresMetadataWriter {
                                         WriteMode::Append => TypeChangeWriteMode::Append,
                                     },
                                 },
-                                column: new_col.name.clone(),
-                                from: (*existing_type).to_string(),
-                                to: new_col.ducklake_type.clone(),
+                                column: new_column.name.clone(),
+                                from: existing_column.ducklake_type.clone(),
+                                to: new_column.ducklake_type.clone(),
                             });
                         }
-                    } else if mode == WriteMode::Append && !new_col.is_nullable {
+                    } else if mode == WriteMode::Append
+                        && new_column.parent_index.is_none()
+                        && !new_column.is_nullable
+                    {
                         return Err(crate::error::DuckLakeError::InvalidConfig(format!(
                             "Schema evolution error: new column '{}' must be nullable. Adding non-nullable columns is not allowed.",
-                            new_col.name
+                            new_column.name
                         )));
                     }
                 }
@@ -4133,19 +4210,6 @@ impl MetadataWriter for PostgresMetadataWriter {
             // file (begin > base) and a schema-changing Replace ends/inserts the
             // changed columns (begin/end > base); a fileless same-schema Replace
             // leaves no trace and resolves last-writer-wins, exactly like SQLite.
-            let fresh_ids = reserve_ids(
-                "ducklake_column",
-                "column_id",
-                columns.len() as i64,
-                &mut tx,
-            )
-            .await?;
-            let column_ids: Vec<i64> = columns
-                .iter()
-                .zip(fresh_ids.iter())
-                .map(|(col, &fresh)| existing_ids.get(&col.name).copied().unwrap_or(fresh))
-                .collect();
-
             // base = catalog head observed at begin. The Replace commit aborts if
             // any file/column of the table moved past it (a concurrent writer
             // committed a newer generation). Snapshot ids are commit-ordered, so
@@ -4169,7 +4233,8 @@ impl MetadataWriter for PostgresMetadataWriter {
                 base_snapshot_id,
                 schema_id,
                 table_id,
-                column_ids,
+                column_ids: top_level_column_ids(&catalog_columns, &field_ids)?,
+                field_ids,
             })
         })
     }

--- a/src/metadata_writer_postgres_single.rs
+++ b/src/metadata_writer_postgres_single.rs
@@ -23,9 +23,11 @@ use crate::Result;
 use crate::error::{TypeChangeOperation, TypeChangeWriteMode};
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
-    ColumnDef, ColumnStat, CommitIds, DataFileInfo, MetadataWriter, SnapshotCommitMetadata,
-    WriteMode, WriteSetupResult, columns_differ, quote_snapshot_name, quote_snapshot_table,
-    table_write_changes, validate_name,
+    ColumnDef, ColumnStat, CommitIds, DataFileInfo, ExistingCatalogColumn, MetadataWriter,
+    SnapshotCommitMetadata, WriteMode, WriteSetupResult, assign_column_ids, catalog_column_defs,
+    catalog_column_type_equal, catalog_column_type_requires_migration, catalog_columns_differ,
+    quote_snapshot_name, quote_snapshot_table, table_write_changes, top_level_column_ids,
+    validate_name,
 };
 use crate::partition::PartitionTransform;
 use sqlx::Row;
@@ -795,11 +797,18 @@ async fn finalize_snapshot(
     };
 
     // Classify this commit as DDL vs pure data write. `current` is the table's
-    // live columns ordered by `column_order`; an empty set means a brand-new table
-    // (the creating write is DDL). Mirrors upstream `SchemaChangesMade()`.
+    // live recursive column tree ordered by `column_order`.
     use std::collections::{HashMap, HashSet};
+    let proposed = catalog_column_defs(columns)?;
+    if proposed.len() != column_ids.len() {
+        return Err(crate::DuckLakeError::InvalidConfig(format!(
+            "column_ids has {} entries for {} catalog column nodes",
+            column_ids.len(),
+            proposed.len()
+        )));
+    }
     let current = sqlx::query(
-        "SELECT column_name, column_type, column_order, nulls_allowed, column_id
+        "SELECT column_id, column_name, column_type, column_order, nulls_allowed, parent_column
          FROM ducklake_column
          WHERE table_id = $1 AND end_snapshot IS NULL
          ORDER BY column_order",
@@ -808,16 +817,40 @@ async fn finalize_snapshot(
     .fetch_all(&mut **tx)
     .await?;
 
-    let mut existing: Vec<(String, String, bool)> = Vec::with_capacity(current.len());
-    for row in &current {
-        let name: String = row.try_get("column_name")?;
-        let ty: String = row.try_get("column_type")?;
-        let nullable: bool = row
-            .try_get::<Option<bool>, _>("nulls_allowed")?
-            .unwrap_or(true);
-        existing.push((name, ty, nullable));
+    let existing_catalog_columns = current
+        .iter()
+        .map(|row| {
+            Ok::<_, sqlx::Error>(ExistingCatalogColumn {
+                column_id: row.try_get("column_id")?,
+                name: row.try_get("column_name")?,
+                ducklake_type: row.try_get("column_type")?,
+                parent_column: row.try_get("parent_column")?,
+            })
+        })
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    let existing_nullability = current
+        .iter()
+        .map(|row| {
+            Ok::<_, sqlx::Error>(
+                row.try_get::<Option<bool>, _>("nulls_allowed")?
+                    .unwrap_or(true),
+            )
+        })
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    let committed_ids = assign_column_ids(&proposed, &existing_catalog_columns, column_ids)?;
+    if committed_ids != column_ids {
+        return Err(crate::DuckLakeError::Conflict(
+            "table columns were created concurrently with different field ids; retry the write"
+                .to_string(),
+        ));
     }
-    let is_ddl = existing.is_empty() || columns_differ(&existing, columns);
+    let is_ddl = current.is_empty()
+        || catalog_columns_differ(
+            &existing_catalog_columns,
+            &existing_nullability,
+            &proposed,
+            column_ids,
+        );
     if is_ddl {
         // A DDL commit bumps the per-catalog schema_version (the insert above only
         // carried it forward). A pure data write keeps the carried value.
@@ -827,79 +860,88 @@ async fn finalize_snapshot(
     // Reconcile the column generation SURGICALLY so each column keeps a stable
     // column_id (== parquet field_id) across writes: end only removed columns,
     // insert only new ones, and leave unchanged columns (and their ids) in place.
-    let new_names: HashSet<&str> = columns.iter().map(|c| c.name()).collect();
-    let mut current_by_name: HashMap<String, (i64, bool, i64)> = HashMap::new();
+    let proposed_ids = column_ids.iter().copied().collect::<HashSet<_>>();
+    let mut current_by_id: HashMap<i64, (i64, bool, String)> = HashMap::new();
     for row in &current {
-        let name: String = row.try_get("column_name")?;
+        let column_id: i64 = row.try_get("column_id")?;
         let order: i64 = row.try_get("column_order")?;
         let nullable: bool = row
             .try_get::<Option<bool>, _>("nulls_allowed")?
             .unwrap_or(true);
-        let committed_column_id: i64 = row.try_get("column_id")?;
-        if !new_names.contains(name.as_str()) {
-            // Column dropped in the new schema: end its generation.
+        let ducklake_type: String = row.try_get("column_type")?;
+        if !proposed_ids.contains(&column_id) {
             sqlx::query(
                 "UPDATE ducklake_column SET end_snapshot = $1
-                 WHERE table_id = $2 AND column_name = $3 AND end_snapshot IS NULL",
+                 WHERE table_id = $2 AND column_id = $3 AND end_snapshot IS NULL",
             )
             .bind(snapshot_id)
             .bind(table_id)
-            .bind(&name)
+            .bind(column_id)
             .execute(&mut **tx)
             .await?;
         }
-        current_by_name.insert(name, (order, nullable, committed_column_id));
+        current_by_id.insert(column_id, (order, nullable, ducklake_type));
     }
 
-    for (order, (col, column_id)) in columns.iter().zip(column_ids.iter()).enumerate() {
-        match current_by_name.get(col.name()) {
-            // Existing column kept: its id stays stable. Sync order/nullability
-            // only if they changed (type changes are rejected at begin).
-            Some(&(cur_order, cur_nullable, cur_column_id)) => {
-                // The caller has already stamped `column_id` into its staged
-                // parquet as the field_id, so a committed id that disagrees means
-                // the staged file cannot be read back against this table: the read
-                // path null-fills a current column whose field_id is missing from a
-                // file that carries field_ids. That happens when two writers both
-                // began against an absent table and one created it first, or when
-                // the column was dropped and re-added in between. The file has to
-                // be rewritten under the committed ids, so abort and let the caller
-                // retry from a fresh begin.
-                if cur_column_id != *column_id {
-                    return Err(crate::DuckLakeError::Conflict(format!(
-                        "column '{}' of table {table_id} committed as column_id \
-                         {cur_column_id}, but this write staged its data under field_id \
-                         {column_id}; another writer created or altered the table since \
-                         this write began (retry the write against the new generation)",
-                        col.name()
-                    )));
-                }
-                if cur_order != order as i64 || cur_nullable != col.is_nullable() {
+    for (order, (column, column_id)) in proposed.iter().zip(column_ids).enumerate() {
+        let parent_id = column.parent_index.map(|index| column_ids[index]);
+        match current_by_id.get(column_id) {
+            Some((cur_order, cur_nullable, cur_type)) => {
+                let migrate_type = catalog_column_type_requires_migration(cur_type, column);
+                if migrate_type {
                     sqlx::query(
-                        "UPDATE ducklake_column SET column_order = $1, nulls_allowed = $2
-                         WHERE table_id = $3 AND column_name = $4 AND end_snapshot IS NULL",
+                        "UPDATE ducklake_column SET end_snapshot = $1
+                         WHERE table_id = $2 AND column_id = $3 AND end_snapshot IS NULL",
+                    )
+                    .bind(snapshot_id)
+                    .bind(table_id)
+                    .bind(column_id)
+                    .execute(&mut **tx)
+                    .await?;
+                    sqlx::query(
+                        "INSERT INTO ducklake_column
+                             (column_id, table_id, column_name, column_type, column_order,
+                              nulls_allowed, parent_column, begin_snapshot)
+                         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+                    )
+                    .bind(column_id)
+                    .bind(table_id)
+                    .bind(&column.name)
+                    .bind(&column.ducklake_type)
+                    .bind(order as i64)
+                    .bind(column.is_nullable)
+                    .bind(parent_id)
+                    .bind(snapshot_id)
+                    .execute(&mut **tx)
+                    .await?;
+                } else if *cur_order != order as i64 || *cur_nullable != column.is_nullable {
+                    sqlx::query(
+                        "UPDATE ducklake_column
+                         SET column_order = $1, nulls_allowed = $2
+                         WHERE table_id = $3 AND column_id = $4 AND end_snapshot IS NULL",
                     )
                     .bind(order as i64)
-                    .bind(col.is_nullable())
+                    .bind(column.is_nullable)
                     .bind(table_id)
-                    .bind(col.name())
+                    .bind(column_id)
                     .execute(&mut **tx)
                     .await?;
                 }
             },
-            // Newly added column: insert it with its reserved id.
             None => {
                 sqlx::query(
                     "INSERT INTO ducklake_column
-                         (column_id, table_id, column_name, column_type, column_order, nulls_allowed, begin_snapshot)
-                     VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                         (column_id, table_id, column_name, column_type, column_order,
+                          nulls_allowed, parent_column, begin_snapshot)
+                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
                 )
                 .bind(column_id)
                 .bind(table_id)
-                .bind(col.name())
-                .bind(col.ducklake_type())
+                .bind(&column.name)
+                .bind(&column.ducklake_type)
                 .bind(order as i64)
-                .bind(col.is_nullable())
+                .bind(column.is_nullable)
+                .bind(parent_id)
                 .bind(snapshot_id)
                 .execute(&mut **tx)
                 .await?;
@@ -1075,26 +1117,31 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
 
             // Reserve a contiguous column_id block from the monotonic counter and
             // insert with explicit ids, keeping the allocator authoritative.
-            let n = columns.len() as i64;
+            let catalog_columns = catalog_column_defs(columns)?;
+            let n = catalog_columns.len() as i64;
             let last_column_id = reserve_ids(&mut tx, "next_column_id", n).await?;
             let first_column_id = last_column_id - n + 1;
-            let mut column_ids = Vec::with_capacity(columns.len());
-            for (order, col) in columns.iter().enumerate() {
-                let column_id = first_column_id + order as i64;
+            let field_ids = (first_column_id..=last_column_id).collect::<Vec<_>>();
+            for (order, (column, column_id)) in
+                catalog_columns.iter().zip(field_ids.iter()).enumerate()
+            {
+                let parent_id = column.parent_index.map(|index| field_ids[index]);
                 sqlx::query(
-                    "INSERT INTO ducklake_column (column_id, table_id, column_name, column_type, column_order, nulls_allowed, begin_snapshot)
-                     VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                    "INSERT INTO ducklake_column
+                         (column_id, table_id, column_name, column_type, column_order,
+                          nulls_allowed, parent_column, begin_snapshot)
+                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
                 )
                 .bind(column_id)
                 .bind(table_id)
-                .bind(col.name())
-                .bind(col.ducklake_type())
+                .bind(&column.name)
+                .bind(&column.ducklake_type)
                 .bind(order as i64)
-                .bind(col.is_nullable())
+                .bind(column.is_nullable)
+                .bind(parent_id)
                 .bind(snapshot_id)
                 .execute(&mut *tx)
                 .await?;
-                column_ids.push(column_id);
             }
 
             // A column set on an already-existing table is an ALTER; on a table
@@ -1116,7 +1163,7 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
             }
 
             tx.commit().await?;
-            Ok(column_ids)
+            top_level_column_ids(&catalog_columns, &field_ids)
         })
     }
 
@@ -1425,7 +1472,8 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
             for (name, _transform) in columns {
                 let column_id: i64 = sqlx::query_scalar(
                     "SELECT column_id FROM ducklake_column
-                     WHERE table_id = $1 AND column_name = $2 AND end_snapshot IS NULL",
+                     WHERE table_id = $1 AND column_name = $2 AND end_snapshot IS NULL
+                       AND parent_column IS NULL",
                 )
                 .bind(table_id)
                 .bind(name)
@@ -1612,7 +1660,8 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
                 })?;
                 let exists: Option<i64> = sqlx::query_scalar(
                     "SELECT column_id FROM ducklake_column
-                     WHERE table_id = $1 AND column_name = $2 AND end_snapshot IS NULL",
+                     WHERE table_id = $1 AND column_name = $2 AND end_snapshot IS NULL
+                       AND parent_column IS NULL",
                 )
                 .bind(table_id)
                 .bind(&column)
@@ -1893,7 +1942,8 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
 
             // Reserve the column ids first so the counter UPDATE takes the write
             // lock up front. These ids match the staged parquet field ids.
-            let n = columns.len() as i64;
+            let catalog_columns = catalog_column_defs(columns)?;
+            let n = catalog_columns.len() as i64;
             let last_column_id = reserve_ids(&mut tx, "next_column_id", n).await?;
             // Freshly reserved ids. Only a genuinely-new column actually consumes
             // one below; an existing column keeps its current id, so some of these
@@ -1951,7 +2001,7 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
             // unchanged column must keep its id, or files already written would
             // read back as NULL).
             let rows = sqlx::query(
-                "SELECT column_name, column_type, nulls_allowed, column_id
+                "SELECT column_name, column_type, column_id, parent_column
                  FROM ducklake_column
                  WHERE table_id = $1 AND end_snapshot IS NULL
                  ORDER BY column_order",
@@ -1960,40 +2010,39 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
             .fetch_all(&mut *tx)
             .await?;
 
-            let mut existing_columns: Vec<(String, String, bool)> = Vec::with_capacity(rows.len());
-            let mut existing_ids: std::collections::HashMap<String, i64> =
-                std::collections::HashMap::new();
+            let mut existing_catalog_columns = Vec::with_capacity(rows.len());
             for row in rows {
                 let name: String = row.try_get(0)?;
-                let col_type: String = row.try_get(1)?;
-                let nullable: bool = row.try_get::<Option<bool>, _>(2)?.unwrap_or(true);
-                let cid: i64 = row.try_get(3)?;
-                existing_ids.insert(name.clone(), cid);
-                existing_columns.push((name, col_type, nullable));
+                let ducklake_type: String = row.try_get(1)?;
+                let column_id: i64 = row.try_get(2)?;
+                let parent_column: Option<i64> = row.try_get(3)?;
+                existing_catalog_columns.push(ExistingCatalogColumn {
+                    column_id,
+                    name,
+                    ducklake_type,
+                    parent_column,
+                });
             }
+            let field_ids =
+                assign_column_ids(&catalog_columns, &existing_catalog_columns, &fresh_ids)?;
 
             // A data write must not change a column's type — that is schema
             // evolution, and this backend has no promote_column_type. The comparison
             // is canonical (`int64` ≡ `bigint`). Append also requires a new column
             // to be nullable.
-            if !existing_columns.is_empty() {
+            if !existing_catalog_columns.is_empty() {
                 use std::collections::HashMap;
 
-                let existing_map: HashMap<&str, (&str, bool)> = existing_columns
+                let existing_map: HashMap<i64, &ExistingCatalogColumn> = existing_catalog_columns
                     .iter()
-                    .map(|(name, col_type, nullable)| {
-                        (name.as_str(), (col_type.as_str(), *nullable))
-                    })
+                    .map(|column| (column.column_id, column))
                     .collect();
 
-                for new_col in columns.iter() {
-                    if let Some((existing_type, _existing_nullable)) =
-                        existing_map.get(new_col.name())
-                    {
-                        if !crate::types::types_equal_canonical(
-                            existing_type,
-                            new_col.ducklake_type(),
-                        ) {
+                for (new_column, column_id) in catalog_columns.iter().zip(&field_ids) {
+                    if let Some(existing_column) = existing_map.get(column_id) {
+                        let same_type =
+                            catalog_column_type_equal(&existing_column.ducklake_type, new_column);
+                        if !same_type {
                             return Err(crate::error::DuckLakeError::UnsupportedTypeChange {
                                 operation: TypeChangeOperation::DataWrite {
                                     mode: match mode {
@@ -2001,28 +2050,24 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
                                         WriteMode::Append => TypeChangeWriteMode::Append,
                                     },
                                 },
-                                column: new_col.name().to_string(),
-                                from: (*existing_type).to_string(),
-                                to: new_col.ducklake_type().to_string(),
+                                column: new_column.name.clone(),
+                                from: existing_column.ducklake_type.clone(),
+                                to: new_column.ducklake_type.clone(),
                             });
                         }
-                    } else if mode == WriteMode::Append && !new_col.is_nullable() {
+                    } else if mode == WriteMode::Append
+                        && new_column.parent_index.is_none()
+                        && !new_column.is_nullable
+                    {
                         return Err(crate::error::DuckLakeError::InvalidConfig(format!(
                             "Schema evolution error: new column '{}' must be nullable. Adding non-nullable columns is not allowed.",
-                            new_col.name()
+                            new_column.name
                         )));
                     }
                 }
             }
 
-            // Reuse an existing column's id, consume a fresh one only for a new
-            // column. These are baked into the staged parquet's field_id metadata,
-            // so they must equal what finalize_snapshot commits.
-            let column_ids: Vec<i64> = columns
-                .iter()
-                .zip(fresh_ids.iter())
-                .map(|(col, &fresh)| existing_ids.get(col.name()).copied().unwrap_or(fresh))
-                .collect();
+            let column_ids = top_level_column_ids(&catalog_columns, &field_ids)?;
 
             // Inserts nothing: this commit only persists the counter advance for the
             // column ids (and the sequence advances, which are non-transactional
@@ -2035,6 +2080,7 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
                 schema_id,
                 table_id,
                 column_ids,
+                field_ids,
             })
         })
     }

--- a/src/metadata_writer_sqlite.rs
+++ b/src/metadata_writer_sqlite.rs
@@ -10,8 +10,10 @@ use crate::maintenance::{
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
     ColumnDef, ColumnStat, CommitIds, DataFileInfo, DeleteFileEntry, DeleteFileInfo,
-    MetadataWriter, SnapshotCommitMetadata, WriteMode, WriteSetupResult, columns_differ,
-    table_write_changes, validate_delete_entries, validate_name,
+    ExistingCatalogColumn, MetadataWriter, SnapshotCommitMetadata, WriteMode, WriteSetupResult,
+    assign_column_ids, catalog_column_defs, catalog_column_type_equal,
+    catalog_column_type_requires_migration, catalog_columns_differ, table_write_changes,
+    top_level_column_ids, validate_delete_entries, validate_name,
 };
 use crate::partition::PartitionTransform;
 use sqlx::AssertSqlSafe;
@@ -1268,7 +1270,7 @@ async fn live_columns_for_stats(
     for row in sqlx::query(
         "SELECT column_id, column_name, column_type
          FROM ducklake_column
-         WHERE table_id = ? AND end_snapshot IS NULL
+         WHERE table_id = ? AND end_snapshot IS NULL AND parent_column IS NULL
          ORDER BY column_order",
     )
     .bind(table_id)
@@ -1281,6 +1283,8 @@ async fn live_columns_for_stats(
         column_ids.push(column_id);
         columns.push(ColumnDef {
             name,
+            data_type: crate::types::ducklake_to_arrow_type(&ducklake_type)
+                .unwrap_or(arrow::datatypes::DataType::Null),
             ducklake_type,
             is_nullable: true,
         });
@@ -1306,6 +1310,8 @@ async fn recompute_table_column_stats(
     column_ids: &[i64],
 ) -> Result<()> {
     use crate::stats_encode::{FileColumnStat, aggregate_global_column_stats};
+    let catalog_columns = catalog_column_defs(columns)?;
+    let column_ids = top_level_column_ids(&catalog_columns, column_ids)?;
 
     // Total live files: the completeness denominator. A live file missing from
     // the per-column rows below (statless) forces the roll-up to UNKNOWN.
@@ -1406,8 +1412,16 @@ async fn finalize_snapshot(
     // the Postgres writer's `table_was_created || columns_differ` and upstream
     // `SchemaChangesMade()`.
     use std::collections::{HashMap, HashSet};
+    let proposed = catalog_column_defs(columns)?;
+    if proposed.len() != column_ids.len() {
+        return Err(crate::DuckLakeError::InvalidConfig(format!(
+            "column_ids has {} entries for {} catalog column nodes",
+            column_ids.len(),
+            proposed.len()
+        )));
+    }
     let current = sqlx::query(
-        "SELECT column_name, column_type, column_order, nulls_allowed
+        "SELECT column_id, column_name, column_type, column_order, nulls_allowed, parent_column
          FROM ducklake_column
          WHERE table_id = ? AND end_snapshot IS NULL
          ORDER BY column_order",
@@ -1415,18 +1429,41 @@ async fn finalize_snapshot(
     .bind(table_id)
     .fetch_all(&mut **tx)
     .await?;
-
-    let mut existing: Vec<(String, String, bool)> = Vec::with_capacity(current.len());
-    for row in &current {
-        let name: String = row.try_get("column_name")?;
-        let ty: String = row.try_get("column_type")?;
-        let nullable: bool = row
-            .try_get::<Option<bool>, _>("nulls_allowed")?
-            .unwrap_or(true);
-        existing.push((name, ty, nullable));
+    let existing_catalog_columns = current
+        .iter()
+        .map(|row| {
+            Ok::<_, sqlx::Error>(ExistingCatalogColumn {
+                column_id: row.try_get("column_id")?,
+                name: row.try_get("column_name")?,
+                ducklake_type: row.try_get("column_type")?,
+                parent_column: row.try_get("parent_column")?,
+            })
+        })
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    let existing_nullability = current
+        .iter()
+        .map(|row| {
+            Ok::<_, sqlx::Error>(
+                row.try_get::<Option<bool>, _>("nulls_allowed")?
+                    .unwrap_or(true),
+            )
+        })
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    let committed_ids = assign_column_ids(&proposed, &existing_catalog_columns, column_ids)?;
+    if committed_ids != column_ids {
+        return Err(crate::DuckLakeError::Conflict(
+            "table columns were created concurrently with different field ids; retry the write"
+                .to_string(),
+        ));
     }
     let table_was_created = table_begin_snapshot == snapshot_id;
-    let is_ddl = table_was_created || columns_differ(&existing, columns);
+    let is_ddl = table_was_created
+        || catalog_columns_differ(
+            &existing_catalog_columns,
+            &existing_nullability,
+            &proposed,
+            column_ids,
+        );
     if is_ddl {
         // A DDL commit bumps the per-catalog schema_version (the insert above only
         // carried it forward). A pure data write keeps the carried value.
@@ -1438,60 +1475,88 @@ async fn finalize_snapshot(
     // insert only new ones, and leave unchanged columns (and their ids) in place.
     // Re-minting ids every write would orphan the field_ids baked into
     // already-written files, making their rows read back as NULL.
-    let new_names: HashSet<&str> = columns.iter().map(|c| c.name.as_str()).collect();
-    let mut current_by_name: HashMap<String, (i64, bool)> = HashMap::new();
+    let proposed_ids = column_ids.iter().copied().collect::<HashSet<_>>();
+    let mut current_by_id: HashMap<i64, (i64, bool, String)> = HashMap::new();
     for row in &current {
-        let name: String = row.try_get("column_name")?;
+        let column_id: i64 = row.try_get("column_id")?;
         let order: i64 = row.try_get("column_order")?;
         let nullable: bool = row
             .try_get::<Option<bool>, _>("nulls_allowed")?
             .unwrap_or(true);
-        if !new_names.contains(name.as_str()) {
-            // Column dropped in the new schema: end its generation.
+        let ducklake_type: String = row.try_get("column_type")?;
+        if !proposed_ids.contains(&column_id) {
             sqlx::query(
                 "UPDATE ducklake_column SET end_snapshot = ?
-                 WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL",
+                 WHERE table_id = ? AND column_id = ? AND end_snapshot IS NULL",
             )
             .bind(snapshot_id)
             .bind(table_id)
-            .bind(&name)
+            .bind(column_id)
             .execute(&mut **tx)
             .await?;
         }
-        current_by_name.insert(name, (order, nullable));
+        current_by_id.insert(column_id, (order, nullable, ducklake_type));
     }
 
-    for (order, (col, column_id)) in columns.iter().zip(column_ids.iter()).enumerate() {
-        match current_by_name.get(&col.name) {
-            // Existing column kept: its id stays stable. Sync order/nullability
-            // only if they changed (type changes are rejected at begin).
-            Some(&(cur_order, cur_nullable)) => {
-                if cur_order != order as i64 || cur_nullable != col.is_nullable {
+    for (order, (column, column_id)) in proposed.iter().zip(column_ids).enumerate() {
+        let parent_id = column.parent_index.map(|index| column_ids[index]);
+        match current_by_id.get(column_id) {
+            Some((cur_order, cur_nullable, cur_type)) => {
+                let migrate_type = catalog_column_type_requires_migration(cur_type, column);
+                if migrate_type {
                     sqlx::query(
-                        "UPDATE ducklake_column SET column_order = ?, nulls_allowed = ?
-                         WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL",
+                        "UPDATE ducklake_column SET end_snapshot = ?
+                         WHERE table_id = ? AND column_id = ? AND end_snapshot IS NULL",
+                    )
+                    .bind(snapshot_id)
+                    .bind(table_id)
+                    .bind(column_id)
+                    .execute(&mut **tx)
+                    .await?;
+                    sqlx::query(
+                        "INSERT INTO ducklake_column
+                             (column_id, table_id, column_name, column_type, column_order,
+                              nulls_allowed, parent_column, begin_snapshot)
+                         VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    )
+                    .bind(column_id)
+                    .bind(table_id)
+                    .bind(&column.name)
+                    .bind(&column.ducklake_type)
+                    .bind(order as i64)
+                    .bind(column.is_nullable)
+                    .bind(parent_id)
+                    .bind(snapshot_id)
+                    .execute(&mut **tx)
+                    .await?;
+                } else if *cur_order != order as i64 || *cur_nullable != column.is_nullable {
+                    sqlx::query(
+                        "UPDATE ducklake_column
+                         SET column_order = ?, nulls_allowed = ?
+                         WHERE table_id = ? AND column_id = ? AND end_snapshot IS NULL",
                     )
                     .bind(order as i64)
-                    .bind(col.is_nullable)
+                    .bind(column.is_nullable)
                     .bind(table_id)
-                    .bind(&col.name)
+                    .bind(column_id)
                     .execute(&mut **tx)
                     .await?;
                 }
             },
-            // Newly added column: insert it with its reserved id.
             None => {
                 sqlx::query(
                     "INSERT INTO ducklake_column
-                         (column_id, table_id, column_name, column_type, column_order, nulls_allowed, begin_snapshot)
-                     VALUES (?, ?, ?, ?, ?, ?, ?)",
+                         (column_id, table_id, column_name, column_type, column_order,
+                          nulls_allowed, parent_column, begin_snapshot)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 )
                 .bind(column_id)
                 .bind(table_id)
-                .bind(&col.name)
-                .bind(&col.ducklake_type)
+                .bind(&column.name)
+                .bind(&column.ducklake_type)
                 .bind(order as i64)
-                .bind(col.is_nullable)
+                .bind(column.is_nullable)
+                .bind(parent_id)
                 .bind(snapshot_id)
                 .execute(&mut **tx)
                 .await?;
@@ -1726,9 +1791,10 @@ impl MetadataWriter for SqliteMetadataWriter {
 
             // Locate the live version of the column.
             let row = sqlx::query(
-                "SELECT column_id, column_type, column_order, nulls_allowed
+                "SELECT column_id, column_type, column_order, nulls_allowed, parent_column
                  FROM ducklake_column
-                 WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL",
+                 WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL
+                   AND parent_column IS NULL",
             )
             .bind(table_id)
             .bind(column_name)
@@ -1745,6 +1811,7 @@ impl MetadataWriter for SqliteMetadataWriter {
             let nulls_allowed: bool = row
                 .try_get::<Option<bool>, _>("nulls_allowed")?
                 .unwrap_or(true);
+            let parent_column: Option<i64> = row.try_get("parent_column")?;
 
             // No-op / not-a-widening guards. Canonical equality first so an
             // alias-only restatement is reported as "no change", not attempted.
@@ -1781,8 +1848,8 @@ impl MetadataWriter for SqliteMetadataWriter {
             .await?;
             sqlx::query(
                 "INSERT INTO ducklake_column
-                     (column_id, begin_snapshot, end_snapshot, table_id, column_order, column_name, column_type, nulls_allowed)
-                 VALUES (?, ?, NULL, ?, ?, ?, ?, ?)",
+                     (column_id, begin_snapshot, end_snapshot, table_id, column_order, column_name, column_type, nulls_allowed, parent_column)
+                 VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?)",
             )
             .bind(column_id)
             .bind(new_snapshot)
@@ -1791,6 +1858,7 @@ impl MetadataWriter for SqliteMetadataWriter {
             .bind(column_name)
             .bind(new_ducklake_type)
             .bind(nulls_allowed)
+            .bind(parent_column)
             .execute(&mut *tx)
             .await?;
 
@@ -1841,7 +1909,8 @@ impl MetadataWriter for SqliteMetadataWriter {
             for (name, _transform) in columns {
                 let column_id: i64 = sqlx::query_scalar(
                     "SELECT column_id FROM ducklake_column
-                     WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL",
+                     WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL
+                       AND parent_column IS NULL",
                 )
                 .bind(table_id)
                 .bind(name)
@@ -2035,7 +2104,8 @@ impl MetadataWriter for SqliteMetadataWriter {
                 })?;
                 let exists: Option<i64> = sqlx::query_scalar(
                     "SELECT column_id FROM ducklake_column
-                     WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL",
+                     WHERE table_id = ? AND column_name = ? AND end_snapshot IS NULL
+                       AND parent_column IS NULL",
                 )
                 .bind(table_id)
                 .bind(&column)
@@ -2170,26 +2240,31 @@ impl MetadataWriter for SqliteMetadataWriter {
             // Reserve a contiguous column_id block from the monotonic counter and
             // insert with explicit ids, keeping the allocator authoritative (the
             // write path's begin/commit reserve column ids from the same counter).
-            let n = columns.len() as i64;
+            let catalog_columns = catalog_column_defs(columns)?;
+            let n = catalog_columns.len() as i64;
             let last_column_id = reserve_ids(&mut tx, "next_column_id", n).await?;
             let first_column_id = last_column_id - n + 1;
-            let mut column_ids = Vec::with_capacity(columns.len());
-            for (order, col) in columns.iter().enumerate() {
-                let column_id = first_column_id + order as i64;
+            let column_ids = (first_column_id..=last_column_id).collect::<Vec<_>>();
+            for (order, (column, column_id)) in
+                catalog_columns.iter().zip(column_ids.iter()).enumerate()
+            {
+                let parent_id = column.parent_index.map(|index| column_ids[index]);
                 sqlx::query(
-                    "INSERT INTO ducklake_column (column_id, table_id, column_name, column_type, column_order, nulls_allowed, begin_snapshot)
-                     VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    "INSERT INTO ducklake_column
+                         (column_id, table_id, column_name, column_type, column_order,
+                          nulls_allowed, parent_column, begin_snapshot)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 )
                 .bind(column_id)
                 .bind(table_id)
-                .bind(&col.name)
-                .bind(&col.ducklake_type)
+                .bind(&column.name)
+                .bind(&column.ducklake_type)
                 .bind(order as i64)
-                .bind(col.is_nullable)
+                .bind(column.is_nullable)
+                .bind(parent_id)
                 .bind(snapshot_id)
                 .execute(&mut *tx)
                 .await?;
-                column_ids.push(column_id);
             }
 
             if table_begin_snapshot != snapshot_id {
@@ -2202,7 +2277,7 @@ impl MetadataWriter for SqliteMetadataWriter {
                 .await?;
             }
             tx.commit().await?;
-            Ok(column_ids)
+            top_level_column_ids(&catalog_columns, &column_ids)
         })
     }
 
@@ -3975,7 +4050,8 @@ impl MetadataWriter for SqliteMetadataWriter {
             // Reserve the column ids first so the counter UPDATE takes the write
             // lock up front, avoiding a lock-upgrade deadlock between concurrent
             // begins. These ids match the staged parquet field ids.
-            let n = columns.len() as i64;
+            let catalog_columns = catalog_column_defs(columns)?;
+            let n = catalog_columns.len() as i64;
             let last_column_id = reserve_ids(&mut tx, "next_column_id", n).await?;
             // Freshly reserved ids. Only a genuinely-new column actually consumes
             // one below; an existing column keeps its current id, so some of these
@@ -4052,7 +4128,7 @@ impl MetadataWriter for SqliteMetadataWriter {
             // field_ids already baked into previously-written files, so an
             // unchanged column must keep its id.
             let rows = sqlx::query(
-                "SELECT column_name, column_type, nulls_allowed, column_id
+                "SELECT column_name, column_type, nulls_allowed, column_id, parent_column
                  FROM ducklake_column
                  WHERE table_id = ? AND end_snapshot IS NULL
                  ORDER BY column_order",
@@ -4061,17 +4137,23 @@ impl MetadataWriter for SqliteMetadataWriter {
             .fetch_all(&mut *tx)
             .await?;
 
-            let mut existing_columns: Vec<(String, String, bool)> = Vec::with_capacity(rows.len());
-            let mut existing_ids: std::collections::HashMap<String, i64> =
-                std::collections::HashMap::new();
+            let mut existing_catalog_columns = Vec::with_capacity(rows.len());
             for row in rows {
                 let name: String = row.try_get(0)?;
                 let col_type: String = row.try_get(1)?;
-                let nullable: bool = row.try_get::<Option<bool>, _>(2)?.unwrap_or(true);
+                let _nullable: bool = row.try_get::<Option<bool>, _>(2)?.unwrap_or(true);
                 let cid: i64 = row.try_get(3)?;
-                existing_ids.insert(name.clone(), cid);
-                existing_columns.push((name, col_type, nullable));
+                let parent_column: Option<i64> = row.try_get(4)?;
+                existing_catalog_columns.push(ExistingCatalogColumn {
+                    column_id: cid,
+                    name,
+                    ducklake_type: col_type,
+                    parent_column,
+                });
             }
+
+            let field_ids =
+                assign_column_ids(&catalog_columns, &existing_catalog_columns, &fresh_ids)?;
 
             // Data-write policy (§5): a data write — Replace OR Append — must NOT
             // change a column's type. A type change is schema evolution and must
@@ -4081,28 +4163,19 @@ impl MetadataWriter for SqliteMetadataWriter {
             // restatement is a no-op, not an error. Append additionally requires a
             // genuinely new column to be nullable (a Replace overwrites every row,
             // so a new non-nullable column is fine there).
-            if !existing_columns.is_empty() {
+            if !existing_catalog_columns.is_empty() {
                 use std::collections::HashMap;
 
-                // Build map of existing columns: name -> (type, nullable)
-                let existing_map: HashMap<&str, (&str, bool)> = existing_columns
+                let existing_map: HashMap<i64, &ExistingCatalogColumn> = existing_catalog_columns
                     .iter()
-                    .map(|(name, col_type, nullable)| {
-                        (name.as_str(), (col_type.as_str(), *nullable))
-                    })
+                    .map(|column| (column.column_id, column))
                     .collect();
 
-                for new_col in columns.iter() {
-                    if let Some((existing_type, _existing_nullable)) =
-                        existing_map.get(new_col.name.as_str())
-                    {
-                        // Same-name column: a (canonical) type change is rejected in
-                        // BOTH modes. Not `types_compatible` — that accepts widenings,
-                        // which is exactly the silent acceptance we are closing.
-                        if !crate::types::types_equal_canonical(
-                            existing_type,
-                            &new_col.ducklake_type,
-                        ) {
+                for (new_column, column_id) in catalog_columns.iter().zip(&field_ids) {
+                    if let Some(existing_column) = existing_map.get(column_id) {
+                        let same_type =
+                            catalog_column_type_equal(&existing_column.ducklake_type, new_column);
+                        if !same_type {
                             return Err(crate::error::DuckLakeError::UnsupportedTypeChange {
                                 operation: TypeChangeOperation::DataWrite {
                                     mode: match mode {
@@ -4110,21 +4183,21 @@ impl MetadataWriter for SqliteMetadataWriter {
                                         WriteMode::Append => TypeChangeWriteMode::Append,
                                     },
                                 },
-                                column: new_col.name.clone(),
-                                from: (*existing_type).to_string(),
-                                to: new_col.ducklake_type.clone(),
+                                column: new_column.name.clone(),
+                                from: existing_column.ducklake_type.clone(),
+                                to: new_column.ducklake_type.clone(),
                             });
                         }
-                        // Nullable changes remain allowed (strict -> nullable is safe for reads).
-                    } else if mode == WriteMode::Append && !new_col.is_nullable {
-                        // New column on append - must be nullable.
+                    } else if mode == WriteMode::Append
+                        && new_column.parent_index.is_none()
+                        && !new_column.is_nullable
+                    {
                         return Err(crate::error::DuckLakeError::InvalidConfig(format!(
                             "Schema evolution error: new column '{}' must be nullable. Adding non-nullable columns is not allowed.",
-                            new_col.name
+                            new_column.name
                         )));
                     }
                 }
-                // Columns in existing but not in new schema are implicitly removed - this is allowed.
             }
 
             // Final per-column ids: reuse the existing id for a column already in
@@ -4135,12 +4208,6 @@ impl MetadataWriter for SqliteMetadataWriter {
             // read path resolves columns by `end_snapshot IS NULL` only (not
             // snapshot-scoped), so inserting at begin would leak the new
             // generation to concurrent reads during the upload window.
-            let column_ids: Vec<i64> = columns
-                .iter()
-                .zip(fresh_ids.iter())
-                .map(|(col, &fresh)| existing_ids.get(&col.name).copied().unwrap_or(fresh))
-                .collect();
-
             // No snapshot row, no column rows, and no Replace retirement are
             // written here — all are deferred to the atomic commit so the head
             // never resolves to an incomplete snapshot. TX-A commits only the
@@ -4154,7 +4221,8 @@ impl MetadataWriter for SqliteMetadataWriter {
                 base_snapshot_id,
                 schema_id,
                 table_id,
-                column_ids,
+                column_ids: top_level_column_ids(&catalog_columns, &field_ids)?,
+                field_ids,
             })
         })
     }
@@ -4719,6 +4787,95 @@ mod tests {
             live, 1,
             "exactly one live version per field-id after promote"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn top_level_name_resolution_ignores_nested_collision() {
+        let (writer, _temp) = create_test_writer().await;
+        let snapshot = writer.create_snapshot().unwrap();
+        let (schema_id, _) = writer.get_or_create_schema("main", None, snapshot).unwrap();
+        let (table_id, _) = writer
+            .get_or_create_table(schema_id, "events", None, snapshot)
+            .unwrap();
+        writer
+            .set_columns(
+                table_id,
+                &[ColumnDef::new("id", "int32", false).unwrap()],
+                snapshot,
+            )
+            .unwrap();
+        let top_level_id: i64 = sqlx::query_scalar(
+            "SELECT column_id FROM ducklake_column
+             WHERE table_id = ? AND column_name = 'id' AND parent_column IS NULL",
+        )
+        .bind(table_id)
+        .fetch_one(&writer.pool)
+        .await
+        .unwrap();
+        let nested_id = top_level_id + 1;
+        sqlx::query(
+            "INSERT INTO ducklake_column
+                 (column_id, table_id, column_name, column_type, column_order,
+                  nulls_allowed, parent_column, begin_snapshot)
+             VALUES (?, ?, 'id', 'int16', 1, 1, ?, ?)",
+        )
+        .bind(nested_id)
+        .bind(table_id)
+        .bind(top_level_id)
+        .bind(snapshot)
+        .execute(&writer.pool)
+        .await
+        .unwrap();
+
+        writer.promote_column_type(table_id, "id", "int64").unwrap();
+        writer
+            .set_partition_spec(
+                table_id,
+                &[("id".to_string(), PartitionTransform::Identity)],
+            )
+            .unwrap();
+        writer
+            .set_sort_spec(
+                table_id,
+                &[crate::sort::SortField::column(
+                    0,
+                    "id",
+                    crate::sort::SortDirection::Asc,
+                    crate::sort::NullOrder::NullsLast,
+                )],
+            )
+            .unwrap();
+
+        let top_level_type: String = sqlx::query_scalar(
+            "SELECT column_type FROM ducklake_column
+             WHERE table_id = ? AND column_name = 'id' AND parent_column IS NULL
+               AND end_snapshot IS NULL",
+        )
+        .bind(table_id)
+        .fetch_one(&writer.pool)
+        .await
+        .unwrap();
+        let nested: (String, Option<i64>) = sqlx::query_as(
+            "SELECT column_type, parent_column FROM ducklake_column
+             WHERE table_id = ? AND column_id = ? AND end_snapshot IS NULL",
+        )
+        .bind(table_id)
+        .bind(nested_id)
+        .fetch_one(&writer.pool)
+        .await
+        .unwrap();
+        let partition_column_id: i64 = sqlx::query_scalar(
+            "SELECT column_id FROM ducklake_partition_column
+             WHERE table_id = ? ORDER BY partition_id DESC LIMIT 1",
+        )
+        .bind(table_id)
+        .fetch_one(&writer.pool)
+        .await
+        .unwrap();
+
+        assert_eq!(top_level_type, "int64");
+        assert_eq!(nested, ("int16".to_string(), Some(top_level_id)));
+        assert_eq!(partition_column_id, top_level_id);
     }
 
     /// Phase D (old-version data → latest): a catalog whose `ducklake_column` is in

--- a/src/multicatalog_provider.rs
+++ b/src/multicatalog_provider.rs
@@ -17,7 +17,7 @@ use crate::metadata_provider::{
     DuckLakeFileData, DuckLakeFileMetadata, DuckLakeStatistics, DuckLakeTableColumn,
     DuckLakeTableColumnStatistics, DuckLakeTableFile, DuckLakeTableStatistics, FileWithTable,
     MetadataProvider, SchemaMetadata, SnapshotMetadata, TableMetadata, TableWithSchema, block_on,
-    reconstruct_list_columns, reconstruct_list_columns_with_table,
+    reconstruct_columns, reconstruct_columns_with_table,
 };
 use crate::partition::PartitionSpec;
 use crate::sort::SortSpec;
@@ -363,12 +363,14 @@ impl MetadataProvider for MulticatalogProvider {
                             column_name: row.try_get(1)?,
                             column_type: row.try_get(2)?,
                             is_nullable: nulls_allowed.unwrap_or(true),
+                            data_type: None,
+                            nested_column_ids: Vec::new(),
                         },
                         parent_column,
                     ))
                 })
                 .collect();
-            Ok(reconstruct_list_columns(raw?))
+            reconstruct_columns(raw?)
         })
     }
 
@@ -1137,6 +1139,8 @@ impl MetadataProvider for MulticatalogProvider {
                         column_name: row.try_get(3)?,
                         column_type: row.try_get(4)?,
                         is_nullable: nulls_allowed.unwrap_or(true),
+                        data_type: None,
+                        nested_column_ids: Vec::new(),
                     };
                     Ok((
                         ColumnWithTable {
@@ -1148,7 +1152,7 @@ impl MetadataProvider for MulticatalogProvider {
                     ))
                 })
                 .collect();
-            Ok(reconstruct_list_columns_with_table(raw?))
+            reconstruct_columns_with_table(raw?)
         })
     }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -239,7 +239,7 @@ impl SchemaProvider for DuckLakeSchema {
                 WriteMode::Replace,
                 setup.base_snapshot_id,
                 &columns,
-                &setup.column_ids,
+                &setup.field_ids,
             )
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
 

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -286,6 +286,11 @@ pub(crate) fn sort_batches_by_spec(
         .iter()
         .map(|c| arrow::compute::take(c, &indices, None))
         .collect::<std::result::Result<Vec<ArrayRef>, _>>()?;
+    let sorted_columns = sorted_columns
+        .iter()
+        .zip(full_schema.fields())
+        .map(|(column, field)| crate::column_rename::coerce_column(column, field.data_type()))
+        .collect::<datafusion::common::Result<Vec<_>>>()?;
     Ok(vec![RecordBatch::try_new(full_schema, sorted_columns)?])
 }
 
@@ -412,5 +417,72 @@ mod tests {
     #[test]
     fn from_rows_empty_is_none() {
         assert_eq!(SortSpec::from_rows(vec![]), None);
+    }
+
+    #[cfg(feature = "write")]
+    #[test]
+    fn sort_batches_preserves_nested_field_metadata() {
+        use std::{collections::HashMap, sync::Arc};
+
+        use arrow::{
+            array::{ArrayRef, Int32Array, Int64Array, StringArray, StructArray},
+            datatypes::{DataType, Field, Schema},
+            record_batch::RecordBatch,
+        };
+
+        let field_id =
+            |value: &str| HashMap::from([("PARQUET:field_id".to_string(), value.to_string())]);
+        let money_fields = vec![
+            Arc::new(Field::new("amount", DataType::Int32, false).with_metadata(field_id("2"))),
+            Arc::new(Field::new("currency", DataType::Utf8, false).with_metadata(field_id("3"))),
+        ];
+        let money: ArrayRef = Arc::new(StructArray::new(
+            money_fields.clone().into(),
+            vec![
+                Arc::new(Int32Array::from(vec![20, 10])),
+                Arc::new(StringArray::from(vec!["EUR", "USD"])),
+            ],
+            None,
+        ));
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("money", DataType::Struct(money_fields.into()), false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int64Array::from(vec![2, 1])), money],
+        )
+        .unwrap();
+        let sort_spec = SortSpec {
+            sort_id: 1,
+            fields: vec![SortField::column(0, "id", SortDirection::Asc, NullOrder::NullsLast)],
+        };
+
+        let sorted = sort_batches_by_spec(vec![batch], &schema, Some(&sort_spec)).unwrap();
+
+        assert_eq!(
+            sorted[0]
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .values(),
+            &[1, 2]
+        );
+        assert_eq!(
+            sorted[0].schema().field(1).data_type(),
+            sorted[0].column(1).data_type()
+        );
+        let DataType::Struct(fields) = sorted[0].column(1).data_type() else {
+            panic!("money must remain a struct");
+        };
+        assert_eq!(
+            fields[0].metadata().get("PARQUET:field_id"),
+            Some(&"2".into())
+        );
+        assert_eq!(
+            fields[1].metadata().get("PARQUET:field_id"),
+            Some(&"3".into())
+        );
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -1988,8 +1988,14 @@ impl DuckLakeTable {
         // parquet field-id that is neither a reserved embedded column nor one of
         // the current catalog `column_id`s is a since-dropped column. Compaction
         // uses this to refuse merging a file whose data would be lost.
-        let current_column_ids: std::collections::HashSet<i32> =
-            self.columns.iter().map(|c| c.column_id as i32).collect();
+        let current_column_ids: std::collections::HashSet<i32> = self
+            .columns
+            .iter()
+            .flat_map(|column| {
+                std::iter::once(column.column_id).chain(column.nested_column_ids.iter().copied())
+            })
+            .map(|column_id| column_id as i32)
+            .collect();
         let drops_current_columns = field_id_map.keys().any(|fid| {
             *fid != ROW_ID_PARQUET_FIELD_ID
                 && *fid != SNAPSHOT_ID_PARQUET_FIELD_ID
@@ -2459,7 +2465,17 @@ impl DuckLakeTable {
     /// to the catalog on read.
     #[cfg(feature = "write")]
     pub(crate) fn column_ids(&self) -> Vec<i64> {
-        self.columns.iter().map(|c| c.column_id).collect()
+        let mut ids = Vec::new();
+        for column in &self.columns {
+            ids.push(column.column_id);
+            ids.extend_from_slice(&column.nested_column_ids);
+        }
+        ids
+    }
+
+    #[cfg(feature = "write")]
+    pub(crate) fn top_level_column_ids(&self) -> Vec<i64> {
+        self.columns.iter().map(|column| column.column_id).collect()
     }
 
     /// Whether `file` carries a data column that is no longer in the table's
@@ -2648,9 +2664,16 @@ impl DuckLakeTable {
             // Keep only matched rows, then apply the assignments to them.
             let matched_phys: Vec<ArrayRef> = phys_cols
                 .iter()
-                .map(|c| arrow::compute::filter(c.as_ref(), &mask))
-                .collect::<std::result::Result<_, _>>()
-                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+                .enumerate()
+                .map(|(i, column)| {
+                    let filtered = arrow::compute::filter(column.as_ref(), &mask)
+                        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+                    crate::column_rename::coerce_column(
+                        &filtered,
+                        self.physical_schema.field(i).data_type(),
+                    )
+                })
+                .collect::<DataFusionResult<_>>()?;
             let matched_batch =
                 RecordBatch::try_new(self.physical_schema.clone(), matched_phys.clone())?;
             let matched_rows = matched_batch.num_rows();

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::io::{Read, Seek, SeekFrom};
 use std::sync::Arc;
 
-use arrow::datatypes::{Field, Schema, SchemaRef};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use datafusion::error::DataFusionError;
 use datafusion::execution::SendableRecordBatchStream;
@@ -461,7 +461,7 @@ impl DuckLakeTableWriter {
         // column (not a catalog column), so it is absent from `columns`/`column_ids`
         // and the metadata commit never sees it.
         let schema_with_ids = {
-            let mut schema = build_schema_with_field_ids(arrow_schema, &setup.column_ids);
+            let mut schema = build_schema_with_field_ids(arrow_schema, &setup.field_ids)?;
             if embed_rowid {
                 let mut fields: Vec<Field> =
                     schema.fields().iter().map(|f| f.as_ref().clone()).collect();
@@ -550,7 +550,7 @@ impl DuckLakeTableWriter {
                 table_key,
                 None,
                 schema_with_ids.clone(),
-                setup.column_ids.len(),
+                arrow_schema.fields().len(),
                 self.build_writer_props(),
                 self.target_file_size,
                 // Keep `TableWriteSession::file_path` accurate for the first file.
@@ -572,6 +572,7 @@ impl DuckLakeTableWriter {
             table_id: setup.table_id,
             columns,
             column_ids: setup.column_ids,
+            field_ids: setup.field_ids,
             schema_with_ids,
             writer: Some(writer),
             temp: Some(temp),
@@ -739,11 +740,13 @@ impl DuckLakeTableWriter {
     ///
     /// `data_schema` describes ONLY the table's data columns (catalog types, no
     /// rowid/snapshot); `data_column_ids` are their catalog `column_id`s (baked
-    /// in as parquet field-ids so a read maps them back). Each batch in `batches`
-    /// must have the data columns in order, then a trailing `Int64` rowid column,
-    /// and — when `embed_snapshot_id` — a further trailing `Int64` snapshot-id
-    /// column. Streams to a local staging file and multipart-uploads it, so peak
-    /// memory stays bounded regardless of file size.
+    /// in as parquet field-ids so a read maps them back), including nested field
+    /// ids. `stats_column_ids` contains only the top-level catalog ids used to
+    /// label per-column statistics. Each batch in `batches` must have the data
+    /// columns in order, then a trailing `Int64` rowid column, and — when
+    /// `embed_snapshot_id` — a further trailing `Int64` snapshot-id column.
+    /// Streams to a local staging file and multipart-uploads it, so peak memory
+    /// stays bounded regardless of file size.
     #[allow(clippy::too_many_arguments)]
     pub async fn write_compacted_file(
         &self,
@@ -751,6 +754,7 @@ impl DuckLakeTableWriter {
         table_name: &str,
         data_schema: &Schema,
         data_column_ids: &[i64],
+        stats_column_ids: &[i64],
         batches: &[RecordBatch],
         embed_snapshot_id: bool,
         partition_subpath: Option<&str>,
@@ -779,6 +783,7 @@ impl DuckLakeTableWriter {
             table_name,
             data_schema,
             data_column_ids,
+            stats_column_ids,
             stream,
             embed_snapshot_id,
             partition_subpath,
@@ -797,6 +802,7 @@ impl DuckLakeTableWriter {
         table_name: &str,
         data_schema: &Schema,
         data_column_ids: &[i64],
+        stats_column_ids: &[i64],
         mut batches: SendableRecordBatchStream,
         embed_snapshot_id: bool,
         partition_subpath: Option<&str>,
@@ -822,7 +828,7 @@ impl DuckLakeTableWriter {
         // embedded rowid column, and for a merged partial file the snapshot-id
         // column. Neither embedded column is a catalog column.
         let schema_with_ids = {
-            let base = build_schema_with_field_ids(data_schema, data_column_ids);
+            let base = build_schema_with_field_ids(data_schema, data_column_ids)?;
             let mut fields: Vec<Field> = base.fields().iter().map(|f| f.as_ref().clone()).collect();
             fields.push(embedded_rowid_field());
             if embed_snapshot_id {
@@ -856,12 +862,11 @@ impl DuckLakeTableWriter {
                     schema_with_ids.fields().len()
                 )));
             }
-            let batch_with_ids =
-                RecordBatch::try_new(schema_with_ids.clone(), batch.columns().to_vec())?;
+            let batch_with_ids = apply_field_ids(&batch, schema_with_ids.clone())?;
             crate::stats_collect::accumulate_nan_flags(
                 &mut nan_flags,
                 &batch,
-                data_column_ids.len(),
+                stats_column_ids.len(),
             );
             writer.write(&batch_with_ids)?;
             row_count += batch.num_rows() as i64;
@@ -885,7 +890,7 @@ impl DuckLakeTableWriter {
         // consuming the stream because the Parquet footer omits that signal.
         let column_stats = crate::stats_collect::collect_column_stats(
             temp.path(),
-            data_column_ids,
+            stats_column_ids,
             row_count,
             &nan_flags,
         );
@@ -984,7 +989,7 @@ impl DuckLakeTableWriter {
             self.metadata
                 .begin_write_transaction(schema_name, table_name, &columns, mode)?;
         let schema_with_ids =
-            Arc::new(build_schema_with_field_ids(arrow_schema, &setup.column_ids));
+            Arc::new(build_schema_with_field_ids(arrow_schema, &setup.field_ids)?);
 
         let scoped_base = match self.metadata.catalog_id() {
             Some(id) => join_paths(&self.base_key_path, &format!("cat_{id}"))?,
@@ -1042,7 +1047,7 @@ impl DuckLakeTableWriter {
                 .expected_base_snapshot_id
                 .unwrap_or(setup.base_snapshot_id),
             &columns,
-            &setup.column_ids,
+            &setup.field_ids,
             &options.commit_metadata,
             options.expected_base_snapshot_id,
         )?;
@@ -1138,7 +1143,7 @@ impl DuckLakeTableWriter {
             self.metadata
                 .begin_write_transaction(schema_name, table_name, &columns, mode)?;
         let schema_with_ids =
-            Arc::new(build_schema_with_field_ids(arrow_schema, &setup.column_ids));
+            Arc::new(build_schema_with_field_ids(arrow_schema, &setup.field_ids)?);
 
         let scoped_base = match self.metadata.catalog_id() {
             Some(id) => join_paths(&self.base_key_path, &format!("cat_{id}"))?,
@@ -1226,7 +1231,7 @@ impl DuckLakeTableWriter {
             mode,
             setup.base_snapshot_id,
             &columns,
-            &setup.column_ids,
+            &setup.field_ids,
         )?;
 
         Ok(WriteResult {
@@ -1327,11 +1332,12 @@ impl DuckLakeTableWriter {
         column_ids: &[i64],
         batches: &[RecordBatch],
     ) -> Result<Vec<DataFileInfo>> {
+        let data_column_count = schema_with_ids.fields().len();
         let mut roller = RollingFileWriter::new(
             table_key.to_string(),
             rel_prefix.map(str::to_string),
             schema_with_ids,
-            column_ids.len(),
+            data_column_count,
             self.build_writer_props(),
             self.target_file_size,
             None,
@@ -1476,8 +1482,7 @@ impl RollingFileWriter {
         if self.open.is_none() {
             self.open = Some(self.open_file()?);
         }
-        let batch_with_ids =
-            RecordBatch::try_new(self.schema_with_ids.clone(), batch.columns().to_vec())?;
+        let batch_with_ids = apply_field_ids(batch, self.schema_with_ids.clone())?;
         let open = self.open.as_mut().expect("file opened above");
         crate::stats_collect::accumulate_nan_flags(
             &mut open.nan_flags,
@@ -1644,11 +1649,10 @@ struct PartitionSink {
 impl PartitionSink {
     /// Split `batch` by partition and write each group to that partition's roller.
     fn write_batch(&mut self, batch: &RecordBatch) -> Result<()> {
-        // The group batches are built with the field-id-tagged schema, so the roller
-        // re-imposing that schema is a no-op rather than a mismatch.
+        let batch_with_ids = apply_field_ids(batch, self.schema_with_ids.clone())?;
         let groups = crate::partition::split_batches_by_partition(
             &self.schema_with_ids,
-            std::slice::from_ref(batch),
+            std::slice::from_ref(&batch_with_ids),
             &self.spec,
         )?;
         for (values, batches) in groups {
@@ -1688,7 +1692,7 @@ impl PartitionSink {
                             Some(rel)
                         },
                         self.schema_with_ids.clone(),
-                        self.column_ids.len(),
+                        self.schema_with_ids.fields().len(),
                         self.props.clone(),
                         self.target_file_size,
                         None,
@@ -1736,9 +1740,11 @@ impl PartitionSink {
     }
 }
 
-/// Streaming write session./// Streaming write session. Batches stream to a local staging file; the
+/// Streaming write session. Batches stream to a local staging file; the
 /// finished parquet is uploaded in `finish()`. If the session is dropped
 /// without finishing, the staging file is removed and nothing is uploaded.
+/// Top-level column IDs drive statistics and partitions, while recursive field
+/// IDs drive catalog rows and Parquet metadata.
 #[derive(Debug)]
 pub struct TableWriteSession {
     metadata: Arc<dyn MetadataWriter>,
@@ -1757,12 +1763,12 @@ pub struct TableWriteSession {
     /// Explicit table-state precondition supplied through [`TableWriteOptions`].
     expected_base_snapshot_id: Option<i64>,
     table_id: i64,
-    /// Column generation for this write (in `column_order`). Threaded to the
-    /// metadata writer at `finish()` so single-catalog backends, which defer the
-    /// column generation out of `begin_write_transaction`, can insert the
-    /// column rows with `column_ids` at the atomic commit.
+    /// Top-level Arrow column generation for this write. Threaded to the metadata
+    /// writer at `finish()` so single-catalog backends can flatten and insert the
+    /// recursive column rows with `field_ids` at the atomic commit.
     columns: Vec<ColumnDef>,
     column_ids: Vec<i64>,
+    field_ids: Vec<i64>,
     schema_with_ids: SchemaRef,
     /// Parquet writer streaming to the local staging file (`temp`). Batches are
     /// written to disk as they arrive rather than buffered in memory, so peak
@@ -1850,14 +1856,13 @@ impl TableWriteSession {
         }
         self.validate_batch_schema(batch)?;
 
-        let batch_with_ids =
-            RecordBatch::try_new(self.schema_with_ids.clone(), batch.columns().to_vec())?;
+        let batch_with_ids = apply_field_ids(batch, self.schema_with_ids.clone())?;
         // Note float-column NaN presence before the batch streams to disk (the
         // footer we later harvest has no NaN flag). Only the catalog data columns.
         crate::stats_collect::accumulate_nan_flags(
             &mut self.nan_flags,
             &batch_with_ids,
-            self.column_ids.len(),
+            self.schema_with_ids.fields().len(),
         );
         let writer = self.writer.as_mut().unwrap();
         writer.write(&batch_with_ids)?;
@@ -1883,7 +1888,10 @@ impl TableWriteSession {
             .zip(expected_schema.fields().iter())
             .enumerate()
         {
-            if batch_field.data_type() != expected_field.data_type() {
+            if !Self::data_type_contains_ignoring_nested_names(
+                expected_field.data_type(),
+                batch_field.data_type(),
+            ) {
                 return Err(crate::error::DuckLakeError::InvalidConfig(format!(
                     "Schema mismatch at column {}: batch has type {:?}, expected {:?}",
                     i,
@@ -1893,6 +1901,56 @@ impl TableWriteSession {
             }
         }
         Ok(())
+    }
+
+    fn data_type_contains_ignoring_nested_names(expected: &DataType, actual: &DataType) -> bool {
+        match (expected, actual) {
+            (DataType::List(expected), DataType::List(actual))
+            | (DataType::LargeList(expected), DataType::LargeList(actual))
+            | (DataType::ListView(expected), DataType::ListView(actual))
+            | (DataType::LargeListView(expected), DataType::LargeListView(actual)) => {
+                Self::field_contains_ignoring_name(expected, actual)
+            },
+            (
+                DataType::FixedSizeList(expected, expected_size),
+                DataType::FixedSizeList(actual, actual_size),
+            ) => {
+                expected_size == actual_size && Self::field_contains_ignoring_name(expected, actual)
+            },
+            (DataType::Map(expected, expected_sorted), DataType::Map(actual, actual_sorted)) => {
+                expected_sorted == actual_sorted
+                    && Self::field_contains_ignoring_name(expected, actual)
+            },
+            (DataType::Struct(expected), DataType::Struct(actual)) => {
+                expected.len() == actual.len()
+                    && expected
+                        .iter()
+                        .zip(actual.iter())
+                        .all(|(expected, actual)| {
+                            Self::field_contains_ignoring_name(expected, actual)
+                        })
+            },
+            (
+                DataType::Dictionary(expected_key, expected_value),
+                DataType::Dictionary(actual_key, actual_value),
+            ) => {
+                Self::data_type_contains_ignoring_nested_names(expected_key, actual_key)
+                    && Self::data_type_contains_ignoring_nested_names(expected_value, actual_value)
+            },
+            _ => expected.contains(actual),
+        }
+    }
+
+    fn field_contains_ignoring_name(expected: &Field, actual: &Field) -> bool {
+        Self::data_type_contains_ignoring_nested_names(expected.data_type(), actual.data_type())
+            && expected.dict_is_ordered() == actual.dict_is_ordered()
+            && (expected.is_nullable() || !actual.is_nullable())
+            && actual.metadata().iter().all(|(key, value)| {
+                expected
+                    .metadata()
+                    .get(key)
+                    .is_some_and(|expected| expected == value)
+            })
     }
 
     pub fn row_count(&self) -> i64 {
@@ -1940,7 +1998,7 @@ impl TableWriteSession {
                 self.mode,
                 self.base_snapshot_id,
                 &self.columns,
-                &self.column_ids,
+                &self.field_ids,
                 &self.commit_metadata,
                 self.expected_base_snapshot_id,
             )?;
@@ -1972,7 +2030,7 @@ impl TableWriteSession {
                 self.mode,
                 self.base_snapshot_id,
                 &self.columns,
-                &self.column_ids,
+                &self.field_ids,
                 &self.commit_metadata,
                 self.expected_base_snapshot_id,
             )?;
@@ -2003,7 +2061,7 @@ impl TableWriteSession {
             self.mode,
             self.base_snapshot_id,
             &self.columns,
-            &self.column_ids,
+            &self.field_ids,
             &self.commit_metadata,
             self.expected_base_snapshot_id,
         )?;
@@ -2091,7 +2149,7 @@ impl TableWriteSession {
                     self.mode,
                     self.base_snapshot_id,
                     &self.columns,
-                    &self.column_ids,
+                    &self.field_ids,
                     &self.commit_metadata,
                     self.expected_base_snapshot_id,
                 )?,
@@ -2107,12 +2165,11 @@ impl TableWriteSession {
                     self.mode,
                     self.base_snapshot_id,
                     &self.columns,
-                    &self.column_ids,
+                    &self.field_ids,
                     &self.commit_metadata,
                     self.expected_base_snapshot_id,
                 )?,
         };
-
         Ok(WriteResult {
             snapshot_id: committed.snapshot_id,
             table_id: committed.table_id,
@@ -2219,20 +2276,91 @@ fn arrow_schema_to_column_defs(schema: &Schema) -> Result<Vec<ColumnDef>> {
         .collect()
 }
 
-fn build_schema_with_field_ids(schema: &Schema, column_ids: &[i64]) -> Schema {
-    let fields: Vec<Field> = schema
+fn build_schema_with_field_ids(schema: &Schema, column_ids: &[i64]) -> Result<Schema> {
+    fn with_field_id(field: &Field, column_ids: &[i64], next_id: &mut usize) -> Result<Field> {
+        let field_id = column_ids.get(*next_id).copied().ok_or_else(|| {
+            crate::error::DuckLakeError::Internal(format!(
+                "Missing field id for Arrow field '{}' at recursive position {}",
+                field.name(),
+                *next_id,
+            ))
+        })?;
+        *next_id += 1;
+        let data_type = match field.data_type() {
+            DataType::List(child) => DataType::List(Arc::new(
+                with_field_id(child, column_ids, next_id)?.with_name("element"),
+            )),
+            DataType::LargeList(child) => DataType::LargeList(Arc::new(
+                with_field_id(child, column_ids, next_id)?.with_name("element"),
+            )),
+            DataType::FixedSizeList(child, size) => DataType::FixedSizeList(
+                Arc::new(with_field_id(child, column_ids, next_id)?.with_name("element")),
+                *size,
+            ),
+            DataType::Struct(children) => DataType::Struct(
+                children
+                    .iter()
+                    .map(|child| with_field_id(child, column_ids, next_id).map(Arc::new))
+                    .collect::<Result<Vec<_>>>()?
+                    .into(),
+            ),
+            DataType::Map(entries, sorted) => {
+                let DataType::Struct(children) = entries.data_type() else {
+                    return Err(crate::error::DuckLakeError::InvalidConfig(
+                        "Arrow map entries must be a struct".to_string(),
+                    ));
+                };
+                let entries_type = DataType::Struct(
+                    children
+                        .iter()
+                        .map(|child| with_field_id(child, column_ids, next_id).map(Arc::new))
+                        .collect::<Result<Vec<_>>>()?
+                        .into(),
+                );
+                DataType::Map(
+                    Arc::new(
+                        Field::new("key_value", entries_type, entries.is_nullable())
+                            .with_metadata(entries.metadata().clone()),
+                    ),
+                    *sorted,
+                )
+            },
+            data_type => data_type.clone(),
+        };
+        let mut metadata: HashMap<String, String> = field.metadata().clone();
+        metadata.insert("PARQUET:field_id".to_string(), field_id.to_string());
+        Ok(Field::new(field.name(), data_type, field.is_nullable()).with_metadata(metadata))
+    }
+
+    let mut next_id = 0;
+    let fields = schema
         .fields()
         .iter()
-        .zip(column_ids.iter())
-        .map(|(field, &col_id)| {
-            let mut metadata: HashMap<String, String> = field.metadata().clone();
-            metadata.insert("PARQUET:field_id".to_string(), col_id.to_string());
-            Field::new(field.name(), field.data_type().clone(), field.is_nullable())
-                .with_metadata(metadata)
-        })
-        .collect();
+        .map(|field| with_field_id(field, column_ids, &mut next_id))
+        .collect::<Result<Vec<_>>>()?;
+    if next_id != column_ids.len() {
+        return Err(crate::error::DuckLakeError::Internal(format!(
+            "Field id count {} exceeds Arrow schema node count {next_id}",
+            column_ids.len(),
+        )));
+    }
 
-    Schema::new_with_metadata(fields, schema.metadata().clone())
+    Ok(Schema::new_with_metadata(fields, schema.metadata().clone()))
+}
+
+fn apply_field_ids(batch: &RecordBatch, schema: SchemaRef) -> Result<RecordBatch> {
+    let columns = batch
+        .columns()
+        .iter()
+        .zip(schema.fields())
+        .map(|(column, field)| {
+            crate::column_rename::array_with_data_type(column, field.data_type())
+                .map_err(crate::error::DuckLakeError::Arrow)
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(crate::column_rename::record_batch_with_schema(
+        schema, columns,
+    )?)
 }
 
 fn calculate_footer_size_from_bytes(buffer: &[u8]) -> Result<i64> {
@@ -2259,7 +2387,7 @@ fn calculate_footer_size_from_bytes(buffer: &[u8]) -> Result<i64> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{Int32Array, StringArray};
+    use arrow::array::{Decimal128Array, Int32Array, StringArray, StringViewArray, StructArray};
     use arrow::datatypes::DataType;
 
     #[test]
@@ -2287,7 +2415,7 @@ mod tests {
         ]);
 
         let column_ids = vec![1, 2];
-        let schema_with_ids = build_schema_with_field_ids(&schema, &column_ids);
+        let schema_with_ids = build_schema_with_field_ids(&schema, &column_ids).unwrap();
 
         // Check that field_ids are embedded in metadata
         let field0_metadata = schema_with_ids.field(0).metadata();
@@ -2300,6 +2428,115 @@ mod tests {
         assert_eq!(
             field1_metadata.get("PARQUET:field_id"),
             Some(&"2".to_string())
+        );
+    }
+
+    #[test]
+    fn test_build_schema_with_nested_field_ids() {
+        let map = DataType::Map(
+            Arc::new(Field::new(
+                "entries",
+                DataType::Struct(
+                    vec![
+                        Arc::new(Field::new("key", DataType::Utf8, false)),
+                        Arc::new(Field::new(
+                            "value",
+                            DataType::List(Arc::new(Field::new("item", DataType::Int32, true))),
+                            true,
+                        )),
+                    ]
+                    .into(),
+                ),
+                false,
+            )),
+            false,
+        );
+        let schema = Schema::new(vec![Field::new("attrs", map, true)]);
+
+        let schema = build_schema_with_field_ids(&schema, &[10, 11, 12, 13]).unwrap();
+        let root = schema.field(0);
+        assert_eq!(root.metadata().get("PARQUET:field_id"), Some(&"10".into()));
+        let DataType::Map(entries, false) = root.data_type() else {
+            panic!("expected map");
+        };
+        assert!(!entries.metadata().contains_key("PARQUET:field_id"));
+        let DataType::Struct(children) = entries.data_type() else {
+            panic!("expected entries struct");
+        };
+        assert_eq!(
+            children[0].metadata().get("PARQUET:field_id"),
+            Some(&"11".into())
+        );
+        assert_eq!(
+            children[1].metadata().get("PARQUET:field_id"),
+            Some(&"12".into())
+        );
+        let DataType::List(element) = children[1].data_type() else {
+            panic!("expected list value");
+        };
+        assert_eq!(
+            element.metadata().get("PARQUET:field_id"),
+            Some(&"13".into())
+        );
+    }
+
+    #[test]
+    fn test_apply_field_ids_rewrites_nested_field_metadata() {
+        let fields = vec![
+            Arc::new(Field::new("amount", DataType::Decimal128(38, 16), false)),
+            Arc::new(Field::new("currency", DataType::Utf8View, false)),
+        ];
+        let values = StructArray::new(
+            fields.clone().into(),
+            vec![
+                Arc::new(
+                    Decimal128Array::from(vec![1, 2])
+                        .with_precision_and_scale(38, 16)
+                        .unwrap(),
+                ),
+                Arc::new(StringViewArray::from(vec!["USD", "EUR"])),
+            ],
+            None,
+        );
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "money",
+            DataType::Struct(fields.into()),
+            false,
+        )]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(values)]).unwrap();
+        let schema_with_ids = Arc::new(build_schema_with_field_ids(&schema, &[1, 2, 3]).unwrap());
+
+        let rewritten = apply_field_ids(&batch, schema_with_ids.clone()).unwrap();
+
+        assert_eq!(rewritten.schema(), schema_with_ids);
+        let DataType::Struct(fields) = rewritten.column(0).data_type() else {
+            panic!("expected struct");
+        };
+        assert_eq!(
+            fields[0].metadata().get("PARQUET:field_id"),
+            Some(&"2".to_string())
+        );
+        assert_eq!(
+            fields[1].metadata().get("PARQUET:field_id"),
+            Some(&"3".to_string())
+        );
+        let mut writer = ArrowWriter::try_new(Vec::new(), schema_with_ids, None).unwrap();
+        writer.write(&rewritten).unwrap();
+    }
+
+    #[test]
+    fn build_schema_with_field_ids_rejects_missing_recursive_id() {
+        let schema = Schema::new(vec![Field::new(
+            "items",
+            DataType::List(Arc::new(Field::new("item", DataType::Int32, true))),
+            true,
+        )]);
+
+        let error = build_schema_with_field_ids(&schema, &[10]).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Internal error: Missing field id for Arrow field 'item' at recursive position 1",
         );
     }
 
@@ -2320,7 +2557,7 @@ mod tests {
         .unwrap();
 
         let column_ids = vec![10, 20];
-        let schema_with_ids = Arc::new(build_schema_with_field_ids(&schema, &column_ids));
+        let schema_with_ids = Arc::new(build_schema_with_field_ids(&schema, &column_ids).unwrap());
 
         let props = WriterProperties::builder()
             .set_writer_version(parquet::file::properties::WriterVersion::PARQUET_2_0)
@@ -2328,8 +2565,7 @@ mod tests {
         let mut writer =
             ArrowWriter::try_new(Vec::new(), schema_with_ids.clone(), Some(props)).unwrap();
 
-        let batch_with_ids =
-            RecordBatch::try_new(schema_with_ids, batch.columns().to_vec()).unwrap();
+        let batch_with_ids = apply_field_ids(&batch, schema_with_ids).unwrap();
         writer.write(&batch_with_ids).unwrap();
         let buffer = writer.into_inner().unwrap();
 
@@ -2351,12 +2587,11 @@ mod tests {
         let props = WriterProperties::builder()
             .set_writer_version(parquet::file::properties::WriterVersion::PARQUET_2_0)
             .build();
-        let schema_with_ids = Arc::new(build_schema_with_field_ids(&batch.schema(), &[1]));
+        let schema_with_ids = Arc::new(build_schema_with_field_ids(&batch.schema(), &[1]).unwrap());
         let mut writer =
             ArrowWriter::try_new(Vec::new(), schema_with_ids.clone(), Some(props)).unwrap();
 
-        let batch_with_ids =
-            RecordBatch::try_new(schema_with_ids, batch.columns().to_vec()).unwrap();
+        let batch_with_ids = apply_field_ids(&batch, schema_with_ids).unwrap();
         writer.write(&batch_with_ids).unwrap();
         let buffer = writer.into_inner().unwrap();
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,25 +6,44 @@ use std::sync::Arc;
 use crate::metadata_provider::DuckLakeTableColumn;
 use crate::{DuckLakeError, Result};
 use arrow::datatypes::{DataType, Field, IntervalUnit, Schema, TimeUnit};
+use parquet::arrow::PARQUET_FIELD_ID_META_KEY;
 use parquet::file::metadata::ParquetMetaData;
+
+pub(crate) const MAX_NESTED_TYPE_DEPTH: usize = 128;
 
 /// Convert a DuckLake type string to an Arrow DataType
 pub fn ducklake_to_arrow_type(ducklake_type: &str) -> Result<DataType> {
-    // Normalize type string (lowercase, remove whitespace)
-    let normalized = ducklake_type.trim().to_lowercase();
+    ducklake_to_arrow_type_inner(ducklake_type, 0)
+}
+
+fn ducklake_to_arrow_type_inner(ducklake_type: &str, depth: usize) -> Result<DataType> {
+    if depth > MAX_NESTED_TYPE_DEPTH {
+        return Err(DuckLakeError::UnsupportedType(format!(
+            "Type exceeds maximum nesting depth {MAX_NESTED_TYPE_DEPTH}"
+        )));
+    }
+    let type_str = ducklake_type.trim();
 
     // Handle parameterized types first
-    if let Some(decimal_params) = parse_decimal(&normalized)? {
+    if let Some(decimal_params) = parse_decimal(type_str)? {
         return Ok(decimal_params);
     }
 
     // Handle list/array types
-    if let Some(list_type) = parse_list_type(&normalized)? {
+    if let Some(list_type) = parse_list_type(type_str, depth)? {
         return Ok(list_type);
     }
 
+    if let Some(struct_type) = parse_struct_type(type_str, depth)? {
+        return Ok(struct_type);
+    }
+
+    if let Some(map_type) = parse_map_type(type_str, depth)? {
+        return Ok(map_type);
+    }
+
     // Handle basic types
-    match normalized.as_str() {
+    match type_str.to_ascii_lowercase().as_str() {
         // Boolean
         "boolean" | "bool" => Ok(DataType::Boolean),
 
@@ -84,22 +103,7 @@ pub fn ducklake_to_arrow_type(ducklake_type: &str) -> Result<DataType> {
         // Time with timezone - not directly supported, use string
         "timetz" | "time with time zone" => Ok(DataType::Utf8View),
 
-        _ => {
-            // Check for complex types (struct, map)
-            if normalized.starts_with("struct") {
-                Err(DuckLakeError::UnsupportedType(format!(
-                    "Struct type '{}' not yet supported. Please open an issue at https://github.com/hotdata-dev/datafusion-ducklake if you need this feature.",
-                    ducklake_type
-                )))
-            } else if normalized.starts_with("map") {
-                Err(DuckLakeError::UnsupportedType(format!(
-                    "Map type '{}' not yet supported. Please open an issue at https://github.com/hotdata-dev/datafusion-ducklake if you need this feature.",
-                    ducklake_type
-                )))
-            } else {
-                Err(DuckLakeError::UnsupportedType(ducklake_type.to_string()))
-            }
-        },
+        _ => Err(DuckLakeError::UnsupportedType(ducklake_type.to_string())),
     }
 }
 
@@ -160,6 +164,10 @@ pub fn arrow_to_ducklake_type(arrow_type: &DataType) -> Result<String> {
         // Null type - map to varchar as there's no direct equivalent
         DataType::Null => Ok("varchar".to_string()),
 
+        // Dictionary keys are an Arrow encoding detail. DuckLake records the logical value
+        // type, while Parquet preserves dictionary encoding in the data file.
+        DataType::Dictionary(_, value) => arrow_to_ducklake_type(value),
+
         // List types
         DataType::List(field) | DataType::LargeList(field) => {
             let inner = arrow_to_ducklake_type(field.data_type())?;
@@ -169,14 +177,36 @@ pub fn arrow_to_ducklake_type(arrow_type: &DataType) -> Result<String> {
             let inner = arrow_to_ducklake_type(field.data_type())?;
             Ok(format!("list<{}>", inner))
         },
-        DataType::Struct(_) => Err(DuckLakeError::UnsupportedType(format!(
-            "Struct type '{}' not yet supported for writing",
-            arrow_type
-        ))),
-        DataType::Map(_, _) => Err(DuckLakeError::UnsupportedType(format!(
-            "Map type '{}' not yet supported for writing",
-            arrow_type
-        ))),
+        DataType::Struct(fields) => {
+            let fields = fields
+                .iter()
+                .map(|field| {
+                    Ok(format!(
+                        "{}:{}",
+                        field.name(),
+                        arrow_to_ducklake_type(field.data_type())?
+                    ))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(format!("struct<{}>", fields.join(",")))
+        },
+        DataType::Map(entries, _) => {
+            let DataType::Struct(fields) = entries.data_type() else {
+                return Err(DuckLakeError::UnsupportedType(
+                    "Arrow map entries must be a struct".to_string(),
+                ));
+            };
+            let [key, value] = fields.as_ref() else {
+                return Err(DuckLakeError::UnsupportedType(
+                    "Arrow maps must have key and value fields".to_string(),
+                ));
+            };
+            Ok(format!(
+                "map<{},{}>",
+                arrow_to_ducklake_type(key.data_type())?,
+                arrow_to_ducklake_type(value.data_type())?
+            ))
+        },
 
         // Other unsupported types
         other => Err(DuckLakeError::UnsupportedType(format!(
@@ -230,7 +260,8 @@ fn decimal_data_type(precision: u8, scale: i8) -> DataType {
 /// Returns `Ok(None)` if the type string is not a decimal type.
 /// Returns `Err` if it is a decimal type but has invalid precision/scale.
 fn parse_decimal(type_str: &str) -> Result<Option<DataType>> {
-    if !type_str.starts_with("decimal") && !type_str.starts_with("numeric") {
+    let normalized = type_str.to_ascii_lowercase();
+    if !normalized.starts_with("decimal") && !normalized.starts_with("numeric") {
         return Ok(None);
     }
 
@@ -287,9 +318,9 @@ fn parse_decimal(type_str: &str) -> Result<Option<DataType>> {
 /// - `list<element_type>` / `array<element_type>` (DuckDB style)
 /// - `element_type[]` (Postgres style, e.g. `varchar[]`, `float[]`)
 ///
-/// Only simple (non-nested) element types are supported.
-fn parse_list_type(type_str: &str) -> Result<Option<DataType>> {
-    let inner = if type_str.starts_with("list<") || type_str.starts_with("array<") {
+fn parse_list_type(type_str: &str, depth: usize) -> Result<Option<DataType>> {
+    let normalized = type_str.to_ascii_lowercase();
+    let inner = if normalized.starts_with("list<") || normalized.starts_with("array<") {
         // list<type> or array<type>
         let start = type_str.find('<').unwrap();
         if !type_str.ends_with('>') {
@@ -311,20 +342,136 @@ fn parse_list_type(type_str: &str) -> Result<Option<DataType>> {
         )));
     }
 
-    // Only support simple (non-nested) element types
-    if inner.contains('<') || inner.contains('[') || inner.contains('{') {
-        return Err(DuckLakeError::UnsupportedType(format!(
-            "Nested complex type '{}' not yet supported",
-            type_str
-        )));
-    }
-
-    let element_type = ducklake_to_arrow_type(inner)?;
+    let element_type = ducklake_to_arrow_type_inner(inner, depth + 1)?;
     Ok(Some(DataType::List(Arc::new(Field::new(
         "item",
         element_type,
         true,
     )))))
+}
+
+fn parse_struct_type(type_str: &str, depth: usize) -> Result<Option<DataType>> {
+    if !type_str.to_ascii_lowercase().starts_with("struct<") {
+        return Ok(None);
+    }
+    if !type_str.ends_with('>') {
+        return Err(DuckLakeError::UnsupportedType(format!(
+            "Struct type '{type_str}' is missing its closing '>'"
+        )));
+    }
+    let inner = &type_str[7..type_str.len() - 1];
+    if inner.is_empty() {
+        return Ok(Some(DataType::Struct(Vec::<Arc<Field>>::new().into())));
+    }
+    let fields = split_top_level(inner, ',')?
+        .into_iter()
+        .map(|field| {
+            let Some(separator) = top_level_separator(field, ':') else {
+                return Err(DuckLakeError::UnsupportedType(format!(
+                    "Struct field '{field}' must use name:type syntax"
+                )));
+            };
+            let name = field[..separator].trim();
+            let type_name = field[separator + 1..].trim();
+            if name.is_empty() || type_name.is_empty() {
+                return Err(DuckLakeError::UnsupportedType(format!(
+                    "Struct field '{field}' must have a name and type"
+                )));
+            }
+            Ok(Arc::new(Field::new(
+                name,
+                ducklake_to_arrow_type_inner(type_name, depth + 1)?,
+                true,
+            )))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(Some(DataType::Struct(fields.into())))
+}
+
+fn parse_map_type(type_str: &str, depth: usize) -> Result<Option<DataType>> {
+    if !type_str.to_ascii_lowercase().starts_with("map<") {
+        return Ok(None);
+    }
+    if !type_str.ends_with('>') {
+        return Err(DuckLakeError::UnsupportedType(format!(
+            "Map type '{type_str}' is missing its closing '>'"
+        )));
+    }
+    let parts = split_top_level(&type_str[4..type_str.len() - 1], ',')?;
+    let [key_type, value_type] = parts.as_slice() else {
+        return Err(DuckLakeError::UnsupportedType(format!(
+            "Map type '{type_str}' must have key and value types"
+        )));
+    };
+    let entries = DataType::Struct(
+        vec![
+            Arc::new(Field::new(
+                "key",
+                ducklake_to_arrow_type_inner(key_type, depth + 1)?,
+                false,
+            )),
+            Arc::new(Field::new(
+                "value",
+                ducklake_to_arrow_type_inner(value_type, depth + 1)?,
+                true,
+            )),
+        ]
+        .into(),
+    );
+    Ok(Some(DataType::Map(
+        Arc::new(Field::new("entries", entries, false)),
+        false,
+    )))
+}
+
+fn split_top_level(value: &str, separator: char) -> Result<Vec<&str>> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+    let mut angle_depth = 0_i32;
+    let mut paren_depth = 0_i32;
+    for (index, character) in value.char_indices() {
+        match character {
+            '<' => angle_depth += 1,
+            '>' => angle_depth -= 1,
+            '(' => paren_depth += 1,
+            ')' => paren_depth -= 1,
+            _ => {},
+        }
+        if angle_depth < 0 || paren_depth < 0 {
+            return Err(DuckLakeError::UnsupportedType(format!(
+                "Unbalanced nested type '{value}'"
+            )));
+        }
+        if character == separator && angle_depth == 0 && paren_depth == 0 {
+            parts.push(value[start..index].trim());
+            start = index + character.len_utf8();
+        }
+    }
+    if angle_depth != 0 || paren_depth != 0 {
+        return Err(DuckLakeError::UnsupportedType(format!(
+            "Unbalanced nested type '{value}'"
+        )));
+    }
+    parts.push(value[start..].trim());
+    Ok(parts)
+}
+
+fn top_level_separator(value: &str, separator: char) -> Option<usize> {
+    let mut angle_depth = 0_i32;
+    let mut paren_depth = 0_i32;
+    for (index, character) in value.char_indices() {
+        match character {
+            '<' => angle_depth += 1,
+            '>' => angle_depth -= 1,
+            '(' => paren_depth += 1,
+            ')' => paren_depth -= 1,
+            _ => {},
+        }
+        if character == separator && angle_depth == 0 && paren_depth == 0 {
+            return Some(index);
+        }
+    }
+    None
 }
 
 /// Normalize a DuckLake type string to its canonical form.
@@ -466,12 +613,15 @@ pub fn types_equal_canonical(a: &str, b: &str) -> bool {
     }
 }
 
-/// Build an Arrow schema from a list of DuckLake table columns
+/// Build an Arrow schema from a list of DuckLake table columns.
+///
+/// Struct fields are nullable on reads because a field added after older files were written is
+/// absent from those files even when its current catalog row is non-nullable.
 pub fn build_arrow_schema(columns: &[DuckLakeTableColumn]) -> Result<Schema> {
     let fields: Result<Vec<Field>> = columns
         .iter()
         .map(|col| {
-            let data_type = ducklake_to_arrow_type(&col.column_type)?;
+            let data_type = read_compatible_data_type(&col.data_type()?, true);
             Ok(Field::new(&col.column_name, data_type, col.is_nullable))
         })
         .collect();
@@ -479,37 +629,68 @@ pub fn build_arrow_schema(columns: &[DuckLakeTableColumn]) -> Result<Schema> {
     Ok(Schema::new(fields?))
 }
 
+fn read_compatible_data_type(data_type: &DataType, nullable_struct_fields: bool) -> DataType {
+    let rewrite_field = |field: &Arc<Field>, nullable: bool| {
+        Arc::new(
+            field
+                .as_ref()
+                .clone()
+                .with_data_type(read_compatible_data_type(field.data_type(), true))
+                .with_nullable(field.is_nullable() || nullable),
+        )
+    };
+    match data_type {
+        DataType::List(field) => DataType::List(rewrite_field(field, false)),
+        DataType::LargeList(field) => DataType::LargeList(rewrite_field(field, false)),
+        DataType::FixedSizeList(field, size) => {
+            DataType::FixedSizeList(rewrite_field(field, false), *size)
+        },
+        DataType::Struct(fields) => DataType::Struct(
+            fields
+                .iter()
+                .map(|field| rewrite_field(field, nullable_struct_fields))
+                .collect::<Vec<_>>()
+                .into(),
+        ),
+        DataType::Map(entries, sorted) => DataType::Map(
+            Arc::new(
+                entries
+                    .as_ref()
+                    .clone()
+                    .with_data_type(read_compatible_data_type(entries.data_type(), false)),
+            ),
+            *sorted,
+        ),
+        _ => data_type.clone(),
+    }
+}
+
 /// Extract field_id to column_name mapping from Parquet metadata.
 /// DuckLake column_id == Parquet field_id, enabling column matching after renames.
 pub fn extract_parquet_field_ids(metadata: &ParquetMetaData) -> HashMap<i32, String> {
     let schema_descr = metadata.file_metadata().schema_descr();
-    // DuckLake assigns one field_id per *top-level* column (`column_id` == the
-    // top-level field's field_id), so read ids off the top-level fields — the
-    // root group's direct children — NOT the Parquet leaf columns.
-    //
-    // For a scalar the top-level field *is* the leaf, so both are equivalent. But
-    // for a nested column (List / struct / map) the field_id lives on the group
-    // node while the leaves carry none — e.g. a `List<Float32>` column `v` is
-    // `v (group, field_id=2) -> list -> element (leaf, no id)`. Walking the leaves
-    // (`num_columns()`) misses `v`'s id entirely, so the matcher treats the column
-    // as absent and null-fills it. Walking top-level fields finds the id where it
-    // actually sits.
-    let entries = schema_descr
-        .root_schema()
-        .get_fields()
-        .iter()
-        .filter_map(|field| {
-            let basic_info = field.get_basic_info();
-            basic_info
-                .has_id()
-                .then(|| (basic_info.id(), field.name().to_string()))
-        });
-    field_ids_dropping_duplicates(entries)
+    fn collect(type_: &parquet::schema::types::Type, entries: &mut Vec<(i32, String)>) {
+        let basic_info = type_.get_basic_info();
+        if basic_info.has_id() {
+            entries.push((basic_info.id(), type_.name().to_string()));
+        }
+        if type_.is_group() {
+            for child in type_.get_fields() {
+                collect(child, entries);
+            }
+        }
+    }
+
+    let mut entries = Vec::new();
+    for field in schema_descr.root_schema().get_fields() {
+        collect(field, &mut entries);
+    }
+    field_ids_dropping_duplicates(entries.into_iter())
 }
 
 /// Collect a `field_id -> name` map, dropping any `field_id` shared by more than
-/// one top-level column. DuckLake assigns exactly one field_id per top-level
-/// column, so a collision is malformed/adversarial parquet; binding the catalog
+/// one field. DuckLake assigns exactly one field_id per catalog column node, so
+/// a collision is malformed/adversarial parquet; binding the catalog
 /// column with that id to either physical column risks reading the wrong data.
 /// Dropping the id makes the reader null-fill that column (via its "field_id
 /// absent" path) instead of silently substituting the wrong one.
@@ -534,6 +715,180 @@ fn field_ids_dropping_duplicates(
     map
 }
 
+fn arrow_field_id_names(schema: &Schema) -> HashMap<i32, String> {
+    fn collect(field: &Field, names: &mut HashMap<i32, String>) {
+        if let Some(id) = field
+            .metadata()
+            .get(PARQUET_FIELD_ID_META_KEY)
+            .and_then(|value| value.parse().ok())
+        {
+            names.insert(id, field.name().clone());
+        }
+        match field.data_type() {
+            DataType::List(child)
+            | DataType::LargeList(child)
+            | DataType::FixedSizeList(child, _)
+            | DataType::Map(child, _) => collect(child, names),
+            DataType::Struct(fields) => {
+                for child in fields {
+                    collect(child, names);
+                }
+            },
+            _ => {},
+        }
+    }
+
+    let mut names = HashMap::new();
+    for field in schema.fields() {
+        collect(field, &mut names);
+    }
+    names
+}
+
+fn data_type_has_field_ids(data_type: &DataType) -> bool {
+    let fields: &[Arc<Field>] = match data_type {
+        DataType::List(field)
+        | DataType::LargeList(field)
+        | DataType::FixedSizeList(field, _)
+        | DataType::Map(field, _) => std::slice::from_ref(field),
+        DataType::Struct(fields) => fields,
+        _ => return false,
+    };
+    fields.iter().any(|field| {
+        field.metadata().contains_key(PARQUET_FIELD_ID_META_KEY)
+            || data_type_has_field_ids(field.data_type())
+    })
+}
+
+fn read_data_type_with_field_id_mapping(
+    data_type: &DataType,
+    nested_column_ids: &[i64],
+    parquet_field_ids: &HashMap<i32, String>,
+    arrow_field_names: &HashMap<i32, String>,
+    match_by_id: bool,
+) -> Result<DataType> {
+    fn rewrite_field(
+        field: &Field,
+        ids: &mut std::slice::Iter<'_, i64>,
+        parquet_field_ids: &HashMap<i32, String>,
+        arrow_field_names: &HashMap<i32, String>,
+        match_by_id: bool,
+    ) -> Result<Arc<Field>> {
+        let column_id = ids.next().ok_or_else(|| {
+            DuckLakeError::InvalidConfig(
+                "Nested column metadata has fewer field ids than its Arrow type".to_string(),
+            )
+        })?;
+        let field_id = i32::try_from(*column_id).map_err(|_| {
+            DuckLakeError::Internal(format!(
+                "column_id {column_id} for nested column '{}' exceeds i32 range for Parquet field_id",
+                field.name()
+            ))
+        })?;
+        let is_absent = match_by_id && !parquet_field_ids.contains_key(&field_id);
+        let name = if let Some(parquet_name) = parquet_field_ids.get(&field_id) {
+            arrow_field_names
+                .get(&field_id)
+                .unwrap_or(parquet_name)
+                .clone()
+        } else if match_by_id {
+            format!("__ducklake_absent_field_{field_id}")
+        } else {
+            field.name().clone()
+        };
+        let data_type = rewrite_type(
+            field.data_type(),
+            ids,
+            parquet_field_ids,
+            arrow_field_names,
+            match_by_id,
+        )?;
+        Ok(Arc::new(
+            field
+                .clone()
+                .with_name(name)
+                .with_data_type(data_type)
+                .with_nullable(field.is_nullable() || is_absent),
+        ))
+    }
+
+    fn rewrite_type(
+        data_type: &DataType,
+        ids: &mut std::slice::Iter<'_, i64>,
+        parquet_field_ids: &HashMap<i32, String>,
+        arrow_field_names: &HashMap<i32, String>,
+        match_by_id: bool,
+    ) -> Result<DataType> {
+        match data_type {
+            DataType::List(field) => Ok(DataType::List(rewrite_field(
+                field,
+                ids,
+                parquet_field_ids,
+                arrow_field_names,
+                match_by_id,
+            )?)),
+            DataType::LargeList(field) => Ok(DataType::LargeList(rewrite_field(
+                field,
+                ids,
+                parquet_field_ids,
+                arrow_field_names,
+                match_by_id,
+            )?)),
+            DataType::FixedSizeList(field, size) => Ok(DataType::FixedSizeList(
+                rewrite_field(
+                    field,
+                    ids,
+                    parquet_field_ids,
+                    arrow_field_names,
+                    match_by_id,
+                )?,
+                *size,
+            )),
+            DataType::Struct(fields) => Ok(DataType::Struct(
+                fields
+                    .iter()
+                    .map(|field| {
+                        rewrite_field(
+                            field,
+                            ids,
+                            parquet_field_ids,
+                            arrow_field_names,
+                            match_by_id,
+                        )
+                    })
+                    .collect::<Result<Vec<_>>>()?
+                    .into(),
+            )),
+            DataType::Map(entries, sorted) => Ok(DataType::Map(
+                Arc::new(entries.as_ref().clone().with_data_type(rewrite_type(
+                    entries.data_type(),
+                    ids,
+                    parquet_field_ids,
+                    arrow_field_names,
+                    match_by_id,
+                )?)),
+                *sorted,
+            )),
+            _ => Ok(data_type.clone()),
+        }
+    }
+
+    let mut ids = nested_column_ids.iter();
+    let result = rewrite_type(
+        data_type,
+        &mut ids,
+        parquet_field_ids,
+        arrow_field_names,
+        match_by_id,
+    )?;
+    if ids.next().is_some() {
+        return Err(DuckLakeError::InvalidConfig(
+            "Nested column metadata has more field ids than its Arrow type".to_string(),
+        ));
+    }
+    Ok(result)
+}
+
 /// Build a schema for reading Parquet files across schema evolution.
 /// Returns (read_schema, name_mapping): read_schema uses each column's physical
 /// name in the file, and name_mapping maps that physical name -> current name for
@@ -546,11 +901,12 @@ pub fn build_read_schema_with_field_id_mapping(
     file_schema: Option<&Schema>,
 ) -> Result<(Schema, HashMap<String, String>)> {
     let mut name_mapping: HashMap<String, String> = HashMap::new();
+    let arrow_field_names = file_schema.map(arrow_field_id_names).unwrap_or_default();
 
     let fields: Result<Vec<Field>> = current_columns
         .iter()
         .map(|col| {
-            let mut data_type = ducklake_to_arrow_type(&col.column_type)?;
+            let mut data_type = col.data_type()?;
             let field_id = i32::try_from(col.column_id).map_err(|_| {
                 DuckLakeError::Internal(format!(
                     "column_id {} for column '{}' exceeds i32 range for Parquet field_id",
@@ -580,23 +936,17 @@ pub fn build_read_schema_with_field_id_mapping(
                     (format!("__ducklake_absent_field_{}", field_id), true, true)
                 };
 
-            // For list/nested columns the Parquet reader reproduces the *file's*
-            // child field name (e.g. "" for files our streaming writer produces
-            // vs "item" for files written through the Arrow writer), and
-            // DataFusion's scan validates each batch against the read schema. The
-            // reconstructed name (always "item") may not match, so adopt the
-            // file's actual type for these columns when the file schema is known.
-            // Scalars keep the reconstructed type (precise per the catalog). An
-            // absent column has a synthetic name not in the file, so skip it.
-            if !is_absent
-                && matches!(
-                    data_type,
-                    DataType::List(_) | DataType::LargeList(_) | DataType::FixedSizeList(_, _)
-                )
-                && let Some(fs) = file_schema
-                && let Ok(file_field) = fs.field_with_name(&read_name)
-            {
-                data_type = file_field.data_type().clone();
+            if !is_absent && !col.nested_column_ids.is_empty() {
+                let match_nested_by_id = file_schema
+                    .and_then(|schema| schema.field_with_name(&read_name).ok())
+                    .is_some_and(|field| data_type_has_field_ids(field.data_type()));
+                data_type = read_data_type_with_field_id_mapping(
+                    &data_type,
+                    &col.nested_column_ids,
+                    parquet_field_ids,
+                    &arrow_field_names,
+                    match_nested_by_id,
+                )?;
             }
 
             if needs_rename {
@@ -630,12 +980,16 @@ mod tests {
                 column_name: "userId".to_string(), // Current name (renamed)
                 column_type: "int32".to_string(),
                 is_nullable: true,
+                data_type: None,
+                nested_column_ids: Vec::new(),
             },
             DuckLakeTableColumn {
                 column_id: 2,
                 column_name: "name".to_string(), // Not renamed
                 column_type: "varchar".to_string(),
                 is_nullable: true,
+                data_type: None,
+                nested_column_ids: Vec::new(),
             },
         ];
 
@@ -664,6 +1018,8 @@ mod tests {
             column_name: "id".to_string(),
             column_type: "int32".to_string(),
             is_nullable: true,
+            data_type: None,
+            nested_column_ids: Vec::new(),
         }];
 
         let mut parquet_field_ids = HashMap::new();
@@ -685,6 +1041,8 @@ mod tests {
             column_name: "id".to_string(),
             column_type: "int32".to_string(),
             is_nullable: true,
+            data_type: None,
+            nested_column_ids: Vec::new(),
         }];
 
         let parquet_field_ids = HashMap::new(); // No field_ids in Parquet
@@ -710,12 +1068,16 @@ mod tests {
                 column_name: "id".to_string(),
                 column_type: "int32".to_string(),
                 is_nullable: true,
+                data_type: None,
+                nested_column_ids: Vec::new(),
             },
             DuckLakeTableColumn {
                 column_id: 2,
                 column_name: "tag".to_string(),
                 column_type: "varchar".to_string(),
                 is_nullable: true,
+                data_type: None,
+                nested_column_ids: Vec::new(),
             },
         ];
 
@@ -742,6 +1104,122 @@ mod tests {
             name_mapping.get(read_schema.field(1).name()),
             Some(&"tag".to_string())
         );
+    }
+
+    #[test]
+    fn test_build_read_schema_keeps_new_nested_field() {
+        let current_columns = vec![DuckLakeTableColumn {
+            column_id: 1,
+            column_name: "payload".to_string(),
+            column_type: "struct<a:int32,b:varchar,c:int32>".to_string(),
+            is_nullable: false,
+            data_type: Some(DataType::Struct(
+                vec![
+                    Arc::new(Field::new("a", DataType::Int32, false)),
+                    Arc::new(Field::new("b", DataType::Utf8View, true)),
+                    Arc::new(Field::new("c", DataType::Int32, false)),
+                ]
+                .into(),
+            )),
+            nested_column_ids: vec![2, 3, 4],
+        }];
+        let parquet_field_ids = HashMap::from([
+            (1, "payload".to_string()),
+            (2, "a".to_string()),
+            (3, "old_b".to_string()),
+        ]);
+        let id_metadata =
+            |id: i32| HashMap::from([(PARQUET_FIELD_ID_META_KEY.to_string(), id.to_string())]);
+        let file_schema = Schema::new(vec![
+            Field::new(
+                "payload",
+                DataType::Struct(
+                    vec![
+                        Arc::new(
+                            Field::new("a", DataType::Int32, false).with_metadata(id_metadata(2)),
+                        ),
+                        Arc::new(
+                            Field::new("old_b", DataType::Utf8, true).with_metadata(id_metadata(3)),
+                        ),
+                    ]
+                    .into(),
+                ),
+                false,
+            )
+            .with_metadata(id_metadata(1)),
+        ]);
+
+        let (read_schema, _) = build_read_schema_with_field_id_mapping(
+            &current_columns,
+            &parquet_field_ids,
+            Some(&file_schema),
+        )
+        .unwrap();
+        let DataType::Struct(fields) = read_schema.field(0).data_type() else {
+            panic!("payload must remain a struct");
+        };
+
+        assert_eq!(fields.len(), 3);
+        assert_eq!(fields[0].name(), "a");
+        assert_eq!(fields[1].name(), "old_b");
+        assert_eq!(fields[2].name(), "__ducklake_absent_field_4");
+        assert_eq!(fields[2].data_type(), &DataType::Int32);
+        assert!(fields[2].is_nullable());
+    }
+
+    #[test]
+    fn test_build_read_schema_does_not_reuse_dropped_nested_name() {
+        let current_columns = vec![DuckLakeTableColumn {
+            column_id: 1,
+            column_name: "payload".to_string(),
+            column_type: "struct<c:int32>".to_string(),
+            is_nullable: false,
+            data_type: Some(DataType::Struct(
+                vec![Arc::new(Field::new("c", DataType::Int32, true))].into(),
+            )),
+            nested_column_ids: vec![4],
+        }];
+        let parquet_field_ids = HashMap::from([(1, "payload".to_string()), (3, "c".to_string())]);
+        let id_metadata =
+            |id: i32| HashMap::from([(PARQUET_FIELD_ID_META_KEY.to_string(), id.to_string())]);
+        let file_schema = Schema::new(vec![
+            Field::new(
+                "payload",
+                DataType::Struct(
+                    vec![Arc::new(
+                        Field::new("c", DataType::Int32, true).with_metadata(id_metadata(3)),
+                    )]
+                    .into(),
+                ),
+                false,
+            )
+            .with_metadata(id_metadata(1)),
+        ]);
+
+        let (read_schema, _) = build_read_schema_with_field_id_mapping(
+            &current_columns,
+            &parquet_field_ids,
+            Some(&file_schema),
+        )
+        .unwrap();
+        let DataType::Struct(fields) = read_schema.field(0).data_type() else {
+            panic!("payload must remain a struct");
+        };
+
+        assert_eq!(fields[0].name(), "__ducklake_absent_field_4");
+    }
+
+    #[test]
+    fn test_nested_type_depth_is_bounded() {
+        let nested = format!(
+            "{}int32{}",
+            "list<".repeat(MAX_NESTED_TYPE_DEPTH + 1),
+            ">".repeat(MAX_NESTED_TYPE_DEPTH + 1)
+        );
+
+        let error = ducklake_to_arrow_type(&nested).unwrap_err();
+
+        assert!(error.to_string().contains("maximum nesting depth"));
     }
 
     #[test]
@@ -844,6 +1322,15 @@ mod tests {
             arrow_to_ducklake_type(&DataType::LargeBinary).unwrap(),
             "blob"
         );
+    }
+
+    #[test]
+    fn test_dictionary_uses_logical_value_type() {
+        let dictionary = DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8));
+        assert_eq!(arrow_to_ducklake_type(&dictionary).unwrap(), "varchar");
+
+        let list = DataType::List(Arc::new(Field::new("item", dictionary, true)));
+        assert_eq!(arrow_to_ducklake_type(&list).unwrap(), "list<varchar>");
     }
 
     #[test]
@@ -998,51 +1485,48 @@ mod tests {
     }
 
     #[test]
-    fn test_unsupported_struct_type_errors() {
-        // Test struct type returns error
-        let result = ducklake_to_arrow_type("struct<a:int32,b:varchar>");
-        assert!(result.is_err());
-        match result {
-            Err(DuckLakeError::UnsupportedType(msg)) => {
-                assert!(msg.contains("struct<a:int32,b:varchar>"));
-                assert!(msg.contains("not yet supported"));
-                assert!(msg.contains("open an issue"));
-            },
-            _ => panic!("Expected UnsupportedType error for struct type"),
-        }
+    fn test_struct_type() {
+        let result = ducklake_to_arrow_type("STRUCT<Price:DECIMAL(38,16),Label:VARCHAR>").unwrap();
+        assert_eq!(
+            result,
+            DataType::Struct(
+                vec![
+                    Arc::new(Field::new("Price", DataType::Decimal128(38, 16), true,)),
+                    Arc::new(Field::new("Label", DataType::Utf8View, true)),
+                ]
+                .into(),
+            )
+        );
     }
 
     #[test]
-    fn test_unsupported_map_type_errors() {
-        // Test map type returns error
-        let result = ducklake_to_arrow_type("map<varchar,int32>");
-        assert!(result.is_err());
-        match result {
-            Err(DuckLakeError::UnsupportedType(msg)) => {
-                assert!(msg.contains("map<varchar,int32>"));
-                assert!(msg.contains("not yet supported"));
-                assert!(msg.contains("open an issue"));
-            },
-            _ => panic!("Expected UnsupportedType error for map type"),
-        }
+    fn test_map_type() {
+        let result = ducklake_to_arrow_type("map<varchar,list<int32>>").unwrap();
+        let DataType::Map(entries, false) = result else {
+            panic!("expected map");
+        };
+        let DataType::Struct(fields) = entries.data_type() else {
+            panic!("expected map entries struct");
+        };
+        assert_eq!(fields[0].name(), "key");
+        assert_eq!(fields[0].data_type(), &DataType::Utf8View);
+        assert_eq!(
+            fields[1].data_type(),
+            &DataType::List(Arc::new(Field::new("item", DataType::Int32, true)))
+        );
     }
 
     #[test]
-    fn test_nested_complex_types_error() {
-        // Nested complex types return error
-        let result = ducklake_to_arrow_type("list<struct<a:int32,b:varchar>>");
-        assert!(result.is_err());
-        match result {
-            Err(DuckLakeError::UnsupportedType(msg)) => {
-                assert!(msg.contains("Nested complex type"));
-                assert!(msg.contains("not yet supported"));
-            },
-            _ => panic!("Expected UnsupportedType error for nested complex type"),
-        }
+    fn test_arbitrarily_composed_nested_types() {
+        let type_name = "list<struct<levels:list<struct<price:decimal(38, 16)>>,attrs:map<varchar,list<int32>>>>";
+        let arrow = ducklake_to_arrow_type(type_name).unwrap();
+        assert_eq!(arrow_to_ducklake_type(&arrow).unwrap(), type_name);
 
-        // Nested list also errors
-        assert!(ducklake_to_arrow_type("list<list<int32>>").is_err());
-        assert!(ducklake_to_arrow_type("int32[][]").is_err());
+        let nested_lists = ducklake_to_arrow_type("int32[][]").unwrap();
+        assert_eq!(
+            arrow_to_ducklake_type(&nested_lists).unwrap(),
+            "list<list<int32>>"
+        );
     }
 
     #[test]
@@ -1237,17 +1721,12 @@ mod tests {
     }
 
     #[test]
-    fn test_arrow_to_ducklake_unsupported_struct() {
+    fn test_arrow_to_ducklake_struct() {
         let struct_type = DataType::Struct(vec![Field::new("a", DataType::Int32, true)].into());
-        let result = arrow_to_ducklake_type(&struct_type);
-        assert!(result.is_err());
-        match result {
-            Err(DuckLakeError::UnsupportedType(msg)) => {
-                assert!(msg.contains("Struct type"));
-                assert!(msg.contains("not yet supported"));
-            },
-            _ => panic!("Expected UnsupportedType error"),
-        }
+        assert_eq!(
+            arrow_to_ducklake_type(&struct_type).unwrap(),
+            "struct<a:int32>"
+        );
     }
 
     #[test]
@@ -1367,12 +1846,16 @@ mod tests {
                 column_name: "id".to_string(),
                 column_type: "int32".to_string(),
                 is_nullable: true,
+                data_type: None,
+                nested_column_ids: Vec::new(),
             },
             DuckLakeTableColumn {
                 column_id: 2,
                 column_name: "tags".to_string(),
                 column_type: "list<varchar>".to_string(),
                 is_nullable: true,
+                data_type: None,
+                nested_column_ids: Vec::new(),
             },
         ];
 
@@ -1385,17 +1868,23 @@ mod tests {
     }
 
     #[test]
-    fn test_build_schema_with_unsupported_type() {
-        // Test that build_arrow_schema propagates complex type errors
+    fn test_build_schema_with_struct_type() {
         let columns = vec![DuckLakeTableColumn {
             column_id: 1,
             column_name: "data".to_string(),
             column_type: "struct<a:int32>".to_string(),
             is_nullable: true,
+            data_type: Some(DataType::Struct(
+                vec![Arc::new(Field::new("a", DataType::Int32, false))].into(),
+            )),
+            nested_column_ids: Vec::new(),
         }];
 
-        let result = build_arrow_schema(&columns);
-        assert!(result.is_err());
+        let schema = build_arrow_schema(&columns).unwrap();
+        assert_eq!(
+            schema.field(0).data_type(),
+            &DataType::Struct(vec![Field::new("a", DataType::Int32, true)].into())
+        );
     }
 
     #[test]
@@ -1405,6 +1894,8 @@ mod tests {
             column_name: "id".to_string(),
             column_type: "int32".to_string(),
             is_nullable: true,
+            data_type: None,
+            nested_column_ids: Vec::new(),
         }];
 
         let mut parquet_field_ids = HashMap::new();
@@ -1421,6 +1912,8 @@ mod tests {
             column_name: "id".to_string(),
             column_type: "int32".to_string(),
             is_nullable: true,
+            data_type: None,
+            nested_column_ids: Vec::new(),
         }];
 
         let parquet_field_ids = HashMap::new();
@@ -1451,6 +1944,8 @@ mod tests {
             column_name: "id".to_string(),
             column_type: "int32".to_string(),
             is_nullable: true,
+            data_type: None,
+            nested_column_ids: Vec::new(),
         }];
 
         let mut parquet_field_ids = HashMap::new();

--- a/tests/it/compaction_sqlite_tests.rs
+++ b/tests/it/compaction_sqlite_tests.rs
@@ -11,8 +11,8 @@
 
 use std::sync::Arc;
 
-use arrow::array::{Array, Int32Array, Int64Array};
-use arrow::datatypes::{DataType, Field, Schema};
+use arrow::array::{Array, Int32Array, Int64Array, ListArray};
+use arrow::datatypes::{DataType, Field, Int32Type, Schema};
 use arrow::record_batch::RecordBatch;
 use datafusion::execution::memory_pool::FairSpillPool;
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
@@ -724,6 +724,106 @@ async fn merge_harvests_output_stats_and_removes_source_stats() {
         1,
         "merged file's id-column zone map should span the union of the sources"
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn merge_nested_table_uses_top_level_stats_ids() {
+    let temp = TempDir::new().unwrap();
+    let values1 = ListArray::from_iter_primitive::<Int32Type, _, _>(vec![
+        Some(vec![Some(10), Some(11)]),
+        Some(vec![Some(20)]),
+    ]);
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("items", values1.data_type().clone(), true),
+    ]));
+    let writer: Arc<dyn MetadataWriter> = Arc::new(make_writer(&temp).await);
+    let batch1 = batch(
+        Arc::clone(&schema),
+        vec![Arc::new(Int32Array::from(vec![1, 2])), Arc::new(values1)],
+    );
+    DuckLakeTableWriter::new(Arc::clone(&writer), object_store())
+        .unwrap()
+        .write_table("main", "t", &[batch1])
+        .await
+        .unwrap();
+
+    let values2 = ListArray::from_iter_primitive::<Int32Type, _, _>(vec![
+        Some(vec![Some(30), Some(31)]),
+        Some(vec![Some(40)]),
+    ]);
+    let batch2 = batch(
+        schema,
+        vec![Arc::new(Int32Array::from(vec![3, 4])), Arc::new(values2)],
+    );
+    DuckLakeTableWriter::new(writer, object_store())
+        .unwrap()
+        .append_table("main", "t", &[batch2])
+        .await
+        .unwrap();
+
+    assert_eq!(
+        run_merge(&temp, MergeOptions::default()).await,
+        CompactionResult {
+            files_processed: 2,
+            files_created: 1,
+            rows_written: 4,
+        },
+    );
+
+    let p = pool(&temp).await;
+    assert_eq!(
+        scalar_i64(
+            &p,
+            "SELECT COUNT(*) FROM ducklake_data_file WHERE end_snapshot IS NULL",
+        )
+        .await,
+        1,
+    );
+    assert_eq!(
+        scalar_i64(
+            &p,
+            "SELECT COUNT(*) FROM ducklake_file_column_stats s
+             JOIN ducklake_data_file d ON d.data_file_id = s.data_file_id
+             JOIN ducklake_column c ON c.column_id = s.column_id
+             WHERE d.end_snapshot IS NULL AND c.parent_column IS NOT NULL",
+        )
+        .await,
+        0,
+        "compaction stats must not label an embedded column with a nested field id",
+    );
+
+    let provider = SqliteMetadataProvider::new(&ro_url(&temp)).await.unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog(
+        "ducklake",
+        Arc::new(DuckLakeCatalog::new(provider).unwrap()),
+    );
+    let batches = ctx
+        .sql("SELECT id, items FROM ducklake.main.t ORDER BY id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(batches.len(), 1);
+    let ids = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .unwrap();
+    let values = batches[0]
+        .column(1)
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .unwrap();
+    assert_eq!(ids.values(), &[1, 2, 3, 4]);
+    let expected = [vec![10, 11], vec![20], vec![30, 31], vec![40]];
+    for (index, expected) in expected.iter().enumerate() {
+        let values = values.value(index);
+        let values = values.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(values.values(), expected);
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/it/concurrent_write_tests.rs
+++ b/tests/it/concurrent_write_tests.rs
@@ -422,13 +422,25 @@ async fn test_stress_concurrent_writes() {
     for i in 0..50 {
         let writer_clone = Arc::clone(&writer);
         let task = tokio::spawn(async move {
-            let table_writer =
-                DuckLakeTableWriter::new(writer_clone, create_object_store()).unwrap();
             let batch = create_user_batch(&[i], &[&format!("stress_{}", i)]);
             let table_name = format!("stress_table_{}", i % 10);
-            table_writer
-                .append_table("main", &table_name, &[batch])
-                .await
+            for _ in 0..10 {
+                let table_writer =
+                    DuckLakeTableWriter::new(Arc::clone(&writer_clone), create_object_store())
+                        .unwrap();
+                match table_writer
+                    .append_table("main", &table_name, std::slice::from_ref(&batch))
+                    .await
+                {
+                    Err(datafusion_ducklake::DuckLakeError::Conflict(_)) => {
+                        tokio::task::yield_now().await;
+                    },
+                    result => return result,
+                }
+            }
+            Err(datafusion_ducklake::DuckLakeError::Conflict(
+                "concurrent write retry limit exceeded".to_string(),
+            ))
         });
         tasks.push(task);
     }

--- a/tests/it/multicatalog_postgres_tests.rs
+++ b/tests/it/multicatalog_postgres_tests.rs
@@ -9,6 +9,9 @@
 //! - Per-catalog dense `schema_version` allocation
 //! - No orphan mapping rows after writes
 
+use std::sync::Arc;
+
+use arrow::datatypes::{DataType, Field};
 use datafusion_ducklake::metadata_writer::{
     ColumnDef, DataFileInfo, MetadataWriter, SnapshotCommitMetadata, WriteMode,
 };
@@ -121,6 +124,96 @@ async fn visible_records_at_head(pool: &PgPool, catalog_id: i64, table_id: i64) 
     .unwrap()
     .try_get(0)
     .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn postgres_writer_persists_recursive_columns() {
+    let (pool, _container) = spin_up_postgres().await.unwrap();
+    let catalog_id = MulticatalogManager::new(pool.clone())
+        .create_catalog("nested_columns")
+        .await
+        .unwrap();
+    let writer = PostgresMetadataWriter::with_pool(pool.clone(), catalog_id)
+        .await
+        .unwrap();
+    let levels = DataType::List(Arc::new(Field::new(
+        "item",
+        DataType::Struct(
+            vec![
+                Arc::new(Field::new("price", DataType::Decimal128(38, 16), false)),
+                Arc::new(Field::new("count", DataType::UInt32, false)),
+            ]
+            .into(),
+        ),
+        false,
+    )));
+    let columns = vec![ColumnDef::from_arrow("bids", &levels, false).unwrap()];
+
+    let setup = writer
+        .begin_write_transaction("public", "depths", &columns, WriteMode::Replace)
+        .unwrap();
+    assert_eq!(setup.column_ids, vec![setup.field_ids[0]]);
+    assert_eq!(setup.field_ids.len(), 4);
+    writer
+        .register_data_file(
+            setup.table_id,
+            "public",
+            "depths",
+            setup.snapshot_id,
+            &DataFileInfo::new("depths.parquet", 1, 1),
+            WriteMode::Replace,
+            setup.base_snapshot_id,
+            &columns,
+            &setup.field_ids,
+        )
+        .unwrap();
+
+    let rows = sqlx::query(
+        "SELECT column_id, column_name, column_type, parent_column
+         FROM ducklake_column
+         WHERE table_id = $1 AND end_snapshot IS NULL
+         ORDER BY column_order",
+    )
+    .bind(setup.table_id)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    let actual = rows
+        .iter()
+        .map(|row| {
+            (
+                row.try_get::<i64, _>("column_id").unwrap(),
+                row.try_get::<String, _>("column_name").unwrap(),
+                row.try_get::<String, _>("column_type").unwrap(),
+                row.try_get::<Option<i64>, _>("parent_column").unwrap(),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        actual,
+        vec![
+            (setup.field_ids[0], "bids".into(), "list".into(), None),
+            (
+                setup.field_ids[1],
+                "element".into(),
+                "struct".into(),
+                Some(setup.field_ids[0]),
+            ),
+            (
+                setup.field_ids[2],
+                "price".into(),
+                "decimal(38, 16)".into(),
+                Some(setup.field_ids[1]),
+            ),
+            (
+                setup.field_ids[3],
+                "count".into(),
+                "uint32".into(),
+                Some(setup.field_ids[1]),
+            ),
+        ]
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/it/mysql_metadata_provider_test.rs
+++ b/tests/it/mysql_metadata_provider_test.rs
@@ -741,13 +741,13 @@ async fn test_get_table_structure() {
     assert_eq!(columns.len(), 3, "users table should have 3 columns");
 
     assert_eq!(columns[0].column_name, "id");
-    assert_eq!(columns[0].column_type, "INT");
+    assert_eq!(columns[0].column_type, "int32");
 
     assert_eq!(columns[1].column_name, "name");
-    assert_eq!(columns[1].column_type, "VARCHAR");
+    assert_eq!(columns[1].column_type, "varchar");
 
     assert_eq!(columns[2].column_name, "email");
-    assert_eq!(columns[2].column_type, "VARCHAR");
+    assert_eq!(columns[2].column_type, "varchar");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/it/mysql_metadata_writer_test.rs
+++ b/tests/it/mysql_metadata_writer_test.rs
@@ -9,11 +9,13 @@
 //! as `tests/it/mysql_metadata_provider_test.rs`: it is ignored under
 //! `skip-tests-with-docker` on macOS (Docker unavailable there).
 
+use arrow::datatypes::{DataType, Field};
 use datafusion_ducklake::{
     ColumnDef, DataFileInfo, MetadataProvider, MetadataWriter, MySqlMetadataProvider,
     MySqlMetadataWriter, SnapshotCommitMetadata, WriteMode,
 };
 use sqlx::Row;
+use std::sync::Arc;
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::mysql::Mysql;
 
@@ -191,4 +193,95 @@ async fn mysql_writer_roundtrip_write_then_read() {
     assert_eq!(empty_structure[0].column_name, "c1");
     let empty_files = provider.get_table_files_for_select(empty_id, snap).unwrap();
     assert!(empty_files.is_empty(), "empty_t has no data files");
+
+    let levels = DataType::List(Arc::new(Field::new(
+        "item",
+        DataType::Struct(
+            vec![
+                Arc::new(Field::new("price", DataType::Decimal128(38, 16), false)),
+                Arc::new(Field::new("count", DataType::UInt32, false)),
+            ]
+            .into(),
+        ),
+        false,
+    )));
+    let nested_columns = vec![ColumnDef::from_arrow("bids", &levels, false).unwrap()];
+    let nested_setup = writer
+        .begin_write_transaction("main", "depths", &nested_columns, WriteMode::Replace)
+        .unwrap();
+    assert_eq!(nested_setup.column_ids, vec![nested_setup.field_ids[0]]);
+    assert_eq!(nested_setup.field_ids.len(), 4);
+    let nested_commit = writer
+        .register_data_file(
+            nested_setup.table_id,
+            "main",
+            "depths",
+            nested_setup.snapshot_id,
+            &DataFileInfo::new("depths.parquet", 1, 1),
+            WriteMode::Replace,
+            nested_setup.base_snapshot_id,
+            &nested_columns,
+            &nested_setup.field_ids,
+        )
+        .unwrap();
+    let nested_structure = provider
+        .get_table_structure(nested_setup.table_id, nested_commit.snapshot_id)
+        .unwrap();
+    assert_eq!(nested_structure.len(), 1);
+    assert_eq!(nested_structure[0].column_name, "bids");
+    assert_eq!(
+        nested_structure[0].column_type,
+        "list<struct<price:decimal(38, 16),count:uint32>>"
+    );
+
+    let nested_rows = sqlx::query(
+        "SELECT column_id, column_name, column_type, parent_column
+         FROM ducklake_column
+         WHERE table_id = ? AND end_snapshot IS NULL
+         ORDER BY column_order",
+    )
+    .bind(nested_setup.table_id)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    let nested_actual = nested_rows
+        .iter()
+        .map(|row| {
+            (
+                row.try_get::<i64, _>("column_id").unwrap(),
+                row.try_get::<String, _>("column_name").unwrap(),
+                row.try_get::<String, _>("column_type").unwrap(),
+                row.try_get::<Option<i64>, _>("parent_column").unwrap(),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        nested_actual,
+        vec![
+            (
+                nested_setup.field_ids[0],
+                "bids".into(),
+                "list".into(),
+                None
+            ),
+            (
+                nested_setup.field_ids[1],
+                "element".into(),
+                "struct".into(),
+                Some(nested_setup.field_ids[0]),
+            ),
+            (
+                nested_setup.field_ids[2],
+                "price".into(),
+                "decimal(38, 16)".into(),
+                Some(nested_setup.field_ids[1]),
+            ),
+            (
+                nested_setup.field_ids[3],
+                "count".into(),
+                "uint32".into(),
+                Some(nested_setup.field_ids[1]),
+            ),
+        ]
+    );
 }

--- a/tests/it/postgres_metadata_provider_test.rs
+++ b/tests/it/postgres_metadata_provider_test.rs
@@ -765,13 +765,13 @@ async fn test_get_table_structure() {
     assert_eq!(columns.len(), 3, "users table should have 3 columns");
 
     assert_eq!(columns[0].column_name, "id");
-    assert_eq!(columns[0].column_type, "INT");
+    assert_eq!(columns[0].column_type, "int32");
 
     assert_eq!(columns[1].column_name, "name");
-    assert_eq!(columns[1].column_type, "VARCHAR");
+    assert_eq!(columns[1].column_type, "varchar");
 
     assert_eq!(columns[2].column_name, "email");
-    assert_eq!(columns[2].column_type, "VARCHAR");
+    assert_eq!(columns[2].column_type, "varchar");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/it/postgres_single_catalog_write_tests.rs
+++ b/tests/it/postgres_single_catalog_write_tests.rs
@@ -18,10 +18,10 @@ use testcontainers::ContainerAsync;
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::postgres::Postgres;
 
-use datafusion_ducklake::metadata_writer::{ColumnDef, MetadataWriter, WriteMode};
+use datafusion_ducklake::metadata_writer::{ColumnDef, DataFileInfo, MetadataWriter, WriteMode};
 use datafusion_ducklake::{
-    DuckLakeCatalog, DuckLakeTableWriter, PostgresMetadataProvider,
-    PostgresSingleCatalogMetadataWriter,
+    DuckLakeCatalog, DuckLakeTableWriter, NullOrder, PartitionTransform, PostgresMetadataProvider,
+    PostgresSingleCatalogMetadataWriter, SortDirection, SortField,
 };
 
 /// Returns everything the caller must keep alive — dropping the container tears
@@ -634,6 +634,59 @@ async fn sort_spec_set_then_reset() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn partition_and_sort_specs_ignore_nested_name_collision() {
+    let (writer, pool, _conn, _tmp, _container) = setup().await.unwrap();
+    let snapshot = writer.create_snapshot().unwrap();
+    let (schema_id, _) = writer.get_or_create_schema("main", None, snapshot).unwrap();
+    let (table_id, _) = writer
+        .get_or_create_table(schema_id, "t", None, snapshot)
+        .unwrap();
+    let columns = vec![
+        ColumnDef::new("id", "int64", false).unwrap(),
+        ColumnDef::from_arrow(
+            "payload",
+            &DataType::Struct(vec![Field::new("id", DataType::Int32, true)].into()),
+            true,
+        )
+        .unwrap(),
+    ];
+    writer.set_columns(table_id, &columns, snapshot).unwrap();
+    let top_level_id: i64 = sqlx::query_scalar(
+        "SELECT column_id FROM ducklake_column
+         WHERE table_id = $1 AND column_name = 'id' AND parent_column IS NULL",
+    )
+    .bind(table_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    writer
+        .set_partition_spec(
+            table_id,
+            &[("id".to_string(), PartitionTransform::Identity)],
+        )
+        .unwrap();
+    writer
+        .set_sort_spec(
+            table_id,
+            &[SortField::column(0, "id", SortDirection::Asc, NullOrder::NullsLast)],
+        )
+        .unwrap();
+
+    let partition_id: i64 = sqlx::query_scalar(
+        "SELECT column_id FROM ducklake_partition_column
+         WHERE table_id = $1 ORDER BY partition_id DESC LIMIT 1",
+    )
+    .bind(table_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(partition_id, top_level_id);
+    assert!(writer.live_sort_spec(table_id).unwrap().is_some());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
 async fn set_partition_spec_rejects_unknown_column() {
     use datafusion_ducklake::PartitionTransform;
 
@@ -690,6 +743,92 @@ async fn append_rejects_a_column_type_change() {
         ),
         "unexpected error: {err}"
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn append_migrates_legacy_list_catalog_rows() {
+    let (writer, pool, _conn, _tmp, _container) = setup().await.unwrap();
+    let snapshot = writer.create_snapshot().unwrap();
+    let (schema_id, _) = writer.get_or_create_schema("main", None, snapshot).unwrap();
+    let (table_id, _) = writer
+        .get_or_create_table(schema_id, "t", None, snapshot)
+        .unwrap();
+    let columns = vec![ColumnDef::new("values", "list<float32>", true).unwrap()];
+    let ids = writer.set_columns(table_id, &columns, snapshot).unwrap();
+    let list_id = ids[0];
+    let old_element_id: i64 = sqlx::query_scalar(
+        "SELECT column_id FROM ducklake_column
+         WHERE table_id = $1 AND parent_column = $2 AND end_snapshot IS NULL",
+    )
+    .bind(table_id)
+    .bind(list_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    sqlx::query("DELETE FROM ducklake_column WHERE column_id = $1")
+        .bind(old_element_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE ducklake_column SET column_type = 'list<float32>' WHERE column_id = $1")
+        .bind(list_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let write = writer
+        .begin_write_transaction("main", "t", &columns, WriteMode::Append)
+        .unwrap();
+    writer
+        .register_data_file(
+            write.table_id,
+            "main",
+            "t",
+            write.snapshot_id,
+            &DataFileInfo::new("data.parquet", 1, 1),
+            WriteMode::Append,
+            write.base_snapshot_id,
+            &columns,
+            &write.field_ids,
+        )
+        .unwrap();
+
+    let versions = sqlx::query_as::<_, (String, i64, Option<i64>)>(
+        "SELECT column_type, begin_snapshot, end_snapshot
+         FROM ducklake_column
+         WHERE table_id = $1 AND column_id = $2
+         ORDER BY begin_snapshot",
+    )
+    .bind(table_id)
+    .bind(list_id)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        versions,
+        vec![
+            ("list<float32>".into(), snapshot, Some(write.snapshot_id)),
+            ("list".into(), write.snapshot_id, None),
+        ]
+    );
+
+    let rows = sqlx::query_as::<_, (i64, String, String, Option<i64>)>(
+        "SELECT column_id, column_name, column_type, parent_column
+         FROM ducklake_column
+         WHERE table_id = $1 AND end_snapshot IS NULL
+         ORDER BY column_order",
+    )
+    .bind(table_id)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0], (list_id, "values".into(), "list".into(), None));
+    assert_eq!(rows[1].1, "element");
+    assert_eq!(rows[1].2, "float32");
+    assert_eq!(rows[1].3, Some(list_id));
+    assert_ne!(rows[1].0, old_element_id);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/it/sql_update_tests.rs
+++ b/tests/it/sql_update_tests.rs
@@ -14,10 +14,13 @@
 
 #![cfg(all(feature = "write-sqlite", feature = "metadata-sqlite"))]
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
-use arrow::array::{Array, Int32Array, Int64Array, UInt64Array};
-use arrow::datatypes::{DataType, Field, Schema};
+use arrow::array::{
+    Array, Int32Array, Int64Array, ListArray, StringArray, StringViewArray, StructArray,
+    UInt64Array,
+};
+use arrow::datatypes::{DataType, Field, Int32Type, Schema};
 use arrow::record_batch::RecordBatch;
 use datafusion::prelude::*;
 use object_store::local::LocalFileSystem;
@@ -27,8 +30,8 @@ use tempfile::TempDir;
 
 use datafusion_ducklake::sort::{NullOrder, SortDirection, SortField};
 use datafusion_ducklake::{
-    DuckLakeCatalog, DuckLakeTableWriter, MetadataProvider, MetadataWriter, SqliteMetadataProvider,
-    SqliteMetadataWriter, WriteMode, register_ducklake_functions,
+    DuckLakeCatalog, DuckLakeTableWriter, MetadataProvider, MetadataWriter, PartitionTransform,
+    SqliteMetadataProvider, SqliteMetadataWriter, WriteMode, register_ducklake_functions,
 };
 
 /// The `(id, val)` schema used throughout.
@@ -313,6 +316,193 @@ async fn update_sets_value_where_id() {
         "id=2 gets the new value; others unchanged"
     );
     assert_eq!(rows.len(), 4, "row count is unchanged by UPDATE");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_table_with_list_column() {
+    let temp_dir = TempDir::new().unwrap();
+    let writer = Arc::new(make_writer(&temp_dir).await);
+    let values = ListArray::from_iter_primitive::<Int32Type, _, _>(vec![
+        Some(vec![Some(10), Some(11)]),
+        Some(vec![Some(20)]),
+    ]);
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("items", values.data_type().clone(), true),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![Arc::new(Int32Array::from(vec![1, 2])), Arc::new(values)],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(writer, object_store())
+        .unwrap()
+        .write_table("main", "list_table", &[batch])
+        .await
+        .unwrap();
+
+    let ctx = writable_ctx(&temp_dir).await;
+    assert_eq!(
+        run_dml_count(
+            &ctx,
+            "UPDATE ducklake.main.list_table SET id = 20 WHERE id = 2",
+        )
+        .await,
+        1,
+    );
+
+    let batches = read_ctx(&temp_dir, false)
+        .await
+        .sql("SELECT id, items FROM ducklake.main.list_table ORDER BY id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(batches.len(), 1);
+    let ids = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .unwrap();
+    let values = batches[0]
+        .column(1)
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .unwrap();
+    assert_eq!(ids.values(), &[1, 20]);
+    let first = values.value(0);
+    let first = first.as_any().downcast_ref::<Int32Array>().unwrap();
+    let second = values.value(1);
+    let second = second.as_any().downcast_ref::<Int32Array>().unwrap();
+    assert_eq!(first.values(), &[10, 11]);
+    assert_eq!(second.values(), &[20]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_table_with_struct_column() {
+    let temp_dir = TempDir::new().unwrap();
+    let writer = Arc::new(make_writer(&temp_dir).await);
+    let fields = vec![
+        Arc::new(
+            Field::new("label", DataType::Utf8, false).with_metadata(HashMap::from([(
+                "PARQUET:field_id".to_string(),
+                "3".to_string(),
+            )])),
+        ),
+        Arc::new(
+            Field::new("score", DataType::Int32, false).with_metadata(HashMap::from([(
+                "PARQUET:field_id".to_string(),
+                "4".to_string(),
+            )])),
+        ),
+    ];
+    let values = StructArray::new(
+        fields.clone().into(),
+        vec![
+            Arc::new(StringArray::from(vec!["one", "two"])),
+            Arc::new(Int32Array::from(vec![10, 20])),
+        ],
+        None,
+    );
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("attrs", DataType::Struct(fields.into()), false),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![Arc::new(Int32Array::from(vec![1, 2])), Arc::new(values)],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(writer, object_store())
+        .unwrap()
+        .write_table("main", "struct_table", &[batch])
+        .await
+        .unwrap();
+    let provider = SqliteMetadataProvider::new(&format!(
+        "sqlite:{}",
+        temp_dir.path().join("test.db").display()
+    ))
+    .await
+    .unwrap();
+    let snapshot = provider.get_current_snapshot().unwrap();
+    let catalog_schema = provider
+        .get_schema_by_name("main", snapshot)
+        .unwrap()
+        .unwrap();
+    let table = provider
+        .get_table_by_name(catalog_schema.schema_id, "struct_table", snapshot)
+        .unwrap()
+        .unwrap();
+    let metadata_writer = make_writer(&temp_dir).await;
+    metadata_writer
+        .set_partition_spec(
+            table.table_id,
+            &[("id".to_string(), PartitionTransform::Identity)],
+        )
+        .unwrap();
+    metadata_writer
+        .set_sort_spec(
+            table.table_id,
+            &[SortField::column(0, "id", SortDirection::Asc, NullOrder::NullsLast)],
+        )
+        .unwrap();
+
+    let ctx = writable_ctx(&temp_dir).await;
+    assert_eq!(
+        run_dml_count(
+            &ctx,
+            "UPDATE ducklake.main.struct_table SET id = 20 WHERE id = 2",
+        )
+        .await,
+        1,
+    );
+    let ctx = writable_ctx(&temp_dir).await;
+    assert_eq!(
+        run_dml_count(
+            &ctx,
+            "UPDATE ducklake.main.struct_table SET id = 200 WHERE id = 20",
+        )
+        .await,
+        1,
+    );
+
+    let batches = read_ctx(&temp_dir, false)
+        .await
+        .sql("SELECT id, attrs FROM ducklake.main.struct_table ORDER BY id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(batches.len(), 1);
+    let ids = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .unwrap();
+    let attrs = batches[0]
+        .column(1)
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .unwrap();
+    let labels = attrs
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringViewArray>()
+        .unwrap();
+    let scores = attrs
+        .column(1)
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .unwrap();
+
+    assert_eq!(ids.values(), &[1, 200]);
+    assert_eq!(
+        labels.iter().collect::<Vec<_>>(),
+        vec![Some("one"), Some("two")]
+    );
+    assert_eq!(scores.values(), &[10, 20]);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/it/sqlite_metadata_provider_test.rs
+++ b/tests/it/sqlite_metadata_provider_test.rs
@@ -728,15 +728,15 @@ async fn test_get_table_structure() {
     assert_eq!(columns.len(), 3, "users table should have 3 columns");
 
     assert_eq!(columns[0].column_name, "id");
-    assert_eq!(columns[0].column_type, "INT");
+    assert_eq!(columns[0].column_type, "int32");
     assert!(!columns[0].is_nullable);
 
     assert_eq!(columns[1].column_name, "name");
-    assert_eq!(columns[1].column_type, "VARCHAR");
+    assert_eq!(columns[1].column_type, "varchar");
     assert!(columns[1].is_nullable);
 
     assert_eq!(columns[2].column_name, "email");
-    assert_eq!(columns[2].column_type, "VARCHAR");
+    assert_eq!(columns[2].column_type, "varchar");
     assert!(columns[2].is_nullable);
 }
 

--- a/tests/it/write_tests.rs
+++ b/tests/it/write_tests.rs
@@ -8,27 +8,30 @@
 use std::sync::Arc;
 
 use arrow::array::{
-    Array, BinaryViewArray, BooleanArray, Date32Array, Float64Array, Int32Array, Int64Array,
-    ListArray, ListBuilder, StringArray, StringBuilder, StringViewArray, TimestampMicrosecondArray,
-    TimestampNanosecondArray,
+    Array, BinaryViewArray, BooleanArray, Date32Array, Decimal128Array, Float32Array, Float64Array,
+    Int32Array, Int64Array, ListArray, ListBuilder, MapArray, StringArray, StringBuilder,
+    StringViewArray, StructArray, TimestampMicrosecondArray, TimestampNanosecondArray, UInt32Array,
+    UInt64Array,
 };
-use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use arrow::buffer::{OffsetBuffer, ScalarBuffer};
+use arrow::datatypes::{DataType, Field, Float32Type, Schema, TimeUnit};
 use arrow::record_batch::RecordBatch;
 use datafusion::prelude::*;
 use object_store::local::LocalFileSystem;
+use sqlx::Row;
 use tempfile::TempDir;
 
 use datafusion_ducklake::{
     DuckLakeCatalog, DuckLakeTableWriter, MetadataWriter, SqliteMetadataProvider,
-    SqliteMetadataWriter, WriteMode,
+    SqliteMetadataWriter, WriteMode, register_ducklake_functions,
 };
 
-/// Create a local filesystem object store
+/// Create a local filesystem object store.
 fn create_object_store() -> Arc<dyn object_store::ObjectStore> {
     Arc::new(LocalFileSystem::new())
 }
 
-/// Helper to create a test environment with writer and data directory
+/// Create a test environment with a writer and data directory.
 async fn create_test_env() -> (SqliteMetadataWriter, TempDir) {
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("test.db");
@@ -44,7 +47,7 @@ async fn create_test_env() -> (SqliteMetadataWriter, TempDir) {
     (writer, temp_dir)
 }
 
-/// Helper to create a SessionContext with a DuckLakeCatalog
+/// Create a `SessionContext` with a `DuckLakeCatalog`.
 async fn create_read_context(temp_dir: &TempDir) -> SessionContext {
     let db_path = temp_dir.path().join("test.db");
     let conn_str = format!("sqlite:{}", db_path.display());
@@ -55,6 +58,123 @@ async fn create_read_context(temp_dir: &TempDir) -> SessionContext {
     let ctx = SessionContext::new();
     ctx.register_catalog("test", Arc::new(catalog));
     ctx
+}
+
+fn parquet_schema_fields(path: &std::path::Path) -> Vec<(String, Option<i32>)> {
+    fn collect(field: &parquet::schema::types::Type, result: &mut Vec<(String, Option<i32>)>) {
+        let info = field.get_basic_info();
+        result.push((field.name().to_string(), info.has_id().then(|| info.id())));
+        if field.is_group() {
+            for child in field.get_fields() {
+                collect(child, result);
+            }
+        }
+    }
+
+    let builder =
+        datafusion::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(
+            std::fs::File::open(path).unwrap(),
+        )
+        .unwrap();
+    let root = builder
+        .metadata()
+        .file_metadata()
+        .schema_descr()
+        .root_schema();
+    let mut result = Vec::new();
+    for field in root.get_fields() {
+        collect(field, &mut result);
+    }
+    result
+}
+
+fn assert_duckdb_extension_reads_depths(catalog_path: &std::path::Path) {
+    let conformance_path = catalog_path.with_file_name("duckdb-conformance.db");
+    std::fs::copy(catalog_path, &conformance_path).unwrap();
+
+    // This fork's catalog schema predates fields the official DuckLake extension requires. Add
+    // those compatibility fields to a disposable catalog copy before testing the
+    // nested data layout; none of these statements alter ducklake_column, the
+    // source catalog, or the Parquet file.
+    let setup = format!(
+        "INSTALL sqlite; LOAD sqlite; \
+         ATTACH '{}' AS raw (TYPE sqlite); \
+         ALTER TABLE raw.ducklake_snapshot ADD COLUMN next_catalog_id BIGINT DEFAULT 0; \
+         ALTER TABLE raw.ducklake_snapshot ADD COLUMN next_file_id BIGINT DEFAULT 0; \
+         UPDATE raw.ducklake_snapshot SET next_catalog_id = 0, next_file_id = 0; \
+         ALTER TABLE raw.ducklake_schema ADD COLUMN schema_uuid VARCHAR; \
+         UPDATE raw.ducklake_schema SET \
+             schema_uuid = '00000000-0000-0000-0000-000000000001', path = path || '/'; \
+         ALTER TABLE raw.ducklake_table ADD COLUMN table_uuid VARCHAR; \
+         UPDATE raw.ducklake_table SET \
+             table_uuid = '00000000-0000-0000-0000-000000000002', path = path || '/'; \
+         CREATE TABLE raw.ducklake_tag( \
+             object_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, key VARCHAR, value VARCHAR \
+         ); \
+         CREATE TABLE raw.ducklake_inlined_data_tables( \
+             table_id BIGINT, table_name VARCHAR, schema_version BIGINT \
+         ); \
+         CREATE TABLE raw.ducklake_column_tag( \
+             table_id BIGINT, column_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, \
+             key VARCHAR, value VARCHAR \
+         ); \
+         CREATE TABLE raw.ducklake_column_mapping( \
+             mapping_id BIGINT, table_id BIGINT, type VARCHAR \
+         ); \
+         CREATE TABLE raw.ducklake_name_mapping( \
+             mapping_id BIGINT, column_id BIGINT, source_name VARCHAR, \
+             target_field_id BIGINT, parent_column BIGINT, is_partition BOOLEAN \
+         ); \
+         CREATE TABLE raw.ducklake_view( \
+             view_id BIGINT, view_uuid VARCHAR, begin_snapshot BIGINT, end_snapshot BIGINT, \
+             schema_id BIGINT, view_name VARCHAR, dialect VARCHAR, sql VARCHAR, column_aliases VARCHAR \
+         ); \
+         CREATE TABLE raw.ducklake_macro( \
+             schema_id BIGINT, macro_id BIGINT, macro_name VARCHAR, \
+             begin_snapshot BIGINT, end_snapshot BIGINT \
+         ); \
+         CREATE TABLE raw.ducklake_macro_impl( \
+             macro_id BIGINT, impl_id BIGINT, dialect VARCHAR, sql VARCHAR, type VARCHAR \
+         ); \
+         CREATE TABLE raw.ducklake_macro_parameters( \
+             macro_id BIGINT, impl_id BIGINT, column_id BIGINT, parameter_name VARCHAR, \
+             parameter_type VARCHAR, default_value VARCHAR, default_value_type VARCHAR \
+         ); \
+         ALTER TABLE raw.ducklake_data_file ADD COLUMN file_order BIGINT DEFAULT 0; \
+         ALTER TABLE raw.ducklake_data_file ADD COLUMN file_format VARCHAR DEFAULT 'parquet'; \
+         ALTER TABLE raw.ducklake_data_file ADD COLUMN partial_file_info VARCHAR; \
+         UPDATE raw.ducklake_data_file SET footer_size = NULL; \
+         ALTER TABLE raw.ducklake_delete_file ADD COLUMN format VARCHAR DEFAULT 'parquet'; \
+         DETACH raw; \
+         INSTALL ducklake; LOAD ducklake; \
+         ATTACH 'ducklake:{}' AS official (META_TYPE 'sqlite');",
+        conformance_path.display(),
+        conformance_path.display()
+    );
+    let connection = duckdb::Connection::open_in_memory().unwrap();
+    connection.execute_batch(&setup).unwrap();
+    let mut statement = connection
+        .prepare(
+            "SELECT id, CAST(bids[1].price AS VARCHAR), len(bids)
+             FROM official.main.depths ORDER BY id",
+        )
+        .unwrap();
+    let rows = statement
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, i32>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, i64>(2)?,
+            ))
+        })
+        .unwrap()
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .unwrap();
+
+    assert_eq!(
+        rows,
+        vec![(1, "101.0000000000000000".to_string(), 2), (2, "99.0000000000000000".to_string(), 1),],
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -279,8 +399,6 @@ async fn test_write_and_read_list_column_roundtrip() {
     // get null-filled by the field-id read mapping. The field-id sits on the
     // top-level node; the List leaf carries none, so a leaf-only field-id lookup
     // would treat the column as absent. Isolates WRITE (raw parquet) vs READ.
-    use arrow::datatypes::Float32Type;
-
     let (writer, temp_dir) = create_test_env().await;
     let object_store = create_object_store();
 
@@ -343,6 +461,345 @@ async fn test_write_and_read_list_column_roundtrip() {
     assert_eq!(
         nulls, 0,
         "READ side: ducklake must return v VALUES, not null-fill the List column"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_write_and_read_list_struct_column_roundtrip() {
+    let (writer, temp_dir) = create_test_env().await;
+    let object_store = create_object_store();
+    const SCALE: i128 = 10_000_000_000_000_000;
+    let level_fields = vec![
+        Arc::new(Field::new("price", DataType::Decimal128(38, 16), false)),
+        Arc::new(Field::new("size", DataType::Decimal128(38, 16), false)),
+        Arc::new(Field::new("count", DataType::UInt32, false)),
+        Arc::new(Field::new("order_id", DataType::UInt64, false)),
+    ];
+    let levels = StructArray::new(
+        level_fields.clone().into(),
+        vec![
+            Arc::new(
+                Decimal128Array::from(vec![101 * SCALE, 100 * SCALE, 99 * SCALE])
+                    .with_precision_and_scale(38, 16)
+                    .unwrap(),
+            ),
+            Arc::new(
+                Decimal128Array::from(vec![7 * SCALE, 8 * SCALE, 9 * SCALE])
+                    .with_precision_and_scale(38, 16)
+                    .unwrap(),
+            ),
+            Arc::new(UInt32Array::from(vec![1, 2, 3])),
+            Arc::new(UInt64Array::from(vec![11, 12, 13])),
+        ],
+        None,
+    );
+    let bids = ListArray::new(
+        Arc::new(Field::new(
+            "element",
+            DataType::Struct(level_fields.into()),
+            false,
+        )),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0_i32, 2, 3])),
+        Arc::new(levels),
+        None,
+    );
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("bids", bids.data_type().clone(), false),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![Arc::new(Int32Array::from(vec![1, 2])), Arc::new(bids)],
+    )
+    .unwrap();
+
+    DuckLakeTableWriter::new(Arc::new(writer), object_store)
+        .unwrap()
+        .write_table("main", "depths", &[batch])
+        .await
+        .unwrap();
+
+    assert_duckdb_extension_reads_depths(&temp_dir.path().join("test.db"));
+
+    let ctx = create_read_context(&temp_dir).await;
+    let batches = ctx
+        .sql("SELECT id, bids FROM test.main.depths ORDER BY id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(batches.len(), 1);
+    assert_eq!(batches[0].num_rows(), 2);
+    let bids = batches[0]
+        .column(1)
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .unwrap();
+    assert_eq!(bids.value_offsets(), &[0, 2, 3]);
+    let levels = bids
+        .values()
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .unwrap();
+    assert_eq!(
+        levels
+            .column_by_name("price")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Decimal128Array>()
+            .unwrap()
+            .values(),
+        &[101 * SCALE, 100 * SCALE, 99 * SCALE]
+    );
+    assert_eq!(
+        levels
+            .column_by_name("order_id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .unwrap()
+            .values(),
+        &[11, 12, 13]
+    );
+
+    let pool = sqlx::SqlitePool::connect(&format!(
+        "sqlite:{}",
+        temp_dir.path().join("test.db").display()
+    ))
+    .await
+    .unwrap();
+    let rows = sqlx::query(
+        "SELECT c.column_id, c.column_name, c.column_type, c.parent_column
+         FROM ducklake_column c
+         JOIN ducklake_table t ON t.table_id = c.table_id
+         WHERE t.table_name = 'depths' AND c.end_snapshot IS NULL
+         ORDER BY c.column_order",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(rows.len(), 7);
+    let ids = rows
+        .iter()
+        .map(|row| row.get::<i64, _>("column_id"))
+        .collect::<Vec<_>>();
+    let actual = rows
+        .iter()
+        .map(|row| {
+            (
+                row.get::<String, _>("column_name"),
+                row.get::<String, _>("column_type"),
+                row.get::<Option<i64>, _>("parent_column"),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        actual,
+        vec![
+            ("id".to_string(), "int32".to_string(), None),
+            ("bids".to_string(), "list".to_string(), None),
+            ("element".to_string(), "struct".to_string(), Some(ids[1])),
+            (
+                "price".to_string(),
+                "decimal(38, 16)".to_string(),
+                Some(ids[2]),
+            ),
+            (
+                "size".to_string(),
+                "decimal(38, 16)".to_string(),
+                Some(ids[2]),
+            ),
+            ("count".to_string(), "uint32".to_string(), Some(ids[2])),
+            ("order_id".to_string(), "uint64".to_string(), Some(ids[2])),
+        ]
+    );
+
+    let parquet_path = std::fs::read_dir(temp_dir.path().join("data/main/depths"))
+        .unwrap()
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .find(|path| {
+            path.extension()
+                .is_some_and(|extension| extension == "parquet")
+        })
+        .unwrap();
+    assert_eq!(
+        parquet_schema_fields(&parquet_path),
+        vec![
+            ("id".to_string(), Some(ids[0] as i32)),
+            ("bids".to_string(), Some(ids[1] as i32)),
+            ("list".to_string(), None),
+            ("element".to_string(), Some(ids[2] as i32)),
+            ("price".to_string(), Some(ids[3] as i32)),
+            ("size".to_string(), Some(ids[4] as i32)),
+            ("count".to_string(), Some(ids[5] as i32)),
+            ("order_id".to_string(), Some(ids[6] as i32)),
+        ]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_write_and_read_struct_list_and_map_roundtrip() {
+    let (writer, temp_dir) = create_test_env().await;
+    let values = ListArray::new(
+        Arc::new(Field::new("item", DataType::Int32, true)),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0_i32, 2, 3])),
+        Arc::new(Int32Array::from(vec![10, 20, 30])),
+        None,
+    );
+    let payload_fields = vec![
+        Arc::new(Field::new("label", DataType::Utf8, false)),
+        Arc::new(Field::new("values", values.data_type().clone(), false)),
+    ];
+    let payload = StructArray::new(
+        payload_fields.into(),
+        vec![Arc::new(StringArray::from(vec!["first", "second"])), Arc::new(values)],
+        None,
+    );
+    let entry_fields = vec![
+        Arc::new(Field::new("key", DataType::Utf8, false)),
+        Arc::new(Field::new("value", DataType::Int32, true)),
+    ];
+    let entries = StructArray::new(
+        entry_fields.clone().into(),
+        vec![
+            Arc::new(StringArray::from(vec!["a", "b", "c"])),
+            Arc::new(Int32Array::from(vec![1, 2, 3])),
+        ],
+        None,
+    );
+    let attrs = MapArray::new(
+        Arc::new(Field::new(
+            "entries",
+            DataType::Struct(entry_fields.into()),
+            false,
+        )),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0_i32, 2, 3])),
+        entries,
+        None,
+        false,
+    );
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("payload", payload.data_type().clone(), false),
+        Field::new("attrs", attrs.data_type().clone(), true),
+    ]));
+    let batch = RecordBatch::try_new(schema, vec![Arc::new(payload), Arc::new(attrs)]).unwrap();
+
+    DuckLakeTableWriter::new(Arc::new(writer), create_object_store())
+        .unwrap()
+        .write_table("main", "nested", &[batch])
+        .await
+        .unwrap();
+
+    let batches = create_read_context(&temp_dir)
+        .await
+        .sql("SELECT payload, attrs FROM test.main.nested")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let payload = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .unwrap();
+    let values = payload
+        .column_by_name("values")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .unwrap();
+    assert_eq!(values.value_offsets(), &[0, 2, 3]);
+    assert_eq!(
+        values
+            .values()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap()
+            .values(),
+        &[10, 20, 30]
+    );
+    let attrs = batches[0]
+        .column(1)
+        .as_any()
+        .downcast_ref::<MapArray>()
+        .unwrap();
+    assert_eq!(attrs.value_offsets(), &[0, 2, 3]);
+    assert_eq!(
+        attrs
+            .values()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap()
+            .values(),
+        &[1, 2, 3]
+    );
+
+    let pool = sqlx::SqlitePool::connect(&format!(
+        "sqlite:{}",
+        temp_dir.path().join("test.db").display()
+    ))
+    .await
+    .unwrap();
+    let rows = sqlx::query(
+        "SELECT c.column_id, c.column_name, c.column_type, c.parent_column
+         FROM ducklake_column c
+         JOIN ducklake_table t ON t.table_id = c.table_id
+         WHERE t.table_name = 'nested' AND c.end_snapshot IS NULL
+         ORDER BY c.column_order",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    let ids = rows
+        .iter()
+        .map(|row| row.get::<i64, _>("column_id"))
+        .collect::<Vec<_>>();
+    let actual = rows
+        .iter()
+        .map(|row| {
+            (
+                row.get::<String, _>("column_name"),
+                row.get::<String, _>("column_type"),
+                row.get::<Option<i64>, _>("parent_column"),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        actual,
+        vec![
+            ("payload".to_string(), "struct".to_string(), None),
+            ("label".to_string(), "varchar".to_string(), Some(ids[0])),
+            ("values".to_string(), "list".to_string(), Some(ids[0])),
+            ("element".to_string(), "int32".to_string(), Some(ids[2])),
+            ("attrs".to_string(), "map".to_string(), None),
+            ("key".to_string(), "varchar".to_string(), Some(ids[4])),
+            ("value".to_string(), "int32".to_string(), Some(ids[4])),
+        ]
+    );
+
+    let parquet_path = std::fs::read_dir(temp_dir.path().join("data/main/nested"))
+        .unwrap()
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .find(|path| {
+            path.extension()
+                .is_some_and(|extension| extension == "parquet")
+        })
+        .unwrap();
+    assert_eq!(
+        parquet_schema_fields(&parquet_path),
+        vec![
+            ("payload".to_string(), Some(ids[0] as i32)),
+            ("label".to_string(), Some(ids[1] as i32)),
+            ("values".to_string(), Some(ids[2] as i32)),
+            ("list".to_string(), None),
+            ("element".to_string(), Some(ids[3] as i32)),
+            ("attrs".to_string(), Some(ids[4] as i32)),
+            ("key_value".to_string(), None),
+            ("key".to_string(), Some(ids[5] as i32)),
+            ("value".to_string(), Some(ids[6] as i32)),
+        ]
     );
 }
 
@@ -683,6 +1140,181 @@ async fn test_append_list_columns_multi_file() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_append_migrates_legacy_list_catalog_rows() {
+    let (writer, temp_dir) = create_test_env().await;
+    let object_store = create_object_store();
+    let first_values = ListArray::from_iter_primitive::<Float32Type, _, _>(vec![
+        Some(vec![Some(1.0), Some(2.0)]),
+        Some(vec![Some(3.0)]),
+    ]);
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("values", first_values.data_type().clone(), true),
+    ]));
+    let first = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![Arc::new(Int32Array::from(vec![1, 2])), Arc::new(first_values)],
+    )
+    .unwrap();
+    let initial = DuckLakeTableWriter::new(Arc::new(writer.clone()), Arc::clone(&object_store))
+        .unwrap()
+        .write_table("main", "legacy_list", &[first])
+        .await
+        .unwrap();
+
+    let pool = sqlx::SqlitePool::connect(&format!(
+        "sqlite:{}",
+        temp_dir.path().join("test.db").display()
+    ))
+    .await
+    .unwrap();
+    let rows = sqlx::query_as::<_, (i64, String)>(
+        "SELECT column_id, column_name
+         FROM ducklake_column
+         WHERE table_id = (SELECT table_id FROM ducklake_table WHERE table_name = 'legacy_list')
+           AND end_snapshot IS NULL
+         ORDER BY column_order",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    let list_id = rows[1].0;
+    let old_element_id = rows[2].0;
+    sqlx::query("DELETE FROM ducklake_column WHERE column_id = ?")
+        .bind(old_element_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE ducklake_column SET column_type = 'list<float32>' WHERE column_id = ?")
+        .bind(list_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let second_values =
+        ListArray::from_iter_primitive::<Float32Type, _, _>(vec![Some(vec![Some(4.0), Some(5.0)])]);
+    let second = RecordBatch::try_new(
+        schema,
+        vec![Arc::new(Int32Array::from(vec![3])), Arc::new(second_values)],
+    )
+    .unwrap();
+    let migration = DuckLakeTableWriter::new(Arc::new(writer), object_store)
+        .unwrap()
+        .append_table("main", "legacy_list", &[second])
+        .await
+        .unwrap();
+
+    let list_versions = sqlx::query_as::<_, (String, i64, Option<i64>)>(
+        "SELECT column_type, begin_snapshot, end_snapshot
+         FROM ducklake_column
+         WHERE table_id = (SELECT table_id FROM ducklake_table WHERE table_name = 'legacy_list')
+           AND column_id = ?
+         ORDER BY begin_snapshot",
+    )
+    .bind(list_id)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        list_versions,
+        vec![
+            (
+                "list<float32>".into(),
+                initial.snapshot_id,
+                Some(migration.snapshot_id),
+            ),
+            ("list".into(), migration.snapshot_id, None),
+        ]
+    );
+
+    let catalog_rows = sqlx::query_as::<_, (i64, String, String, Option<i64>)>(
+        "SELECT column_id, column_name, column_type, parent_column
+         FROM ducklake_column
+         WHERE table_id = (SELECT table_id FROM ducklake_table WHERE table_name = 'legacy_list')
+           AND end_snapshot IS NULL
+         ORDER BY column_order",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(catalog_rows.len(), 3);
+    assert_eq!(
+        catalog_rows[1],
+        (list_id, "values".into(), "list".into(), None)
+    );
+    assert_eq!(catalog_rows[2].1, "element");
+    assert_eq!(catalog_rows[2].2, "float32");
+    assert_eq!(catalog_rows[2].3, Some(list_id));
+    assert_ne!(catalog_rows[2].0, old_element_id);
+
+    let historical = SessionContext::new();
+    let provider = Arc::new(
+        SqliteMetadataProvider::new(&format!(
+            "sqlite:{}",
+            temp_dir.path().join("test.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    register_ducklake_functions(&historical, provider);
+    let historical_rows = historical
+        .sql(&format!(
+            "SELECT id FROM ducklake_table_at('main', 'legacy_list', {}) ORDER BY id",
+            initial.snapshot_id
+        ))
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let historical_ids = historical_rows
+        .iter()
+        .flat_map(|batch| {
+            let ids = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            (0..ids.len())
+                .map(|index| ids.value(index))
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(historical_ids, vec![1, 2]);
+
+    let batches = create_read_context(&temp_dir)
+        .await
+        .sql("SELECT id, \"values\" FROM test.main.legacy_list ORDER BY id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let mut actual = Vec::new();
+    for batch in batches {
+        let ids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let values = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .unwrap();
+        for row in 0..batch.num_rows() {
+            let value = values.value(row);
+            let value = value.as_any().downcast_ref::<Float32Array>().unwrap();
+            actual.push((ids.value(row), value.values().to_vec()));
+        }
+    }
+    assert_eq!(
+        actual,
+        vec![(1, vec![1.0, 2.0]), (2, vec![3.0]), (3, vec![4.0, 5.0])]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_multiple_tables_same_schema() {
     let (writer, temp_dir) = create_test_env().await;
     let object_store = create_object_store();
@@ -844,6 +1476,62 @@ async fn test_streaming_write_api() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_streaming_write_list_column() {
+    use arrow::datatypes::Int32Type;
+
+    let (writer, temp_dir) = create_test_env().await;
+    let object_store = create_object_store();
+    let values = ListArray::from_iter_primitive::<Int32Type, _, _>(vec![
+        Some(vec![Some(10), Some(11)]),
+        Some(vec![Some(20)]),
+    ]);
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("items", values.data_type().clone(), true),
+    ]));
+    let batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![Arc::new(Int32Array::from(vec![1, 2])), Arc::new(values)],
+    )
+    .unwrap();
+
+    let table_writer = DuckLakeTableWriter::new(Arc::new(writer), object_store).unwrap();
+    let mut session = table_writer
+        .begin_write("main", "streaming_list", &schema, WriteMode::Replace)
+        .unwrap();
+    session.write_batch(&batch).unwrap();
+    assert_eq!(session.finish().await.unwrap().records_written, 2);
+
+    let batches = create_read_context(&temp_dir)
+        .await
+        .sql("SELECT id, items FROM test.main.streaming_list ORDER BY id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(batches.len(), 1);
+    assert_eq!(batches[0].num_rows(), 2);
+    let ids = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .unwrap();
+    let values = batches[0]
+        .column(1)
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .unwrap();
+    assert_eq!(ids.values(), &[1, 2]);
+    let first = values.value(0);
+    let first = first.as_any().downcast_ref::<Int32Array>().unwrap();
+    let second = values.value(1);
+    let second = second.as_any().downcast_ref::<Int32Array>().unwrap();
+    assert_eq!(first.values(), &[10, 11]);
+    assert_eq!(second.values(), &[20]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_streaming_write_to_custom_path() {
     let (writer, temp_dir) = create_test_env().await;
     let object_store = create_object_store();
@@ -997,6 +1685,231 @@ async fn test_append_add_nullable_column() {
         .unwrap()
         .value(0);
     assert_eq!(count, 4);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_append_add_non_nullable_struct_field_reads_old_files_as_null() {
+    let (writer, temp_dir) = create_test_env().await;
+    let object_store = create_object_store();
+    let first_fields = vec![
+        Arc::new(Field::new("a", DataType::Int32, false)),
+        Arc::new(Field::new("b", DataType::Utf8, true)),
+    ];
+    let first_payload = StructArray::new(
+        first_fields.clone().into(),
+        vec![
+            Arc::new(Int32Array::from(vec![10, 20])),
+            Arc::new(StringArray::from(vec!["first", "second"])),
+        ],
+        None,
+    );
+    let first_schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("payload", DataType::Struct(first_fields.into()), false),
+    ]));
+    let first = RecordBatch::try_new(
+        first_schema,
+        vec![Arc::new(Int32Array::from(vec![1, 2])), Arc::new(first_payload)],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(Arc::new(writer.clone()), Arc::clone(&object_store))
+        .unwrap()
+        .write_table("main", "evolve_struct", &[first])
+        .await
+        .unwrap();
+
+    let second_fields = vec![
+        Arc::new(Field::new("a", DataType::Int32, false)),
+        Arc::new(Field::new("b", DataType::Utf8, true)),
+        Arc::new(Field::new("c", DataType::Int32, false)),
+    ];
+    let second_payload = StructArray::new(
+        second_fields.clone().into(),
+        vec![
+            Arc::new(Int32Array::from(vec![30])),
+            Arc::new(StringArray::from(vec!["third"])),
+            Arc::new(Int32Array::from(vec![300])),
+        ],
+        None,
+    );
+    let second_schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("payload", DataType::Struct(second_fields.into()), false),
+    ]));
+    let second = RecordBatch::try_new(
+        second_schema,
+        vec![Arc::new(Int32Array::from(vec![3])), Arc::new(second_payload)],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(Arc::new(writer), object_store)
+        .unwrap()
+        .append_table("main", "evolve_struct", &[second])
+        .await
+        .unwrap();
+
+    let batches = create_read_context(&temp_dir)
+        .await
+        .sql("SELECT id, payload FROM test.main.evolve_struct ORDER BY id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let mut actual = Vec::new();
+    for batch in batches {
+        let ids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let payload = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+        let a = payload
+            .column_by_name("a")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let c = payload
+            .column_by_name("c")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        for row in 0..batch.num_rows() {
+            actual.push((
+                ids.value(row),
+                a.value(row),
+                (!c.is_null(row)).then(|| c.value(row)),
+            ));
+        }
+    }
+    assert_eq!(
+        actual,
+        vec![(1, 10, None), (2, 20, None), (3, 30, Some(300))]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_append_add_non_nullable_list_struct_field_reads_old_files_as_null() {
+    let (writer, temp_dir) = create_test_env().await;
+    let object_store = create_object_store();
+    let first_fields = vec![Arc::new(Field::new("price", DataType::Int32, false))];
+    let first_levels = StructArray::new(
+        first_fields.clone().into(),
+        vec![Arc::new(Int32Array::from(vec![10, 20]))],
+        None,
+    );
+    let first_bids = ListArray::new(
+        Arc::new(Field::new(
+            "element",
+            DataType::Struct(first_fields.into()),
+            false,
+        )),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0_i32, 2])),
+        Arc::new(first_levels),
+        None,
+    );
+    let first_schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("bids", first_bids.data_type().clone(), false),
+    ]));
+    let first = RecordBatch::try_new(
+        first_schema,
+        vec![Arc::new(Int32Array::from(vec![1])), Arc::new(first_bids)],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(Arc::new(writer.clone()), Arc::clone(&object_store))
+        .unwrap()
+        .write_table("main", "evolve_depths", &[first])
+        .await
+        .unwrap();
+
+    let second_fields = vec![
+        Arc::new(Field::new("price", DataType::Int32, false)),
+        Arc::new(Field::new("venue", DataType::Utf8, false)),
+    ];
+    let second_levels = StructArray::new(
+        second_fields.clone().into(),
+        vec![Arc::new(Int32Array::from(vec![30])), Arc::new(StringArray::from(vec!["X"]))],
+        None,
+    );
+    let second_bids = ListArray::new(
+        Arc::new(Field::new(
+            "element",
+            DataType::Struct(second_fields.into()),
+            false,
+        )),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0_i32, 1])),
+        Arc::new(second_levels),
+        None,
+    );
+    let second_schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("bids", second_bids.data_type().clone(), false),
+    ]));
+    let second = RecordBatch::try_new(
+        second_schema,
+        vec![Arc::new(Int32Array::from(vec![2])), Arc::new(second_bids)],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(Arc::new(writer), object_store)
+        .unwrap()
+        .append_table("main", "evolve_depths", &[second])
+        .await
+        .unwrap();
+
+    let batches = create_read_context(&temp_dir)
+        .await
+        .sql("SELECT id, bids FROM test.main.evolve_depths ORDER BY id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let mut actual = Vec::new();
+    for batch in batches {
+        let ids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let bids = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .unwrap();
+        for row in 0..batch.num_rows() {
+            let levels = bids.value(row);
+            let levels = levels.as_any().downcast_ref::<StructArray>().unwrap();
+            let prices = levels
+                .column_by_name("price")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            let venues =
+                arrow::compute::cast(levels.column_by_name("venue").unwrap(), &DataType::Utf8)
+                    .unwrap();
+            let venues = venues.as_any().downcast_ref::<StringArray>().unwrap();
+            let values = (0..levels.len())
+                .map(|index| {
+                    (
+                        prices.value(index),
+                        (!venues.is_null(index)).then(|| venues.value(index).to_string()),
+                    )
+                })
+                .collect::<Vec<_>>();
+            actual.push((ids.value(row), values));
+        }
+    }
+    assert_eq!(
+        actual,
+        vec![(1, vec![(10, None), (20, None)]), (2, vec![(30, Some("X".to_string()))]),]
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD041 -->

### Summary

Add read and write support for recursively composed DuckLake `list`, `struct`, and `map` columns.
The catalog now stores every typed node as a `ducklake_column` row linked through
`parent_column`, and readers reconstruct the Arrow tree up to a defensive depth limit of 128.
The implementation supports representative nested shapes such as
`List<Struct<price, size, count, order_id>>` without adding a private format extension.

Writers allocate stable IDs in whole‑table depth‑first preorder. Each catalog `column_id` is also
written as the Parquet `field_id` on the corresponding typed node. Parquet's structural `list` and
`key_value` wrappers remain unnumbered, as required by DuckLake.

### Changes

- Parse and render recursively composed `list`, `struct`, and `map` Arrow types with a depth limit
  of 128 for both type strings and catalog reconstruction.
- Reconstruct nested catalog columns from `parent_column`, preserving child names, nullability,
  order, and IDs.
- Reject duplicate IDs, duplicate nested paths, missing parents, cycles, malformed maps, and
  unreachable child rows.
- Flatten Arrow schemas into bare composite parent rows and full scalar leaf types in depth‑first
  preorder.
- Keep top‑level IDs separate from recursive field IDs so partition metadata and column statistics
  retain their existing top‑level semantics.
- Apply nested field metadata to Arrow arrays before Parquet writes without copying their value
  buffers.
- Preserve field IDs through ordinary writes, rolling files, partitioned writes, compaction,
  rewrites, fileless table creation, and existing‑file registration.
- Label file statistics with top‑level column IDs while retaining recursive IDs in Parquet, and
  treat nested IDs as live during compaction safety checks.
- Accept Arrow's standard nested child names when validating rewrite and streaming batches.
- Resolve promotion, partition, and sort columns only against live top‑level rows.
- Preserve lossy logical catalog spellings such as `geometry`, `json`, and `timetz` during
  recursive reconstruction while canonicalizing ordinary aliases such as `INT` to `int32`.
- Upgrade legacy single‑row `list<T>` metadata to recursive parent and element rows on the next
  matching write while preserving the list column ID and the legacy row for historical snapshots.
- Build each file's nested read schema from current catalog fields and stable field IDs so fields
  added inside structs, including non‑nullable fields and structs inside lists, read as `NULL` in
  older files.
- Return errors for missing recursive field IDs, excessive nesting, and unsupported scalar catalog
  types instead of panicking.
- Extend SQLite, DuckDB, PostgreSQL, and MySQL metadata providers and writers with the same
  recursive representation.
- Validate the official DuckLake extension against a disposable catalog copy without mutating the
  catalog used by the DataFusion read‑back.
- Document recursive type support and the legacy and nested‑evolution fixes in the changelog and
  compatibility matrix.
- Cover simple lists, `list<struct>`, top‑level structs, structs containing lists, maps, and deeper
  mixed compositions.

### Recursive type flow

```mermaid
flowchart LR
    Arrow["Arrow schema<br/>recursive typed nodes"] --> Flatten["Depth-first flattening<br/>stable node IDs"]
    Flatten --> Rows["ducklake_column rows<br/>parent_column + column_order"]
    Flatten --> Parquet["Parquet schema<br/>field_id = column_id"]
    Rows --> Providers["Metadata providers<br/>SQLite, DuckDB, PostgreSQL, MySQL"]
    Providers --> Rebuild["Recursive catalog reconstruction"]
    Rebuild --> Read["DuckLake table read"]
    Parquet --> Read
    Read --> Batches["Arrow batches<br/>original nested shape"]
```

### Commit and branch

- Branch: `ducklake-recursive-column-types-pr`.
- Feature commit: `5e6246335a8d31169abcf592c46797166f838f2e feat: support recursive DuckLake column types`.
- Base: `613220febcbb62c975b1f791000e0723a3e1ac5f` (`origin/main`).
- Shape: exactly one commit ahead of `origin/main`.
- Remote: `faysou:ducklake-recursive-column-types-pr`.
- PR: [datafusion-contrib/datafusion-ducklake#230](https://github.com/datafusion-contrib/datafusion-ducklake/pull/230).

### Verification

- `cargo fmt --all -- --check`: passed on the rebased branch.
- `cargo clippy --all-targets --all-features --no-deps -- -D warnings`: passed on the rebased
  branch.
- SQLite/DataFusion `test_append_migrates_legacy_list_catalog_rows`: passed with exact catalog row
  boundaries and an actual read of the pre‑migration snapshot.
- SQLite/DataFusion `test_append_add_non_nullable_struct_field_reads_old_files_as_null`: passed.
- SQLite/DataFusion `test_append_add_non_nullable_list_struct_field_reads_old_files_as_null`:
  passed.
- SQLite/DataFusion `test_write_and_read_list_struct_column_roundtrip`: passed.
- SQLite/DataFusion `test_write_and_read_struct_list_and_map_roundtrip`: passed.
- SQLite/DataFusion `test_append_list_columns_multi_file`: passed.
- SQLite/DataFusion `update_table_with_list_column`: passed.
- SQLite/DataFusion `update_table_with_struct_column`: passed after resolving the recursive field ID
  path with the multi‑file append‑and‑delete commit.
- SQLite/DataFusion `partitioned_update_spanning_partitions_is_one_snapshot`: passed.
- The six `test_build_read_schema_*` unit tests and eleven `test_reconstruct_columns*` unit tests:
  passed.
- SQLite provider `test_get_table_structure`: passed under both feature sets used by the failed
  macOS and full single‑catalog CI jobs, including canonical `INT` to `int32` output.
- Unit guards for legacy list compatibility and recursive type depth: passed.
- PostgreSQL single‑catalog legacy list migration, snapshot row versioning, and nested name
  collision regressions: passed against disposable Docker containers.
- The all‑feature clippy check compiles the DuckDB, MySQL, PostgreSQL, and SQLite backend paths.
- GitHub CI run `31167653099`: all five jobs passed, including the macOS and full Docker suites
  that exposed the scalar alias regression.
- `git diff --check`: passed.

### Specification proof

| DuckLake rule | Implementation invariant | Discriminating proof |
| ------------- | ------------------------ | -------------------- |
| Nested types use recursive [`ducklake_column`](https://ducklake.select/docs/stable/specification/tables/ducklake_column) rows joined by `parent_column`. | Providers build one tree from the ordered rows; writers emit one row for each typed Arrow node. | SQLite integration tests and focused DuckDB, MySQL, and PostgreSQL writer tests assert IDs, names, bare composite types, and parent IDs. |
| [`list`, `struct`, and `map`](https://ducklake.select/docs/stable/specification/data_types) may compose recursively. | The parser, Arrow conversion, catalog flattener, provider reconstruction, and Parquet schema walk recurse, with a defensive maximum nesting depth of 128. | `test_arbitrarily_composed_nested_types` covers `list<struct<list<struct>,map<varchar,list<int32>>>>`; depth regressions reject oversized type strings and catalog graphs. |
| [`column_order`](https://ducklake.select/docs/stable/specification/tables/ducklake_column) is whole‑table depth‑first preorder. | One recursive flattening pass determines both catalog order and field‑ID order for every backend. | `test_catalog_column_defs_use_depth_first_preorder` asserts the exact mixed list, struct, and map sequence and its top‑level ID projection. |
| A typed Parquet node carries the same ID as its [`ducklake_column`](https://ducklake.select/docs/stable/specification/tables/ducklake_column) row; structural wrappers carry none. | Schema rewriting numbers list parents, list elements, structs, struct fields, maps, keys, and values, while leaving `list` and `key_value` wrappers unnumbered. | The two SQLite round trips assert the complete physical Parquet tree and every expected ID, including the `List<Struct>` group nodes. |
| [`ducklake_file_column_stats`](https://ducklake.select/docs/stable/specification/tables/ducklake_file_column_stats) refers to catalog columns through `column_id`. | Compaction passes top‑level IDs to statistics collection and recursive IDs only to Parquet schema construction. | `merge_nested_table_uses_top_level_stats_ids` asserts that the compacted file has no statistics rows for nested IDs and reads all nested values back exactly. |
| [Schema evolution](https://ducklake.select/docs/stable/duckdb/usage/schema_evolution) resolves Parquet fields through the stable identifiers stored in `ducklake_column`. | Per‑file read schemas keep the current nested catalog shape, map existing children by field ID, and make children absent from older files nullable under synthetic names. | Struct and `list<struct>` append regressions declare new children non‑nullable, then return exact old and new rows with those children null‑filled only in old rows; the official extension also reads the static recursive representation. |

### Reference implementation

The recursive representation matches the official DuckLake extension:

- [`FieldIdFromType`](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_field_data.cpp#L73-L114)
  allocates IDs in depth‑first order and names list and map children `element`, `key`, and `value`.
- [`ColumnToSQLRecursive`](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_metadata_manager.cpp#L2639-L2682)
  writes one catalog row per typed node with the same parent links and bare composite type names.
- [`GetFieldIdValue`](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_insert.cpp#L310-L323)
  passes that recursive ID tree to the Parquet writer.
- [Catalog reconstruction](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_metadata_manager.cpp#L832-L863)
  rebuilds children through `parent_column` and rejects a missing parent.

This crate stores Arrow's nested‑field nullability, which DuckDB's logical type does not carry. Its
read schema permits nulls for struct fields because older files can predate a field whose current
catalog row is non‑nullable. It also uses contiguous zero‑based `column_order` values instead of
copying `column_id`. The specification permits any unique ordering values, including gaps, so both
representations produce the same depth‑first sequence, catalog graph, and Parquet field IDs.

### DuckDB extension check

The fork's broader metadata schema predates several catalog fields that the official DuckLake
extension requires at attach time. The test copies the catalog beside the fixture and adds those
unrelated compatibility fields only to the copy. It does not alter the source catalog,
`ducklake_column`, or the Parquet file, so the query proves that the extension accepts and reads
this change's recursive column and field‑ID representation without affecting the DataFusion
read‑back.

Run the focused check with the bundled DuckDB dependency:

```bash
CARGO_BUILD_JOBS=8 cargo test --all-features \
  test_write_and_read_list_struct_column_roundtrip -- --nocapture
```

### Upstream readiness

The branch is reviewable as one commit on current `origin/main` and contains only the recursive
column implementation, compatibility fixes, documentation, and tests.

An append that loses a concurrent field‑ID allocation race returns `DuckLakeError::Conflict` and
must be retried against the committed schema. The already uploaded file is not registered by the
failed metadata transaction and remains eligible for the existing orphan cleanup flow.

### Review boundary

This change owns recursive type conversion, recursive catalog rows, nested Parquet field IDs, and
the ID split needed by writes and rewrites. It preserves nested nullability in catalog metadata,
while exposing read‑compatible nullable struct fields for files written before nested additions.
It retains explicit errors for scalar catalog types that Arrow cannot represent. It leaves
per‑leaf statistics representable but does not add nested‑field pruning.
