### PR TITLE
feat(write): single-catalog (standard DuckLake) Postgres writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `PostgresSingleCatalogMetadataWriter` — writes the **standard, spec-compliant** single-catalog DuckLake layout on PostgreSQL (no `catalog_id` columns, no `ducklake_catalog*` map tables, unscoped relative paths), so Postgres catalogs are interchangeable with the SQLite/MySQL backends and DuckDB's `ducklake` extension. SQL `CREATE TABLE AS SELECT` works on this path, unlike the multicatalog writer (#165).
+
 ## [0.6.0] - 2026-07-20
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ DataFusion-DuckLake is a DataFusion extension that provides read and write acces
 
 The extension integrates DuckLake with Apache DataFusion by implementing DataFusion's catalog and table provider interfaces.
 
-Reads are supported on all four catalog backends. Writes are feature-gated and currently implemented for SQLite (`write-sqlite`) and PostgreSQL (`write-postgres`). SQLite uses the standard single-catalog layout and supports SQL `CREATE TABLE AS SELECT` + `INSERT INTO`; PostgreSQL writes go through the **experimental, library-specific multi-catalog layout** (not part of the DuckLake spec) where tables are created via `DuckLakeTableWriter` and appended to with `INSERT INTO`. See `COMPATIBILITY.md` for the full backend/feature matrix.
+Reads are supported on all four catalog backends. Writes are feature-gated and currently implemented for SQLite (`write-sqlite`) and PostgreSQL (`write-postgres`). Both have a **standard single-catalog** writer (`SqliteMetadataWriter`, `PostgresSingleCatalogMetadataWriter`) that produces the spec-compliant layout and supports SQL `CREATE TABLE AS SELECT` + `INSERT INTO`. PostgreSQL additionally has `PostgresMetadataWriter`, the **experimental, library-specific multi-catalog layout** (not part of the DuckLake spec) where tables are created via `DuckLakeTableWriter` and appended to with `INSERT INTO`. See `COMPATIBILITY.md` for the full backend/feature matrix.
 
 ## Commands
 
@@ -52,12 +52,12 @@ The codebase follows a layered architecture with clear separation of concerns:
    - **No HashMaps**: Catalog and schema providers query metadata on-demand rather than caching
 
 3. **Write Layer** (feature-gated, `write` / `write-sqlite` / `write-postgres`)
-   - `MetadataWriter` trait (`metadata_writer.rs`) defines catalog mutations; implemented by `SqliteMetadataWriter` (`metadata_writer_sqlite.rs`) and `PostgresMetadataWriter` (`metadata_writer_postgres.rs`)
+   - `MetadataWriter` trait (`metadata_writer.rs`) defines catalog mutations; implemented by `SqliteMetadataWriter` (`metadata_writer_sqlite.rs`), `PostgresSingleCatalogMetadataWriter` (`metadata_writer_postgres_single.rs`, standard spec layout), and `PostgresMetadataWriter` (`metadata_writer_postgres.rs`, multi-catalog layout)
    - `DuckLakeTableWriter` / `TableWriteSession` (`table_writer.rs`): write Arrow batches to Parquet with configurable compression and row-group sizing
    - `DuckLakeInsertExec` (`insert_exec.rs`): DataFusion execution plan backing `INSERT INTO` / `CREATE TABLE AS SELECT`. Declares `required_input_distribution() == SinglePartition` so multi-partition inputs are coalesced before writing (guards against silently dropping rows; see `tests/it/insert_partitioning_tests.rs`)
    - A catalog becomes writable via `DuckLakeCatalog::with_writer(provider, writer)`
    - `maintenance.rs`: expire snapshots, clean up superseded files, reclaim orphaned files (Rust API, not SQL DDL)
-   - Multi-catalog (PostgreSQL, **experimental & library-specific** — not part of the DuckLake spec, not accepted upstream): `MulticatalogManager` (`multicatalog.rs`) creates/manages many catalogs in one store; `MulticatalogProvider` (`multicatalog_provider.rs`, feature `multicatalog-postgres`) reads them. All PostgreSQL writes currently go through this path. SQL CTAS is unsupported here (first write of a table goes through `DuckLakeTableWriter`); `INSERT INTO` works once the table exists.
+   - Multi-catalog (PostgreSQL, **experimental & library-specific** — not part of the DuckLake spec, not accepted upstream): `MulticatalogManager` (`multicatalog.rs`) creates/manages many catalogs in one store; `MulticatalogProvider` (`multicatalog_provider.rs`, feature `multicatalog-postgres`) reads them. SQL CTAS is unsupported here (first write of a table goes through `DuckLakeTableWriter`); `INSERT INTO` works once the table exists. PostgreSQL writes no longer require this path — use `PostgresSingleCatalogMetadataWriter` for the spec-compliant layout.
 
 4. **Additional capabilities**
    - `information_schema.rs`: SQL-queryable catalog metadata (snapshots, schemata, tables, columns, files)
@@ -264,7 +264,7 @@ substring filters still work; and targeting one former file is
 
 Representative groups:
 - **Reads & deletes**: `delete_filter_tests.rs`, `missing_delete_file_tests.rs`, `table_tests.rs`, `row_count_tests.rs`
-- **Writes**: `write_tests.rs`, `sql_write_tests.rs`, `concurrent_write_tests.rs`, `insert_partitioning_tests.rs`
+- **Writes**: `write_tests.rs`, `sql_write_tests.rs`, `concurrent_write_tests.rs`, `insert_partitioning_tests.rs`, `postgres_single_catalog_write_tests.rs`
 - **Backends**: `sqlite_metadata_provider_test.rs`, `postgres_metadata_provider_test.rs`, `mysql_metadata_provider_test.rs`, `hybrid_asyncdb.rs`
 - **Multicatalog**: `multicatalog_provider_tests.rs`, `multicatalog_postgres_tests.rs`, `multicatalog_hardening_tests.rs`
 - **Capabilities**: `information_schema_test.rs`, `row_id_tests.rs`, `rowid_physical_position_tests.rs`, `renamed_columns_tests.rs`, `table_changes_tests.rs`, `encryption_tests.rs`, `maintenance_sqlite_tests.rs`

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -25,6 +25,18 @@ below) where tables are created via `DuckLakeTableWriter` and then appended to w
 | PostgreSQL |  ✅  |  ✅   |      ✅       | `metadata-postgres`, `write-postgres`, `multicatalog-postgres` |
 | MySQL      |  ✅  |  ❌   |      ❌       | `metadata-mysql`                                       |
 
+PostgreSQL has **two** writers, both behind `write-postgres`:
+
+| Writer | Layout | Spec-compliant | SQL `CREATE TABLE`/CTAS | Read back with |
+|--------|--------|:--------------:|:-----------------------:|----------------|
+| `PostgresSingleCatalogMetadataWriter` | Standard single-catalog | ✅ | ✅ | `PostgresMetadataProvider` (and any other DuckLake reader, incl. DuckDB) |
+| `PostgresMetadataWriter` | Library-specific multi-catalog | ❌ | ❌ | `MulticatalogProvider` only |
+
+Use `PostgresSingleCatalogMetadataWriter` unless you specifically need many
+catalogs in one database. It produces the same catalog shape as the SQLite and
+MySQL writers: no `catalog_id` columns, no `ducklake_catalog*` map tables, and
+unscoped relative paths (`{data_path}/{schema}/{table}/…`).
+
 **Multi-catalog** (PostgreSQL only, **experimental**) lets a single metadata store hold
 multiple independent DuckLake catalogs. Reading multiple catalogs requires
 `multicatalog-postgres` (`MulticatalogProvider`); creating/managing them requires
@@ -33,11 +45,13 @@ multiple independent DuckLake catalogs. Reading multiple catalogs requires
 > ⚠️ The multi-catalog layout is **specific to this library** — it is not part of the
 > DuckLake specification and is not (yet) supported or accepted upstream. Catalogs
 > written this way are only readable through `MulticatalogProvider`, not as standard
-> single-catalog DuckLake stores. PostgreSQL writes currently go through this path, so
-> **all PostgreSQL write support should be treated as experimental** and subject to
-> change. Note also that SQL `CREATE TABLE`/CTAS is not available on this path (the first
-> write of a table goes through `DuckLakeTableWriter`); `INSERT INTO` works once a table
-> exists.
+> single-catalog DuckLake stores, so **multi-catalog should be treated as
+> experimental** and subject to change. Note also that SQL `CREATE TABLE`/CTAS is not
+> available on this path (the first write of a table goes through
+> `DuckLakeTableWriter`); `INSERT INTO` works once a table exists.
+>
+> PostgreSQL writes no longer *require* this path: `PostgresSingleCatalogMetadataWriter`
+> writes the standard spec-compliant layout and supports CTAS.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -108,11 +108,41 @@ df.show().await?;
 
 ## Writing a catalog
 
-PostgreSQL writes go through the **experimental multi-catalog layout** described in the
-[next section](#multi-catalog-postgresql-experimental) — treat them as a preview. Tables
-are created through the writer API; once a table exists, you append to it with SQL
-`INSERT INTO`. (SQL `CREATE TABLE` / CTAS is not supported on this path — DataFusion
-cannot create the schema, so the first write goes through `DuckLakeTableWriter`.)
+PostgreSQL has two writers, both behind the `write-postgres` feature:
+
+- **`PostgresSingleCatalogMetadataWriter`** — the **standard, spec-compliant**
+  single-catalog layout. Same catalog shape as the SQLite and MySQL writers, so the
+  catalog is readable (and writable) by other DuckLake implementations including
+  DuckDB's `ducklake` extension. SQL `CREATE TABLE AS SELECT` and `INSERT INTO` both
+  work. **Prefer this one.**
+- **`PostgresMetadataWriter`** — the **experimental multi-catalog layout** described in
+  [its own section](#multi-catalog-postgresql-experimental), for hosting many catalogs
+  in one database. Library-specific, not in the DuckLake spec, and no CTAS.
+
+```rust,ignore
+use datafusion::prelude::*;
+use datafusion_ducklake::metadata_writer::MetadataWriter; // set_data_path
+use datafusion_ducklake::{
+    DuckLakeCatalog, PostgresMetadataProvider, PostgresSingleCatalogMetadataWriter,
+};
+use std::sync::Arc;
+
+// Bootstrap the standard DuckLake tables and point the catalog at its data root
+let writer = PostgresSingleCatalogMetadataWriter::new_with_init(
+    "postgresql://user:pass@localhost:5432/db",
+).await?;
+writer.set_data_path("/abs/path/to/data")?;
+
+// CTAS and INSERT both work on this path
+let provider = PostgresMetadataProvider::new("postgresql://user:pass@localhost:5432/db").await?;
+let catalog = DuckLakeCatalog::with_writer(Arc::new(provider), Arc::new(writer))?;
+let ctx = SessionContext::new();
+ctx.register_catalog("ducklake", Arc::new(catalog));
+ctx.sql("CREATE TABLE ducklake.main.events AS SELECT 1 AS id").await?.collect().await?;
+```
+
+The multi-catalog path instead looks like this — tables are created through the writer
+API (no CTAS), then appended to with SQL:
 
 ```rust,ignore
 use datafusion::prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,8 @@ pub mod metadata_writer_duckdb;
 pub mod metadata_writer_mysql;
 #[cfg(feature = "write-postgres")]
 pub mod metadata_writer_postgres;
+#[cfg(feature = "write-postgres")]
+pub mod metadata_writer_postgres_single;
 #[cfg(feature = "write-sqlite")]
 pub mod metadata_writer_sqlite;
 #[cfg(feature = "write-postgres")]
@@ -143,6 +145,8 @@ pub use metadata_writer_duckdb::DuckdbMetadataWriter;
 pub use metadata_writer_mysql::MySqlMetadataWriter;
 #[cfg(feature = "write-postgres")]
 pub use metadata_writer_postgres::PostgresMetadataWriter;
+#[cfg(feature = "write-postgres")]
+pub use metadata_writer_postgres_single::PostgresSingleCatalogMetadataWriter;
 #[cfg(feature = "write-sqlite")]
 pub use metadata_writer_sqlite::SqliteMetadataWriter;
 #[cfg(feature = "write-postgres")]

--- a/src/metadata_writer_postgres_single.rs
+++ b/src/metadata_writer_postgres_single.rs
@@ -58,8 +58,9 @@ use crate::Result;
 use crate::error::{TypeChangeOperation, TypeChangeWriteMode};
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
-    ColumnDef, ColumnStat, CommitIds, DataFileInfo, MetadataWriter, WriteMode, WriteSetupResult,
-    columns_differ, validate_name,
+    ColumnDef, ColumnStat, CommitIds, DataFileInfo, MetadataWriter, SnapshotCommitMetadata,
+    WriteMode, WriteSetupResult, columns_differ, quote_snapshot_name, quote_snapshot_table,
+    table_write_changes, validate_name,
 };
 use crate::partition::PartitionTransform;
 use sqlx::Row;
@@ -89,6 +90,16 @@ const SQL_CREATE_TABLES: &[&str] = &[
         snapshot_id BIGINT NOT NULL PRIMARY KEY,
         snapshot_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         schema_version BIGINT NOT NULL DEFAULT 0
+    )"#,
+    // Per-snapshot change summary + commit metadata (DuckLake spec). `insert_snapshot`
+    // seeds one row per snapshot with `changes_made` NULL; the commit paths fill it in
+    // via `record_snapshot_changes`, appending as a comma-separated list.
+    r#"CREATE TABLE IF NOT EXISTS ducklake_snapshot_changes (
+        snapshot_id BIGINT NOT NULL PRIMARY KEY,
+        changes_made VARCHAR,
+        author VARCHAR,
+        commit_message VARCHAR,
+        commit_extra_info VARCHAR
     )"#,
     r#"CREATE TABLE IF NOT EXISTS ducklake_schema_versions (
         begin_snapshot BIGINT NOT NULL,
@@ -449,7 +460,120 @@ async fn insert_snapshot(tx: &mut sqlx::Transaction<'_, sqlx::Postgres>) -> Resu
     .bind(schema_version)
     .execute(&mut **tx)
     .await?;
+    // Seed the change row so the commit paths can UPDATE it (and so every snapshot
+    // has exactly one row, as the spec expects).
+    sqlx::query(
+        "INSERT INTO ducklake_snapshot_changes (snapshot_id, changes_made)
+         VALUES ($1, NULL)",
+    )
+    .bind(snapshot_id)
+    .execute(&mut **tx)
+    .await?;
     Ok((snapshot_id, schema_version))
+}
+
+/// Append to this snapshot's `changes_made` list and stamp its commit metadata.
+///
+/// Appending (rather than overwriting) matters because a single snapshot can
+/// accumulate several changes — e.g. a first write creates the schema, the table,
+/// and inserts rows. Postgres lets one placeholder be reused, so `$1` appears
+/// three times in the CASE rather than being bound three times as on MySQL.
+async fn record_snapshot_changes(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    snapshot_id: i64,
+    changes_made: &str,
+    commit_metadata: &SnapshotCommitMetadata,
+) -> Result<()> {
+    let changes_made = (!changes_made.is_empty()).then_some(changes_made);
+    sqlx::query(
+        "UPDATE ducklake_snapshot_changes
+         SET changes_made = CASE
+                 WHEN changes_made IS NULL THEN $1
+                 WHEN $1 IS NULL THEN changes_made
+                 ELSE changes_made || ',' || $1
+             END,
+             author = $2,
+             commit_message = $3,
+             commit_extra_info = $4
+         WHERE snapshot_id = $5",
+    )
+    .bind(changes_made)
+    .bind(commit_metadata.author())
+    .bind(commit_metadata.message())
+    .bind(commit_metadata.extra_info())
+    .bind(snapshot_id)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+/// Record the change summary for a data-write commit: whether this snapshot also
+/// created the schema/table or altered it, plus the insert/delete shape from
+/// [`table_write_changes`]. Mirrors the MySQL and SQLite writers.
+async fn record_table_write_changes(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    snapshot_id: i64,
+    table_id: i64,
+    schema_name: &str,
+    table_name: &str,
+    mode: WriteMode,
+    commit_metadata: &SnapshotCommitMetadata,
+) -> Result<()> {
+    let row = sqlx::query(
+        "SELECT s.begin_snapshot AS schema_begin_snapshot,
+                t.begin_snapshot AS table_begin_snapshot
+         FROM ducklake_table t
+         JOIN ducklake_schema s ON s.schema_id = t.schema_id
+         WHERE t.table_id = $1",
+    )
+    .bind(table_id)
+    .fetch_one(&mut **tx)
+    .await?;
+    let schema_begin_snapshot: i64 = row.try_get("schema_begin_snapshot")?;
+    let table_begin_snapshot: i64 = row.try_get("table_begin_snapshot")?;
+    let altered: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+            SELECT 1 FROM ducklake_schema_versions
+            WHERE table_id = $1 AND begin_snapshot = $2
+         )",
+    )
+    .bind(table_id)
+    .bind(snapshot_id)
+    .fetch_one(&mut **tx)
+    .await?;
+    let replaced_existing_data: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+            SELECT 1 FROM ducklake_data_file
+            WHERE table_id = $1 AND end_snapshot = $2
+         )",
+    )
+    .bind(table_id)
+    .bind(snapshot_id)
+    .fetch_one(&mut **tx)
+    .await?;
+
+    let mut changes = Vec::new();
+    if schema_begin_snapshot == snapshot_id {
+        changes.push(format!(
+            "created_schema:{}",
+            quote_snapshot_name(schema_name)
+        ));
+    }
+    if table_begin_snapshot == snapshot_id {
+        changes.push(format!(
+            "created_table:{}",
+            quote_snapshot_table(schema_name, table_name)
+        ));
+    } else if altered {
+        changes.push(format!("altered_table:{table_id}"));
+    }
+    changes.push(table_write_changes(
+        table_id,
+        mode,
+        false,
+        replaced_existing_data,
+    ));
+    record_snapshot_changes(tx, snapshot_id, &changes.join(","), commit_metadata).await
 }
 
 /// Bump the per-catalog monotonic `schema_version` on a DDL snapshot to
@@ -798,15 +922,18 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
     ) -> Result<(i64, bool)> {
         validate_name(name, "Schema")?;
         block_on(async {
+            // One transaction so the schema row and its change record publish together.
+            let mut tx = self.pool.begin().await?;
             let existing = sqlx::query(
                 "SELECT schema_id FROM ducklake_schema
                  WHERE schema_name = $1 AND end_snapshot IS NULL",
             )
             .bind(name)
-            .fetch_optional(&self.pool)
+            .fetch_optional(&mut *tx)
             .await?;
 
             if let Some(row) = existing {
+                tx.commit().await?;
                 return Ok((row.try_get(0)?, false));
             }
 
@@ -822,10 +949,18 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
             .bind(name)
             .bind(schema_path)
             .bind(snapshot_id)
-            .fetch_one(&self.pool)
+            .fetch_one(&mut *tx)
             .await?
             .try_get(0)?;
 
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &format!("created_schema:{}", quote_snapshot_name(name)),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
+            tx.commit().await?;
             Ok((schema_id, true))
         })
     }
@@ -839,18 +974,27 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
     ) -> Result<(i64, bool)> {
         validate_name(name, "Table")?;
         block_on(async {
+            let mut tx = self.pool.begin().await?;
             let existing = sqlx::query(
                 "SELECT table_id FROM ducklake_table
                  WHERE schema_id = $1 AND table_name = $2 AND end_snapshot IS NULL",
             )
             .bind(schema_id)
             .bind(name)
-            .fetch_optional(&self.pool)
+            .fetch_optional(&mut *tx)
             .await?;
 
             if let Some(row) = existing {
+                tx.commit().await?;
                 return Ok((row.try_get(0)?, false));
             }
+
+            // Needed for the qualified name in the change record.
+            let schema_name: String =
+                sqlx::query_scalar("SELECT schema_name FROM ducklake_schema WHERE schema_id = $1")
+                    .bind(schema_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
 
             let table_path = path.unwrap_or(name);
             let table_id: i64 = sqlx::query(
@@ -861,10 +1005,18 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
             .bind(name)
             .bind(table_path)
             .bind(snapshot_id)
-            .fetch_one(&self.pool)
+            .fetch_one(&mut *tx)
             .await?
             .try_get(0)?;
 
+            record_snapshot_changes(
+                &mut tx,
+                snapshot_id,
+                &format!("created_table:{}", quote_snapshot_table(&schema_name, name)),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
+            tx.commit().await?;
             Ok((table_id, true))
         })
     }
@@ -918,6 +1070,24 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
                 column_ids.push(column_id);
             }
 
+            // A column set on an already-existing table is an ALTER; on a table
+            // created in this same snapshot it is part of the create, already
+            // recorded by get_or_create_table.
+            let table_begin_snapshot: i64 =
+                sqlx::query_scalar("SELECT begin_snapshot FROM ducklake_table WHERE table_id = $1")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
+            if table_begin_snapshot != snapshot_id {
+                record_snapshot_changes(
+                    &mut tx,
+                    snapshot_id,
+                    &format!("altered_table:{table_id}"),
+                    &SnapshotCommitMetadata::default(),
+                )
+                .await?;
+            }
+
             tx.commit().await?;
             Ok(column_ids)
         })
@@ -927,17 +1097,52 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
     fn register_data_file(
         &self,
         table_id: i64,
-        // The schema/table rows were created at begin, so the names are unused
-        // here; accepted only to satisfy the trait shared with multicatalog Postgres.
-        _schema_name: &str,
-        _table_name: &str,
-        _snapshot_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        snapshot_id: i64,
         file: &DataFileInfo,
         mode: WriteMode,
         base_snapshot: i64,
         columns: &[ColumnDef],
         column_ids: &[i64],
     ) -> Result<CommitIds> {
+        self.register_data_file_with_commit_metadata(
+            table_id,
+            schema_name,
+            table_name,
+            snapshot_id,
+            file,
+            mode,
+            base_snapshot,
+            columns,
+            column_ids,
+            &SnapshotCommitMetadata::default(),
+            None,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn register_data_file_with_commit_metadata(
+        &self,
+        table_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        _snapshot_id: i64,
+        file: &DataFileInfo,
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+        commit_metadata: &SnapshotCommitMetadata,
+        expected_base_snapshot_id: Option<i64>,
+    ) -> Result<CommitIds> {
+        if expected_base_snapshot_id.is_some() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "conditional writes are not supported by the single-catalog Postgres metadata \
+                 writer"
+                    .to_string(),
+            ));
+        }
         block_on(async {
             // Single atomic commit: insert the deferred snapshot row + finalize the
             // column generation + retire the prior generation (Replace), then
@@ -1005,6 +1210,17 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
             .execute(&mut *tx)
             .await?;
 
+            record_table_write_changes(
+                &mut tx,
+                snapshot_id,
+                table_id,
+                schema_name,
+                table_name,
+                mode,
+                commit_metadata,
+            )
+            .await?;
+
             let schema_id: i64 =
                 sqlx::query("SELECT schema_id FROM ducklake_table WHERE table_id = $1")
                     .bind(table_id)
@@ -1025,15 +1241,52 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
     fn register_data_files(
         &self,
         table_id: i64,
-        _schema_name: &str,
-        _table_name: &str,
-        _snapshot_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        snapshot_id: i64,
         files: &[DataFileInfo],
         mode: WriteMode,
         base_snapshot: i64,
         columns: &[ColumnDef],
         column_ids: &[i64],
     ) -> Result<CommitIds> {
+        self.register_data_files_with_commit_metadata(
+            table_id,
+            schema_name,
+            table_name,
+            snapshot_id,
+            files,
+            mode,
+            base_snapshot,
+            columns,
+            column_ids,
+            &SnapshotCommitMetadata::default(),
+            None,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn register_data_files_with_commit_metadata(
+        &self,
+        table_id: i64,
+        schema_name: &str,
+        table_name: &str,
+        _snapshot_id: i64,
+        files: &[DataFileInfo],
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+        commit_metadata: &SnapshotCommitMetadata,
+        expected_base_snapshot_id: Option<i64>,
+    ) -> Result<CommitIds> {
+        if expected_base_snapshot_id.is_some() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "conditional multi-file writes are not supported by the single-catalog Postgres \
+                 metadata writer"
+                    .to_string(),
+            ));
+        }
         if files.is_empty() {
             return Err(crate::DuckLakeError::InvalidConfig(
                 "register_data_files: files must be non-empty".to_string(),
@@ -1101,6 +1354,16 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
             .bind(total_bytes)
             .bind(table_id)
             .execute(&mut *tx)
+            .await?;
+            record_table_write_changes(
+                &mut tx,
+                snapshot_id,
+                table_id,
+                schema_name,
+                table_name,
+                mode,
+                commit_metadata,
+            )
             .await?;
             let schema_id: i64 =
                 sqlx::query("SELECT schema_id FROM ducklake_table WHERE table_id = $1")
@@ -1187,6 +1450,13 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
 
             let new_schema_version = bump_schema_version(&mut tx, new_snapshot).await?;
             record_schema_version(&mut tx, new_snapshot, new_schema_version, table_id).await?;
+            record_snapshot_changes(
+                &mut tx,
+                new_snapshot,
+                &format!("altered_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
             tx.commit().await?;
             Ok(new_snapshot)
         })
@@ -1250,6 +1520,13 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
             }
             let new_schema_version = bump_schema_version(&mut tx, new_snapshot).await?;
             record_schema_version(&mut tx, new_snapshot, new_schema_version, table_id).await?;
+            record_snapshot_changes(
+                &mut tx,
+                new_snapshot,
+                &format!("altered_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
             tx.commit().await?;
             Ok(new_snapshot)
         })
@@ -1361,6 +1638,13 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
             }
 
             // A sort-order change does NOT bump schema_version.
+            record_snapshot_changes(
+                &mut tx,
+                new_snapshot,
+                &format!("altered_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
             tx.commit().await?;
             Ok(new_snapshot)
         })
@@ -1389,6 +1673,13 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
                 return Ok(head);
             }
             // A sort-order change does NOT bump schema_version.
+            record_snapshot_changes(
+                &mut tx,
+                new_snapshot,
+                &format!("altered_table:{table_id}"),
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
             tx.commit().await?;
             Ok(new_snapshot)
         })
@@ -1398,9 +1689,8 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
     fn publish_snapshot(
         &self,
         table_id: i64,
-        // The schema/table rows were created at begin; names unused (trait parity).
-        _schema_name: &str,
-        _table_name: &str,
+        schema_name: &str,
+        table_name: &str,
         _snapshot_id: i64,
         mode: WriteMode,
         base_snapshot: i64,
@@ -1417,6 +1707,16 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
             let snapshot_id =
                 finalize_snapshot(&mut tx, table_id, columns, column_ids, mode, base_snapshot)
                     .await?;
+            record_table_write_changes(
+                &mut tx,
+                snapshot_id,
+                table_id,
+                schema_name,
+                table_name,
+                mode,
+                &SnapshotCommitMetadata::default(),
+            )
+            .await?;
             let schema_id: i64 =
                 sqlx::query("SELECT schema_id FROM ducklake_table WHERE table_id = $1")
                     .bind(table_id)
@@ -1511,6 +1811,15 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
             // (idempotent, lossless — NULL means "not partitioned").
             sqlx::query(
                 "ALTER TABLE ducklake_data_file ADD COLUMN IF NOT EXISTS partition_id BIGINT",
+            )
+            .execute(&self.pool)
+            .await?;
+            // A catalog created elsewhere may have `changes_made` NOT NULL, but
+            // `insert_snapshot` seeds the row with NULL and fills it in at commit.
+            // Dropping a non-existent NOT NULL is a no-op in Postgres, so this is
+            // idempotent without a probe.
+            sqlx::query(
+                "ALTER TABLE ducklake_snapshot_changes ALTER COLUMN changes_made DROP NOT NULL",
             )
             .execute(&self.pool)
             .await?;

--- a/src/metadata_writer_postgres_single.rs
+++ b/src/metadata_writer_postgres_single.rs
@@ -283,6 +283,24 @@ async fn reserve_ids(
     Ok(last)
 }
 
+/// Take one id from the sequence backing an IDENTITY column without inserting a row,
+/// so `begin_write_transaction` can hand out a schema/table id that only becomes a
+/// visible row at commit. Sequences are non-transactional, so an unused reservation
+/// just leaves a gap.
+async fn reserve_identity(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    table: &str,
+    column: &str,
+) -> Result<i64> {
+    Ok(
+        sqlx::query_scalar("SELECT nextval(pg_get_serial_sequence($1, $2))")
+            .bind(table)
+            .bind(column)
+            .fetch_one(&mut **tx)
+            .await?,
+    )
+}
+
 /// Seed an id counter from the current MAX of its backing column, so a pre-existing
 /// catalog keeps allocating without reuse. `WHERE NOT EXISTS` makes a re-open a no-op.
 async fn seed_counter(pool: &PgPool, key: &str, max_sql: &'static str) -> Result<()> {
@@ -700,25 +718,81 @@ async fn live_partition_id(
     .await?)
 }
 
-/// The atomic commit point: insert the deferred snapshot row, finalize the column
-/// generation, and for `Replace` retire the prior data generation — all in the
-/// caller's transaction, so a reader never sees a half-published head.
+/// The atomic commit point: insert the snapshot row, create the schema/table rows
+/// if absent, finalize the column generation, and for `Replace` retire the prior
+/// data generation — all in the caller's transaction, so a reader never sees a
+/// half-published head.
 ///
-/// The column generation is deferred to here rather than written at begin because
-/// the read path resolves columns by `end_snapshot IS NULL` alone (not
-/// snapshot-scoped), so writing them early would leak them to concurrent reads.
+/// Schema, table and column rows are all written here rather than at begin. The
+/// read path resolves columns by `end_snapshot IS NULL` alone, and resolves
+/// schemas/tables by `snapshot >= begin_snapshot` with no check that the snapshot
+/// exists — so a row written at begin with a guessed id becomes visible as soon as
+/// any writer reaches that id, even if this write never commits.
+#[allow(clippy::too_many_arguments)]
 async fn finalize_snapshot(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
-    table_id: i64,
+    schema_name: &str,
+    table_name: &str,
+    table_id_hint: i64,
     columns: &[ColumnDef],
     column_ids: &[i64],
     mode: WriteMode,
     base_snapshot: i64,
-) -> Result<i64> {
+) -> Result<CommitIds> {
     // Allocate the snapshot FIRST (carrying schema_version forward): this takes
     // the counter lock up front, serializing concurrent commits. schema_version is
     // corrected to a DDL bump below once we've classified the commit.
     let (snapshot_id, mut schema_version) = insert_snapshot(tx).await?;
+
+    let schema_id: i64 =
+        match sqlx::query_scalar(
+            "SELECT schema_id FROM ducklake_schema
+         WHERE schema_name = $1 AND end_snapshot IS NULL",
+        )
+        .bind(schema_name)
+        .fetch_optional(&mut **tx)
+        .await?
+        {
+            Some(id) => id,
+            None => sqlx::query_scalar(
+                "INSERT INTO ducklake_schema (schema_name, path, path_is_relative, begin_snapshot)
+                 VALUES ($1, $1, TRUE, $2) RETURNING schema_id",
+            )
+            .bind(schema_name)
+            .bind(snapshot_id)
+            .fetch_one(&mut **tx)
+            .await?,
+        };
+
+    // A new table keeps the id reserved at begin: the caller already holds it in
+    // `WriteSetupResult` and passes it back here. `table_id` is IDENTITY, hence
+    // OVERRIDING SYSTEM VALUE.
+    let table_id: i64 = match sqlx::query_scalar(
+        "SELECT table_id FROM ducklake_table
+         WHERE schema_id = $1 AND table_name = $2 AND end_snapshot IS NULL",
+    )
+    .bind(schema_id)
+    .bind(table_name)
+    .fetch_optional(&mut **tx)
+    .await?
+    {
+        Some(id) => id,
+        None => {
+            sqlx::query(
+                "INSERT INTO ducklake_table
+                     (table_id, schema_id, table_name, path, path_is_relative, begin_snapshot)
+                 OVERRIDING SYSTEM VALUE
+                 VALUES ($1, $2, $3, $3, TRUE, $4)",
+            )
+            .bind(table_id_hint)
+            .bind(schema_id)
+            .bind(table_name)
+            .bind(snapshot_id)
+            .execute(&mut **tx)
+            .await?;
+            table_id_hint
+        },
+    };
 
     // Classify this commit as DDL vs pure data write. `current` is the table's
     // live columns ordered by `column_order`; an empty set means a brand-new table
@@ -829,7 +903,11 @@ async fn finalize_snapshot(
     if is_ddl {
         record_schema_version(tx, snapshot_id, schema_version, table_id).await?;
     }
-    Ok(snapshot_id)
+    Ok(CommitIds {
+        snapshot_id,
+        schema_id,
+        table_id,
+    })
 }
 
 impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
@@ -1066,24 +1144,35 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
         commit_metadata: &SnapshotCommitMetadata,
         expected_base_snapshot_id: Option<i64>,
     ) -> Result<CommitIds> {
-        if expected_base_snapshot_id.is_some() {
-            return Err(crate::DuckLakeError::InvalidConfig(
-                "conditional writes are not supported by the single-catalog Postgres metadata \
-                 writer"
-                    .to_string(),
-            ));
-        }
         block_on(async {
-            // Single atomic commit: insert the deferred snapshot row + finalize the
-            // column generation + retire the prior generation (Replace), then
-            // register this file and advance the monotonic row-lineage counter —
-            // all in one transaction, so the head only ever resolves to
-            // fully-populated data.
+            // Single atomic commit: insert the snapshot row + create schema/table if
+            // absent + finalize the column generation + retire the prior generation
+            // (Replace), then register this file and advance the monotonic
+            // row-lineage counter — all in one transaction, so the head only ever
+            // resolves to fully-populated data.
             let mut tx = self.pool.begin().await?;
 
-            let snapshot_id =
-                finalize_snapshot(&mut tx, table_id, columns, column_ids, mode, base_snapshot)
-                    .await?;
+            let ids = finalize_snapshot(
+                &mut tx,
+                schema_name,
+                table_name,
+                table_id,
+                columns,
+                column_ids,
+                mode,
+                base_snapshot,
+            )
+            .await?;
+            let (snapshot_id, table_id) = (ids.snapshot_id, ids.table_id);
+
+            // Caller-supplied precondition: the table's data-file generation must
+            // not have moved past the snapshot the input was read at. Replace is
+            // already fenced against `base_snapshot` inside finalize_snapshot.
+            if mode != WriteMode::Replace
+                && let Some(expected_base_snapshot_id) = expected_base_snapshot_id
+            {
+                detect_replace_conflict(&mut tx, table_id, expected_base_snapshot_id).await?;
+            }
 
             // Partition-spec fence: this file must be consistent with the table's live
             // partition generation at commit time (both directions — see
@@ -1151,19 +1240,8 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
             )
             .await?;
 
-            let schema_id: i64 =
-                sqlx::query("SELECT schema_id FROM ducklake_table WHERE table_id = $1")
-                    .bind(table_id)
-                    .fetch_one(&mut *tx)
-                    .await?
-                    .try_get(0)?;
-
             tx.commit().await?;
-            Ok(CommitIds {
-                snapshot_id,
-                schema_id,
-                table_id,
-            })
+            Ok(ids)
         })
     }
 
@@ -1210,13 +1288,6 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
         commit_metadata: &SnapshotCommitMetadata,
         expected_base_snapshot_id: Option<i64>,
     ) -> Result<CommitIds> {
-        if expected_base_snapshot_id.is_some() {
-            return Err(crate::DuckLakeError::InvalidConfig(
-                "conditional multi-file writes are not supported by the single-catalog Postgres \
-                 metadata writer"
-                    .to_string(),
-            ));
-        }
         if files.is_empty() {
             return Err(crate::DuckLakeError::InvalidConfig(
                 "register_data_files: files must be non-empty".to_string(),
@@ -1224,9 +1295,23 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
         }
         block_on(async {
             let mut tx = self.pool.begin().await?;
-            let snapshot_id =
-                finalize_snapshot(&mut tx, table_id, columns, column_ids, mode, base_snapshot)
-                    .await?;
+            let ids = finalize_snapshot(
+                &mut tx,
+                schema_name,
+                table_name,
+                table_id,
+                columns,
+                column_ids,
+                mode,
+                base_snapshot,
+            )
+            .await?;
+            let (snapshot_id, table_id) = (ids.snapshot_id, ids.table_id);
+            if mode != WriteMode::Replace
+                && let Some(expected_base_snapshot_id) = expected_base_snapshot_id
+            {
+                detect_replace_conflict(&mut tx, table_id, expected_base_snapshot_id).await?;
+            }
             // Partition-spec fence (both directions, every file): each file must be
             // consistent with the table's live partition generation at commit time.
             // The tx rolls back on a Conflict.
@@ -1295,18 +1380,8 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
                 commit_metadata,
             )
             .await?;
-            let schema_id: i64 =
-                sqlx::query("SELECT schema_id FROM ducklake_table WHERE table_id = $1")
-                    .bind(table_id)
-                    .fetch_one(&mut *tx)
-                    .await?
-                    .try_get(0)?;
             tx.commit().await?;
-            Ok(CommitIds {
-                snapshot_id,
-                schema_id,
-                table_id,
-            })
+            Ok(ids)
         })
     }
 
@@ -1634,31 +1709,29 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
         // the new head visible atomically.
         block_on(async {
             let mut tx = self.pool.begin().await?;
-            let snapshot_id =
-                finalize_snapshot(&mut tx, table_id, columns, column_ids, mode, base_snapshot)
-                    .await?;
+            let ids = finalize_snapshot(
+                &mut tx,
+                schema_name,
+                table_name,
+                table_id,
+                columns,
+                column_ids,
+                mode,
+                base_snapshot,
+            )
+            .await?;
             record_table_write_changes(
                 &mut tx,
-                snapshot_id,
-                table_id,
+                ids.snapshot_id,
+                ids.table_id,
                 schema_name,
                 table_name,
                 mode,
                 &SnapshotCommitMetadata::default(),
             )
             .await?;
-            let schema_id: i64 =
-                sqlx::query("SELECT schema_id FROM ducklake_table WHERE table_id = $1")
-                    .bind(table_id)
-                    .fetch_one(&mut *tx)
-                    .await?
-                    .try_get(0)?;
             tx.commit().await?;
-            Ok(CommitIds {
-                snapshot_id,
-                schema_id,
-                table_id,
-            })
+            Ok(ids)
         })
     }
 
@@ -1816,61 +1889,42 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
                     .await?
                     .try_get(0)?;
 
-            // Tentative id for WriteSetupResult; the real one is assigned at the
-            // commit (finalize_snapshot), so it may differ under concurrency.
+            // Informational only. The committed id is assigned by finalize_snapshot
+            // from the counter, so under concurrency it may differ from this.
             let snapshot_id: i64 = base_snapshot_id + 1;
 
-            let schema_id: i64 = {
-                let existing = sqlx::query(
-                    "SELECT schema_id FROM ducklake_schema
-                     WHERE schema_name = $1 AND end_snapshot IS NULL",
-                )
-                .bind(schema_name)
-                .fetch_optional(&mut *tx)
-                .await?;
-
-                if let Some(row) = existing {
-                    row.try_get(0)?
-                } else {
-                    // Unscoped relative path — see get_or_create_schema.
-                    sqlx::query(
-                        "INSERT INTO ducklake_schema (schema_name, path, path_is_relative, begin_snapshot)
-                         VALUES ($1, $2, TRUE, $3) RETURNING schema_id",
-                    )
-                    .bind(schema_name)
-                    .bind(schema_name)
-                    .bind(snapshot_id)
-                    .fetch_one(&mut *tx)
-                    .await?
-                    .try_get(0)?
-                }
+            // Look up, do NOT create. Reserving from the IDENTITY sequence hands out
+            // an id without inserting a row, so a write that dies before commit
+            // leaves nothing behind — schema/table visibility is
+            // `snapshot >= begin_snapshot` with no check that the snapshot exists,
+            // so a row written here against a guessed id would become readable the
+            // moment any writer reached it. Unused reservations leave sequence gaps,
+            // which are expected and harmless.
+            let schema_id: i64 = match sqlx::query_scalar(
+                "SELECT schema_id FROM ducklake_schema
+                 WHERE schema_name = $1 AND end_snapshot IS NULL",
+            )
+            .bind(schema_name)
+            .fetch_optional(&mut *tx)
+            .await?
+            {
+                Some(id) => id,
+                None => reserve_identity(&mut tx, "ducklake_schema", "schema_id").await?,
             };
 
-            let table_id: i64 = {
-                let existing = sqlx::query(
-                    "SELECT table_id FROM ducklake_table
-                     WHERE schema_id = $1 AND table_name = $2 AND end_snapshot IS NULL",
-                )
-                .bind(schema_id)
-                .bind(table_name)
-                .fetch_optional(&mut *tx)
-                .await?;
-
-                if let Some(row) = existing {
-                    row.try_get(0)?
-                } else {
-                    sqlx::query(
-                        "INSERT INTO ducklake_table (schema_id, table_name, path, path_is_relative, begin_snapshot)
-                         VALUES ($1, $2, $3, TRUE, $4) RETURNING table_id",
-                    )
-                    .bind(schema_id)
-                    .bind(table_name)
-                    .bind(table_name)
-                    .bind(snapshot_id)
-                    .fetch_one(&mut *tx)
-                    .await?
-                    .try_get(0)?
-                }
+            let table_id: i64 = match sqlx::query_scalar(
+                "SELECT t.table_id FROM ducklake_table t
+                 JOIN ducklake_schema s ON s.schema_id = t.schema_id
+                 WHERE s.schema_name = $1 AND s.end_snapshot IS NULL
+                   AND t.table_name = $2 AND t.end_snapshot IS NULL",
+            )
+            .bind(schema_name)
+            .bind(table_name)
+            .fetch_optional(&mut *tx)
+            .await?
+            {
+                Some(id) => id,
+                None => reserve_identity(&mut tx, "ducklake_table", "table_id").await?,
             };
 
             // Get existing columns to (a) check schema compatibility for appends
@@ -1951,9 +2005,9 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
                 .map(|(col, &fresh)| existing_ids.get(col.name()).copied().unwrap_or(fresh))
                 .collect();
 
-            // Commits only the idempotent get-or-create schema/table rows. Those
-            // reads ARE snapshot-scoped, so the rows stay invisible until the
-            // snapshot publishes; everything else is deferred to the atomic commit.
+            // Inserts nothing: this commit only persists the counter advance for the
+            // column ids (and the sequence advances, which are non-transactional
+            // anyway). Every metadata row is written by finalize_snapshot.
             tx.commit().await?;
 
             Ok(WriteSetupResult {

--- a/src/metadata_writer_postgres_single.rs
+++ b/src/metadata_writer_postgres_single.rs
@@ -1,0 +1,1742 @@
+//! Single-catalog PostgreSQL implementation of [`MetadataWriter`].
+//!
+//! This is the **standard, spec-compliant** DuckLake layout on PostgreSQL — the
+//! same on-disk/in-catalog shape the SQLite and MySQL writers produce, and the
+//! shape DuckDB's `ducklake` extension reads. It is deliberately separate from
+//! [`crate::metadata_writer_postgres::PostgresMetadataWriter`], which implements
+//! this crate's *library-specific* multicatalog layout (extra `catalog_id`
+//! columns plus `ducklake_catalog*` map tables) and is not part of the DuckLake
+//! specification.
+//!
+//! Modelled on [`crate::metadata_writer_mysql::MySqlMetadataWriter`] rather than
+//! the multicatalog Postgres writer: same single-catalog structure, same
+//! supported surface, with the SQL mapped to the Postgres dialect.
+//!
+//! ## Supported surface
+//!
+//! The write primitives the crate's table-write path needs (INSERT / REPLACE /
+//! CREATE TABLE), plus partition and sort specs. Deliberately NOT supported —
+//! these inherit their erroring trait defaults: deletes
+//! ([`MetadataWriter::set_delete_file`]), upserts, compaction, and type
+//! promotion ([`MetadataWriter::promote_column_type`]).
+//! [`MetadataWriter::catalog_id`] inherits the `None` default, which is what
+//! keeps newly-written file paths in the unscoped
+//! `{data_path}/{schema}/{table}/…` layout (the multicatalog writer returns
+//! `Some(id)` and scopes them under `cat_{id}/…`).
+//!
+//! Requires a multi-threaded Tokio runtime (`#[tokio::test(flavor =
+//! "multi_thread")]`): the sync trait methods bridge async sqlx via
+//! [`crate::metadata_provider::block_on`], exactly like the SQLite and MySQL
+//! writers.
+//!
+//! ## Postgres dialect adaptations vs the MySQL template
+//!
+//! 1. **`RETURNING` exists.** IDENTITY-backed ids (`schema_id`, `table_id`,
+//!    `data_file_id`) come straight back from `INSERT … RETURNING`, replacing
+//!    MySQL's `last_insert_id()` round-trip. [`reserve_ids`] likewise collapses
+//!    to a single `UPDATE … RETURNING`.
+//! 2. **`snapshot_id` stays counter-allocated, not IDENTITY.** Upstream's
+//!    `ducklake_snapshot.snapshot_id` is a plain `BIGINT PRIMARY KEY`, and a
+//!    counter row gives the property the `Replace` conflict test depends on: the
+//!    `UPDATE` takes an exclusive row lock held to commit, so every commit
+//!    transaction serializes on it and *snapshot id order equals commit order*.
+//!    A bare Postgres sequence would not — sequences are non-transactional, so
+//!    two concurrent writers can commit out of id order and the scalar
+//!    `> base_snapshot` test would miss a conflict. The multicatalog writer gets
+//!    the same guarantee from its per-catalog `FOR UPDATE` lock, which has no
+//!    single-catalog equivalent.
+//! 3. **DDL type mapping.** `TINYINT(1)`→`BOOLEAN`, `VARCHAR(1024)`/`TEXT`→
+//!    `VARCHAR`, `DATETIME(6)`→`TIMESTAMP`, no `ENGINE = InnoDB`.
+//! 4. **No backticks.** `key`/`value` are non-reserved in Postgres and the
+//!    providers read them unquoted, so they stay bare here too.
+//! 5. **`INSERT IGNORE`→`INSERT … ON CONFLICT (table_id) DO NOTHING`.**
+//! 6. **`ADD COLUMN IF NOT EXISTS`** replaces MySQL's `information_schema` probe.
+//! 7. **Self-referential `INSERT … SELECT` is legal**, so [`seed_counter`] is a
+//!    single idempotent statement rather than MySQL's check-then-insert.
+
+use crate::Result;
+use crate::error::{TypeChangeOperation, TypeChangeWriteMode};
+use crate::metadata_provider::block_on;
+use crate::metadata_writer::{
+    ColumnDef, ColumnStat, CommitIds, DataFileInfo, MetadataWriter, WriteMode, WriteSetupResult,
+    columns_differ, validate_name,
+};
+use crate::partition::PartitionTransform;
+use sqlx::Row;
+use sqlx::postgres::{PgPool, PgPoolOptions};
+
+const DEFAULT_MAX_CONNECTIONS: u32 = 5;
+
+/// The DuckLake catalog tables in Postgres dialect, one `CREATE TABLE` per entry.
+/// sqlx runs each `query()` as a single prepared statement, so the DDL must be
+/// split rather than sent as one `;`-joined script.
+///
+/// Columns and their order match the SQLite and MySQL writers' schemas (and so
+/// upstream DuckLake) for catalog compatibility; only the SQL types are mapped.
+/// IDENTITY PKs back the ids read via `RETURNING`
+/// (`schema_id`/`table_id`/`data_file_id`/`delete_file_id`). `snapshot_id` is a
+/// plain PK assigned from the `next_snapshot_id` counter, and `ducklake_column`
+/// is a bare table (no PK) so a versioned column can hold multiple rows sharing
+/// a `column_id` — matching upstream, and unlike the multicatalog writer's
+/// composite-PK variant.
+const SQL_CREATE_TABLES: &[&str] = &[
+    r#"CREATE TABLE IF NOT EXISTS ducklake_metadata (
+        key VARCHAR NOT NULL,
+        value VARCHAR NOT NULL,
+        scope VARCHAR
+    )"#,
+    r#"CREATE TABLE IF NOT EXISTS ducklake_snapshot (
+        snapshot_id BIGINT NOT NULL PRIMARY KEY,
+        snapshot_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        schema_version BIGINT NOT NULL DEFAULT 0
+    )"#,
+    r#"CREATE TABLE IF NOT EXISTS ducklake_schema_versions (
+        begin_snapshot BIGINT NOT NULL,
+        schema_version BIGINT NOT NULL,
+        table_id BIGINT NOT NULL,
+        UNIQUE (table_id, begin_snapshot)
+    )"#,
+    r#"CREATE TABLE IF NOT EXISTS ducklake_schema (
+        schema_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+        schema_name VARCHAR NOT NULL,
+        path VARCHAR NOT NULL DEFAULT '',
+        path_is_relative BOOLEAN NOT NULL DEFAULT TRUE,
+        begin_snapshot BIGINT NOT NULL,
+        end_snapshot BIGINT
+    )"#,
+    r#"CREATE TABLE IF NOT EXISTS ducklake_table (
+        table_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+        schema_id BIGINT NOT NULL,
+        table_name VARCHAR NOT NULL,
+        path VARCHAR NOT NULL DEFAULT '',
+        path_is_relative BOOLEAN NOT NULL DEFAULT TRUE,
+        begin_snapshot BIGINT NOT NULL,
+        end_snapshot BIGINT
+    )"#,
+    // Bare table (no PRIMARY KEY), mirroring upstream `ducklake_column`: a column
+    // is versioned by `[begin_snapshot, end_snapshot)` and — although this writer
+    // never promotes types — the shape stays identical to SQLite/MySQL/upstream so
+    // catalogs interoperate. The four `*default*` columns and `parent_column` are
+    // left NULL (no nested-type / column-default writes).
+    r#"CREATE TABLE IF NOT EXISTS ducklake_column (
+        column_id BIGINT,
+        begin_snapshot BIGINT,
+        end_snapshot BIGINT,
+        table_id BIGINT,
+        column_order BIGINT,
+        column_name VARCHAR,
+        column_type VARCHAR,
+        initial_default VARCHAR,
+        default_value VARCHAR,
+        nulls_allowed BOOLEAN,
+        parent_column BIGINT,
+        default_value_type VARCHAR,
+        default_value_dialect VARCHAR
+    )"#,
+    r#"CREATE TABLE IF NOT EXISTS ducklake_data_file (
+        data_file_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+        table_id BIGINT NOT NULL,
+        path VARCHAR NOT NULL,
+        path_is_relative BOOLEAN NOT NULL DEFAULT TRUE,
+        file_size_bytes BIGINT NOT NULL,
+        footer_size BIGINT,
+        encryption_key VARCHAR,
+        record_count BIGINT,
+        row_id_start BIGINT,
+        mapping_id BIGINT,
+        begin_snapshot BIGINT NOT NULL,
+        end_snapshot BIGINT,
+        partition_id BIGINT
+    )"#,
+    // Per-table row-lineage + running totals. `next_row_id` allocates rowids
+    // monotonically over the table's lifetime; `record_count`/`file_size_bytes`
+    // mirror the currently-visible totals for DuckDB's `ducklake_table_info`.
+    r#"CREATE TABLE IF NOT EXISTS ducklake_table_stats (
+        table_id BIGINT PRIMARY KEY,
+        record_count BIGINT NOT NULL DEFAULT 0,
+        next_row_id BIGINT NOT NULL DEFAULT 0,
+        file_size_bytes BIGINT NOT NULL DEFAULT 0
+    )"#,
+    // Per-file, per-column zone maps (DuckLake spec) — powers file pruning.
+    // Column set mirrors the official extension and the other backends.
+    r#"CREATE TABLE IF NOT EXISTS ducklake_file_column_stats (
+        data_file_id BIGINT NOT NULL,
+        table_id BIGINT NOT NULL,
+        column_id BIGINT NOT NULL,
+        column_size_bytes BIGINT,
+        value_count BIGINT,
+        null_count BIGINT,
+        min_value VARCHAR,
+        max_value VARCHAR,
+        contains_nan BOOLEAN,
+        extra_stats VARCHAR
+    )"#,
+    // Table-wide per-column roll-up (DuckLake spec) — feeds the optimizer.
+    r#"CREATE TABLE IF NOT EXISTS ducklake_table_column_stats (
+        table_id BIGINT NOT NULL,
+        column_id BIGINT NOT NULL,
+        contains_null BOOLEAN,
+        contains_nan BOOLEAN,
+        min_value VARCHAR,
+        max_value VARCHAR,
+        extra_stats VARCHAR
+    )"#,
+    // Created for catalog-shape parity and so the provider's LEFT JOINs resolve;
+    // this writer never inserts delete files (`set_delete_file` is unsupported).
+    r#"CREATE TABLE IF NOT EXISTS ducklake_delete_file (
+        delete_file_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+        data_file_id BIGINT NOT NULL,
+        table_id BIGINT NOT NULL,
+        path VARCHAR NOT NULL,
+        path_is_relative BOOLEAN NOT NULL DEFAULT TRUE,
+        file_size_bytes BIGINT NOT NULL,
+        footer_size BIGINT,
+        encryption_key VARCHAR,
+        delete_count BIGINT,
+        begin_snapshot BIGINT NOT NULL,
+        end_snapshot BIGINT
+    )"#,
+    r#"CREATE TABLE IF NOT EXISTS ducklake_files_scheduled_for_deletion (
+        data_file_id BIGINT NOT NULL,
+        path VARCHAR NOT NULL,
+        path_is_relative BOOLEAN NOT NULL DEFAULT TRUE,
+        schedule_start TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )"#,
+    // Partition spec generations (DuckLake spec); end_snapshot NULL == active.
+    r#"CREATE TABLE IF NOT EXISTS ducklake_partition_info (
+        partition_id BIGINT NOT NULL,
+        table_id BIGINT NOT NULL,
+        begin_snapshot BIGINT NOT NULL,
+        end_snapshot BIGINT
+    )"#,
+    // Partition-key columns for a spec (DuckLake spec), ordered by partition_key_index.
+    r#"CREATE TABLE IF NOT EXISTS ducklake_partition_column (
+        partition_id BIGINT NOT NULL,
+        table_id BIGINT NOT NULL,
+        partition_key_index BIGINT NOT NULL,
+        column_id BIGINT NOT NULL,
+        transform VARCHAR NOT NULL
+    )"#,
+    // Per-file partition values (DuckLake spec): the value every row in the file
+    // shares for a partition key, DuckDB-canonical VARCHAR (NULL is legal).
+    r#"CREATE TABLE IF NOT EXISTS ducklake_file_partition_value (
+        data_file_id BIGINT NOT NULL,
+        table_id BIGINT NOT NULL,
+        partition_key_index BIGINT NOT NULL,
+        partition_value VARCHAR
+    )"#,
+    // Sort spec generations (DuckLake spec); end_snapshot NULL == active. sort_id
+    // is allocated from the next_sort_id counter (like partition_id).
+    r#"CREATE TABLE IF NOT EXISTS ducklake_sort_info (
+        sort_id BIGINT NOT NULL,
+        table_id BIGINT NOT NULL,
+        begin_snapshot BIGINT NOT NULL,
+        end_snapshot BIGINT
+    )"#,
+    // Sort-key expressions for a spec (DuckLake spec), ordered by sort_key_index.
+    // expression is a sort expression in `dialect` (this crate produces bare column
+    // names under `duckdb`); sort_direction ASC/DESC; null_order NULLS_FIRST/LAST.
+    r#"CREATE TABLE IF NOT EXISTS ducklake_sort_expression (
+        sort_id BIGINT NOT NULL,
+        table_id BIGINT NOT NULL,
+        sort_key_index BIGINT NOT NULL,
+        expression VARCHAR NOT NULL,
+        dialect VARCHAR NOT NULL,
+        sort_direction VARCHAR NOT NULL,
+        null_order VARCHAR NOT NULL
+    )"#,
+];
+
+/// Single-catalog PostgreSQL metadata writer for standard DuckLake catalogs.
+///
+/// Use this (not [`crate::metadata_writer_postgres::PostgresMetadataWriter`])
+/// when the catalog must be readable and writable by other DuckLake
+/// implementations, including DuckDB's `ducklake` extension.
+#[derive(Debug, Clone)]
+pub struct PostgresSingleCatalogMetadataWriter {
+    pool: PgPool,
+}
+
+impl PostgresSingleCatalogMetadataWriter {
+    /// Open a writer against an existing single-catalog Postgres DuckLake
+    /// catalog. Does not create the catalog tables — call
+    /// [`MetadataWriter::initialize_schema`] (or use [`Self::new_with_init`])
+    /// for a fresh database.
+    pub async fn new(connection_string: &str) -> Result<Self> {
+        Self::with_max_connections(connection_string, DEFAULT_MAX_CONNECTIONS).await
+    }
+
+    /// Open a writer with a bounded connection pool.
+    pub async fn with_max_connections(
+        connection_string: &str,
+        max_connections: u32,
+    ) -> Result<Self> {
+        let pool = PgPoolOptions::new()
+            .max_connections(max_connections)
+            .connect(connection_string)
+            .await?;
+        Ok(Self {
+            pool,
+        })
+    }
+
+    /// Adopt an existing pool (e.g. one shared with a
+    /// [`crate::metadata_provider_postgres::PostgresMetadataProvider`]).
+    pub fn from_pool(pool: PgPool) -> Self {
+        Self {
+            pool,
+        }
+    }
+
+    /// Open a writer and create/upgrade the DuckLake catalog tables.
+    pub async fn new_with_init(connection_string: &str) -> Result<Self> {
+        let writer = Self::new(connection_string).await?;
+        writer.initialize_schema()?;
+        Ok(writer)
+    }
+}
+
+/// Atomically reserve `n` consecutive ids from a monotonic counter stored in
+/// `ducklake_metadata` (seeded by `initialize_schema`), returning the LAST id of
+/// the block — the reserved ids are `last - n + 1 ..= last`.
+///
+/// Postgres has `UPDATE … RETURNING`, so unlike MySQL this is one statement. The
+/// `UPDATE` takes an exclusive row lock held until commit, so a concurrent
+/// `reserve_ids` on the same `key` blocks here rather than handing out an
+/// overlapping id — the same serialization SQLite gets from its single-writer
+/// lock. Used for `column_id`, `snapshot_id`, `partition_id` and `sort_id`.
+async fn reserve_ids(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    key: &str,
+    n: i64,
+) -> Result<i64> {
+    let last: i64 = sqlx::query(
+        "UPDATE ducklake_metadata
+         SET value = CAST(CAST(value AS BIGINT) + $1 AS VARCHAR)
+         WHERE key = $2 AND scope IS NULL
+         RETURNING CAST(value AS BIGINT)",
+    )
+    .bind(n)
+    .bind(key)
+    .fetch_one(&mut **tx)
+    .await?
+    .try_get(0)?;
+    Ok(last)
+}
+
+/// Seed a monotonic id counter row if it does not already exist, starting from
+/// the current MAX of its backing column so a pre-existing catalog keeps
+/// allocating without reuse. Idempotent: the `WHERE NOT EXISTS` guard makes a
+/// re-open a no-op. (Postgres, unlike MySQL, permits the self-referential
+/// `INSERT … SELECT` against `ducklake_metadata`.)
+async fn seed_counter(pool: &PgPool, key: &str, max_sql: &'static str) -> Result<()> {
+    let start: i64 = sqlx::query(max_sql).fetch_one(pool).await?.try_get(0)?;
+    sqlx::query(
+        "INSERT INTO ducklake_metadata (key, value, scope)
+         SELECT $1, $2, NULL
+         WHERE NOT EXISTS (
+             SELECT 1 FROM ducklake_metadata WHERE key = $1 AND scope IS NULL
+         )",
+    )
+    .bind(key)
+    .bind(start.to_string())
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Optimistic-concurrency check for a `Replace` commit (mirrors the SQLite /
+/// MySQL writers). Run before retiring the prior generation: if any data file of
+/// the table has `begin_snapshot` or `end_snapshot` newer than `base_snapshot`
+/// (the head observed when this write began), another writer published a newer
+/// generation in the meantime, so this `Replace` aborts with
+/// [`crate::DuckLakeError::Conflict`] rather than clobbering it. (`Append` does
+/// not call this: concurrent appends commute.)
+async fn detect_replace_conflict(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    table_id: i64,
+    base_snapshot: i64,
+) -> Result<()> {
+    let conflict: Option<i64> = sqlx::query(
+        "SELECT 1 FROM ducklake_data_file
+         WHERE table_id = $1 AND (begin_snapshot > $2 OR end_snapshot > $2)
+         LIMIT 1",
+    )
+    .bind(table_id)
+    .bind(base_snapshot)
+    .fetch_optional(&mut **tx)
+    .await?
+    .map(|row| row.try_get(0))
+    .transpose()?;
+    if conflict.is_some() {
+        return Err(crate::DuckLakeError::Conflict(format!(
+            "Replace on table {table_id} conflicts with a concurrent write committed since \
+             snapshot {base_snapshot}; aborting (retry the write against the new generation)"
+        )));
+    }
+    Ok(())
+}
+
+/// Retire the prior generation's still-visible data files at `snapshot_id` and
+/// zero the visible stat totals. The `begin_snapshot < snapshot_id` guard spares
+/// files registered for *this* snapshot, so a multi-file write does not retire
+/// its own siblings. `next_row_id` is left untouched (rowids stay monotonic).
+async fn retire_prior_generation(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    table_id: i64,
+    snapshot_id: i64,
+) -> Result<()> {
+    sqlx::query(
+        "UPDATE ducklake_data_file SET end_snapshot = $1
+         WHERE table_id = $2 AND end_snapshot IS NULL AND begin_snapshot < $1",
+    )
+    .bind(snapshot_id)
+    .bind(table_id)
+    .execute(&mut **tx)
+    .await?;
+
+    sqlx::query(
+        "UPDATE ducklake_table_stats SET record_count = 0, file_size_bytes = 0 WHERE table_id = $1",
+    )
+    .bind(table_id)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+/// Seed the per-table stats row if absent. `ON CONFLICT DO NOTHING` on the
+/// `table_id` PK is the Postgres spelling of MySQL's `INSERT IGNORE`.
+async fn seed_table_stats(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    table_id: i64,
+) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO ducklake_table_stats (table_id, record_count, next_row_id, file_size_bytes)
+         VALUES ($1, 0, 0, 0)
+         ON CONFLICT (table_id) DO NOTHING",
+    )
+    .bind(table_id)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+/// Insert the next `ducklake_snapshot` row, carrying `schema_version` forward
+/// (the pure-data-write default), and return `(snapshot_id, schema_version)`.
+///
+/// `snapshot_id` is allocated from the `next_snapshot_id` counter. [`reserve_ids`]
+/// takes an exclusive row lock on that counter row held until this transaction
+/// commits, so this is the "write-lock-first" serialization point of a commit —
+/// every commit transaction contends on the single counter row, so per-catalog
+/// id order equals commit order and the scalar `> base_snapshot` conflict test is
+/// exact. See the module docs for why a bare IDENTITY sequence is not used here.
+/// A DDL commit follows this with [`bump_schema_version`].
+async fn insert_snapshot(tx: &mut sqlx::Transaction<'_, sqlx::Postgres>) -> Result<(i64, i64)> {
+    let snapshot_id = reserve_ids(tx, "next_snapshot_id", 1).await?;
+    // Carry the current per-catalog schema_version forward; a DDL commit corrects
+    // this to a bump via `bump_schema_version` below. Read before the INSERT so
+    // the MAX is over the pre-existing rows only (matches the other writers).
+    let schema_version: i64 =
+        sqlx::query("SELECT COALESCE(MAX(schema_version), 0) FROM ducklake_snapshot")
+            .fetch_one(&mut **tx)
+            .await?
+            .try_get(0)?;
+    sqlx::query(
+        "INSERT INTO ducklake_snapshot (snapshot_id, snapshot_time, schema_version)
+         VALUES ($1, NOW(), $2)",
+    )
+    .bind(snapshot_id)
+    .bind(schema_version)
+    .execute(&mut **tx)
+    .await?;
+    Ok((snapshot_id, schema_version))
+}
+
+/// Bump the per-catalog monotonic `schema_version` on a DDL snapshot to
+/// `prev_max + 1` (max over the OTHER snapshots, so re-running is stable) and
+/// return the new value. Mirrors upstream `if (SchemaChangesMade()) schema_version++`.
+async fn bump_schema_version(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    snapshot_id: i64,
+) -> Result<i64> {
+    let prev_max: i64 = sqlx::query(
+        "SELECT COALESCE(MAX(schema_version), 0) FROM ducklake_snapshot WHERE snapshot_id <> $1",
+    )
+    .bind(snapshot_id)
+    .fetch_one(&mut **tx)
+    .await?
+    .try_get(0)?;
+    let new_version = prev_max + 1;
+    sqlx::query("UPDATE ducklake_snapshot SET schema_version = $1 WHERE snapshot_id = $2")
+        .bind(new_version)
+        .bind(snapshot_id)
+        .execute(&mut **tx)
+        .await?;
+    Ok(new_version)
+}
+
+/// Record a `ducklake_schema_versions` ledger row for a DDL that leaves the table
+/// live (create, column add/remove/reorder). Not called for a drop.
+async fn record_schema_version(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    snapshot_id: i64,
+    schema_version: i64,
+    table_id: i64,
+) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO ducklake_schema_versions (begin_snapshot, schema_version, table_id)
+         VALUES ($1, $2, $3)",
+    )
+    .bind(snapshot_id)
+    .bind(schema_version)
+    .bind(table_id)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+/// Persist the harvested per-column stats for a just-registered data file
+/// (per-file zone maps). See the SQLite writer's equivalent for the rationale.
+async fn insert_file_column_stats(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    table_id: i64,
+    data_file_id: i64,
+    column_stats: &[ColumnStat],
+) -> Result<()> {
+    for stat in column_stats {
+        sqlx::query(
+            "INSERT INTO ducklake_file_column_stats
+                 (data_file_id, table_id, column_id, column_size_bytes,
+                  value_count, null_count, min_value, max_value, contains_nan, extra_stats)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NULL)",
+        )
+        .bind(data_file_id)
+        .bind(table_id)
+        .bind(stat.column_id)
+        .bind(stat.column_size_bytes)
+        .bind(stat.value_count)
+        .bind(stat.null_count)
+        .bind(stat.min_value.as_deref())
+        .bind(stat.max_value.as_deref())
+        .bind(stat.contains_nan)
+        .execute(&mut **tx)
+        .await?;
+    }
+    Ok(())
+}
+
+/// Persist a partitioned data file's partition metadata within the commit
+/// transaction: set `ducklake_data_file.partition_id` and insert one
+/// `ducklake_file_partition_value` row per partition key. A no-op for an
+/// unpartitioned file.
+async fn insert_partition_metadata(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    table_id: i64,
+    data_file_id: i64,
+    file: &DataFileInfo,
+) -> Result<()> {
+    if let Some(partition_id) = file.partition_id {
+        sqlx::query("UPDATE ducklake_data_file SET partition_id = $1 WHERE data_file_id = $2")
+            .bind(partition_id)
+            .bind(data_file_id)
+            .execute(&mut **tx)
+            .await?;
+    }
+    for (key_index, value) in &file.partition_values {
+        sqlx::query(
+            "INSERT INTO ducklake_file_partition_value
+                 (data_file_id, table_id, partition_key_index, partition_value)
+             VALUES ($1, $2, $3, $4)",
+        )
+        .bind(data_file_id)
+        .bind(table_id)
+        .bind(i64::from(*key_index))
+        .bind(value.clone())
+        .execute(&mut **tx)
+        .await?;
+    }
+    Ok(())
+}
+
+/// Recompute `ducklake_table_column_stats` from the table's live files and
+/// replace the stored rows. See the SQLite writer's equivalent for the rationale.
+async fn recompute_table_column_stats(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    table_id: i64,
+    columns: &[ColumnDef],
+    column_ids: &[i64],
+) -> Result<()> {
+    use crate::stats_encode::{FileColumnStat, aggregate_global_column_stats};
+
+    let live_file_count: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_data_file WHERE table_id = $1 AND end_snapshot IS NULL",
+    )
+    .bind(table_id)
+    .fetch_one(&mut **tx)
+    .await?
+    .try_get(0)?;
+
+    let mut per_file: Vec<FileColumnStat> = Vec::new();
+    for row in sqlx::query(
+        "SELECT s.column_id, s.min_value, s.max_value, s.null_count, s.contains_nan
+         FROM ducklake_file_column_stats s
+         JOIN ducklake_data_file d ON d.data_file_id = s.data_file_id
+         WHERE d.table_id = $1 AND d.end_snapshot IS NULL",
+    )
+    .bind(table_id)
+    .fetch_all(&mut **tx)
+    .await?
+    {
+        per_file.push(FileColumnStat {
+            column_id: row.try_get(0)?,
+            min_value: row.try_get(1)?,
+            max_value: row.try_get(2)?,
+            null_count: row.try_get(3)?,
+            contains_nan: row.try_get(4)?,
+        });
+    }
+
+    let numeric_of = |column_id: i64| -> bool {
+        column_ids
+            .iter()
+            .position(|id| *id == column_id)
+            .and_then(|i| columns.get(i))
+            .map(|c| crate::stats_encode::is_numeric_ducklake_type(c.ducklake_type()))
+            .unwrap_or(false)
+    };
+    let globals = aggregate_global_column_stats(&per_file, live_file_count, numeric_of);
+
+    sqlx::query("DELETE FROM ducklake_table_column_stats WHERE table_id = $1")
+        .bind(table_id)
+        .execute(&mut **tx)
+        .await?;
+    for g in globals {
+        sqlx::query(
+            "INSERT INTO ducklake_table_column_stats
+                 (table_id, column_id, contains_null, contains_nan, min_value, max_value, extra_stats)
+             VALUES ($1, $2, $3, $4, $5, $6, NULL)",
+        )
+        .bind(table_id)
+        .bind(g.column_id)
+        .bind(g.contains_null)
+        .bind(g.contains_nan)
+        .bind(g.min_value)
+        .bind(g.max_value)
+        .execute(&mut **tx)
+        .await?;
+    }
+    Ok(())
+}
+
+/// Read the table's live partition generation for the commit-time fence.
+async fn live_partition_id(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    table_id: i64,
+) -> Result<Option<i64>> {
+    Ok(sqlx::query_scalar(
+        "SELECT partition_id FROM ducklake_partition_info
+         WHERE table_id = $1 AND end_snapshot IS NULL",
+    )
+    .bind(table_id)
+    .fetch_optional(&mut **tx)
+    .await?)
+}
+
+/// The atomic commit point for a single-catalog write. Inserts the deferred
+/// `ducklake_snapshot` row, finalizes the column generation, and — for
+/// `Replace` — retires the prior data generation. All within the caller's
+/// transaction, so a reader never sees a half-published head.
+///
+/// The column generation is deferred to here (rather than written in
+/// `begin_write_transaction`) because the read path resolves a table's columns by
+/// `end_snapshot IS NULL` only (not snapshot-scoped), so inserting the new
+/// generation at begin would leak it to concurrent reads during the upload
+/// window. `column_ids` are the ids reserved at begin and already baked into the
+/// staged parquet's `field_id` metadata.
+async fn finalize_snapshot(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    table_id: i64,
+    columns: &[ColumnDef],
+    column_ids: &[i64],
+    mode: WriteMode,
+    base_snapshot: i64,
+) -> Result<i64> {
+    // Allocate the snapshot FIRST (carrying schema_version forward): this takes
+    // the counter lock up front, serializing concurrent commits. schema_version is
+    // corrected to a DDL bump below once we've classified the commit.
+    let (snapshot_id, mut schema_version) = insert_snapshot(tx).await?;
+
+    // Classify this commit as DDL vs pure data write. `current` is the table's
+    // live columns ordered by `column_order`; an empty set means a brand-new table
+    // (the creating write is DDL). Mirrors upstream `SchemaChangesMade()`.
+    use std::collections::{HashMap, HashSet};
+    let current = sqlx::query(
+        "SELECT column_name, column_type, column_order, nulls_allowed
+         FROM ducklake_column
+         WHERE table_id = $1 AND end_snapshot IS NULL
+         ORDER BY column_order",
+    )
+    .bind(table_id)
+    .fetch_all(&mut **tx)
+    .await?;
+
+    let mut existing: Vec<(String, String, bool)> = Vec::with_capacity(current.len());
+    for row in &current {
+        let name: String = row.try_get("column_name")?;
+        let ty: String = row.try_get("column_type")?;
+        let nullable: bool = row
+            .try_get::<Option<bool>, _>("nulls_allowed")?
+            .unwrap_or(true);
+        existing.push((name, ty, nullable));
+    }
+    let is_ddl = existing.is_empty() || columns_differ(&existing, columns);
+    if is_ddl {
+        // A DDL commit bumps the per-catalog schema_version (the insert above only
+        // carried it forward). A pure data write keeps the carried value.
+        schema_version = bump_schema_version(tx, snapshot_id).await?;
+    }
+
+    // Reconcile the column generation SURGICALLY so each column keeps a stable
+    // column_id (== parquet field_id) across writes: end only removed columns,
+    // insert only new ones, and leave unchanged columns (and their ids) in place.
+    let new_names: HashSet<&str> = columns.iter().map(|c| c.name()).collect();
+    let mut current_by_name: HashMap<String, (i64, bool)> = HashMap::new();
+    for row in &current {
+        let name: String = row.try_get("column_name")?;
+        let order: i64 = row.try_get("column_order")?;
+        let nullable: bool = row
+            .try_get::<Option<bool>, _>("nulls_allowed")?
+            .unwrap_or(true);
+        if !new_names.contains(name.as_str()) {
+            // Column dropped in the new schema: end its generation.
+            sqlx::query(
+                "UPDATE ducklake_column SET end_snapshot = $1
+                 WHERE table_id = $2 AND column_name = $3 AND end_snapshot IS NULL",
+            )
+            .bind(snapshot_id)
+            .bind(table_id)
+            .bind(&name)
+            .execute(&mut **tx)
+            .await?;
+        }
+        current_by_name.insert(name, (order, nullable));
+    }
+
+    for (order, (col, column_id)) in columns.iter().zip(column_ids.iter()).enumerate() {
+        match current_by_name.get(col.name()) {
+            // Existing column kept: its id stays stable. Sync order/nullability
+            // only if they changed (type changes are rejected at begin).
+            Some(&(cur_order, cur_nullable)) => {
+                if cur_order != order as i64 || cur_nullable != col.is_nullable() {
+                    sqlx::query(
+                        "UPDATE ducklake_column SET column_order = $1, nulls_allowed = $2
+                         WHERE table_id = $3 AND column_name = $4 AND end_snapshot IS NULL",
+                    )
+                    .bind(order as i64)
+                    .bind(col.is_nullable())
+                    .bind(table_id)
+                    .bind(col.name())
+                    .execute(&mut **tx)
+                    .await?;
+                }
+            },
+            // Newly added column: insert it with its reserved id.
+            None => {
+                sqlx::query(
+                    "INSERT INTO ducklake_column
+                         (column_id, table_id, column_name, column_type, column_order, nulls_allowed, begin_snapshot)
+                     VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                )
+                .bind(column_id)
+                .bind(table_id)
+                .bind(col.name())
+                .bind(col.ducklake_type())
+                .bind(order as i64)
+                .bind(col.is_nullable())
+                .bind(snapshot_id)
+                .execute(&mut **tx)
+                .await?;
+            },
+        }
+    }
+
+    if mode == WriteMode::Replace {
+        // Abort if a concurrent writer published a newer generation since this
+        // write began.
+        detect_replace_conflict(tx, table_id, base_snapshot).await?;
+        // Seed the stats row (first write to a brand-new table) so retire's
+        // zero-update has a row, then retire the prior data generation.
+        seed_table_stats(tx, table_id).await?;
+        retire_prior_generation(tx, table_id, snapshot_id).await?;
+    }
+
+    // Record the schema-change ledger row for a DDL commit. A pure data write
+    // carries schema_version forward and writes no row.
+    if is_ddl {
+        record_schema_version(tx, snapshot_id, schema_version, table_id).await?;
+    }
+    Ok(snapshot_id)
+}
+
+impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
+    fn create_snapshot(&self) -> Result<i64> {
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            // A bare snapshot carries no schema change of its own → carry
+            // schema_version forward (no DDL bump, no ledger row).
+            let (snapshot_id, _schema_version) = insert_snapshot(&mut tx).await?;
+            tx.commit().await?;
+            Ok(snapshot_id)
+        })
+    }
+
+    fn get_or_create_schema(
+        &self,
+        name: &str,
+        path: Option<&str>,
+        snapshot_id: i64,
+    ) -> Result<(i64, bool)> {
+        validate_name(name, "Schema")?;
+        block_on(async {
+            let existing = sqlx::query(
+                "SELECT schema_id FROM ducklake_schema
+                 WHERE schema_name = $1 AND end_snapshot IS NULL",
+            )
+            .bind(name)
+            .fetch_optional(&self.pool)
+            .await?;
+
+            if let Some(row) = existing {
+                return Ok((row.try_get(0)?, false));
+            }
+
+            // Unscoped, relative path: the file layout stays
+            // `{data_path}/{schema}/{table}/…`, matching every other
+            // single-catalog backend (the multicatalog writer scopes to
+            // `cat_{id}/{schema}` instead).
+            let schema_path = path.unwrap_or(name);
+            let schema_id: i64 = sqlx::query(
+                "INSERT INTO ducklake_schema (schema_name, path, path_is_relative, begin_snapshot)
+                 VALUES ($1, $2, TRUE, $3) RETURNING schema_id",
+            )
+            .bind(name)
+            .bind(schema_path)
+            .bind(snapshot_id)
+            .fetch_one(&self.pool)
+            .await?
+            .try_get(0)?;
+
+            Ok((schema_id, true))
+        })
+    }
+
+    fn get_or_create_table(
+        &self,
+        schema_id: i64,
+        name: &str,
+        path: Option<&str>,
+        snapshot_id: i64,
+    ) -> Result<(i64, bool)> {
+        validate_name(name, "Table")?;
+        block_on(async {
+            let existing = sqlx::query(
+                "SELECT table_id FROM ducklake_table
+                 WHERE schema_id = $1 AND table_name = $2 AND end_snapshot IS NULL",
+            )
+            .bind(schema_id)
+            .bind(name)
+            .fetch_optional(&self.pool)
+            .await?;
+
+            if let Some(row) = existing {
+                return Ok((row.try_get(0)?, false));
+            }
+
+            let table_path = path.unwrap_or(name);
+            let table_id: i64 = sqlx::query(
+                "INSERT INTO ducklake_table (schema_id, table_name, path, path_is_relative, begin_snapshot)
+                 VALUES ($1, $2, $3, TRUE, $4) RETURNING table_id",
+            )
+            .bind(schema_id)
+            .bind(name)
+            .bind(table_path)
+            .bind(snapshot_id)
+            .fetch_one(&self.pool)
+            .await?
+            .try_get(0)?;
+
+            Ok((table_id, true))
+        })
+    }
+
+    fn set_columns(
+        &self,
+        table_id: i64,
+        columns: &[ColumnDef],
+        snapshot_id: i64,
+    ) -> Result<Vec<i64>> {
+        if columns.is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "Table must have at least one column".to_string(),
+            ));
+        }
+        block_on(async {
+            // Transaction for atomicity: if column insertion fails, we don't leave
+            // existing columns marked as ended.
+            let mut tx = self.pool.begin().await?;
+
+            sqlx::query(
+                "UPDATE ducklake_column SET end_snapshot = $1
+                 WHERE table_id = $2 AND end_snapshot IS NULL",
+            )
+            .bind(snapshot_id)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+
+            // Reserve a contiguous column_id block from the monotonic counter and
+            // insert with explicit ids, keeping the allocator authoritative.
+            let n = columns.len() as i64;
+            let last_column_id = reserve_ids(&mut tx, "next_column_id", n).await?;
+            let first_column_id = last_column_id - n + 1;
+            let mut column_ids = Vec::with_capacity(columns.len());
+            for (order, col) in columns.iter().enumerate() {
+                let column_id = first_column_id + order as i64;
+                sqlx::query(
+                    "INSERT INTO ducklake_column (column_id, table_id, column_name, column_type, column_order, nulls_allowed, begin_snapshot)
+                     VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                )
+                .bind(column_id)
+                .bind(table_id)
+                .bind(col.name())
+                .bind(col.ducklake_type())
+                .bind(order as i64)
+                .bind(col.is_nullable())
+                .bind(snapshot_id)
+                .execute(&mut *tx)
+                .await?;
+                column_ids.push(column_id);
+            }
+
+            tx.commit().await?;
+            Ok(column_ids)
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn register_data_file(
+        &self,
+        table_id: i64,
+        // The schema/table rows were created at begin, so the names are unused
+        // here; accepted only to satisfy the trait shared with multicatalog Postgres.
+        _schema_name: &str,
+        _table_name: &str,
+        _snapshot_id: i64,
+        file: &DataFileInfo,
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+    ) -> Result<CommitIds> {
+        block_on(async {
+            // Single atomic commit: insert the deferred snapshot row + finalize the
+            // column generation + retire the prior generation (Replace), then
+            // register this file and advance the monotonic row-lineage counter —
+            // all in one transaction, so the head only ever resolves to
+            // fully-populated data.
+            let mut tx = self.pool.begin().await?;
+
+            let snapshot_id =
+                finalize_snapshot(&mut tx, table_id, columns, column_ids, mode, base_snapshot)
+                    .await?;
+
+            // Partition-spec fence: this file must be consistent with the table's live
+            // partition generation at commit time (both directions — see
+            // enforce_partition_fence). The tx rolls back on a Conflict.
+            let partition_generation = live_partition_id(&mut tx, table_id).await?;
+            crate::metadata_writer::enforce_partition_fence(table_id, partition_generation, file)?;
+
+            // Seed the stats row for the Append path (Replace already seeded it in
+            // finalize_snapshot); ON CONFLICT DO NOTHING is a no-op if it exists.
+            seed_table_stats(&mut tx, table_id).await?;
+
+            let row_id_start: i64 =
+                sqlx::query("SELECT next_row_id FROM ducklake_table_stats WHERE table_id = $1")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?
+                    .try_get(0)?;
+
+            let data_file_id: i64 = sqlx::query(
+                "INSERT INTO ducklake_data_file
+                     (table_id, path, path_is_relative, file_size_bytes,
+                      footer_size, record_count, row_id_start, begin_snapshot)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING data_file_id",
+            )
+            .bind(table_id)
+            .bind(&file.path)
+            .bind(file.path_is_relative)
+            .bind(file.file_size_bytes)
+            .bind(file.footer_size)
+            .bind(file.record_count)
+            .bind(row_id_start)
+            .bind(snapshot_id)
+            .fetch_one(&mut *tx)
+            .await?
+            .try_get(0)?;
+
+            // Persist the file's zone maps + refresh the roll-up.
+            insert_file_column_stats(&mut tx, table_id, data_file_id, &file.column_stats).await?;
+            insert_partition_metadata(&mut tx, table_id, data_file_id, file).await?;
+            recompute_table_column_stats(&mut tx, table_id, columns, column_ids).await?;
+
+            // Advance the counter and accumulate stats. `next_row_id`
+            // monotonically increases over the table's lifetime.
+            sqlx::query(
+                "UPDATE ducklake_table_stats
+                 SET next_row_id     = next_row_id + $1,
+                     record_count    = record_count + $1,
+                     file_size_bytes = file_size_bytes + $2
+                 WHERE table_id = $3",
+            )
+            .bind(file.record_count)
+            .bind(file.file_size_bytes)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+
+            let schema_id: i64 =
+                sqlx::query("SELECT schema_id FROM ducklake_table WHERE table_id = $1")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?
+                    .try_get(0)?;
+
+            tx.commit().await?;
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn register_data_files(
+        &self,
+        table_id: i64,
+        _schema_name: &str,
+        _table_name: &str,
+        _snapshot_id: i64,
+        files: &[DataFileInfo],
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+    ) -> Result<CommitIds> {
+        if files.is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "register_data_files: files must be non-empty".to_string(),
+            ));
+        }
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            let snapshot_id =
+                finalize_snapshot(&mut tx, table_id, columns, column_ids, mode, base_snapshot)
+                    .await?;
+            // Partition-spec fence (both directions, every file): each file must be
+            // consistent with the table's live partition generation at commit time.
+            // The tx rolls back on a Conflict.
+            let partition_generation = live_partition_id(&mut tx, table_id).await?;
+            for file in files {
+                crate::metadata_writer::enforce_partition_fence(
+                    table_id,
+                    partition_generation,
+                    file,
+                )?;
+            }
+            seed_table_stats(&mut tx, table_id).await?;
+            let mut next_row_id: i64 =
+                sqlx::query("SELECT next_row_id FROM ducklake_table_stats WHERE table_id = $1")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?
+                    .try_get(0)?;
+            let mut total_records: i64 = 0;
+            let mut total_bytes: i64 = 0;
+            for file in files {
+                let data_file_id: i64 = sqlx::query(
+                    "INSERT INTO ducklake_data_file
+                         (table_id, path, path_is_relative, file_size_bytes,
+                          footer_size, record_count, row_id_start, begin_snapshot)
+                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING data_file_id",
+                )
+                .bind(table_id)
+                .bind(&file.path)
+                .bind(file.path_is_relative)
+                .bind(file.file_size_bytes)
+                .bind(file.footer_size)
+                .bind(file.record_count)
+                .bind(next_row_id)
+                .bind(snapshot_id)
+                .fetch_one(&mut *tx)
+                .await?
+                .try_get(0)?;
+                insert_file_column_stats(&mut tx, table_id, data_file_id, &file.column_stats)
+                    .await?;
+                insert_partition_metadata(&mut tx, table_id, data_file_id, file).await?;
+                next_row_id += file.record_count;
+                total_records += file.record_count;
+                total_bytes += file.file_size_bytes;
+            }
+            recompute_table_column_stats(&mut tx, table_id, columns, column_ids).await?;
+            sqlx::query(
+                "UPDATE ducklake_table_stats
+                 SET next_row_id     = next_row_id + $1,
+                     record_count    = record_count + $1,
+                     file_size_bytes = file_size_bytes + $2
+                 WHERE table_id = $3",
+            )
+            .bind(total_records)
+            .bind(total_bytes)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            let schema_id: i64 =
+                sqlx::query("SELECT schema_id FROM ducklake_table WHERE table_id = $1")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?
+                    .try_get(0)?;
+            tx.commit().await?;
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
+        })
+    }
+
+    fn set_partition_spec(
+        &self,
+        table_id: i64,
+        columns: &[(String, PartitionTransform)],
+    ) -> Result<i64> {
+        if columns.is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "set_partition_spec: partition spec must have at least one column; \
+                 use reset_partition_spec to remove partitioning"
+                    .to_string(),
+            ));
+        }
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            let partition_id = reserve_ids(&mut tx, "next_partition_id", 1).await?;
+            let (new_snapshot, _carried) = insert_snapshot(&mut tx).await?;
+
+            let mut resolved_column_ids: Vec<i64> = Vec::with_capacity(columns.len());
+            for (name, _transform) in columns {
+                let column_id: i64 = sqlx::query_scalar(
+                    "SELECT column_id FROM ducklake_column
+                     WHERE table_id = $1 AND column_name = $2 AND end_snapshot IS NULL",
+                )
+                .bind(table_id)
+                .bind(name)
+                .fetch_optional(&mut *tx)
+                .await?
+                .ok_or_else(|| {
+                    crate::DuckLakeError::InvalidConfig(format!(
+                        "set_partition_spec: no live column '{name}' in table {table_id}"
+                    ))
+                })?;
+                resolved_column_ids.push(column_id);
+            }
+
+            sqlx::query(
+                "UPDATE ducklake_partition_info SET end_snapshot = $1
+                 WHERE table_id = $2 AND end_snapshot IS NULL",
+            )
+            .bind(new_snapshot)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            sqlx::query(
+                "INSERT INTO ducklake_partition_info
+                     (partition_id, table_id, begin_snapshot, end_snapshot)
+                 VALUES ($1, $2, $3, NULL)",
+            )
+            .bind(partition_id)
+            .bind(table_id)
+            .bind(new_snapshot)
+            .execute(&mut *tx)
+            .await?;
+            for (key_index, column_id) in resolved_column_ids.iter().enumerate() {
+                sqlx::query(
+                    "INSERT INTO ducklake_partition_column
+                         (partition_id, table_id, partition_key_index, column_id, transform)
+                     VALUES ($1, $2, $3, $4, $5)",
+                )
+                .bind(partition_id)
+                .bind(table_id)
+                .bind(key_index as i64)
+                .bind(*column_id)
+                .bind(columns[key_index].1.to_catalog_string())
+                .execute(&mut *tx)
+                .await?;
+            }
+
+            let new_schema_version = bump_schema_version(&mut tx, new_snapshot).await?;
+            record_schema_version(&mut tx, new_snapshot, new_schema_version, table_id).await?;
+            tx.commit().await?;
+            Ok(new_snapshot)
+        })
+    }
+
+    fn live_partition_spec(
+        &self,
+        table_id: i64,
+    ) -> Result<Option<crate::partition::PartitionSpec>> {
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT pi.partition_id, pc.partition_key_index, pc.column_id, pc.transform
+                 FROM ducklake_partition_info AS pi
+                 JOIN ducklake_partition_column AS pc
+                   ON pc.partition_id = pi.partition_id AND pc.table_id = pi.table_id
+                 WHERE pi.table_id = $1 AND pi.end_snapshot IS NULL
+                 ORDER BY pc.partition_key_index",
+            )
+            .bind(table_id)
+            .fetch_all(&self.pool)
+            .await?;
+            let parsed = rows
+                .iter()
+                .map(|row| {
+                    Ok::<_, crate::DuckLakeError>((
+                        row.try_get::<i64, _>(0)?,
+                        i32::try_from(row.try_get::<i64, _>(1)?).unwrap_or(0),
+                        row.try_get::<i64, _>(2)?,
+                        row.try_get::<String, _>(3)?,
+                    ))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            // prune_safe = false: this spec is for laying out a write, never pruning.
+            Ok(crate::partition::PartitionSpec::from_rows(parsed, false))
+        })
+    }
+
+    fn reset_partition_spec(&self, table_id: i64) -> Result<i64> {
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            let (new_snapshot, _carried) = insert_snapshot(&mut tx).await?;
+            let ended = sqlx::query(
+                "UPDATE ducklake_partition_info SET end_snapshot = $1
+                 WHERE table_id = $2 AND end_snapshot IS NULL",
+            )
+            .bind(new_snapshot)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?
+            .rows_affected();
+            if ended == 0 {
+                // Nothing to reset: roll back the speculative snapshot rather than
+                // publishing an empty one, and report the unchanged head.
+                tx.rollback().await?;
+                let head: i64 = sqlx::query_scalar(
+                    "SELECT COALESCE(MAX(snapshot_id), 0) FROM ducklake_snapshot",
+                )
+                .fetch_one(&self.pool)
+                .await?;
+                return Ok(head);
+            }
+            let new_schema_version = bump_schema_version(&mut tx, new_snapshot).await?;
+            record_schema_version(&mut tx, new_snapshot, new_schema_version, table_id).await?;
+            tx.commit().await?;
+            Ok(new_snapshot)
+        })
+    }
+
+    fn live_sort_spec(&self, table_id: i64) -> Result<Option<crate::sort::SortSpec>> {
+        block_on(async {
+            let rows = sqlx::query(
+                "SELECT si.sort_id, se.sort_key_index, se.expression, se.dialect,
+                        se.sort_direction, se.null_order
+                 FROM ducklake_sort_info AS si
+                 JOIN ducklake_sort_expression AS se
+                   ON se.sort_id = si.sort_id AND se.table_id = si.table_id
+                 WHERE si.table_id = $1 AND si.end_snapshot IS NULL
+                 ORDER BY se.sort_key_index",
+            )
+            .bind(table_id)
+            .fetch_all(&self.pool)
+            .await?;
+            let parsed = rows
+                .iter()
+                .map(|row| {
+                    Ok::<_, crate::DuckLakeError>((
+                        row.try_get::<i64, _>(0)?,
+                        i32::try_from(row.try_get::<i64, _>(1)?).unwrap_or(0),
+                        row.try_get::<String, _>(2)?,
+                        row.try_get::<String, _>(3)?,
+                        row.try_get::<String, _>(4)?,
+                        row.try_get::<String, _>(5)?,
+                    ))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(crate::sort::SortSpec::from_rows(parsed))
+        })
+    }
+
+    fn set_sort_spec(&self, table_id: i64, fields: &[crate::sort::SortField]) -> Result<i64> {
+        if fields.is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "set_sort_spec: at least one sort key is required (use reset_sort_spec to clear)"
+                    .to_string(),
+            ));
+        }
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            let sort_id = reserve_ids(&mut tx, "next_sort_id", 1).await?;
+            let (new_snapshot, _carried) = insert_snapshot(&mut tx).await?;
+
+            // Validate every sort key resolves to a live column (v1 supports bare
+            // column keys only), so a bad SET fails here rather than silently
+            // producing unsorted writes later.
+            for field in fields {
+                let column = field.column_candidate().ok_or_else(|| {
+                    crate::DuckLakeError::InvalidConfig(format!(
+                        "set_sort_spec: sort key '{}' is not a bare column; only column \
+                         sort keys are supported",
+                        field.expression
+                    ))
+                })?;
+                let exists: Option<i64> = sqlx::query_scalar(
+                    "SELECT column_id FROM ducklake_column
+                     WHERE table_id = $1 AND column_name = $2 AND end_snapshot IS NULL",
+                )
+                .bind(table_id)
+                .bind(&column)
+                .fetch_optional(&mut *tx)
+                .await?;
+                if exists.is_none() {
+                    return Err(crate::DuckLakeError::InvalidConfig(format!(
+                        "set_sort_spec: no live column '{column}' in table {table_id}"
+                    )));
+                }
+            }
+
+            sqlx::query(
+                "UPDATE ducklake_sort_info SET end_snapshot = $1
+                 WHERE table_id = $2 AND end_snapshot IS NULL",
+            )
+            .bind(new_snapshot)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+            sqlx::query(
+                "INSERT INTO ducklake_sort_info
+                     (sort_id, table_id, begin_snapshot, end_snapshot)
+                 VALUES ($1, $2, $3, NULL)",
+            )
+            .bind(sort_id)
+            .bind(table_id)
+            .bind(new_snapshot)
+            .execute(&mut *tx)
+            .await?;
+            for field in fields {
+                sqlx::query(
+                    "INSERT INTO ducklake_sort_expression
+                         (sort_id, table_id, sort_key_index, expression, dialect,
+                          sort_direction, null_order)
+                     VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                )
+                .bind(sort_id)
+                .bind(table_id)
+                .bind(field.sort_key_index as i64)
+                .bind(&field.expression)
+                .bind(&field.dialect)
+                .bind(field.direction.to_catalog_string())
+                .bind(field.null_order.to_catalog_string())
+                .execute(&mut *tx)
+                .await?;
+            }
+
+            // A sort-order change does NOT bump schema_version.
+            tx.commit().await?;
+            Ok(new_snapshot)
+        })
+    }
+
+    fn reset_sort_spec(&self, table_id: i64) -> Result<i64> {
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            let (new_snapshot, _carried) = insert_snapshot(&mut tx).await?;
+            let ended = sqlx::query(
+                "UPDATE ducklake_sort_info SET end_snapshot = $1
+                 WHERE table_id = $2 AND end_snapshot IS NULL",
+            )
+            .bind(new_snapshot)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?
+            .rows_affected();
+            if ended == 0 {
+                tx.rollback().await?;
+                let head: i64 = sqlx::query_scalar(
+                    "SELECT COALESCE(MAX(snapshot_id), 0) FROM ducklake_snapshot",
+                )
+                .fetch_one(&self.pool)
+                .await?;
+                return Ok(head);
+            }
+            // A sort-order change does NOT bump schema_version.
+            tx.commit().await?;
+            Ok(new_snapshot)
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn publish_snapshot(
+        &self,
+        table_id: i64,
+        // The schema/table rows were created at begin; names unused (trait parity).
+        _schema_name: &str,
+        _table_name: &str,
+        _snapshot_id: i64,
+        mode: WriteMode,
+        base_snapshot: i64,
+        columns: &[ColumnDef],
+        column_ids: &[i64],
+    ) -> Result<CommitIds> {
+        // Fileless commit point (CREATE TABLE, zero-row Replace). This writer
+        // defers the snapshot-row insert out of begin_write_transaction, so the
+        // trait's default no-op is insufficient: insert the deferred snapshot row +
+        // column generation and, for Replace, retire the prior generation — making
+        // the new head visible atomically.
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            let snapshot_id =
+                finalize_snapshot(&mut tx, table_id, columns, column_ids, mode, base_snapshot)
+                    .await?;
+            let schema_id: i64 =
+                sqlx::query("SELECT schema_id FROM ducklake_table WHERE table_id = $1")
+                    .bind(table_id)
+                    .fetch_one(&mut *tx)
+                    .await?
+                    .try_get(0)?;
+            tx.commit().await?;
+            Ok(CommitIds {
+                snapshot_id,
+                schema_id,
+                table_id,
+            })
+        })
+    }
+
+    fn end_table_files(&self, table_id: i64, snapshot_id: i64) -> Result<u64> {
+        // Used by WriteMode::Replace. End-snapshotting every visible file drops the
+        // table's currently-visible row count and byte total to zero. `next_row_id`
+        // is deliberately NOT reset: rowids must stay monotonic across the table's
+        // lifetime so historical snapshots still resolve uniquely.
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+
+            let result = sqlx::query(
+                "UPDATE ducklake_data_file SET end_snapshot = $1
+                 WHERE table_id = $2 AND end_snapshot IS NULL",
+            )
+            .bind(snapshot_id)
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+
+            sqlx::query(
+                "UPDATE ducklake_table_stats
+                 SET record_count = 0, file_size_bytes = 0
+                 WHERE table_id = $1",
+            )
+            .bind(table_id)
+            .execute(&mut *tx)
+            .await?;
+
+            tx.commit().await?;
+            Ok(result.rows_affected())
+        })
+    }
+
+    fn get_data_path(&self) -> Result<String> {
+        block_on(async {
+            let row =
+                sqlx::query("SELECT value FROM ducklake_metadata WHERE key = $1 AND scope IS NULL")
+                    .bind("data_path")
+                    .fetch_optional(&self.pool)
+                    .await?;
+
+            match row {
+                Some(r) => Ok(r.try_get(0)?),
+                None => Err(crate::error::DuckLakeError::InvalidConfig(
+                    "Missing required catalog metadata: 'data_path' not configured.".to_string(),
+                )),
+            }
+        })
+    }
+
+    fn set_data_path(&self, path: &str) -> Result<()> {
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            sqlx::query("DELETE FROM ducklake_metadata WHERE key = 'data_path' AND scope IS NULL")
+                .execute(&mut *tx)
+                .await?;
+
+            sqlx::query(
+                "INSERT INTO ducklake_metadata (key, value, scope)
+                 VALUES ('data_path', $1, NULL)",
+            )
+            .bind(path)
+            .execute(&mut *tx)
+            .await?;
+
+            tx.commit().await?;
+            Ok(())
+        })
+    }
+
+    fn initialize_schema(&self) -> Result<()> {
+        block_on(async {
+            // sqlx runs each query() as a single prepared statement, so create each
+            // table separately (see SQL_CREATE_TABLES).
+            for ddl in SQL_CREATE_TABLES {
+                sqlx::query(*ddl).execute(&self.pool).await?;
+            }
+            // Upgrade a pre-existing catalog to carry ducklake_data_file.partition_id
+            // (idempotent, lossless — NULL means "not partitioned").
+            sqlx::query(
+                "ALTER TABLE ducklake_data_file ADD COLUMN IF NOT EXISTS partition_id BIGINT",
+            )
+            .execute(&self.pool)
+            .await?;
+            // Seed the monotonic id allocators. snapshot_id, column_id, partition_id
+            // and sort_id are reserved inside a transaction (no IDENTITY for these),
+            // so they live in ducklake_metadata. Seeded from the current MAX so a
+            // pre-existing catalog continues without reusing ids; idempotent on
+            // re-open.
+            seed_counter(
+                &self.pool,
+                "next_column_id",
+                "SELECT COALESCE(MAX(column_id), 0) FROM ducklake_column",
+            )
+            .await?;
+            seed_counter(
+                &self.pool,
+                "next_snapshot_id",
+                "SELECT COALESCE(MAX(snapshot_id), 0) FROM ducklake_snapshot",
+            )
+            .await?;
+            seed_counter(
+                &self.pool,
+                "next_partition_id",
+                "SELECT COALESCE(MAX(partition_id), 0) FROM ducklake_partition_info",
+            )
+            .await?;
+            seed_counter(
+                &self.pool,
+                "next_sort_id",
+                "SELECT COALESCE(MAX(sort_id), 0) FROM ducklake_sort_info",
+            )
+            .await?;
+            Ok(())
+        })
+    }
+
+    fn begin_write_transaction(
+        &self,
+        schema_name: &str,
+        table_name: &str,
+        columns: &[ColumnDef],
+        mode: WriteMode,
+    ) -> Result<WriteSetupResult> {
+        validate_name(schema_name, "Schema")?;
+        validate_name(table_name, "Table")?;
+        if columns.is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "Table must have at least one column".to_string(),
+            ));
+        }
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+
+            // Reserve the column ids first so the counter UPDATE takes the write
+            // lock up front. These ids match the staged parquet field ids.
+            let n = columns.len() as i64;
+            let last_column_id = reserve_ids(&mut tx, "next_column_id", n).await?;
+            // Freshly reserved ids. Only a genuinely-new column actually consumes
+            // one below; an existing column keeps its current id, so some of these
+            // may go unused (harmless monotonic-counter gaps).
+            let fresh_ids: Vec<i64> = ((last_column_id - n + 1)..=last_column_id).collect();
+
+            // The catalog head this write is based on; a Replace commit aborts if
+            // another writer published a newer generation of the table past it.
+            let base_snapshot_id: i64 =
+                sqlx::query("SELECT COALESCE(MAX(snapshot_id), 0) FROM ducklake_snapshot")
+                    .fetch_one(&mut *tx)
+                    .await?
+                    .try_get(0)?;
+
+            // Tentative id for WriteSetupResult; the real one is assigned at the
+            // commit (finalize_snapshot), so it may differ under concurrency.
+            let snapshot_id: i64 = base_snapshot_id + 1;
+
+            let schema_id: i64 = {
+                let existing = sqlx::query(
+                    "SELECT schema_id FROM ducklake_schema
+                     WHERE schema_name = $1 AND end_snapshot IS NULL",
+                )
+                .bind(schema_name)
+                .fetch_optional(&mut *tx)
+                .await?;
+
+                if let Some(row) = existing {
+                    row.try_get(0)?
+                } else {
+                    // Unscoped relative path — see get_or_create_schema.
+                    sqlx::query(
+                        "INSERT INTO ducklake_schema (schema_name, path, path_is_relative, begin_snapshot)
+                         VALUES ($1, $2, TRUE, $3) RETURNING schema_id",
+                    )
+                    .bind(schema_name)
+                    .bind(schema_name)
+                    .bind(snapshot_id)
+                    .fetch_one(&mut *tx)
+                    .await?
+                    .try_get(0)?
+                }
+            };
+
+            let table_id: i64 = {
+                let existing = sqlx::query(
+                    "SELECT table_id FROM ducklake_table
+                     WHERE schema_id = $1 AND table_name = $2 AND end_snapshot IS NULL",
+                )
+                .bind(schema_id)
+                .bind(table_name)
+                .fetch_optional(&mut *tx)
+                .await?;
+
+                if let Some(row) = existing {
+                    row.try_get(0)?
+                } else {
+                    sqlx::query(
+                        "INSERT INTO ducklake_table (schema_id, table_name, path, path_is_relative, begin_snapshot)
+                         VALUES ($1, $2, $3, TRUE, $4) RETURNING table_id",
+                    )
+                    .bind(schema_id)
+                    .bind(table_name)
+                    .bind(table_name)
+                    .bind(snapshot_id)
+                    .fetch_one(&mut *tx)
+                    .await?
+                    .try_get(0)?
+                }
+            };
+
+            // Get existing columns to (a) check schema compatibility for appends
+            // and (b) REUSE each column's id (column_id == parquet field_id; an
+            // unchanged column must keep its id, or files already written would
+            // read back as NULL).
+            let rows = sqlx::query(
+                "SELECT column_name, column_type, nulls_allowed, column_id
+                 FROM ducklake_column
+                 WHERE table_id = $1 AND end_snapshot IS NULL
+                 ORDER BY column_order",
+            )
+            .bind(table_id)
+            .fetch_all(&mut *tx)
+            .await?;
+
+            let mut existing_columns: Vec<(String, String, bool)> = Vec::with_capacity(rows.len());
+            let mut existing_ids: std::collections::HashMap<String, i64> =
+                std::collections::HashMap::new();
+            for row in rows {
+                let name: String = row.try_get(0)?;
+                let col_type: String = row.try_get(1)?;
+                let nullable: bool = row.try_get::<Option<bool>, _>(2)?.unwrap_or(true);
+                let cid: i64 = row.try_get(3)?;
+                existing_ids.insert(name.clone(), cid);
+                existing_columns.push((name, col_type, nullable));
+            }
+
+            // Data-write policy (§5): a data write — Replace OR Append — must NOT
+            // change a column's type (that is schema evolution and must go through
+            // promote_column_type, which this backend does not support). The
+            // comparison is canonical (`int64` ≡ `bigint`) so an alias-only
+            // restatement is a no-op. Append additionally requires a genuinely new
+            // column to be nullable.
+            if !existing_columns.is_empty() {
+                use std::collections::HashMap;
+
+                let existing_map: HashMap<&str, (&str, bool)> = existing_columns
+                    .iter()
+                    .map(|(name, col_type, nullable)| {
+                        (name.as_str(), (col_type.as_str(), *nullable))
+                    })
+                    .collect();
+
+                for new_col in columns.iter() {
+                    if let Some((existing_type, _existing_nullable)) =
+                        existing_map.get(new_col.name())
+                    {
+                        if !crate::types::types_equal_canonical(
+                            existing_type,
+                            new_col.ducklake_type(),
+                        ) {
+                            return Err(crate::error::DuckLakeError::UnsupportedTypeChange {
+                                operation: TypeChangeOperation::DataWrite {
+                                    mode: match mode {
+                                        WriteMode::Replace => TypeChangeWriteMode::Replace,
+                                        WriteMode::Append => TypeChangeWriteMode::Append,
+                                    },
+                                },
+                                column: new_col.name().to_string(),
+                                from: (*existing_type).to_string(),
+                                to: new_col.ducklake_type().to_string(),
+                            });
+                        }
+                    } else if mode == WriteMode::Append && !new_col.is_nullable() {
+                        return Err(crate::error::DuckLakeError::InvalidConfig(format!(
+                            "Schema evolution error: new column '{}' must be nullable. Adding non-nullable columns is not allowed.",
+                            new_col.name()
+                        )));
+                    }
+                }
+            }
+
+            // Final per-column ids: reuse the existing id for a column already in
+            // the table, consume a freshly reserved id only for a genuinely new
+            // column. These are baked into the staged parquet's field_id metadata,
+            // so they must equal the ids finalize_snapshot commits. Column rows
+            // themselves are written at the commit point (not here): the read path
+            // resolves columns by `end_snapshot IS NULL` only, so inserting at begin
+            // would leak the new generation to concurrent reads.
+            let column_ids: Vec<i64> = columns
+                .iter()
+                .zip(fresh_ids.iter())
+                .map(|(col, &fresh)| existing_ids.get(col.name()).copied().unwrap_or(fresh))
+                .collect();
+
+            // No snapshot row, no column rows, and no Replace retirement are written
+            // here — all are deferred to the atomic commit so the head never
+            // resolves to an incomplete snapshot. This TX commits only the
+            // idempotent get-or-create schema/table rows; they carry begin_snapshot
+            // = the reserved id and stay invisible until the snapshot publishes,
+            // since schema/table reads ARE snapshot-scoped.
+            tx.commit().await?;
+
+            Ok(WriteSetupResult {
+                snapshot_id,
+                base_snapshot_id,
+                schema_id,
+                table_id,
+                column_ids,
+            })
+        })
+    }
+}

--- a/src/metadata_writer_postgres_single.rs
+++ b/src/metadata_writer_postgres_single.rs
@@ -799,7 +799,7 @@ async fn finalize_snapshot(
     // (the creating write is DDL). Mirrors upstream `SchemaChangesMade()`.
     use std::collections::{HashMap, HashSet};
     let current = sqlx::query(
-        "SELECT column_name, column_type, column_order, nulls_allowed
+        "SELECT column_name, column_type, column_order, nulls_allowed, column_id
          FROM ducklake_column
          WHERE table_id = $1 AND end_snapshot IS NULL
          ORDER BY column_order",
@@ -828,13 +828,14 @@ async fn finalize_snapshot(
     // column_id (== parquet field_id) across writes: end only removed columns,
     // insert only new ones, and leave unchanged columns (and their ids) in place.
     let new_names: HashSet<&str> = columns.iter().map(|c| c.name()).collect();
-    let mut current_by_name: HashMap<String, (i64, bool)> = HashMap::new();
+    let mut current_by_name: HashMap<String, (i64, bool, i64)> = HashMap::new();
     for row in &current {
         let name: String = row.try_get("column_name")?;
         let order: i64 = row.try_get("column_order")?;
         let nullable: bool = row
             .try_get::<Option<bool>, _>("nulls_allowed")?
             .unwrap_or(true);
+        let committed_column_id: i64 = row.try_get("column_id")?;
         if !new_names.contains(name.as_str()) {
             // Column dropped in the new schema: end its generation.
             sqlx::query(
@@ -847,14 +848,32 @@ async fn finalize_snapshot(
             .execute(&mut **tx)
             .await?;
         }
-        current_by_name.insert(name, (order, nullable));
+        current_by_name.insert(name, (order, nullable, committed_column_id));
     }
 
     for (order, (col, column_id)) in columns.iter().zip(column_ids.iter()).enumerate() {
         match current_by_name.get(col.name()) {
             // Existing column kept: its id stays stable. Sync order/nullability
             // only if they changed (type changes are rejected at begin).
-            Some(&(cur_order, cur_nullable)) => {
+            Some(&(cur_order, cur_nullable, cur_column_id)) => {
+                // The caller has already stamped `column_id` into its staged
+                // parquet as the field_id, so a committed id that disagrees means
+                // the staged file cannot be read back against this table: the read
+                // path null-fills a current column whose field_id is missing from a
+                // file that carries field_ids. That happens when two writers both
+                // began against an absent table and one created it first, or when
+                // the column was dropped and re-added in between. The file has to
+                // be rewritten under the committed ids, so abort and let the caller
+                // retry from a fresh begin.
+                if cur_column_id != *column_id {
+                    return Err(crate::DuckLakeError::Conflict(format!(
+                        "column '{}' of table {table_id} committed as column_id \
+                         {cur_column_id}, but this write staged its data under field_id \
+                         {column_id}; another writer created or altered the table since \
+                         this write began (retry the write against the new generation)",
+                        col.name()
+                    )));
+                }
                 if cur_order != order as i64 || cur_nullable != col.is_nullable() {
                     sqlx::query(
                         "UPDATE ducklake_column SET column_order = $1, nulls_allowed = $2

--- a/src/metadata_writer_postgres_single.rs
+++ b/src/metadata_writer_postgres_single.rs
@@ -1,58 +1,23 @@
-//! Single-catalog PostgreSQL implementation of [`MetadataWriter`].
+//! Single-catalog PostgreSQL implementation of [`MetadataWriter`] — the standard,
+//! spec-compliant DuckLake layout, readable by DuckDB's `ducklake` extension.
 //!
-//! This is the **standard, spec-compliant** DuckLake layout on PostgreSQL — the
-//! same on-disk/in-catalog shape the SQLite and MySQL writers produce, and the
-//! shape DuckDB's `ducklake` extension reads. It is deliberately separate from
-//! [`crate::metadata_writer_postgres::PostgresMetadataWriter`], which implements
-//! this crate's *library-specific* multicatalog layout (extra `catalog_id`
-//! columns plus `ducklake_catalog*` map tables) and is not part of the DuckLake
-//! specification.
+//! Separate from [`crate::metadata_writer_postgres::PostgresMetadataWriter`], which
+//! writes this crate's multicatalog layout (`catalog_id` columns plus
+//! `ducklake_catalog*` map tables) and is not part of the DuckLake spec.
 //!
-//! Modelled on [`crate::metadata_writer_mysql::MySqlMetadataWriter`] rather than
-//! the multicatalog Postgres writer: same single-catalog structure, same
-//! supported surface, with the SQL mapped to the Postgres dialect.
+//! Modelled on [`crate::metadata_writer_mysql::MySqlMetadataWriter`]: same
+//! single-catalog structure and supported surface, SQL mapped to Postgres. Deletes,
+//! upserts, compaction and type promotion inherit their erroring trait defaults, and
+//! [`MetadataWriter::catalog_id`] inherits `None` so paths stay unscoped. Sync trait
+//! methods bridge async sqlx via `crate::metadata_provider::block_on`, so a
+//! multi-threaded Tokio runtime is required.
 //!
-//! ## Supported surface
-//!
-//! The write primitives the crate's table-write path needs (INSERT / REPLACE /
-//! CREATE TABLE), plus partition and sort specs. Deliberately NOT supported —
-//! these inherit their erroring trait defaults: deletes
-//! ([`MetadataWriter::set_delete_file`]), upserts, compaction, and type
-//! promotion ([`MetadataWriter::promote_column_type`]).
-//! [`MetadataWriter::catalog_id`] inherits the `None` default, which is what
-//! keeps newly-written file paths in the unscoped
-//! `{data_path}/{schema}/{table}/…` layout (the multicatalog writer returns
-//! `Some(id)` and scopes them under `cat_{id}/…`).
-//!
-//! Requires a multi-threaded Tokio runtime (`#[tokio::test(flavor =
-//! "multi_thread")]`): the sync trait methods bridge async sqlx via
-//! `crate::metadata_provider::block_on`, exactly like the SQLite and MySQL
-//! writers.
-//!
-//! ## Postgres dialect adaptations vs the MySQL template
-//!
-//! 1. **`RETURNING` exists.** IDENTITY-backed ids (`schema_id`, `table_id`,
-//!    `data_file_id`) come straight back from `INSERT … RETURNING`, replacing
-//!    MySQL's `last_insert_id()` round-trip. `reserve_ids` likewise collapses
-//!    to a single `UPDATE … RETURNING`.
-//! 2. **`snapshot_id` stays counter-allocated, not IDENTITY.** Upstream's
-//!    `ducklake_snapshot.snapshot_id` is a plain `BIGINT PRIMARY KEY`, and a
-//!    counter row gives the property the `Replace` conflict test depends on: the
-//!    `UPDATE` takes an exclusive row lock held to commit, so every commit
-//!    transaction serializes on it and *snapshot id order equals commit order*.
-//!    A bare Postgres sequence would not — sequences are non-transactional, so
-//!    two concurrent writers can commit out of id order and the scalar
-//!    `> base_snapshot` test would miss a conflict. The multicatalog writer gets
-//!    the same guarantee from its per-catalog `FOR UPDATE` lock, which has no
-//!    single-catalog equivalent.
-//! 3. **DDL type mapping.** `TINYINT(1)`→`BOOLEAN`, `VARCHAR(1024)`/`TEXT`→
-//!    `VARCHAR`, `DATETIME(6)`→`TIMESTAMP`, no `ENGINE = InnoDB`.
-//! 4. **No backticks.** `key`/`value` are non-reserved in Postgres and the
-//!    providers read them unquoted, so they stay bare here too.
-//! 5. **`INSERT IGNORE`→`INSERT … ON CONFLICT (table_id) DO NOTHING`.**
-//! 6. **`ADD COLUMN IF NOT EXISTS`** replaces MySQL's `information_schema` probe.
-//! 7. **Self-referential `INSERT … SELECT` is legal**, so `seed_counter` is a
-//!    single idempotent statement rather than MySQL's check-then-insert.
+//! `snapshot_id` is counter-allocated rather than IDENTITY. Upstream's column is a
+//! plain `BIGINT PRIMARY KEY`, and the counter's `UPDATE` holds a row lock to commit,
+//! so commits serialize and snapshot-id order equals commit order — what the
+//! `Replace` conflict test relies on. Sequences are non-transactional and would not
+//! give that; the multicatalog writer gets it from a per-catalog `FOR UPDATE` lock
+//! that has no single-catalog equivalent.
 
 use crate::Result;
 use crate::error::{TypeChangeOperation, TypeChangeWriteMode};
@@ -68,18 +33,9 @@ use sqlx::postgres::{PgPool, PgPoolOptions};
 
 const DEFAULT_MAX_CONNECTIONS: u32 = 5;
 
-/// The DuckLake catalog tables in Postgres dialect, one `CREATE TABLE` per entry.
-/// sqlx runs each `query()` as a single prepared statement, so the DDL must be
-/// split rather than sent as one `;`-joined script.
-///
-/// Columns and their order match the SQLite and MySQL writers' schemas (and so
-/// upstream DuckLake) for catalog compatibility; only the SQL types are mapped.
-/// IDENTITY PKs back the ids read via `RETURNING`
-/// (`schema_id`/`table_id`/`data_file_id`/`delete_file_id`). `snapshot_id` is a
-/// plain PK assigned from the `next_snapshot_id` counter, and `ducklake_column`
-/// is a bare table (no PK) so a versioned column can hold multiple rows sharing
-/// a `column_id` — matching upstream, and unlike the multicatalog writer's
-/// composite-PK variant.
+/// The DuckLake catalog tables in Postgres dialect. Columns and their order match
+/// the SQLite and MySQL writers (and so upstream); only the SQL types differ. Split
+/// one per entry because sqlx runs each `query()` as a single prepared statement.
 const SQL_CREATE_TABLES: &[&str] = &[
     r#"CREATE TABLE IF NOT EXISTS ducklake_metadata (
         key VARCHAR NOT NULL,
@@ -124,11 +80,9 @@ const SQL_CREATE_TABLES: &[&str] = &[
         begin_snapshot BIGINT NOT NULL,
         end_snapshot BIGINT
     )"#,
-    // Bare table (no PRIMARY KEY), mirroring upstream `ducklake_column`: a column
-    // is versioned by `[begin_snapshot, end_snapshot)` and — although this writer
-    // never promotes types — the shape stays identical to SQLite/MySQL/upstream so
-    // catalogs interoperate. The four `*default*` columns and `parent_column` are
-    // left NULL (no nested-type / column-default writes).
+    // Bare table (no PRIMARY KEY), mirroring upstream: a versioned column needs
+    // several rows sharing one `column_id`. The `*default*` columns and
+    // `parent_column` are left NULL.
     r#"CREATE TABLE IF NOT EXISTS ducklake_column (
         column_id BIGINT,
         begin_snapshot BIGINT,
@@ -307,15 +261,9 @@ impl PostgresSingleCatalogMetadataWriter {
     }
 }
 
-/// Atomically reserve `n` consecutive ids from a monotonic counter stored in
-/// `ducklake_metadata` (seeded by `initialize_schema`), returning the LAST id of
-/// the block — the reserved ids are `last - n + 1 ..= last`.
-///
-/// Postgres has `UPDATE … RETURNING`, so unlike MySQL this is one statement. The
-/// `UPDATE` takes an exclusive row lock held until commit, so a concurrent
-/// `reserve_ids` on the same `key` blocks here rather than handing out an
-/// overlapping id — the same serialization SQLite gets from its single-writer
-/// lock. Used for `column_id`, `snapshot_id`, `partition_id` and `sort_id`.
+/// Reserve `n` consecutive ids from a counter in `ducklake_metadata`, returning the
+/// LAST of the block (`last - n + 1 ..= last`). The `UPDATE` holds an exclusive row
+/// lock until commit, so concurrent reservations block rather than overlap.
 async fn reserve_ids(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     key: &str,
@@ -335,11 +283,8 @@ async fn reserve_ids(
     Ok(last)
 }
 
-/// Seed a monotonic id counter row if it does not already exist, starting from
-/// the current MAX of its backing column so a pre-existing catalog keeps
-/// allocating without reuse. Idempotent: the `WHERE NOT EXISTS` guard makes a
-/// re-open a no-op. (Postgres, unlike MySQL, permits the self-referential
-/// `INSERT … SELECT` against `ducklake_metadata`.)
+/// Seed an id counter from the current MAX of its backing column, so a pre-existing
+/// catalog keeps allocating without reuse. `WHERE NOT EXISTS` makes a re-open a no-op.
 async fn seed_counter(pool: &PgPool, key: &str, max_sql: &'static str) -> Result<()> {
     let start: i64 = sqlx::query(max_sql).fetch_one(pool).await?.try_get(0)?;
     sqlx::query(
@@ -356,13 +301,9 @@ async fn seed_counter(pool: &PgPool, key: &str, max_sql: &'static str) -> Result
     Ok(())
 }
 
-/// Optimistic-concurrency check for a `Replace` commit (mirrors the SQLite /
-/// MySQL writers). Run before retiring the prior generation: if any data file of
-/// the table has `begin_snapshot` or `end_snapshot` newer than `base_snapshot`
-/// (the head observed when this write began), another writer published a newer
-/// generation in the meantime, so this `Replace` aborts with
-/// [`crate::DuckLakeError::Conflict`] rather than clobbering it. (`Append` does
-/// not call this: concurrent appends commute.)
+/// Abort a `Replace` whose base is stale: any data file newer than `base_snapshot`
+/// means another writer published in the meantime. `Append` does not call this —
+/// concurrent appends commute.
 async fn detect_replace_conflict(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     table_id: i64,
@@ -432,16 +373,12 @@ async fn seed_table_stats(
     Ok(())
 }
 
-/// Insert the next `ducklake_snapshot` row, carrying `schema_version` forward
-/// (the pure-data-write default), and return `(snapshot_id, schema_version)`.
+/// Insert the next `ducklake_snapshot` row, carrying `schema_version` forward.
 ///
-/// `snapshot_id` is allocated from the `next_snapshot_id` counter. [`reserve_ids`]
-/// takes an exclusive row lock on that counter row held until this transaction
-/// commits, so this is the "write-lock-first" serialization point of a commit —
-/// every commit transaction contends on the single counter row, so per-catalog
-/// id order equals commit order and the scalar `> base_snapshot` conflict test is
-/// exact. See the module docs for why a bare IDENTITY sequence is not used here.
-/// A DDL commit follows this with [`bump_schema_version`].
+/// Reserving `snapshot_id` takes the counter's row lock, making this the
+/// serialization point of a commit — so id order equals commit order, which the
+/// `> base_snapshot` conflict test depends on. A DDL commit follows with
+/// [`bump_schema_version`].
 async fn insert_snapshot(tx: &mut sqlx::Transaction<'_, sqlx::Postgres>) -> Result<(i64, i64)> {
     let snapshot_id = reserve_ids(tx, "next_snapshot_id", 1).await?;
     // Carry the current per-catalog schema_version forward; a DDL commit corrects
@@ -473,11 +410,8 @@ async fn insert_snapshot(tx: &mut sqlx::Transaction<'_, sqlx::Postgres>) -> Resu
 }
 
 /// Append to this snapshot's `changes_made` list and stamp its commit metadata.
-///
-/// Appending (rather than overwriting) matters because a single snapshot can
-/// accumulate several changes — e.g. a first write creates the schema, the table,
-/// and inserts rows. Postgres lets one placeholder be reused, so `$1` appears
-/// three times in the CASE rather than being bound three times as on MySQL.
+/// Appends rather than overwrites: one snapshot can create a schema, a table, and
+/// insert rows.
 async fn record_snapshot_changes(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     snapshot_id: i64,
@@ -766,17 +700,13 @@ async fn live_partition_id(
     .await?)
 }
 
-/// The atomic commit point for a single-catalog write. Inserts the deferred
-/// `ducklake_snapshot` row, finalizes the column generation, and — for
-/// `Replace` — retires the prior data generation. All within the caller's
-/// transaction, so a reader never sees a half-published head.
+/// The atomic commit point: insert the deferred snapshot row, finalize the column
+/// generation, and for `Replace` retire the prior data generation — all in the
+/// caller's transaction, so a reader never sees a half-published head.
 ///
-/// The column generation is deferred to here (rather than written in
-/// `begin_write_transaction`) because the read path resolves a table's columns by
-/// `end_snapshot IS NULL` only (not snapshot-scoped), so inserting the new
-/// generation at begin would leak it to concurrent reads during the upload
-/// window. `column_ids` are the ids reserved at begin and already baked into the
-/// staged parquet's `field_id` metadata.
+/// The column generation is deferred to here rather than written at begin because
+/// the read path resolves columns by `end_snapshot IS NULL` alone (not
+/// snapshot-scoped), so writing them early would leak them to concurrent reads.
 async fn finalize_snapshot(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     table_id: i64,
@@ -1814,20 +1744,16 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
             )
             .execute(&self.pool)
             .await?;
-            // A catalog created elsewhere may have `changes_made` NOT NULL, but
-            // `insert_snapshot` seeds the row with NULL and fills it in at commit.
-            // Dropping a non-existent NOT NULL is a no-op in Postgres, so this is
-            // idempotent without a probe.
+            // A catalog created elsewhere may have `changes_made` NOT NULL, but the
+            // row is seeded NULL and filled in at commit. Dropping an absent NOT
+            // NULL is a no-op in Postgres, so no probe is needed.
             sqlx::query(
                 "ALTER TABLE ducklake_snapshot_changes ALTER COLUMN changes_made DROP NOT NULL",
             )
             .execute(&self.pool)
             .await?;
-            // Seed the monotonic id allocators. snapshot_id, column_id, partition_id
-            // and sort_id are reserved inside a transaction (no IDENTITY for these),
-            // so they live in ducklake_metadata. Seeded from the current MAX so a
-            // pre-existing catalog continues without reusing ids; idempotent on
-            // re-open.
+            // snapshot_id, column_id, partition_id and sort_id have no IDENTITY —
+            // they are reserved inside a transaction from these counters.
             seed_counter(
                 &self.pool,
                 "next_column_id",
@@ -1973,12 +1899,10 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
                 existing_columns.push((name, col_type, nullable));
             }
 
-            // Data-write policy (§5): a data write — Replace OR Append — must NOT
-            // change a column's type (that is schema evolution and must go through
-            // promote_column_type, which this backend does not support). The
-            // comparison is canonical (`int64` ≡ `bigint`) so an alias-only
-            // restatement is a no-op. Append additionally requires a genuinely new
-            // column to be nullable.
+            // A data write must not change a column's type — that is schema
+            // evolution, and this backend has no promote_column_type. The comparison
+            // is canonical (`int64` ≡ `bigint`). Append also requires a new column
+            // to be nullable.
             if !existing_columns.is_empty() {
                 use std::collections::HashMap;
 
@@ -2018,25 +1942,18 @@ impl MetadataWriter for PostgresSingleCatalogMetadataWriter {
                 }
             }
 
-            // Final per-column ids: reuse the existing id for a column already in
-            // the table, consume a freshly reserved id only for a genuinely new
+            // Reuse an existing column's id, consume a fresh one only for a new
             // column. These are baked into the staged parquet's field_id metadata,
-            // so they must equal the ids finalize_snapshot commits. Column rows
-            // themselves are written at the commit point (not here): the read path
-            // resolves columns by `end_snapshot IS NULL` only, so inserting at begin
-            // would leak the new generation to concurrent reads.
+            // so they must equal what finalize_snapshot commits.
             let column_ids: Vec<i64> = columns
                 .iter()
                 .zip(fresh_ids.iter())
                 .map(|(col, &fresh)| existing_ids.get(col.name()).copied().unwrap_or(fresh))
                 .collect();
 
-            // No snapshot row, no column rows, and no Replace retirement are written
-            // here — all are deferred to the atomic commit so the head never
-            // resolves to an incomplete snapshot. This TX commits only the
-            // idempotent get-or-create schema/table rows; they carry begin_snapshot
-            // = the reserved id and stay invisible until the snapshot publishes,
-            // since schema/table reads ARE snapshot-scoped.
+            // Commits only the idempotent get-or-create schema/table rows. Those
+            // reads ARE snapshot-scoped, so the rows stay invisible until the
+            // snapshot publishes; everything else is deferred to the atomic commit.
             tx.commit().await?;
 
             Ok(WriteSetupResult {

--- a/src/metadata_writer_postgres_single.rs
+++ b/src/metadata_writer_postgres_single.rs
@@ -26,14 +26,14 @@
 //!
 //! Requires a multi-threaded Tokio runtime (`#[tokio::test(flavor =
 //! "multi_thread")]`): the sync trait methods bridge async sqlx via
-//! [`crate::metadata_provider::block_on`], exactly like the SQLite and MySQL
+//! `crate::metadata_provider::block_on`, exactly like the SQLite and MySQL
 //! writers.
 //!
 //! ## Postgres dialect adaptations vs the MySQL template
 //!
 //! 1. **`RETURNING` exists.** IDENTITY-backed ids (`schema_id`, `table_id`,
 //!    `data_file_id`) come straight back from `INSERT … RETURNING`, replacing
-//!    MySQL's `last_insert_id()` round-trip. [`reserve_ids`] likewise collapses
+//!    MySQL's `last_insert_id()` round-trip. `reserve_ids` likewise collapses
 //!    to a single `UPDATE … RETURNING`.
 //! 2. **`snapshot_id` stays counter-allocated, not IDENTITY.** Upstream's
 //!    `ducklake_snapshot.snapshot_id` is a plain `BIGINT PRIMARY KEY`, and a
@@ -51,7 +51,7 @@
 //!    providers read them unquoted, so they stay bare here too.
 //! 5. **`INSERT IGNORE`→`INSERT … ON CONFLICT (table_id) DO NOTHING`.**
 //! 6. **`ADD COLUMN IF NOT EXISTS`** replaces MySQL's `information_schema` probe.
-//! 7. **Self-referential `INSERT … SELECT` is legal**, so [`seed_counter`] is a
+//! 7. **Self-referential `INSERT … SELECT` is legal**, so `seed_counter` is a
 //!    single idempotent statement rather than MySQL's check-then-insert.
 
 use crate::Result;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -48,6 +48,7 @@ mod positional_delete_oracle_postgres_tests;
 mod positional_delete_oracle_tests;
 mod positional_delete_tests;
 mod postgres_metadata_provider_test;
+mod postgres_single_catalog_write_tests;
 mod renamed_columns_tests;
 mod row_count_tests;
 mod row_id_tests;

--- a/tests/it/postgres_single_catalog_write_tests.rs
+++ b/tests/it/postgres_single_catalog_write_tests.rs
@@ -873,6 +873,124 @@ async fn committed_rows_reference_a_real_snapshot() {
     }
 }
 
+/// Two writers both beginning against an absent table reserve different column
+/// ids, and each stamps its own into its staged Parquet as the field_id. Whoever
+/// commits second must not silently adopt the winner's ids — the read path
+/// null-fills a column whose field_id is missing from the file, so the loser's
+/// rows would be catalog-visible but read as NULL.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn concurrent_create_of_the_same_table_conflicts_instead_of_writing_null_columns() {
+    use datafusion_ducklake::SnapshotCommitMetadata;
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+
+    let (writer, pool, conn_str, _tmp, _container) = setup().await.unwrap();
+
+    // Both writers observe `main.t` as absent and reserve disjoint column ids.
+    let a = writer
+        .begin_write_transaction("main", "t", &cols(), WriteMode::Append)
+        .unwrap();
+    let b = writer
+        .begin_write_transaction("main", "t", &cols(), WriteMode::Append)
+        .unwrap();
+    assert_ne!(
+        a.column_ids, b.column_ids,
+        "two begins against an absent table must not hand out the same ids"
+    );
+
+    // A wins and its column ids become the committed generation.
+    writer
+        .register_data_file_with_commit_metadata(
+            a.table_id,
+            "main",
+            "t",
+            a.snapshot_id,
+            &DataFileInfo::new("t/a.parquet", 1024, 1),
+            WriteMode::Append,
+            a.base_snapshot_id,
+            &cols(),
+            &a.column_ids,
+            &SnapshotCommitMetadata::default(),
+            None,
+        )
+        .unwrap();
+
+    // B's file is already stamped with b.column_ids, so committing it here would
+    // register unreadable data.
+    let err = writer
+        .register_data_file_with_commit_metadata(
+            b.table_id,
+            "main",
+            "t",
+            b.snapshot_id,
+            &DataFileInfo::new("t/b.parquet", 1024, 1),
+            WriteMode::Append,
+            b.base_snapshot_id,
+            &cols(),
+            &b.column_ids,
+            &SnapshotCommitMetadata::default(),
+            None,
+        )
+        .unwrap_err();
+    assert!(
+        matches!(err, datafusion_ducklake::DuckLakeError::Conflict(_)),
+        "expected Conflict, got: {err}"
+    );
+
+    // Only A's file is registered, and the committed ids are A's.
+    let files: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ducklake_data_file")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(files, 1, "the conflicting write must not have committed");
+
+    let committed: Vec<i64> = sqlx::query_scalar(
+        "SELECT column_id FROM ducklake_column
+         WHERE end_snapshot IS NULL ORDER BY column_order",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(committed, a.column_ids);
+
+    // Retrying from a fresh begin picks up the committed ids and succeeds.
+    let retry = writer
+        .begin_write_transaction("main", "t", &cols(), WriteMode::Append)
+        .unwrap();
+    assert_eq!(retry.column_ids, a.column_ids);
+    writer
+        .register_data_file_with_commit_metadata(
+            retry.table_id,
+            "main",
+            "t",
+            retry.snapshot_id,
+            &DataFileInfo::new("t/b.parquet", 1024, 1),
+            WriteMode::Append,
+            retry.base_snapshot_id,
+            &cols(),
+            &retry.column_ids,
+            &SnapshotCommitMetadata::default(),
+            None,
+        )
+        .unwrap();
+
+    let ctx = read_context(&conn_str).await;
+    let batches = ctx
+        .sql("SELECT count(*) AS n FROM lake.main.t")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let n = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap()
+        .value(0);
+    assert_eq!(n, 2);
+}
+
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
 async fn conditional_write_accepts_a_current_base_and_rejects_a_stale_one() {

--- a/tests/it/postgres_single_catalog_write_tests.rs
+++ b/tests/it/postgres_single_catalog_write_tests.rs
@@ -1,20 +1,9 @@
 #![cfg(feature = "write-postgres")]
-//! Integration tests for the **single-catalog** (standard DuckLake) Postgres writer.
+//! Integration tests for the single-catalog (standard DuckLake) Postgres writer.
 //!
-//! The point of `PostgresSingleCatalogMetadataWriter` is that it produces the
-//! same catalog shape as the SQLite/MySQL writers and DuckDB's `ducklake`
-//! extension — unlike `PostgresMetadataWriter`, which writes this crate's
-//! library-specific multicatalog layout. So alongside the usual write/read
-//! coverage these tests assert the *shape*:
-//!
-//! - no `ducklake_catalog*` map tables exist
-//! - no `catalog_id` column on any DuckLake table
-//! - `catalog_id()` is `None`, so file paths stay unscoped
-//! - `ducklake_schema.path` / `ducklake_table.path` are bare relative names
-//!   (no `cat_{id}/` prefix)
-//!
-//! Plus the behaviour the multicatalog path cannot offer: SQL `CREATE TABLE AS
-//! SELECT`.
+//! Beyond the usual write/read coverage these assert the catalog *shape* — no
+//! `ducklake_catalog*` tables, no `catalog_id` column, unscoped relative paths —
+//! since that is what makes the catalog readable by other DuckLake tools.
 
 use std::sync::Arc;
 
@@ -35,9 +24,8 @@ use datafusion_ducklake::{
     PostgresSingleCatalogMetadataWriter,
 };
 
-/// Spin up Postgres, open a single-catalog writer against it, and point the
-/// catalog at a temp data directory. Returns everything the caller must keep
-/// alive (dropping the container tears the database down).
+/// Returns everything the caller must keep alive — dropping the container tears
+/// the database down.
 async fn setup() -> anyhow::Result<(
     PostgresSingleCatalogMetadataWriter,
     PgPool,
@@ -111,8 +99,6 @@ async fn table_exists(pool: &PgPool, name: &str) -> bool {
 // Catalog shape: the actual point of #165
 // ---------------------------------------------------------------------------
 
-/// The multicatalog map tables must NOT be created by this writer. Their
-/// presence is what makes a catalog unreadable by other DuckLake tools.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
 async fn creates_no_multicatalog_tables() {
@@ -150,8 +136,6 @@ async fn creates_no_multicatalog_tables() {
     }
 }
 
-/// No DuckLake table may carry a `catalog_id` column — that column is the
-/// multicatalog layout's scoping mechanism and is not in the spec.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
 async fn no_table_carries_a_catalog_id_column() {
@@ -174,8 +158,6 @@ async fn no_table_carries_a_catalog_id_column() {
     );
 }
 
-/// `catalog_id()` returning `None` is what keeps file placement unscoped —
-/// `{data_path}/{schema}/{table}/…` rather than `{data_path}/cat_{id}/…`.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
 async fn catalog_id_is_none() {
@@ -183,8 +165,6 @@ async fn catalog_id_is_none() {
     assert_eq!(writer.catalog_id(), None);
 }
 
-/// Schema and table paths are stored as bare relative names, matching the other
-/// single-catalog backends.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
 async fn paths_are_unscoped_and_relative() {
@@ -222,9 +202,6 @@ async fn paths_are_unscoped_and_relative() {
     assert!(file_rel);
 }
 
-/// `ducklake_column` must be the bare upstream shape so a versioned column can
-/// hold several rows sharing one `column_id`. The multicatalog writer uses a
-/// composite PK instead; upstream and the other single-catalog backends use none.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
 async fn ducklake_column_has_no_primary_key() {
@@ -456,9 +433,6 @@ async fn initialize_schema_is_idempotent() {
     assert_eq!(counters, 4, "each id counter must be seeded exactly once");
 }
 
-/// A DDL commit bumps `schema_version` and writes a ledger row; a pure data
-/// write carries the version forward and writes none. Mirrors upstream's
-/// `if (SchemaChangesMade()) schema_version++`.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
 async fn schema_version_bumps_on_ddl_and_carries_on_data_write() {
@@ -492,8 +466,6 @@ async fn schema_version_bumps_on_ddl_and_carries_on_data_write() {
     assert_eq!(ledger, 1, "only the DDL commit writes a ledger row");
 }
 
-/// Snapshot ids are counter-allocated, so they are dense and ordered by commit —
-/// the property the `Replace` conflict test relies on.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
 async fn snapshot_ids_are_dense_and_commit_ordered() {
@@ -609,7 +581,6 @@ async fn partition_spec_set_then_reset() {
     assert!(writer.live_partition_spec(table_id).unwrap().is_none());
 }
 
-/// Resetting when nothing is set must not publish an empty snapshot.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
 async fn reset_partition_spec_on_unpartitioned_table_is_a_noop() {
@@ -690,9 +661,6 @@ async fn set_partition_spec_rejects_unknown_column() {
 // Error paths
 // ---------------------------------------------------------------------------
 
-/// A data write must never silently change a column's type — that is schema
-/// evolution and belongs to `promote_column_type`, which this writer does not
-/// implement.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
 async fn append_rejects_a_column_type_change() {
@@ -798,9 +766,6 @@ async fn set_data_path_replaces_rather_than_duplicates() {
     assert_eq!(writer.get_data_path().unwrap(), "/tmp/two");
 }
 
-/// Deletes, upserts, compaction and type promotion are out of scope for this
-/// writer and must surface the trait's erroring defaults rather than silently
-/// doing nothing.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
 async fn unsupported_operations_error() {
@@ -833,8 +798,6 @@ async fn changes_for(pool: &PgPool, snapshot_id: i64) -> Option<String> {
         .unwrap()
 }
 
-/// The creating write records the schema, the table, and the insert — all three
-/// accumulate onto the one snapshot's `changes_made`.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
 async fn snapshot_changes_record_create_and_insert() {
@@ -861,8 +824,6 @@ async fn snapshot_changes_record_create_and_insert() {
     );
 }
 
-/// A `Replace` that supersedes existing files records both the delete and the
-/// insert, per `table_write_changes`.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
 async fn replace_records_delete_and_insert() {
@@ -888,7 +849,6 @@ async fn replace_records_delete_and_insert() {
     );
 }
 
-/// Every snapshot must carry exactly one change row — `insert_snapshot` seeds it.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
 async fn every_snapshot_has_exactly_one_change_row() {
@@ -923,8 +883,6 @@ async fn every_snapshot_has_exactly_one_change_row() {
     assert_eq!(snapshots, change_rows);
 }
 
-/// Author / message / extra-info round-trip through
-/// `register_data_file_with_commit_metadata`.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
 async fn commit_metadata_is_persisted() {
@@ -971,8 +929,6 @@ async fn commit_metadata_is_persisted() {
     assert_eq!(extra.as_deref(), Some("job=42"));
 }
 
-/// Conditional (compare-and-swap) writes are not implemented on this backend and
-/// must fail closed rather than commit unconditionally.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
 async fn conditional_writes_are_rejected() {
@@ -1028,7 +984,6 @@ async fn conditional_writes_are_rejected() {
     );
 }
 
-/// Partition DDL is an ALTER and must say so in the change record.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
 async fn partition_ddl_records_altered_table() {
@@ -1053,7 +1008,6 @@ async fn partition_ddl_records_altered_table() {
     assert_eq!(changes, format!("altered_table:{table_id}"));
 }
 
-/// Opening a writer over an existing pool must not re-run DDL or disturb state.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
 async fn from_pool_shares_an_existing_connection_pool() {

--- a/tests/it/postgres_single_catalog_write_tests.rs
+++ b/tests/it/postgres_single_catalog_write_tests.rs
@@ -129,6 +129,7 @@ async fn creates_no_multicatalog_tables() {
     for t in [
         "ducklake_metadata",
         "ducklake_snapshot",
+        "ducklake_snapshot_changes",
         "ducklake_schema",
         "ducklake_table",
         "ducklake_column",
@@ -818,6 +819,238 @@ async fn unsupported_operations_error() {
         "type promotion must be rejected"
     );
     assert!(!writer.supports_update(), "UPDATE is not supported");
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot change records + commit metadata (#209 surface)
+// ---------------------------------------------------------------------------
+
+async fn changes_for(pool: &PgPool, snapshot_id: i64) -> Option<String> {
+    sqlx::query_scalar("SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id = $1")
+        .bind(snapshot_id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+/// The creating write records the schema, the table, and the insert — all three
+/// accumulate onto the one snapshot's `changes_made`.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn snapshot_changes_record_create_and_insert() {
+    let (writer, pool, _conn, _tmp, _container) = setup().await.unwrap();
+
+    let result = DuckLakeTableWriter::new(Arc::new(writer), object_store())
+        .unwrap()
+        .write_table("main", "t", &[batch(vec![1], vec![Some("a")])])
+        .await
+        .unwrap();
+
+    let changes = changes_for(&pool, result.snapshot_id).await.unwrap();
+    assert!(
+        changes.contains(r#"created_schema:"main""#),
+        "missing created_schema in {changes:?}"
+    );
+    assert!(
+        changes.contains(r#"created_table:"main"."t""#),
+        "missing created_table in {changes:?}"
+    );
+    assert!(
+        changes.contains(&format!("inserted_into_table:{}", result.table_id)),
+        "missing inserted_into_table in {changes:?}"
+    );
+}
+
+/// A `Replace` that supersedes existing files records both the delete and the
+/// insert, per `table_write_changes`.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn replace_records_delete_and_insert() {
+    let (writer, pool, _conn, _tmp, _container) = setup().await.unwrap();
+    let tw = DuckLakeTableWriter::new(Arc::new(writer), object_store()).unwrap();
+
+    tw.write_table("main", "t", &[batch(vec![1], vec![Some("a")])])
+        .await
+        .unwrap();
+    let second = tw
+        .write_table("main", "t", &[batch(vec![2], vec![Some("b")])])
+        .await
+        .unwrap();
+
+    let changes = changes_for(&pool, second.snapshot_id).await.unwrap();
+    assert!(
+        changes.contains(&format!("deleted_from_table:{}", second.table_id)),
+        "missing deleted_from_table in {changes:?}"
+    );
+    assert!(
+        changes.contains(&format!("inserted_into_table:{}", second.table_id)),
+        "missing inserted_into_table in {changes:?}"
+    );
+}
+
+/// Every snapshot must carry exactly one change row — `insert_snapshot` seeds it.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn every_snapshot_has_exactly_one_change_row() {
+    let (writer, pool, _conn, _tmp, _container) = setup().await.unwrap();
+    let tw = DuckLakeTableWriter::new(Arc::new(writer), object_store()).unwrap();
+
+    tw.write_table("main", "t", &[batch(vec![1], vec![None])])
+        .await
+        .unwrap();
+    tw.append_table("main", "t", &[batch(vec![2], vec![None])])
+        .await
+        .unwrap();
+
+    let orphans: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ducklake_snapshot s
+         LEFT JOIN ducklake_snapshot_changes c ON c.snapshot_id = s.snapshot_id
+         WHERE c.snapshot_id IS NULL",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(orphans, 0, "every snapshot needs a change row");
+
+    let snapshots: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ducklake_snapshot")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let change_rows: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ducklake_snapshot_changes")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(snapshots, change_rows);
+}
+
+/// Author / message / extra-info round-trip through
+/// `register_data_file_with_commit_metadata`.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn commit_metadata_is_persisted() {
+    use datafusion_ducklake::SnapshotCommitMetadata;
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+
+    let (writer, pool, _conn, _tmp, _container) = setup().await.unwrap();
+    let setup_result = writer
+        .begin_write_transaction("main", "t", &cols(), WriteMode::Append)
+        .unwrap();
+
+    let meta = SnapshotCommitMetadata::new()
+        .with_author("alice")
+        .with_message("nightly load")
+        .with_extra_info("job=42");
+
+    let ids = writer
+        .register_data_file_with_commit_metadata(
+            setup_result.table_id,
+            "main",
+            "t",
+            setup_result.snapshot_id,
+            &DataFileInfo::new("t/data.parquet", 1024, 1),
+            WriteMode::Append,
+            setup_result.base_snapshot_id,
+            &cols(),
+            &setup_result.column_ids,
+            &meta,
+            None,
+        )
+        .unwrap();
+
+    let (author, message, extra): (Option<String>, Option<String>, Option<String>) =
+        sqlx::query_as(
+            "SELECT author, commit_message, commit_extra_info
+             FROM ducklake_snapshot_changes WHERE snapshot_id = $1",
+        )
+        .bind(ids.snapshot_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(author.as_deref(), Some("alice"));
+    assert_eq!(message.as_deref(), Some("nightly load"));
+    assert_eq!(extra.as_deref(), Some("job=42"));
+}
+
+/// Conditional (compare-and-swap) writes are not implemented on this backend and
+/// must fail closed rather than commit unconditionally.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn conditional_writes_are_rejected() {
+    use datafusion_ducklake::SnapshotCommitMetadata;
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+
+    let (writer, _pool, _conn, _tmp, _container) = setup().await.unwrap();
+    let setup_result = writer
+        .begin_write_transaction("main", "t", &cols(), WriteMode::Append)
+        .unwrap();
+
+    let err = writer
+        .register_data_file_with_commit_metadata(
+            setup_result.table_id,
+            "main",
+            "t",
+            setup_result.snapshot_id,
+            &DataFileInfo::new("t/data.parquet", 1024, 1),
+            WriteMode::Append,
+            setup_result.base_snapshot_id,
+            &cols(),
+            &setup_result.column_ids,
+            &SnapshotCommitMetadata::default(),
+            Some(setup_result.base_snapshot_id),
+        )
+        .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("conditional writes are not supported"),
+        "unexpected error: {err}"
+    );
+
+    let files_err = writer
+        .register_data_files_with_commit_metadata(
+            setup_result.table_id,
+            "main",
+            "t",
+            setup_result.snapshot_id,
+            &[DataFileInfo::new("t/data.parquet", 1024, 1)],
+            WriteMode::Append,
+            setup_result.base_snapshot_id,
+            &cols(),
+            &setup_result.column_ids,
+            &SnapshotCommitMetadata::default(),
+            Some(setup_result.base_snapshot_id),
+        )
+        .unwrap_err();
+    assert!(
+        files_err
+            .to_string()
+            .contains("conditional multi-file writes are not supported"),
+        "unexpected error: {files_err}"
+    );
+}
+
+/// Partition DDL is an ALTER and must say so in the change record.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn partition_ddl_records_altered_table() {
+    use datafusion_ducklake::PartitionTransform;
+
+    let (writer, pool, _conn, _tmp, _container) = setup().await.unwrap();
+    let snapshot = writer.create_snapshot().unwrap();
+    let (schema_id, _) = writer.get_or_create_schema("main", None, snapshot).unwrap();
+    let (table_id, _) = writer
+        .get_or_create_table(schema_id, "t", None, snapshot)
+        .unwrap();
+    writer.set_columns(table_id, &cols(), snapshot).unwrap();
+
+    let ddl_snapshot = writer
+        .set_partition_spec(
+            table_id,
+            &[("name".to_string(), PartitionTransform::Identity)],
+        )
+        .unwrap();
+
+    let changes = changes_for(&pool, ddl_snapshot).await.unwrap();
+    assert_eq!(changes, format!("altered_table:{table_id}"));
 }
 
 /// Opening a writer over an existing pool must not re-run DDL or disturb state.

--- a/tests/it/postgres_single_catalog_write_tests.rs
+++ b/tests/it/postgres_single_catalog_write_tests.rs
@@ -1,0 +1,841 @@
+#![cfg(feature = "write-postgres")]
+//! Integration tests for the **single-catalog** (standard DuckLake) Postgres writer.
+//!
+//! The point of `PostgresSingleCatalogMetadataWriter` is that it produces the
+//! same catalog shape as the SQLite/MySQL writers and DuckDB's `ducklake`
+//! extension — unlike `PostgresMetadataWriter`, which writes this crate's
+//! library-specific multicatalog layout. So alongside the usual write/read
+//! coverage these tests assert the *shape*:
+//!
+//! - no `ducklake_catalog*` map tables exist
+//! - no `catalog_id` column on any DuckLake table
+//! - `catalog_id()` is `None`, so file paths stay unscoped
+//! - `ducklake_schema.path` / `ducklake_table.path` are bare relative names
+//!   (no `cat_{id}/` prefix)
+//!
+//! Plus the behaviour the multicatalog path cannot offer: SQL `CREATE TABLE AS
+//! SELECT`.
+
+use std::sync::Arc;
+
+use arrow::array::{Int64Array, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use datafusion::prelude::*;
+use object_store::local::LocalFileSystem;
+use sqlx::postgres::{PgPool, PgPoolOptions};
+use tempfile::TempDir;
+use testcontainers::ContainerAsync;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+use datafusion_ducklake::metadata_writer::{ColumnDef, MetadataWriter, WriteMode};
+use datafusion_ducklake::{
+    DuckLakeCatalog, DuckLakeTableWriter, PostgresMetadataProvider,
+    PostgresSingleCatalogMetadataWriter,
+};
+
+/// Spin up Postgres, open a single-catalog writer against it, and point the
+/// catalog at a temp data directory. Returns everything the caller must keep
+/// alive (dropping the container tears the database down).
+async fn setup() -> anyhow::Result<(
+    PostgresSingleCatalogMetadataWriter,
+    PgPool,
+    String,
+    TempDir,
+    ContainerAsync<Postgres>,
+)> {
+    let container = Postgres::default().start().await?;
+    let port = container.get_host_port_ipv4(5432).await?;
+    let conn_str = format!("postgresql://postgres:postgres@127.0.0.1:{}/postgres", port);
+
+    let writer = PostgresSingleCatalogMetadataWriter::new_with_init(&conn_str).await?;
+
+    let temp_dir = TempDir::new()?;
+    let data_path = temp_dir.path().join("data");
+    std::fs::create_dir_all(&data_path)?;
+    writer.set_data_path(data_path.to_str().unwrap())?;
+
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&conn_str)
+        .await?;
+
+    Ok((writer, pool, conn_str, temp_dir, container))
+}
+
+fn object_store() -> Arc<dyn object_store::ObjectStore> {
+    Arc::new(LocalFileSystem::new())
+}
+
+fn batch(ids: Vec<i64>, names: Vec<Option<&str>>) -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("name", DataType::Utf8, true),
+    ]));
+    RecordBatch::try_new(
+        schema,
+        vec![Arc::new(Int64Array::from(ids)), Arc::new(StringArray::from(names))],
+    )
+    .unwrap()
+}
+
+fn cols() -> Vec<ColumnDef> {
+    vec![
+        ColumnDef::new("id", "int64", false).unwrap(),
+        ColumnDef::new("name", "varchar", true).unwrap(),
+    ]
+}
+
+async fn read_context(conn_str: &str) -> SessionContext {
+    let provider = PostgresMetadataProvider::new(conn_str).await.unwrap();
+    let catalog = DuckLakeCatalog::new(provider).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog("lake", Arc::new(catalog));
+    ctx
+}
+
+async fn table_exists(pool: &PgPool, name: &str) -> bool {
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM information_schema.tables
+         WHERE table_schema = 'public' AND table_name = $1",
+    )
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    count > 0
+}
+
+// ---------------------------------------------------------------------------
+// Catalog shape: the actual point of #165
+// ---------------------------------------------------------------------------
+
+/// The multicatalog map tables must NOT be created by this writer. Their
+/// presence is what makes a catalog unreadable by other DuckLake tools.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn creates_no_multicatalog_tables() {
+    let (_writer, pool, _conn, _tmp, _container) = setup().await.unwrap();
+
+    for t in ["ducklake_catalog", "ducklake_catalog_snapshot_map", "ducklake_catalog_schema_map"] {
+        assert!(
+            !table_exists(&pool, t).await,
+            "single-catalog writer must not create the multicatalog table `{t}`"
+        );
+    }
+
+    // ...and the standard tables must be there.
+    for t in [
+        "ducklake_metadata",
+        "ducklake_snapshot",
+        "ducklake_schema",
+        "ducklake_table",
+        "ducklake_column",
+        "ducklake_data_file",
+        "ducklake_delete_file",
+        "ducklake_table_stats",
+        "ducklake_file_column_stats",
+        "ducklake_table_column_stats",
+        "ducklake_schema_versions",
+        "ducklake_partition_info",
+        "ducklake_partition_column",
+        "ducklake_file_partition_value",
+        "ducklake_sort_info",
+        "ducklake_sort_expression",
+        "ducklake_files_scheduled_for_deletion",
+    ] {
+        assert!(table_exists(&pool, t).await, "missing standard table `{t}`");
+    }
+}
+
+/// No DuckLake table may carry a `catalog_id` column — that column is the
+/// multicatalog layout's scoping mechanism and is not in the spec.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn no_table_carries_a_catalog_id_column() {
+    let (_writer, pool, _conn, _tmp, _container) = setup().await.unwrap();
+
+    let offenders: Vec<String> = sqlx::query_scalar(
+        "SELECT table_name FROM information_schema.columns
+         WHERE table_schema = 'public'
+           AND table_name LIKE 'ducklake\\_%'
+           AND column_name = 'catalog_id'
+         ORDER BY table_name",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+
+    assert!(
+        offenders.is_empty(),
+        "catalog_id must not appear on any DuckLake table; found on {offenders:?}"
+    );
+}
+
+/// `catalog_id()` returning `None` is what keeps file placement unscoped —
+/// `{data_path}/{schema}/{table}/…` rather than `{data_path}/cat_{id}/…`.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn catalog_id_is_none() {
+    let (writer, _pool, _conn, _tmp, _container) = setup().await.unwrap();
+    assert_eq!(writer.catalog_id(), None);
+}
+
+/// Schema and table paths are stored as bare relative names, matching the other
+/// single-catalog backends.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn paths_are_unscoped_and_relative() {
+    let (writer, pool, _conn, _tmp, _container) = setup().await.unwrap();
+
+    DuckLakeTableWriter::new(Arc::new(writer), object_store())
+        .unwrap()
+        .write_table("main", "users", &[batch(vec![1, 2], vec![Some("a"), None])])
+        .await
+        .unwrap();
+
+    let (schema_path, schema_rel): (String, bool) = sqlx::query_as(
+        "SELECT path, path_is_relative FROM ducklake_schema WHERE schema_name = 'main'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(schema_path, "main", "schema path must not be cat_-scoped");
+    assert!(schema_rel);
+
+    let (table_path, table_rel): (String, bool) = sqlx::query_as(
+        "SELECT path, path_is_relative FROM ducklake_table WHERE table_name = 'users'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(table_path, "users");
+    assert!(table_rel);
+
+    // The data file lands relative to the resolved table path.
+    let file_rel: bool = sqlx::query_scalar("SELECT path_is_relative FROM ducklake_data_file")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert!(file_rel);
+}
+
+/// `ducklake_column` must be the bare upstream shape so a versioned column can
+/// hold several rows sharing one `column_id`. The multicatalog writer uses a
+/// composite PK instead; upstream and the other single-catalog backends use none.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn ducklake_column_has_no_primary_key() {
+    let (_writer, pool, _conn, _tmp, _container) = setup().await.unwrap();
+
+    let pk_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM information_schema.table_constraints
+         WHERE table_schema = 'public'
+           AND table_name = 'ducklake_column'
+           AND constraint_type = 'PRIMARY KEY'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(pk_count, 0, "ducklake_column must be a bare table");
+}
+
+// ---------------------------------------------------------------------------
+// Write / read round-trips
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn write_and_read_back() {
+    let (writer, _pool, conn_str, _tmp, _container) = setup().await.unwrap();
+
+    let result = DuckLakeTableWriter::new(Arc::new(writer), object_store())
+        .unwrap()
+        .write_table(
+            "main",
+            "users",
+            &[batch(vec![1, 2, 3], vec![Some("a"), Some("b"), None])],
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.records_written, 3);
+    assert_eq!(result.files_written, 1);
+    assert!(result.snapshot_id > 0);
+
+    let ctx = read_context(&conn_str).await;
+    let batches = ctx
+        .sql("SELECT id, name FROM lake.main.users ORDER BY id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total, 3);
+    let ids = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap();
+    assert_eq!(ids.values(), &[1, 2, 3]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn append_accumulates_rows_and_snapshots() {
+    let (writer, pool, conn_str, _tmp, _container) = setup().await.unwrap();
+    let tw = DuckLakeTableWriter::new(Arc::new(writer), object_store()).unwrap();
+
+    tw.write_table("main", "t", &[batch(vec![1], vec![Some("a")])])
+        .await
+        .unwrap();
+    tw.append_table("main", "t", &[batch(vec![2], vec![Some("b")])])
+        .await
+        .unwrap();
+
+    let snapshots: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ducklake_snapshot")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(snapshots, 2, "each write publishes exactly one snapshot");
+
+    // An unchanged column keeps its column_id across writes (it is the parquet
+    // field_id; churning it would make already-written files read back NULL).
+    let live_ids: Vec<i64> = sqlx::query_scalar(
+        "SELECT column_id FROM ducklake_column WHERE end_snapshot IS NULL ORDER BY column_order",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(live_ids.len(), 2);
+
+    let ctx = read_context(&conn_str).await;
+    let batches = ctx
+        .sql("SELECT count(*) AS n FROM lake.main.t")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let n = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap()
+        .value(0);
+    assert_eq!(n, 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn replace_retires_the_prior_generation() {
+    let (writer, pool, conn_str, _tmp, _container) = setup().await.unwrap();
+    let tw = DuckLakeTableWriter::new(Arc::new(writer), object_store()).unwrap();
+
+    tw.write_table(
+        "main",
+        "t",
+        &[batch(vec![1, 2], vec![Some("a"), Some("b")])],
+    )
+    .await
+    .unwrap();
+    tw.write_table("main", "t", &[batch(vec![9], vec![Some("z")])])
+        .await
+        .unwrap();
+
+    let live: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM ducklake_data_file WHERE end_snapshot IS NULL")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(live, 1, "Replace leaves exactly the new file live");
+
+    let retired: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ducklake_data_file WHERE end_snapshot IS NOT NULL",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(retired, 1);
+
+    let ctx = read_context(&conn_str).await;
+    let batches = ctx
+        .sql("SELECT id FROM lake.main.t")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let ids = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap();
+    assert_eq!(ids.values(), &[9]);
+}
+
+// ---------------------------------------------------------------------------
+// SQL surface — CTAS is the capability the multicatalog path cannot offer
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn sql_ctas_then_insert_then_select() {
+    let (writer, _pool, conn_str, _tmp, _container) = setup().await.unwrap();
+
+    let provider = PostgresMetadataProvider::new(&conn_str).await.unwrap();
+    let catalog = DuckLakeCatalog::with_writer(Arc::new(provider), Arc::new(writer)).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog("lake", Arc::new(catalog));
+
+    ctx.sql("CREATE TABLE lake.main.nums AS SELECT 1 AS id, 'one' AS name")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    // A catalog pins its snapshot at construction, so re-open to observe the
+    // committed CTAS before appending to it.
+    let provider = PostgresMetadataProvider::new(&conn_str).await.unwrap();
+    let writer2 = PostgresSingleCatalogMetadataWriter::new(&conn_str)
+        .await
+        .unwrap();
+    let catalog = DuckLakeCatalog::with_writer(Arc::new(provider), Arc::new(writer2)).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog("lake", Arc::new(catalog));
+
+    ctx.sql("INSERT INTO lake.main.nums VALUES (2, 'two')")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let ctx = read_context(&conn_str).await;
+    let batches = ctx
+        .sql("SELECT count(*) AS n FROM lake.main.nums")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let n = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap()
+        .value(0);
+    assert_eq!(n, 2);
+}
+
+// ---------------------------------------------------------------------------
+// Metadata bookkeeping
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn initialize_schema_is_idempotent() {
+    let (writer, pool, _conn, _tmp, _container) = setup().await.unwrap();
+
+    // Re-running must neither error nor re-seed the counters.
+    writer.initialize_schema().unwrap();
+    writer.initialize_schema().unwrap();
+
+    let counters: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ducklake_metadata
+         WHERE key IN ('next_column_id','next_snapshot_id','next_partition_id','next_sort_id')
+           AND scope IS NULL",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(counters, 4, "each id counter must be seeded exactly once");
+}
+
+/// A DDL commit bumps `schema_version` and writes a ledger row; a pure data
+/// write carries the version forward and writes none. Mirrors upstream's
+/// `if (SchemaChangesMade()) schema_version++`.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn schema_version_bumps_on_ddl_and_carries_on_data_write() {
+    let (writer, pool, _conn, _tmp, _container) = setup().await.unwrap();
+    let tw = DuckLakeTableWriter::new(Arc::new(writer), object_store()).unwrap();
+
+    // Creating write == DDL.
+    tw.write_table("main", "t", &[batch(vec![1], vec![Some("a")])])
+        .await
+        .unwrap();
+    let v1: i64 = sqlx::query_scalar("SELECT MAX(schema_version) FROM ducklake_snapshot")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(v1, 1);
+
+    // Same-schema append == pure data write.
+    tw.append_table("main", "t", &[batch(vec![2], vec![Some("b")])])
+        .await
+        .unwrap();
+    let v2: i64 = sqlx::query_scalar("SELECT MAX(schema_version) FROM ducklake_snapshot")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(v2, 1, "a pure data write must not bump schema_version");
+
+    let ledger: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ducklake_schema_versions")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(ledger, 1, "only the DDL commit writes a ledger row");
+}
+
+/// Snapshot ids are counter-allocated, so they are dense and ordered by commit —
+/// the property the `Replace` conflict test relies on.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn snapshot_ids_are_dense_and_commit_ordered() {
+    let (writer, pool, _conn, _tmp, _container) = setup().await.unwrap();
+    let tw = DuckLakeTableWriter::new(Arc::new(writer), object_store()).unwrap();
+
+    for i in 1..=3 {
+        tw.append_table("main", "t", &[batch(vec![i], vec![Some("x")])])
+            .await
+            .unwrap();
+    }
+
+    let ids: Vec<i64> =
+        sqlx::query_scalar("SELECT snapshot_id FROM ducklake_snapshot ORDER BY snapshot_id")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    assert_eq!(ids, vec![1, 2, 3]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn row_id_start_advances_monotonically() {
+    let (writer, pool, _conn, _tmp, _container) = setup().await.unwrap();
+    let tw = DuckLakeTableWriter::new(Arc::new(writer), object_store()).unwrap();
+
+    tw.write_table("main", "t", &[batch(vec![1, 2], vec![None, None])])
+        .await
+        .unwrap();
+    tw.append_table("main", "t", &[batch(vec![3], vec![None])])
+        .await
+        .unwrap();
+
+    let starts: Vec<i64> =
+        sqlx::query_scalar("SELECT row_id_start FROM ducklake_data_file ORDER BY data_file_id")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    assert_eq!(starts, vec![0, 2]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn column_stats_are_persisted() {
+    let (writer, pool, _conn, _tmp, _container) = setup().await.unwrap();
+
+    DuckLakeTableWriter::new(Arc::new(writer), object_store())
+        .unwrap()
+        .write_table(
+            "main",
+            "t",
+            &[batch(vec![5, 1, 9], vec![Some("a"), Some("b"), None])],
+        )
+        .await
+        .unwrap();
+
+    let (min_v, max_v): (Option<String>, Option<String>) = sqlx::query_as(
+        "SELECT s.min_value, s.max_value
+         FROM ducklake_file_column_stats s
+         JOIN ducklake_column c
+           ON c.column_id = s.column_id AND c.end_snapshot IS NULL
+         WHERE c.column_name = 'id'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(min_v.as_deref(), Some("1"));
+    assert_eq!(max_v.as_deref(), Some("9"));
+
+    let rollup: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ducklake_table_column_stats")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(rollup, 2, "one roll-up row per live column");
+}
+
+// ---------------------------------------------------------------------------
+// Partition / sort specs
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn partition_spec_set_then_reset() {
+    use datafusion_ducklake::PartitionTransform;
+
+    let (writer, pool, _conn, _tmp, _container) = setup().await.unwrap();
+    let snapshot = writer.create_snapshot().unwrap();
+    let (schema_id, _) = writer.get_or_create_schema("main", None, snapshot).unwrap();
+    let (table_id, _) = writer
+        .get_or_create_table(schema_id, "t", None, snapshot)
+        .unwrap();
+    writer.set_columns(table_id, &cols(), snapshot).unwrap();
+
+    writer
+        .set_partition_spec(
+            table_id,
+            &[("name".to_string(), PartitionTransform::Identity)],
+        )
+        .unwrap();
+
+    let spec = writer.live_partition_spec(table_id).unwrap();
+    assert!(spec.is_some(), "spec must be live after SET");
+
+    let live_specs: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ducklake_partition_info WHERE end_snapshot IS NULL",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(live_specs, 1);
+
+    writer.reset_partition_spec(table_id).unwrap();
+    assert!(writer.live_partition_spec(table_id).unwrap().is_none());
+}
+
+/// Resetting when nothing is set must not publish an empty snapshot.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn reset_partition_spec_on_unpartitioned_table_is_a_noop() {
+    let (writer, pool, _conn, _tmp, _container) = setup().await.unwrap();
+    let snapshot = writer.create_snapshot().unwrap();
+    let (schema_id, _) = writer.get_or_create_schema("main", None, snapshot).unwrap();
+    let (table_id, _) = writer
+        .get_or_create_table(schema_id, "t", None, snapshot)
+        .unwrap();
+
+    let before: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ducklake_snapshot")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let head = writer.reset_partition_spec(table_id).unwrap();
+    let after: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ducklake_snapshot")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(before, after, "no-op reset must not publish a snapshot");
+    assert_eq!(head, snapshot);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn sort_spec_set_then_reset() {
+    use datafusion_ducklake::{NullOrder, SortDirection, SortField};
+
+    let (writer, _pool, _conn, _tmp, _container) = setup().await.unwrap();
+    let snapshot = writer.create_snapshot().unwrap();
+    let (schema_id, _) = writer.get_or_create_schema("main", None, snapshot).unwrap();
+    let (table_id, _) = writer
+        .get_or_create_table(schema_id, "t", None, snapshot)
+        .unwrap();
+    writer.set_columns(table_id, &cols(), snapshot).unwrap();
+
+    let field = SortField {
+        sort_key_index: 0,
+        expression: "id".to_string(),
+        dialect: "duckdb".to_string(),
+        direction: SortDirection::Asc,
+        null_order: NullOrder::NullsLast,
+    };
+    writer.set_sort_spec(table_id, &[field]).unwrap();
+    assert!(writer.live_sort_spec(table_id).unwrap().is_some());
+
+    writer.reset_sort_spec(table_id).unwrap();
+    assert!(writer.live_sort_spec(table_id).unwrap().is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn set_partition_spec_rejects_unknown_column() {
+    use datafusion_ducklake::PartitionTransform;
+
+    let (writer, _pool, _conn, _tmp, _container) = setup().await.unwrap();
+    let snapshot = writer.create_snapshot().unwrap();
+    let (schema_id, _) = writer.get_or_create_schema("main", None, snapshot).unwrap();
+    let (table_id, _) = writer
+        .get_or_create_table(schema_id, "t", None, snapshot)
+        .unwrap();
+    writer.set_columns(table_id, &cols(), snapshot).unwrap();
+
+    let err = writer
+        .set_partition_spec(
+            table_id,
+            &[("nope".to_string(), PartitionTransform::Identity)],
+        )
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("no live column 'nope'"),
+        "unexpected error: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Error paths
+// ---------------------------------------------------------------------------
+
+/// A data write must never silently change a column's type — that is schema
+/// evolution and belongs to `promote_column_type`, which this writer does not
+/// implement.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn append_rejects_a_column_type_change() {
+    let (writer, _pool, _conn, _tmp, _container) = setup().await.unwrap();
+
+    writer
+        .begin_write_transaction("main", "t", &cols(), WriteMode::Replace)
+        .unwrap();
+    let snapshot = writer.create_snapshot().unwrap();
+    let (schema_id, _) = writer.get_or_create_schema("main", None, snapshot).unwrap();
+    let (table_id, _) = writer
+        .get_or_create_table(schema_id, "t", None, snapshot)
+        .unwrap();
+    writer.set_columns(table_id, &cols(), snapshot).unwrap();
+
+    let widened = vec![
+        ColumnDef::new("id", "varchar", false).unwrap(),
+        ColumnDef::new("name", "varchar", true).unwrap(),
+    ];
+    let err = writer
+        .begin_write_transaction("main", "t", &widened, WriteMode::Append)
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            datafusion_ducklake::DuckLakeError::UnsupportedTypeChange { .. }
+        ),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn append_rejects_a_new_non_nullable_column() {
+    let (writer, _pool, _conn, _tmp, _container) = setup().await.unwrap();
+    let snapshot = writer.create_snapshot().unwrap();
+    let (schema_id, _) = writer.get_or_create_schema("main", None, snapshot).unwrap();
+    let (table_id, _) = writer
+        .get_or_create_table(schema_id, "t", None, snapshot)
+        .unwrap();
+    writer.set_columns(table_id, &cols(), snapshot).unwrap();
+
+    let mut extended = cols();
+    extended.push(ColumnDef::new("extra", "int64", false).unwrap());
+    let err = writer
+        .begin_write_transaction("main", "t", &extended, WriteMode::Append)
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("must be nullable"),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn set_columns_rejects_an_empty_schema() {
+    let (writer, _pool, _conn, _tmp, _container) = setup().await.unwrap();
+    let snapshot = writer.create_snapshot().unwrap();
+    let (schema_id, _) = writer.get_or_create_schema("main", None, snapshot).unwrap();
+    let (table_id, _) = writer
+        .get_or_create_table(schema_id, "t", None, snapshot)
+        .unwrap();
+
+    let err = writer.set_columns(table_id, &[], snapshot).unwrap_err();
+    assert!(
+        err.to_string().contains("at least one column"),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn get_data_path_errors_when_unset() {
+    let container = Postgres::default().start().await.unwrap();
+    let port = container.get_host_port_ipv4(5432).await.unwrap();
+    let conn_str = format!("postgresql://postgres:postgres@127.0.0.1:{}/postgres", port);
+    let writer = PostgresSingleCatalogMetadataWriter::new_with_init(&conn_str)
+        .await
+        .unwrap();
+
+    let err = writer.get_data_path().unwrap_err();
+    assert!(
+        err.to_string().contains("data_path"),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn set_data_path_replaces_rather_than_duplicates() {
+    let (writer, pool, _conn, _tmp, _container) = setup().await.unwrap();
+
+    writer.set_data_path("/tmp/one").unwrap();
+    writer.set_data_path("/tmp/two").unwrap();
+
+    let rows: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ducklake_metadata WHERE key = 'data_path' AND scope IS NULL",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(rows, 1);
+    assert_eq!(writer.get_data_path().unwrap(), "/tmp/two");
+}
+
+/// Deletes, upserts, compaction and type promotion are out of scope for this
+/// writer and must surface the trait's erroring defaults rather than silently
+/// doing nothing.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn unsupported_operations_error() {
+    let (writer, _pool, _conn, _tmp, _container) = setup().await.unwrap();
+    let snapshot = writer.create_snapshot().unwrap();
+    let (schema_id, _) = writer.get_or_create_schema("main", None, snapshot).unwrap();
+    let (table_id, _) = writer
+        .get_or_create_table(schema_id, "t", None, snapshot)
+        .unwrap();
+    writer.set_columns(table_id, &cols(), snapshot).unwrap();
+
+    assert!(
+        writer
+            .promote_column_type(table_id, "id", "varchar")
+            .is_err(),
+        "type promotion must be rejected"
+    );
+    assert!(!writer.supports_update(), "UPDATE is not supported");
+}
+
+/// Opening a writer over an existing pool must not re-run DDL or disturb state.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn from_pool_shares_an_existing_connection_pool() {
+    let (writer, pool, _conn, _tmp, _container) = setup().await.unwrap();
+    DuckLakeTableWriter::new(Arc::new(writer), object_store())
+        .unwrap()
+        .write_table("main", "t", &[batch(vec![1], vec![Some("a")])])
+        .await
+        .unwrap();
+
+    let adopted = PostgresSingleCatalogMetadataWriter::from_pool(pool.clone());
+    assert_eq!(adopted.catalog_id(), None);
+    let head: i64 = sqlx::query_scalar("SELECT MAX(snapshot_id) FROM ducklake_snapshot")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(head, 1);
+}

--- a/tests/it/postgres_single_catalog_write_tests.rs
+++ b/tests/it/postgres_single_catalog_write_tests.rs
@@ -787,6 +787,144 @@ async fn unsupported_operations_error() {
 }
 
 // ---------------------------------------------------------------------------
+// Commit atomicity
+// ---------------------------------------------------------------------------
+
+/// A write that dies between begin and commit must leave nothing behind. Schema
+/// and table visibility is `snapshot >= begin_snapshot` with no check that the
+/// snapshot exists, so a row written at begin against a guessed id would surface
+/// as soon as any other writer reached that id.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn an_abandoned_write_leaves_no_phantom_schema_or_table() {
+    let (writer, pool, conn_str, _tmp, _container) = setup().await.unwrap();
+
+    // Begin a write against a brand-new schema and table, then abandon it.
+    let abandoned = writer
+        .begin_write_transaction("ghost_schema", "ghost_table", &cols(), WriteMode::Replace)
+        .unwrap();
+
+    // A different writer advances the head past the id the abandoned write saw.
+    DuckLakeTableWriter::new(Arc::new(writer), object_store())
+        .unwrap()
+        .write_table("main", "real", &[batch(vec![1], vec![Some("a")])])
+        .await
+        .unwrap();
+
+    let head: i64 = sqlx::query_scalar("SELECT MAX(snapshot_id) FROM ducklake_snapshot")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert!(
+        head >= abandoned.snapshot_id,
+        "the head must reach the abandoned write's speculative id for this to be a real test"
+    );
+
+    let ghost_schemas: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM ducklake_schema WHERE schema_name = $1")
+            .bind("ghost_schema")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(ghost_schemas, 0, "abandoned write left a phantom schema");
+
+    let ghost_tables: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM ducklake_table WHERE table_name = $1")
+            .bind("ghost_table")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(ghost_tables, 0, "abandoned write left a phantom table");
+
+    // And nothing leaks through the read path either.
+    let ctx = read_context(&conn_str).await;
+    assert!(
+        ctx.sql("SELECT * FROM lake.ghost_schema.ghost_table")
+            .await
+            .is_err(),
+        "phantom table is queryable"
+    );
+}
+
+/// Every committed schema/table row must belong to a snapshot that exists.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn committed_rows_reference_a_real_snapshot() {
+    let (writer, pool, _conn, _tmp, _container) = setup().await.unwrap();
+    let tw = DuckLakeTableWriter::new(Arc::new(writer), object_store()).unwrap();
+    tw.write_table("main", "t", &[batch(vec![1], vec![None])])
+        .await
+        .unwrap();
+    tw.append_table("main", "t", &[batch(vec![2], vec![None])])
+        .await
+        .unwrap();
+
+    for table in ["ducklake_schema", "ducklake_table", "ducklake_column"] {
+        // `table` is one of the three literals above, not caller input.
+        let dangling: i64 = sqlx::query_scalar(sqlx::AssertSqlSafe(format!(
+            "SELECT COUNT(*) FROM {table} x
+             LEFT JOIN ducklake_snapshot s ON s.snapshot_id = x.begin_snapshot
+             WHERE s.snapshot_id IS NULL"
+        )))
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(dangling, 0, "{table} has rows with no backing snapshot");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn conditional_write_accepts_a_current_base_and_rejects_a_stale_one() {
+    use datafusion_ducklake::SnapshotCommitMetadata;
+    use datafusion_ducklake::metadata_writer::DataFileInfo;
+
+    let (writer, pool, _conn, _tmp, _container) = setup().await.unwrap();
+    DuckLakeTableWriter::new(Arc::new(writer.clone()), object_store())
+        .unwrap()
+        .write_table("main", "t", &[batch(vec![1], vec![None])])
+        .await
+        .unwrap();
+
+    let base: i64 = sqlx::query_scalar("SELECT MAX(snapshot_id) FROM ducklake_snapshot")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    let append = |path: &'static str, expected: i64| {
+        let w = writer.clone();
+        move || {
+            let s = w
+                .begin_write_transaction("main", "t", &cols(), WriteMode::Append)
+                .unwrap();
+            w.register_data_file_with_commit_metadata(
+                s.table_id,
+                "main",
+                "t",
+                s.snapshot_id,
+                &DataFileInfo::new(path, 1024, 1),
+                WriteMode::Append,
+                s.base_snapshot_id,
+                &cols(),
+                &s.column_ids,
+                &SnapshotCommitMetadata::default(),
+                Some(expected),
+            )
+        }
+    };
+
+    // The table's generation has not moved past `base`, so this is accepted.
+    append("t/a.parquet", base)().expect("conditional write on a current base");
+
+    // It has now, so replaying the same expectation must conflict rather than commit.
+    let err = append("t/b.parquet", base)().unwrap_err();
+    assert!(
+        matches!(err, datafusion_ducklake::DuckLakeError::Conflict(_)),
+        "expected Conflict, got: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Snapshot change records + commit metadata (#209 surface)
 // ---------------------------------------------------------------------------
 
@@ -927,61 +1065,6 @@ async fn commit_metadata_is_persisted() {
     assert_eq!(author.as_deref(), Some("alice"));
     assert_eq!(message.as_deref(), Some("nightly load"));
     assert_eq!(extra.as_deref(), Some("job=42"));
-}
-
-#[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
-async fn conditional_writes_are_rejected() {
-    use datafusion_ducklake::SnapshotCommitMetadata;
-    use datafusion_ducklake::metadata_writer::DataFileInfo;
-
-    let (writer, _pool, _conn, _tmp, _container) = setup().await.unwrap();
-    let setup_result = writer
-        .begin_write_transaction("main", "t", &cols(), WriteMode::Append)
-        .unwrap();
-
-    let err = writer
-        .register_data_file_with_commit_metadata(
-            setup_result.table_id,
-            "main",
-            "t",
-            setup_result.snapshot_id,
-            &DataFileInfo::new("t/data.parquet", 1024, 1),
-            WriteMode::Append,
-            setup_result.base_snapshot_id,
-            &cols(),
-            &setup_result.column_ids,
-            &SnapshotCommitMetadata::default(),
-            Some(setup_result.base_snapshot_id),
-        )
-        .unwrap_err();
-    assert!(
-        err.to_string()
-            .contains("conditional writes are not supported"),
-        "unexpected error: {err}"
-    );
-
-    let files_err = writer
-        .register_data_files_with_commit_metadata(
-            setup_result.table_id,
-            "main",
-            "t",
-            setup_result.snapshot_id,
-            &[DataFileInfo::new("t/data.parquet", 1024, 1)],
-            WriteMode::Append,
-            setup_result.base_snapshot_id,
-            &cols(),
-            &setup_result.column_ids,
-            &SnapshotCommitMetadata::default(),
-            Some(setup_result.base_snapshot_id),
-        )
-        .unwrap_err();
-    assert!(
-        files_err
-            .to_string()
-            .contains("conditional multi-file writes are not supported"),
-        "unexpected error: {files_err}"
-    );
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Closes #165.

## What

Adds `PostgresSingleCatalogMetadataWriter` — the **standard, spec-compliant** single-catalog DuckLake layout on PostgreSQL.

Until now, PostgreSQL writes existed only through `PostgresMetadataWriter`, which implements this crate's library-specific multicatalog layout: extra `catalog_id` columns, three `ducklake_catalog*` map tables, `cat_{id}/`-scoped paths, and no SQL CTAS. A catalog written that way is readable only by `MulticatalogProvider` — not by DuckDB's `ducklake` extension or any other DuckLake implementation. That made Postgres, the most likely production catalog backend, the one backend that could not produce an interchangeable catalog.

The new writer produces the same shape as the SQLite and MySQL writers:

| | `PostgresSingleCatalogMetadataWriter` | `PostgresMetadataWriter` |
|---|---|---|
| Layout | Standard single-catalog | Library-specific multi-catalog |
| `catalog_id` columns / map tables | none | present |
| File paths | `{data_path}/{schema}/{table}/…` | `{data_path}/cat_{id}/{schema}/…` |
| `ducklake_column` | bare (upstream shape, no PK) | composite PK |
| SQL `CREATE TABLE` / CTAS | ✅ | ❌ |
| Readable by | any DuckLake reader, incl. DuckDB | `MulticatalogProvider` only |

Both live behind `write-postgres`. Existing users are unaffected.

## How

Modelled on `MySqlMetadataWriter`, the closest single-catalog template, with the SQL mapped to the Postgres dialect:

- `RETURNING` replaces MySQL's `last_insert_id()` round-trips for the IDENTITY-backed ids (`schema_id`, `table_id`, `data_file_id`), and collapses `reserve_ids` to one statement.
- `INSERT IGNORE` → `INSERT … ON CONFLICT (table_id) DO NOTHING`.
- `ADD COLUMN IF NOT EXISTS` replaces MySQL's `information_schema` probe.
- `seed_counter` is one idempotent statement (Postgres permits the self-referential `INSERT … SELECT` that MySQL rejects with 1093).

### One deliberate deviation worth reviewing

`snapshot_id` is **counter-allocated, not IDENTITY**. Two reasons:

1. Upstream's `ducklake_snapshot.snapshot_id` is a plain `BIGINT PRIMARY KEY`, so a counter is the more spec-faithful shape — the whole point of this PR.
2. Correctness of the `Replace` conflict test. The counter's `UPDATE` takes an exclusive row lock held to commit, so every commit transaction serializes on it and **snapshot-id order equals commit order**. A bare Postgres sequence would not: sequences are non-transactional, so two writers can commit out of id order and the scalar `> base_snapshot` test would miss a genuine conflict. The multicatalog writer gets that guarantee from its per-catalog `FOR UPDATE` lock, which has no single-catalog equivalent.

## Scope

Matching the issue and the MySQL template, these inherit their **erroring** trait defaults rather than silently no-oping: deletes (`set_delete_file`), upserts, compaction, type promotion (`promote_column_type`). Partition and sort specs *are* supported.

Snapshot id allocators (`next_catalog_id` / `next_file_id`) are **deliberately out of scope** — that is a separate cross-backend change that should land uniformly on SQLite, DuckDB and MySQL too, not be invented inside one new writer.

## Tests

`tests/it/postgres_single_catalog_write_tests.rs` — 25 cases, testcontainers-backed. Beyond the usual write/read coverage they assert the catalog **shape**, which is the actual deliverable:

- no `ducklake_catalog*` map tables exist; all 17 standard tables do
- no DuckLake table carries a `catalog_id` column
- `catalog_id()` is `None`
- schema/table/file paths are bare and relative (no `cat_` prefix)
- `ducklake_column` has no primary key

Plus: write/read round-trip, append accumulation with stable `column_id`s, `Replace` retiring the prior generation, CTAS → INSERT → SELECT, dense commit-ordered snapshot ids, monotonic `row_id_start`, per-file and roll-up column stats, `schema_version` bump-on-DDL / carry-on-data-write, partition and sort spec set/reset, no-op reset publishing no snapshot, `initialize_schema` idempotency, and the rejected paths (type change on append, new non-nullable column, empty schema, missing `data_path`).

## Verification status — please read before merging

Opened as a **draft** because I could not run the Postgres suite locally (no Docker daemon available in the environment I built this in). What *was* verified:

- `cargo check --no-default-features --features write-postgres --lib` — clean
- `cargo check --features write-postgres,metadata-postgres --tests` — clean
- `cargo clippy --features write-postgres,metadata-postgres --lib --tests -- -D warnings` — clean
- `cargo fmt --check` — clean

**The 25 integration tests have never been executed.** CI has Docker, so this PR's run is the first real execution. Treat green CI, not this description, as the evidence.

## Follow-ups (not in this PR)

- Decouple `write-postgres` from `multicatalog-postgres` in `Cargo.toml`, so a single-catalog build doesn't compile the multicatalog path.
- Snapshot id allocators (`next_catalog_id` / `next_file_id`) across all four backends, plus a DuckDB write-round-trip test — the remaining blocker for full DuckDB write-interop.
- Consider extracting the shared Postgres-dialect SQL, or letting the multicatalog writer freeze, so two ~2–4k-line PG writers don't diverge.
