### PR TITLE
test: serialize DuckDB extension installs across parallel tests

### DIFF
--- a/tests/it/cdc_differential_tests.rs
+++ b/tests/it/cdc_differential_tests.rs
@@ -55,8 +55,7 @@ fn write_catalog(path: &Path, statements: &[&str]) -> DataFusionResult<()> {
 /// loaded and the catalog at `path` attached as `c`.
 fn official_connection(path: &Path) -> DataFusionResult<duckdb::Connection> {
     let conn = duckdb::Connection::open_in_memory().map_err(box_err)?;
-    conn.execute("INSTALL ducklake;", []).map_err(box_err)?;
-    conn.execute("INSTALL parquet;", []).map_err(box_err)?;
+    crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", []).map_err(box_err)?;
     conn.execute(&format!("ATTACH 'ducklake:{}' AS c;", path.display()), [])
         .map_err(box_err)?;

--- a/tests/it/cdc_rowid_tests.rs
+++ b/tests/it/cdc_rowid_tests.rs
@@ -25,8 +25,7 @@ use tempfile::TempDir;
 /// run `statements` in order, writing a DuckLake catalog + parquet data.
 fn write_catalog(path: &std::path::Path, statements: &[&str]) -> DataFusionResult<()> {
     let conn = duckdb::Connection::open_in_memory().map_err(box_err)?;
-    conn.execute("INSTALL ducklake;", []).map_err(box_err)?;
-    conn.execute("INSTALL parquet;", []).map_err(box_err)?;
+    crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", []).map_err(box_err)?;
     conn.execute(&format!("ATTACH 'ducklake:{}' AS c;", path.display()), [])
         .map_err(box_err)?;

--- a/tests/it/common/mod.rs
+++ b/tests/it/common/mod.rs
@@ -9,23 +9,44 @@
 #![allow(dead_code)]
 
 use anyhow::Result;
+use std::collections::HashSet;
 use std::path::Path;
-use std::sync::Once;
+use std::sync::{Mutex, OnceLock};
 
-static INSTALL_DUCKLAKE: Once = Once::new();
+/// Extensions this process has already installed. The mutex also serializes the
+/// `INSTALL` itself, so only one thread ever writes the extension directory.
+static INSTALLED_EXTENSIONS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
 
-/// Install the ducklake and parquet extensions exactly once (thread-safe across parallel tests).
+/// Install DuckDB extension `name` at most once per process, serialized across threads.
 ///
-/// Pre-installing parquet avoids race conditions when multiple concurrent tests
-/// trigger DuckDB's auto-install simultaneously (observed on macOS CI).
-fn ensure_ducklake_installed() {
-    INSTALL_DUCKLAKE.call_once(|| {
-        let conn = duckdb::Connection::open_in_memory().expect("open in-memory duckdb");
-        conn.execute("INSTALL ducklake;", [])
-            .expect("install ducklake extension");
-        conn.execute("INSTALL parquet;", [])
-            .expect("install parquet extension");
-    });
+/// `INSTALL` writes into the shared `~/.duckdb/extensions/<version>/<platform>/`
+/// directory that every connection in this binary reads. The integration tests are a
+/// single binary (see `main.rs`) whose tests run as parallel threads, so two threads
+/// installing at the same time race on the same files — observed in CI as
+/// `IO Error: Could not remove file ".../parquet.duckdb_extension": No such file or
+/// directory`. Serializing here removes the race while still downloading once.
+///
+/// `LOAD` stays per-connection: it is cheap, reads the already-installed file, and
+/// every connection needs its own.
+pub fn ensure_extension_installed(name: &str) {
+    let installed = INSTALLED_EXTENSIONS.get_or_init(|| Mutex::new(HashSet::new()));
+    let mut installed = installed.lock().expect("extension-install lock poisoned");
+    if installed.contains(name) {
+        return;
+    }
+    let conn = duckdb::Connection::open_in_memory().expect("open in-memory duckdb");
+    conn.execute(&format!("INSTALL {name};"), [])
+        .unwrap_or_else(|e| panic!("install {name} extension: {e}"));
+    installed.insert(name.to_string());
+}
+
+/// Install the `ducklake` and `parquet` extensions once per process.
+///
+/// Pre-installing parquet avoids races when several tests trigger DuckDB's
+/// auto-install simultaneously (observed on macOS CI).
+pub fn ensure_ducklake_installed() {
+    ensure_extension_installed("ducklake");
+    ensure_extension_installed("parquet");
 }
 
 /// Creates a catalog with a simple table (no deletes)

--- a/tests/it/hybrid_asyncdb.rs
+++ b/tests/it/hybrid_asyncdb.rs
@@ -70,7 +70,7 @@ impl HybridDuckLakeDB {
 
         // Create DuckDB connection for WRITE operations
         let conn = Connection::open_in_memory()?;
-        conn.execute("INSTALL ducklake;", [])?;
+        crate::common::ensure_ducklake_installed();
         conn.execute("LOAD ducklake;", [])?;
 
         let ducklake_path = format!("ducklake:{}", catalog_path.display());

--- a/tests/it/numeric_metadata_validation_tests.rs
+++ b/tests/it/numeric_metadata_validation_tests.rs
@@ -15,7 +15,7 @@ use tempfile::TempDir;
 /// Creates a catalog with data, then corrupts file_size_bytes to a negative value
 fn create_catalog_with_negative_file_size(catalog_path: &std::path::Path) -> anyhow::Result<()> {
     let conn = duckdb::Connection::open_in_memory()?;
-    conn.execute("INSTALL ducklake;", [])?;
+    crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
 
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
@@ -43,7 +43,7 @@ fn create_catalog_with_negative_file_size(catalog_path: &std::path::Path) -> any
 /// Creates a catalog with data, then corrupts footer_size to a negative value
 fn create_catalog_with_negative_footer_size(catalog_path: &std::path::Path) -> anyhow::Result<()> {
     let conn = duckdb::Connection::open_in_memory()?;
-    conn.execute("INSTALL ducklake;", [])?;
+    crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
 
     let ducklake_path = format!("ducklake:{}", catalog_path.display());

--- a/tests/it/object_store_integration_test.rs
+++ b/tests/it/object_store_integration_test.rs
@@ -21,7 +21,7 @@ async fn create_local_test_catalog(catalog_path: &str) -> anyhow::Result<()> {
     let conn = duckdb::Connection::open_in_memory()?;
 
     // Install and load ducklake extension
-    conn.execute("INSTALL ducklake;", [])?;
+    crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
 
     // Create a test table with some data (local filesystem)
@@ -64,7 +64,7 @@ async fn create_s3_test_catalog(
     let conn = duckdb::Connection::open_in_memory()?;
 
     // Install and load ducklake extension
-    conn.execute("INSTALL ducklake;", [])?;
+    crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
 
     eprintln!("Configuring S3 secret for endpoint: {}", s3_endpoint);
@@ -97,7 +97,7 @@ async fn create_s3_test_catalog(
 
     // Load httpfs extension for S3 support
     eprintln!("Loading httpfs extension...");
-    conn.execute("INSTALL httpfs;", [])?;
+    crate::common::ensure_extension_installed("httpfs");
     conn.execute("LOAD httpfs;", [])?;
     eprintln!("httpfs loaded");
 

--- a/tests/it/partition_tests.rs
+++ b/tests/it/partition_tests.rs
@@ -19,9 +19,8 @@ use tempfile::TempDir;
 /// `(region × year)`, so DuckDB writes one data file per partition.
 fn create_partitioned_catalog(catalog_path: &std::path::Path) -> anyhow::Result<()> {
     let conn = duckdb::Connection::open_in_memory()?;
-    conn.execute("INSTALL ducklake;", [])?;
+    crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
-    conn.execute("INSTALL parquet;", [])?;
 
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
     conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;

--- a/tests/it/renamed_columns_tests.rs
+++ b/tests/it/renamed_columns_tests.rs
@@ -30,7 +30,7 @@ use tempfile::TempDir;
 fn create_catalog_with_renamed_column(catalog_path: &Path) -> Result<()> {
     let conn = duckdb::Connection::open_in_memory()?;
 
-    conn.execute("INSTALL ducklake;", [])?;
+    crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
 
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
@@ -67,7 +67,7 @@ fn create_catalog_with_renamed_column(catalog_path: &Path) -> Result<()> {
 fn create_catalog_with_multiple_renames(catalog_path: &Path) -> Result<()> {
     let conn = duckdb::Connection::open_in_memory()?;
 
-    conn.execute("INSTALL ducklake;", [])?;
+    crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
 
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
@@ -356,7 +356,7 @@ async fn test_schema_shows_renamed_columns() -> Result<()> {
 /// and applying it to every file reads the other file's renamed column as NULL.
 fn create_catalog_renamed_with_post_rename_file(catalog_path: &Path) -> Result<()> {
     let conn = duckdb::Connection::open_in_memory()?;
-    conn.execute("INSTALL ducklake;", [])?;
+    crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
     conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
@@ -462,7 +462,7 @@ async fn test_select_star_rename_multifile_reads_all_rows() -> Result<()> {
 /// and read the renamed column correctly.
 fn create_catalog_rename_then_delete(catalog_path: &Path) -> Result<()> {
     let conn = duckdb::Connection::open_in_memory()?;
-    conn.execute("INSTALL ducklake;", [])?;
+    crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
     conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
@@ -530,7 +530,7 @@ async fn test_rename_mixed_with_delete_reads_all_rows() -> Result<()> {
 /// NULL for old files (field_id absent) and values for new files.
 fn create_catalog_drop_readd(catalog_path: &Path) -> Result<()> {
     let conn = duckdb::Connection::open_in_memory()?;
-    conn.execute("INSTALL ducklake;", [])?;
+    crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
     conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
@@ -565,7 +565,7 @@ async fn test_drop_readd_column_reads_null_for_pre_drop_rows() -> Result<()> {
     // Pin the expectation to DuckDB's own answer so it stays honest.
     {
         let conn = duckdb::Connection::open_in_memory()?;
-        conn.execute("INSTALL ducklake;", [])?;
+        crate::common::ensure_ducklake_installed();
         conn.execute("LOAD ducklake;", [])?;
         let ducklake_path = format!("ducklake:{}", catalog_path.display());
         conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;

--- a/tests/it/row_count_tests.rs
+++ b/tests/it/row_count_tests.rs
@@ -45,7 +45,7 @@ fn resolve_table(provider: &DuckdbMetadataProvider, table: &str) -> DataFusionRe
 /// Upstream ground truth: `SELECT COUNT(*)` via DuckDB's own DuckLake reader.
 fn duckdb_count_star(catalog_path: &Path, table: &str) -> DataFusionResult<i64> {
     let conn = duckdb::Connection::open_in_memory().map_err(to_df)?;
-    conn.execute("INSTALL ducklake;", []).map_err(to_df)?;
+    crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", []).map_err(to_df)?;
     conn.execute(
         &format!("ATTACH 'ducklake:{}' AS c;", catalog_path.display()),

--- a/tests/it/row_id_tests.rs
+++ b/tests/it/row_id_tests.rs
@@ -23,8 +23,7 @@ use tempfile::TempDir;
 /// data files, each with its own `row_id_start`.
 fn create_catalog_rowid_two_files(catalog_path: &Path) -> Result<()> {
     let conn = duckdb::Connection::open_in_memory()?;
-    conn.execute("INSTALL ducklake;", [])?;
-    conn.execute("INSTALL parquet;", [])?;
+    crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
 
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
@@ -43,8 +42,7 @@ fn create_catalog_rowid_two_files(catalog_path: &Path) -> Result<()> {
 /// are correctly elided from the output.
 fn create_catalog_rowid_with_deletes(catalog_path: &Path) -> Result<()> {
     let conn = duckdb::Connection::open_in_memory()?;
-    conn.execute("INSTALL ducklake;", [])?;
-    conn.execute("INSTALL parquet;", [])?;
+    crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
 
     let ducklake_path = format!("ducklake:{}", catalog_path.display());
@@ -76,8 +74,7 @@ fn create_catalog_rowid_with_deletes(catalog_path: &Path) -> Result<()> {
 /// for the rewrite file would yield a fresh sequential range, not {0,2,5,7}.
 fn create_catalog_rowid_with_update(catalog_path: &Path) -> Result<()> {
     let conn = duckdb::Connection::open_in_memory()?;
-    conn.execute("INSTALL ducklake;", [])?;
-    conn.execute("INSTALL parquet;", [])?;
+    crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
 
     let ducklake_path = format!("ducklake:{}", catalog_path.display());

--- a/tests/it/rowid_physical_position_tests.rs
+++ b/tests/it/rowid_physical_position_tests.rs
@@ -32,8 +32,7 @@ const BIG: i64 = 600_000;
 
 fn open(catalog_path: &Path) -> anyhow::Result<duckdb::Connection> {
     let conn = duckdb::Connection::open_in_memory()?;
-    conn.execute("INSTALL ducklake;", [])?;
-    conn.execute("INSTALL parquet;", [])?;
+    crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
     conn.execute(
         &format!("ATTACH 'ducklake:{}' AS c;", catalog_path.display()),

--- a/tests/it/table_deletions_repartition_tests.rs
+++ b/tests/it/table_deletions_repartition_tests.rs
@@ -33,8 +33,7 @@ fn box_err<E: std::error::Error + Send + Sync + 'static>(e: E) -> DataFusionErro
 /// then delete `targets`.
 fn build_catalog(path: &Path, targets: &[i64]) -> DataFusionResult<()> {
     let conn = duckdb::Connection::open_in_memory().map_err(box_err)?;
-    conn.execute("INSTALL ducklake;", []).map_err(box_err)?;
-    conn.execute("INSTALL parquet;", []).map_err(box_err)?;
+    crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", []).map_err(box_err)?;
     conn.execute(&format!("ATTACH 'ducklake:{}' AS c;", path.display()), [])
         .map_err(box_err)?;

--- a/tests/it/table_tests.rs
+++ b/tests/it/table_tests.rs
@@ -21,7 +21,7 @@ use tempfile::TempDir;
 fn create_empty_table_catalog(catalog_path: &std::path::Path) -> anyhow::Result<()> {
     let conn = duckdb::Connection::open_in_memory()?;
 
-    conn.execute("INSTALL ducklake;", [])?;
+    crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
 
     // Create data directory (DuckLake only creates it on first INSERT)
@@ -169,7 +169,7 @@ async fn test_empty_table_aggregate() -> DataFusionResult<()> {
 /// the catalog's per-file sizes.
 fn create_populated_table_catalog(catalog_path: &std::path::Path) -> anyhow::Result<()> {
     let conn = duckdb::Connection::open_in_memory()?;
-    conn.execute("INSTALL ducklake;", [])?;
+    crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
 
     let data_dir = catalog_path.with_extension("ducklake.files");
@@ -430,7 +430,7 @@ async fn test_statistics_zero_for_empty_table() -> DataFusionResult<()> {
 /// written as two separate INSERTs so DuckLake emits one file per range.
 fn create_two_file_catalog(catalog_path: &std::path::Path) -> anyhow::Result<()> {
     let conn = duckdb::Connection::open_in_memory()?;
-    conn.execute("INSTALL ducklake;", [])?;
+    crate::common::ensure_ducklake_installed();
     conn.execute("LOAD ducklake;", [])?;
 
     let data_dir = catalog_path.with_extension("ducklake.files");
@@ -557,7 +557,7 @@ async fn test_scan_with_live_deletes_is_correct() -> DataFusionResult<()> {
                 .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
             Ok(())
         };
-        exec("INSTALL ducklake;")?;
+        crate::common::ensure_ducklake_installed();
         exec("LOAD ducklake;")?;
         std::fs::create_dir_all(catalog_path.with_extension("ducklake.files"))
             .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;


### PR DESCRIPTION
## Problem

The `Test (single-catalog backends + encryption, Docker)` job failed on `main` at `f79adff`
([run](https://github.com/datafusion-contrib/datafusion-ducklake/actions/runs/30802768069)) with:

```
---- cdc_differential_tests::diff_delete_then_reinsert stdout ----
IO Error: Could not remove file
".../.duckdb/extensions/v1.4.1/linux_amd64/parquet.duckdb_extension": No such file or directory
```

Not an assertion failure, and nothing to do with the change that was merged — the same job passed on
re-run. `338 passed; 1 failed`, and the one failure never reached a test assertion.

## Root cause

`INSTALL` writes into the shared `~/.duckdb/extensions/<version>/<platform>/` directory that every
connection in the test binary reads. Twelve modules each ran their own raw `INSTALL ducklake;` /
`INSTALL parquet;` — 33 sites in total. Since #228 collapsed the integration tests into a single `it`
binary, those run as parallel threads in **one process**, so two threads installing at the same time
race on the same files: one replaces or removes the file the other is partway through removing.

`tests/it/common/mod.rs` already guarded against exactly this with a `Once`, and its comment records
the same race being seen on macOS CI. But the helper was private, so every other module bypassed it.

It went 14 consecutive runs on `main` without firing. This one ran on a cold target cache — 406s
versus ~321s for the same job on the PR branch — which shifts compile timings and therefore when the
installs bunch up. `~/.duckdb` isn't cached in CI either, so every run installs fresh, which is when
the window is widest. It can recur on any cold-cache run, on `main` or any PR.

## Fix

Share the guard that already existed rather than adding a second mechanism:

- `ensure_extension_installed(name)` is now `pub` and holds a `Mutex<HashSet<String>>`, so it both
  dedupes and **serializes** — only one thread is ever writing the extension directory.
  `ensure_ducklake_installed()` is expressed in terms of it.
- All 33 raw `INSTALL` sites across the twelve modules call the helper: 24 `ducklake`, 8 redundant
  `INSTALL parquet;` dropped (the helper installs parquet), and one `httpfs`.
- `LOAD` stays per-connection — it is cheap, reads the already-installed file, and every connection
  needs its own.

Each extension is now downloaded once per test run rather than up to 24 times.

The rewrite was scripted with an assertion that every dropped `INSTALL parquet;` had a `ducklake`
install within the preceding four lines, so none silently lost its parquet install. That mattered for
`partition_tests.rs`, where the pair straddled a `LOAD`, and `table_tests.rs`, which installed through
a local `exec()` closure rather than `conn.execute`.

All twelve modules are already gated `#![cfg(feature = "metadata-duckdb")]`, the same as `common`, so
no feature combination changes. `src/` is untouched.

## Validation

- `cargo clippy --all-targets --all-features --no-deps -- -D warnings` — clean (CI's exact gate)
- `cargo test --features "duckdb-bundled metadata-duckdb metadata-sqlite write-sqlite" --test it` —
  307 passed, 0 failed

Note that a green CI run here does **not** prove the race is fixed — it fired once in 15 runs, so
passing is the expected outcome either way. The argument is structural: concurrent installs are now
impossible because they are serialized behind a mutex, so the mechanism is removed rather than made
less likely.

---
<sub>Investigated and prepared with Claude Code.</sub>
