### PR TITLE
feat(metadata): commit many tables in one snapshot

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,16 +133,16 @@ pub use delete_exec::DuckLakeDeleteExec;
 pub use insert_exec::DuckLakeInsertExec;
 #[cfg(feature = "write")]
 pub use metadata_writer::{
-    ColumnDef, ColumnStat, CommitIds, CompactionOutputFile, CompactionSourceFile, DataFileInfo,
-    DeleteFileEntry, DeleteFileInfo, MetadataWriter, SourceRetirement, WriteMode, WriteResult,
-    WriteSetupResult,
+    BatchCommit, BatchEntry, BatchOp, BatchTableCommit, ColumnDef, ColumnStat, CommitIds,
+    CompactionOutputFile, CompactionSourceFile, DataFileInfo, DeleteFileEntry, DeleteFileInfo,
+    MetadataWriter, SourceRetirement, WriteMode, WriteResult, WriteSetupResult,
 };
 #[cfg(feature = "write-duckdb")]
 pub use metadata_writer_duckdb::DuckdbMetadataWriter;
 #[cfg(feature = "write-mysql")]
 pub use metadata_writer_mysql::MySqlMetadataWriter;
 #[cfg(feature = "write-postgres")]
-pub use metadata_writer_postgres::PostgresMetadataWriter;
+pub use metadata_writer_postgres::{PostgresMetadataWriter, commit_batch_in_tx};
 #[cfg(feature = "write-sqlite")]
 pub use metadata_writer_sqlite::SqliteMetadataWriter;
 #[cfg(feature = "write-postgres")]

--- a/src/metadata_writer.rs
+++ b/src/metadata_writer.rs
@@ -50,7 +50,10 @@ use arrow::datatypes::DataType;
 ///
 /// Unlike `DuckLakeTableColumn` (used for reading), this struct doesn't have a `column_id`
 /// field since IDs are assigned by the catalog during write operations.
-#[derive(Debug, Clone)]
+///
+/// Equality is structural over all three fields — a multi-table commit uses it to
+/// require that every entry for the same table describes the same columns.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ColumnDef {
     /// Column name
     pub(crate) name: String,
@@ -574,6 +577,82 @@ pub struct WriteResult {
     pub files_written: usize,
     /// Total records written
     pub records_written: i64,
+}
+
+/// What a [`BatchEntry`] does to its table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BatchOp {
+    /// Add the entry's file to the table's current contents.
+    Append,
+    /// Supersede the table's contents with the entry's file, retiring the prior
+    /// generation. Conflict-checked against the entry's `base_snapshot`.
+    Replace,
+    /// Remove the table's contents. Carries no file — this is a metadata-only
+    /// retirement, not a zero-row data file.
+    Truncate,
+}
+
+/// One table-level operation in a multi-table commit.
+///
+/// Entries are grouped by `(schema_name, table_name)`, and within a table they are
+/// applied in list order. The first entry for a table may be any [`BatchOp`]; the
+/// rest must be [`BatchOp::Append`], since a `Replace`/`Truncate` arriving after an
+/// append in the same snapshot would retire rows the caller just asked to add.
+/// Every entry for the same table must describe the same columns.
+#[derive(Debug, Clone)]
+pub struct BatchEntry {
+    /// Schema the table lives in; created if absent.
+    pub schema_name: String,
+    /// Table to write; created if absent.
+    pub table_name: String,
+    /// Table id to use **if the table does not exist yet**. Ignored when it does.
+    pub table_id_hint: i64,
+    /// What this entry does to the table.
+    pub op: BatchOp,
+    /// The data file to register. Required for `Append`/`Replace`, and must be
+    /// absent for `Truncate`.
+    pub file: Option<DataFileInfo>,
+    /// The table's columns, in order.
+    pub columns: Vec<ColumnDef>,
+    /// Column ids adopted for `columns` (`column_ids[i]` pairs with `columns[i]`),
+    /// so a file carrying DuckLake field-ids resolves on read. A file with no
+    /// embedded field-ids resolves by name, so any consistent set works for it.
+    pub column_ids: Vec<i64>,
+    /// The catalog head this entry was planned against. A `Replace` whose table has
+    /// moved past it aborts the whole batch with
+    /// [`crate::DuckLakeError::Conflict`].
+    pub base_snapshot: i64,
+}
+
+/// Per-table result of a multi-table commit.
+#[derive(Debug, Clone)]
+pub struct BatchTableCommit {
+    /// Schema name as supplied on the entries.
+    pub schema_name: String,
+    /// Table name as supplied on the entries.
+    pub table_name: String,
+    /// Committed schema id (may differ from a begin-time reservation).
+    pub schema_id: i64,
+    /// Committed table id (may differ from `table_id_hint`).
+    pub table_id: i64,
+    /// Rows added by this table's entries. `0` for a `Truncate`, and for a
+    /// `Replace` this counts only the newly registered rows, not the retired ones.
+    pub record_count: i64,
+    /// Whether this table's schema changed in this commit (i.e. it contributed to
+    /// the `schema_version` bump).
+    pub schema_changed: bool,
+}
+
+/// The result of a multi-table commit: one snapshot covering every table.
+#[derive(Debug, Clone)]
+pub struct BatchCommit {
+    /// The single snapshot every table became visible at.
+    pub snapshot_id: i64,
+    /// The snapshot's `schema_version` — bumped once if any table's schema
+    /// changed, otherwise carried forward.
+    pub schema_version: i64,
+    /// One entry per distinct table, in first-appearance order.
+    pub tables: Vec<BatchTableCommit>,
 }
 
 /// The ids actually committed by `register_data_file` / `publish_snapshot`.

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -13,9 +13,9 @@ use crate::Result;
 use crate::error::{TypeChangeOperation, TypeChangeWriteMode};
 use crate::metadata_provider::block_on;
 use crate::metadata_writer::{
-    ColumnDef, ColumnStat, CommitIds, DataFileInfo, DeleteFileEntry, DeleteFileInfo,
-    MetadataWriter, WriteMode, WriteSetupResult, columns_differ, validate_delete_entries,
-    validate_name,
+    BatchCommit, BatchEntry, BatchOp, BatchTableCommit, ColumnDef, ColumnStat, CommitIds,
+    DataFileInfo, DeleteFileEntry, DeleteFileInfo, MetadataWriter, WriteMode, WriteSetupResult,
+    columns_differ, validate_delete_entries, validate_name,
 };
 use crate::partition::PartitionTransform;
 use sqlx::AssertSqlSafe;
@@ -331,6 +331,22 @@ pub struct PostgresMetadataWriter {
 }
 
 impl PostgresMetadataWriter {
+    /// Commit operations across several tables as one snapshot, in this writer's own
+    /// transaction.
+    ///
+    /// The self-contained form of [`commit_batch_in_tx`], which is where the
+    /// semantics are documented. Use that one instead when you have metadata of your
+    /// own to commit atomically alongside the DuckLake commit.
+    pub fn commit_batch(&self, entries: &[BatchEntry]) -> Result<BatchCommit> {
+        block_on(async {
+            let mut tx = self.pool.begin().await?;
+            let committed =
+                commit_batch_in_tx(&mut tx, self.catalog_id, self.lock_timeout_ms, entries).await?;
+            tx.commit().await?;
+            Ok(committed)
+        })
+    }
+
     /// Bind a writer to the given pool and catalog id.
     ///
     /// Use [`crate::multicatalog::MulticatalogManager::create_catalog`] to obtain
@@ -619,6 +635,335 @@ async fn retire_prior_generation(
     .execute(&mut **tx)
     .await?;
     Ok(())
+}
+
+/// End every live delete file of a table at `snapshot_id`.
+///
+/// Companion to [`retire_prior_generation`], which ends live *data* files (sparing
+/// the current commit's own, via `begin_snapshot < $1`) and zeroes the visible
+/// totals but deliberately leaves delete files alone — a `Replace` registers a new
+/// generation whose files have no deletes against them yet. Emptying a table has to
+/// end both, or a later reader's live-delete roll-up still counts deletions against
+/// files that no longer exist.
+///
+/// Carries the same `begin_snapshot < $1` guard so it cannot end a delete file
+/// written by the commit it is part of.
+async fn retire_live_delete_files(
+    table_id: i64,
+    snapshot_id: i64,
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+) -> Result<()> {
+    sqlx::query(
+        "UPDATE ducklake_delete_file SET end_snapshot = $1
+         WHERE table_id = $2 AND end_snapshot IS NULL AND begin_snapshot < $1",
+    )
+    .bind(snapshot_id)
+    .bind(table_id)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+/// Register a set of data files against one table inside an already-open commit.
+///
+/// Partition-fences every file against the table's live generation, inserts the
+/// `ducklake_data_file` rows with contiguous rowid ranges drawn from the table's
+/// monotonic counter, persists each file's zone maps and partition values, refreshes
+/// the table's column-stat roll-up, and accumulates the visible totals. Returns the
+/// number of records added.
+///
+/// Does not allocate a snapshot or advance the catalog head — the caller owns both,
+/// which is what lets several tables share one snapshot.
+async fn register_files_for_table(
+    table_id: i64,
+    snapshot_id: i64,
+    files: &[DataFileInfo],
+    columns: &[ColumnDef],
+    column_ids: &[i64],
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+) -> Result<i64> {
+    // Partition-spec fence (both directions, every file): each file must be
+    // consistent with the table's live partition generation at commit time.
+    // Runs inside the lock_catalog-serialized tx; rolls back on a Conflict.
+    // table_ids are global across the multicatalog store, so
+    // ducklake_partition_info scopes by table_id alone.
+    let live_partition_id: Option<i64> = sqlx::query_scalar(
+        "SELECT partition_id FROM ducklake_partition_info
+         WHERE table_id = $1 AND end_snapshot IS NULL",
+    )
+    .bind(table_id)
+    .fetch_optional(&mut **tx)
+    .await?;
+    for file in files {
+        crate::metadata_writer::enforce_partition_fence(table_id, live_partition_id, file)?;
+    }
+    sqlx::query(
+        "INSERT INTO ducklake_table_stats (table_id, record_count, next_row_id, file_size_bytes)
+         VALUES ($1, 0, 0, 0)
+         ON CONFLICT (table_id) DO NOTHING",
+    )
+    .bind(table_id)
+    .execute(&mut **tx)
+    .await?;
+    let mut next_row_id: i64 =
+        sqlx::query("SELECT next_row_id FROM ducklake_table_stats WHERE table_id = $1")
+            .bind(table_id)
+            .fetch_one(&mut **tx)
+            .await?
+            .try_get(0)?;
+    let mut total_records: i64 = 0;
+    let mut total_bytes: i64 = 0;
+    for file in files {
+        let inserted = sqlx::query(
+            "INSERT INTO ducklake_data_file
+                 (table_id, path, path_is_relative, file_size_bytes,
+                  footer_size, record_count, row_id_start, begin_snapshot)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING data_file_id",
+        )
+        .bind(table_id)
+        .bind(&file.path)
+        .bind(file.path_is_relative)
+        .bind(file.file_size_bytes)
+        .bind(file.footer_size)
+        .bind(file.record_count)
+        .bind(next_row_id)
+        .bind(snapshot_id)
+        .fetch_one(&mut **tx)
+        .await?;
+        let data_file_id: i64 = inserted.try_get(0)?;
+        insert_file_column_stats(tx, table_id, data_file_id, &file.column_stats).await?;
+        insert_partition_metadata(tx, table_id, data_file_id, file).await?;
+        next_row_id += file.record_count;
+        total_records += file.record_count;
+        total_bytes += file.file_size_bytes;
+    }
+    recompute_table_column_stats(tx, table_id, columns, column_ids).await?;
+    sqlx::query(
+        "UPDATE ducklake_table_stats
+         SET next_row_id     = next_row_id + $1,
+             record_count    = record_count + $2,
+             file_size_bytes = file_size_bytes + $3
+         WHERE table_id = $4",
+    )
+    .bind(total_records)
+    .bind(total_records)
+    .bind(total_bytes)
+    .bind(table_id)
+    .execute(&mut **tx)
+    .await?;
+    Ok(total_records)
+}
+
+/// Commit operations across **several tables as one snapshot**, inside a
+/// transaction the caller owns.
+///
+/// A DuckLake snapshot versions the whole catalog — it has no `table_id`, and
+/// `ducklake_snapshot_changes` records many tables against one snapshot — so one
+/// snapshot spanning N tables is the format's own model, and the single
+/// `advance_catalog_head` at the end is what makes every table become visible
+/// together or not at all.
+///
+/// # The transaction is yours
+///
+/// This takes `tx` and **does not commit it**, leaving it usable afterwards. That is
+/// the point: an application whose own metadata lives in the same database (a table
+/// registry, generation pointers, load bookkeeping) can commit that metadata in the
+/// same transaction as the DuckLake commit, so the two either both land or both roll
+/// back. Without it, such a caller is forced into a two-phase protocol with a crash
+/// window between the DuckLake commit and its own, plus the reconciliation machinery
+/// to recover from it. Use
+/// [`PostgresMetadataWriter::commit_batch`](PostgresMetadataWriter::commit_batch)
+/// instead if you have no transaction of your own.
+///
+/// # Entries
+///
+/// Entries are grouped by `(schema_name, table_name)` in first-appearance order and
+/// applied in list order within each table. The first entry for a table may be any
+/// [`BatchOp`]; the rest must be [`BatchOp::Append`]. So `replace, append, append` on
+/// one table retires the prior generation and then registers all three files — the
+/// retirement's `begin_snapshot < S` guard spares the batch's own files.
+///
+/// Aborts on the first entry that cannot be applied — a `Replace` whose table moved
+/// past its `base_snapshot`, or field-id drift on an `Append` — naming the entry.
+/// Since nothing is committed here, an abort leaves the caller's transaction to roll
+/// back with no partial batch.
+///
+/// # File ownership
+///
+/// Data files are registered by reference: they belong to the caller, and this never
+/// deletes one, including on the failure path. Cleaning up files whose commit did not
+/// land is the caller's job (see issue #215).
+///
+/// `lock_timeout_ms` bounds the wait for the catalog lock ([`DEFAULT_LOCK_TIMEOUT_MS`]
+/// is the usual value); `0` waits indefinitely.
+pub async fn commit_batch_in_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    catalog_id: i64,
+    lock_timeout_ms: u32,
+    entries: &[BatchEntry],
+) -> Result<BatchCommit> {
+    if entries.is_empty() {
+        return Err(crate::DuckLakeError::InvalidConfig(
+            "commit_batch: entries must be non-empty".to_string(),
+        ));
+    }
+
+    // Group by table, preserving first appearance so the caller's order drives both
+    // the per-table sequence and the reported result order.
+    let mut order: Vec<(String, String)> = Vec::new();
+    let mut groups: std::collections::HashMap<(String, String), Vec<usize>> =
+        std::collections::HashMap::new();
+    for (index, entry) in entries.iter().enumerate() {
+        let key = (entry.schema_name.clone(), entry.table_name.clone());
+        groups
+            .entry(key.clone())
+            .or_insert_with(|| {
+                order.push(key.clone());
+                Vec::new()
+            })
+            .push(index);
+    }
+
+    // Validate everything before writing anything, so a malformed batch costs no
+    // catalog work and reports the offending entry rather than "something failed".
+    for (index, entry) in entries.iter().enumerate() {
+        if entry.columns.is_empty() {
+            return Err(crate::DuckLakeError::InvalidConfig(format!(
+                "commit_batch entry {index} ({}.{}): columns must be non-empty",
+                entry.schema_name, entry.table_name
+            )));
+        }
+        if entry.column_ids.len() != entry.columns.len() {
+            return Err(crate::DuckLakeError::InvalidConfig(format!(
+                "commit_batch entry {index} ({}.{}): column_ids (len {}) must be 1:1 with \
+                 columns (len {})",
+                entry.schema_name,
+                entry.table_name,
+                entry.column_ids.len(),
+                entry.columns.len()
+            )));
+        }
+        match (entry.op, entry.file.is_some()) {
+            (BatchOp::Truncate, true) => {
+                return Err(crate::DuckLakeError::InvalidConfig(format!(
+                    "commit_batch entry {index} ({}.{}): Truncate must not carry a file — it is \
+                     a metadata-only retirement, not a zero-row data file",
+                    entry.schema_name, entry.table_name
+                )));
+            },
+            (BatchOp::Append | BatchOp::Replace, false) => {
+                return Err(crate::DuckLakeError::InvalidConfig(format!(
+                    "commit_batch entry {index} ({}.{}): {:?} requires a file",
+                    entry.schema_name, entry.table_name, entry.op
+                )));
+            },
+            _ => {},
+        }
+    }
+    for key in &order {
+        let indexes = &groups[key];
+        let first = &entries[indexes[0]];
+        for &index in &indexes[1..] {
+            let entry = &entries[index];
+            if entry.op != BatchOp::Append {
+                return Err(crate::DuckLakeError::InvalidConfig(format!(
+                    "commit_batch entry {index} ({}.{}): only the FIRST entry for a table may \
+                     be {:?}; later entries must be Append, since retiring inside the same \
+                     snapshot would discard rows this batch just added",
+                    entry.schema_name, entry.table_name, entry.op
+                )));
+            }
+            if entry.columns != first.columns || entry.column_ids != first.column_ids {
+                return Err(crate::DuckLakeError::InvalidConfig(format!(
+                    "commit_batch entry {index} ({}.{}): every entry for a table must describe \
+                     the same columns and column_ids as its first entry",
+                    entry.schema_name, entry.table_name
+                )));
+            }
+        }
+    }
+
+    // One lock, one snapshot, for the whole batch.
+    lock_catalog(catalog_id, lock_timeout_ms, tx).await?;
+    let snapshot_id = allocate_snapshot(tx).await?;
+
+    let mut ddl_table_ids: Vec<i64> = Vec::new();
+    let mut tables: Vec<BatchTableCommit> = Vec::with_capacity(order.len());
+
+    for key in &order {
+        let indexes = &groups[key];
+        let first = &entries[indexes[0]];
+
+        assert_table_not_in_other_catalog(catalog_id, first.table_id_hint, tx).await?;
+
+        // Truncate rides the Replace path: it wants the same conflict check against
+        // `base_snapshot` and the same data-file retirement + stat zeroing. It differs
+        // only in registering no file, and in also ending live delete files below.
+        let mode = match first.op {
+            BatchOp::Append => WriteMode::Append,
+            BatchOp::Replace | BatchOp::Truncate => WriteMode::Replace,
+        };
+        let (schema_id, table_id, is_ddl) = finalize_table_in_snapshot(
+            catalog_id,
+            snapshot_id,
+            &first.schema_name,
+            &first.table_name,
+            first.table_id_hint,
+            &first.columns,
+            &first.column_ids,
+            mode,
+            first.base_snapshot,
+            tx,
+        )
+        .await?;
+        if is_ddl {
+            ddl_table_ids.push(table_id);
+        }
+        if first.op == BatchOp::Truncate {
+            retire_live_delete_files(table_id, snapshot_id, tx).await?;
+        }
+
+        let files: Vec<DataFileInfo> = indexes
+            .iter()
+            .filter_map(|&index| entries[index].file.clone())
+            .collect();
+        let record_count = if files.is_empty() {
+            0
+        } else {
+            register_files_for_table(
+                table_id,
+                snapshot_id,
+                &files,
+                &first.columns,
+                &first.column_ids,
+                tx,
+            )
+            .await?
+        };
+
+        tables.push(BatchTableCommit {
+            schema_name: first.schema_name.clone(),
+            table_name: first.table_name.clone(),
+            schema_id,
+            table_id,
+            record_count,
+            schema_changed: is_ddl,
+        });
+    }
+
+    // Decided once over every table in the snapshot — see `apply_schema_version` for
+    // why a per-table decision is wrong here.
+    let schema_version = apply_schema_version(catalog_id, snapshot_id, &ddl_table_ids, tx).await?;
+
+    // advance_catalog_head MUST be the last write. The caller's commit is what makes
+    // it (and every table above) visible.
+    advance_catalog_head(catalog_id, snapshot_id, tx).await?;
+
+    Ok(BatchCommit {
+        snapshot_id,
+        schema_version,
+        tables,
+    })
 }
 
 /// Publish `snapshot_id` as the catalog head by mapping it to the catalog.
@@ -1693,76 +2038,8 @@ impl MetadataWriter for PostgresMetadataWriter {
                 Vec::new()
             };
             apply_schema_version(self.catalog_id, snapshot_id, &ddl_tables, &mut tx).await?;
-            // Partition-spec fence (both directions, every file): each file must be
-            // consistent with the table's live partition generation at commit time.
-            // Runs inside the lock_catalog-serialized tx; rolls back on a Conflict.
-            // table_ids are global across the multicatalog store, so
-            // ducklake_partition_info scopes by table_id alone.
-            let live_partition_id: Option<i64> = sqlx::query_scalar(
-                "SELECT partition_id FROM ducklake_partition_info
-                 WHERE table_id = $1 AND end_snapshot IS NULL",
-            )
-            .bind(table_id)
-            .fetch_optional(&mut *tx)
-            .await?;
-            for file in files {
-                crate::metadata_writer::enforce_partition_fence(table_id, live_partition_id, file)?;
-            }
-            sqlx::query(
-                "INSERT INTO ducklake_table_stats (table_id, record_count, next_row_id, file_size_bytes)
-                 VALUES ($1, 0, 0, 0)
-                 ON CONFLICT (table_id) DO NOTHING",
-            )
-            .bind(table_id)
-            .execute(&mut *tx)
-            .await?;
-            let mut next_row_id: i64 =
-                sqlx::query("SELECT next_row_id FROM ducklake_table_stats WHERE table_id = $1")
-                    .bind(table_id)
-                    .fetch_one(&mut *tx)
-                    .await?
-                    .try_get(0)?;
-            let mut total_records: i64 = 0;
-            let mut total_bytes: i64 = 0;
-            for file in files {
-                let inserted = sqlx::query(
-                    "INSERT INTO ducklake_data_file
-                         (table_id, path, path_is_relative, file_size_bytes,
-                          footer_size, record_count, row_id_start, begin_snapshot)
-                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING data_file_id",
-                )
-                .bind(table_id)
-                .bind(&file.path)
-                .bind(file.path_is_relative)
-                .bind(file.file_size_bytes)
-                .bind(file.footer_size)
-                .bind(file.record_count)
-                .bind(next_row_id)
-                .bind(snapshot_id)
-                .fetch_one(&mut *tx)
+            register_files_for_table(table_id, snapshot_id, files, columns, column_ids, &mut tx)
                 .await?;
-                let data_file_id: i64 = inserted.try_get(0)?;
-                insert_file_column_stats(&mut tx, table_id, data_file_id, &file.column_stats)
-                    .await?;
-                insert_partition_metadata(&mut tx, table_id, data_file_id, file).await?;
-                next_row_id += file.record_count;
-                total_records += file.record_count;
-                total_bytes += file.file_size_bytes;
-            }
-            recompute_table_column_stats(&mut tx, table_id, columns, column_ids).await?;
-            sqlx::query(
-                "UPDATE ducklake_table_stats
-                 SET next_row_id     = next_row_id + $1,
-                     record_count    = record_count + $2,
-                     file_size_bytes = file_size_bytes + $3
-                 WHERE table_id = $4",
-            )
-            .bind(total_records)
-            .bind(total_records)
-            .bind(total_bytes)
-            .bind(table_id)
-            .execute(&mut *tx)
-            .await?;
             // advance_catalog_head MUST be the last write before commit.
             advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
             tx.commit().await?;
@@ -3158,14 +3435,9 @@ impl MetadataWriter for PostgresMetadataWriter {
             .bind(table_id)
             .execute(&mut *tx)
             .await?;
-            sqlx::query(
-                "UPDATE ducklake_delete_file SET end_snapshot = $1
-                 WHERE table_id = $2 AND end_snapshot IS NULL",
-            )
-            .bind(snapshot_id)
-            .bind(table_id)
-            .execute(&mut *tx)
-            .await?;
+            // Shared with a batch `Truncate` entry. The guard inside is a no-op here
+            // (this snapshot was just allocated, so nothing can carry it yet).
+            retire_live_delete_files(table_id, snapshot_id, &mut tx).await?;
             sqlx::query(
                 "UPDATE ducklake_table_stats SET record_count = 0, file_size_bytes = 0
                  WHERE table_id = $1",

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -874,9 +874,91 @@ async fn recompute_table_column_stats(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
-async fn finalize_snapshot(
+/// Allocate a snapshot id in commit order (plain IDENTITY).
+///
+/// `schema_version` is inserted as a placeholder and patched by
+/// [`apply_schema_version`] once every table in the commit has been finalized and
+/// we know whether any of them changed its schema.
+async fn allocate_snapshot(tx: &mut sqlx::Transaction<'_, sqlx::Postgres>) -> Result<i64> {
+    let snapshot_id: i64 = sqlx::query(
+        "INSERT INTO ducklake_snapshot (snapshot_time, schema_version)
+         VALUES (NOW(), 0) RETURNING snapshot_id",
+    )
+    .fetch_one(&mut **tx)
+    .await?
+    .try_get(0)?;
+    Ok(snapshot_id)
+}
+
+/// Decide and write the snapshot's `schema_version`, and record one
+/// `ducklake_schema_versions` row per table whose schema changed in it.
+///
+/// `schema_version` is a per-catalog *dense* DDL counter: DDL bumps it, DML carries
+/// it forward (with a v1 floor for the first write to the catalog). The previous
+/// value is `MAX` over the catalog's *mapped* snapshots — no `< snapshot_id` window
+/// is needed because ids are commit-ordered and this commit's snapshot is not mapped
+/// until `advance_catalog_head`.
+///
+/// **This must be called exactly once per snapshot, after all of its tables are
+/// finalized.** A commit spanning several tables cannot decide per table: every
+/// table would read the same unmapped `prev_max`, so a DDL table would write
+/// `prev_max + 1` and a following DML table would write `prev_max` back — silently
+/// lowering the version it just raised. Deciding once over the union
+/// (`ddl_table_ids` non-empty ⇒ DDL) is what makes a multi-table commit correct, and
+/// it is exactly equivalent to the per-table decision when there is only one table.
+async fn apply_schema_version(
     catalog_id: i64,
+    snapshot_id: i64,
+    ddl_table_ids: &[i64],
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+) -> Result<i64> {
+    let prev_max: i64 = sqlx::query(
+        "SELECT COALESCE(MAX(s.schema_version), 0) FROM ducklake_snapshot s
+         JOIN ducklake_catalog_snapshot_map m ON m.snapshot_id = s.snapshot_id
+         WHERE m.catalog_id = $1",
+    )
+    .bind(catalog_id)
+    .fetch_one(&mut **tx)
+    .await?
+    .try_get(0)?;
+    let new_schema_version = if !ddl_table_ids.is_empty() {
+        prev_max + 1
+    } else {
+        prev_max.max(1)
+    };
+    sqlx::query("UPDATE ducklake_snapshot SET schema_version = $1 WHERE snapshot_id = $2")
+        .bind(new_schema_version)
+        .bind(snapshot_id)
+        .execute(&mut **tx)
+        .await?;
+    // One row per DDL table (UNIQUE(table_id, begin_snapshot)).
+    for table_id in ddl_table_ids {
+        sqlx::query(
+            "INSERT INTO ducklake_schema_versions (begin_snapshot, schema_version, table_id)
+             VALUES ($1, $2, $3)",
+        )
+        .bind(snapshot_id)
+        .bind(new_schema_version)
+        .bind(table_id)
+        .execute(&mut **tx)
+        .await?;
+    }
+    Ok(new_schema_version)
+}
+
+/// Write one table's metadata into an **already-allocated** snapshot: get-or-create
+/// its schema and table, run the `Replace` conflict check, and lay down the column
+/// generation surgically (stable `column_id`s == parquet field-ids).
+///
+/// Returns `(schema_id, table_id, is_ddl)`. The caller owns snapshot allocation
+/// ([`allocate_snapshot`]), the `schema_version` decision ([`apply_schema_version`],
+/// which needs `is_ddl` from every table first), registering data files, and
+/// `advance_catalog_head` — so several tables can share one snapshot by calling this
+/// once per table.
+#[allow(clippy::too_many_arguments)]
+async fn finalize_table_in_snapshot(
+    catalog_id: i64,
+    snapshot_id: i64,
     schema_name: &str,
     table_name: &str,
     table_id_hint: i64,
@@ -885,7 +967,7 @@ async fn finalize_snapshot(
     mode: WriteMode,
     base_snapshot: i64,
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
-) -> Result<(i64, i64, i64)> {
+) -> Result<(i64, i64, bool)> {
     // 1. Resolve the live schema id under the lock. Reuse it if present; else
     //    reserve a fresh id from the sequence (the row is inserted in step 4 once
     //    the snapshot id exists for begin_snapshot).
@@ -926,15 +1008,8 @@ async fn finalize_snapshot(
         }
     }
 
-    // 3. Allocate the snapshot id in commit order (plain IDENTITY). schema_version
-    //    is patched in below once we know it.
-    let snapshot_id: i64 = sqlx::query(
-        "INSERT INTO ducklake_snapshot (snapshot_time, schema_version)
-         VALUES (NOW(), 0) RETURNING snapshot_id",
-    )
-    .fetch_one(&mut **tx)
-    .await?
-    .try_get(0)?;
+    // 3. (Snapshot allocation is the caller's — see `allocate_snapshot`. It happens
+    //    before this call so several tables can share one snapshot.)
 
     // 4. Insert the schema row (with its reserved id) if it is new. The catalog id
     //    is encoded into the schema's *path* (not its name) so two catalogs holding
@@ -1032,31 +1107,11 @@ async fn finalize_snapshot(
     }
 
     let is_ddl = table_was_created || columns_differ(&existing_columns, columns);
-
-    // No `< S` window: ids are commit-ordered, so MAX over mapped predecessors is
-    // the immediately-preceding version. DDL bumps; DML carries forward (with a v1
-    // floor for the very first write to the catalog).
-    let prev_max: i64 = sqlx::query(
-        "SELECT COALESCE(MAX(s.schema_version), 0) FROM ducklake_snapshot s
-         JOIN ducklake_catalog_snapshot_map m ON m.snapshot_id = s.snapshot_id
-         WHERE m.catalog_id = $1",
-    )
-    .bind(catalog_id)
-    .fetch_one(&mut **tx)
-    .await?
-    .try_get(0)?;
-    let new_schema_version = if is_ddl {
-        prev_max + 1
-    } else if prev_max == 0 {
-        1
-    } else {
-        prev_max
-    };
-    sqlx::query("UPDATE ducklake_snapshot SET schema_version = $1 WHERE snapshot_id = $2")
-        .bind(new_schema_version)
-        .bind(snapshot_id)
-        .execute(&mut **tx)
-        .await?;
+    // The `schema_version` decision (and its `ducklake_schema_versions` row) is the
+    // caller's, via `apply_schema_version`: it needs `is_ddl` from EVERY table in the
+    // snapshot before it can pick a value. Nothing between here and the end of this
+    // function reads `ducklake_snapshot.schema_version`, so deferring the write is
+    // invisible within the transaction.
 
     // 7. Write the column generation SURGICALLY (mode-independent, matching the
     //    SQLite writer) so each kept column keeps a STABLE column_id (== parquet
@@ -1137,18 +1192,8 @@ async fn finalize_snapshot(
         }
     }
 
-    // 8. One ducklake_schema_versions row per DDL (UNIQUE(table_id, begin_snapshot)).
-    if is_ddl {
-        sqlx::query(
-            "INSERT INTO ducklake_schema_versions (begin_snapshot, schema_version, table_id)
-             VALUES ($1, $2, $3)",
-        )
-        .bind(snapshot_id)
-        .bind(new_schema_version)
-        .bind(table_id)
-        .execute(&mut **tx)
-        .await?;
-    }
+    // 8. (The ducklake_schema_versions row is written by `apply_schema_version`,
+    //    which the caller runs once for the whole snapshot — see step 6.)
 
     // 9. Replace retirement: end the prior generation's files + zero the visible
     //    totals. The `begin_snapshot < S` guard spares this write's own files.
@@ -1164,7 +1209,7 @@ async fn finalize_snapshot(
         retire_prior_generation(table_id, snapshot_id, tx).await?;
     }
 
-    Ok((snapshot_id, schema_id, table_id))
+    Ok((schema_id, table_id, is_ddl))
 }
 
 impl MetadataWriter for PostgresMetadataWriter {
@@ -1501,8 +1546,10 @@ impl MetadataWriter for PostgresMetadataWriter {
             lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
             assert_table_not_in_other_catalog(self.catalog_id, table_id, &mut tx).await?;
 
-            let (snapshot_id, schema_id, table_id) = finalize_snapshot(
+            let snapshot_id = allocate_snapshot(&mut tx).await?;
+            let (schema_id, table_id, is_ddl) = finalize_table_in_snapshot(
                 self.catalog_id,
+                snapshot_id,
                 schema_name,
                 table_name,
                 table_id,
@@ -1513,6 +1560,12 @@ impl MetadataWriter for PostgresMetadataWriter {
                 &mut tx,
             )
             .await?;
+            let ddl_tables = if is_ddl {
+                vec![table_id]
+            } else {
+                Vec::new()
+            };
+            apply_schema_version(self.catalog_id, snapshot_id, &ddl_tables, &mut tx).await?;
 
             // Partition-spec fence: this file must be consistent with the table's live
             // partition generation at commit time (both directions — see
@@ -1620,8 +1673,10 @@ impl MetadataWriter for PostgresMetadataWriter {
             let mut tx = self.pool.begin().await?;
             lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
             assert_table_not_in_other_catalog(self.catalog_id, table_id, &mut tx).await?;
-            let (snapshot_id, schema_id, table_id) = finalize_snapshot(
+            let snapshot_id = allocate_snapshot(&mut tx).await?;
+            let (schema_id, table_id, is_ddl) = finalize_table_in_snapshot(
                 self.catalog_id,
+                snapshot_id,
                 schema_name,
                 table_name,
                 table_id,
@@ -1632,6 +1687,12 @@ impl MetadataWriter for PostgresMetadataWriter {
                 &mut tx,
             )
             .await?;
+            let ddl_tables = if is_ddl {
+                vec![table_id]
+            } else {
+                Vec::new()
+            };
+            apply_schema_version(self.catalog_id, snapshot_id, &ddl_tables, &mut tx).await?;
             // Partition-spec fence (both directions, every file): each file must be
             // consistent with the table's live partition generation at commit time.
             // Runs inside the lock_catalog-serialized tx; rolls back on a Conflict.
@@ -2136,8 +2197,10 @@ impl MetadataWriter for PostgresMetadataWriter {
 
             // finalize inserts the columns with the adopted `column_ids`
             // (OVERRIDING SYSTEM VALUE), so the file's field-ids match.
-            let (snapshot_id, schema_id, table_id) = finalize_snapshot(
+            let snapshot_id = allocate_snapshot(&mut tx).await?;
+            let (schema_id, table_id, is_ddl) = finalize_table_in_snapshot(
                 self.catalog_id,
+                snapshot_id,
                 schema_name,
                 table_name,
                 table_id_hint,
@@ -2148,6 +2211,12 @@ impl MetadataWriter for PostgresMetadataWriter {
                 &mut tx,
             )
             .await?;
+            let ddl_tables = if is_ddl {
+                vec![table_id]
+            } else {
+                Vec::new()
+            };
+            apply_schema_version(self.catalog_id, snapshot_id, &ddl_tables, &mut tx).await?;
 
             // rowids get a fresh range from the table counter — the source range
             // isn't preserved (index copy, which would need it, is out of scope).
@@ -2446,8 +2515,10 @@ impl MetadataWriter for PostgresMetadataWriter {
             lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
             assert_table_not_in_other_catalog(self.catalog_id, table_id, &mut tx).await?;
 
-            let (snapshot_id, schema_id, table_id) = finalize_snapshot(
+            let snapshot_id = allocate_snapshot(&mut tx).await?;
+            let (schema_id, table_id, is_ddl) = finalize_table_in_snapshot(
                 self.catalog_id,
+                snapshot_id,
                 schema_name,
                 table_name,
                 table_id,
@@ -2458,6 +2529,12 @@ impl MetadataWriter for PostgresMetadataWriter {
                 &mut tx,
             )
             .await?;
+            let ddl_tables = if is_ddl {
+                vec![table_id]
+            } else {
+                Vec::new()
+            };
+            apply_schema_version(self.catalog_id, snapshot_id, &ddl_tables, &mut tx).await?;
 
             // Partition-spec fence: the new row versions are a NEW write, so they
             // must agree with the table's live partition generation exactly as
@@ -3254,8 +3331,10 @@ impl MetadataWriter for PostgresMetadataWriter {
             lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
             assert_table_not_in_other_catalog(self.catalog_id, table_id, &mut tx).await?;
 
-            let (snapshot_id, schema_id, table_id) = finalize_snapshot(
+            let snapshot_id = allocate_snapshot(&mut tx).await?;
+            let (schema_id, table_id, is_ddl) = finalize_table_in_snapshot(
                 self.catalog_id,
+                snapshot_id,
                 schema_name,
                 table_name,
                 table_id,
@@ -3266,6 +3345,12 @@ impl MetadataWriter for PostgresMetadataWriter {
                 &mut tx,
             )
             .await?;
+            let ddl_tables = if is_ddl {
+                vec![table_id]
+            } else {
+                Vec::new()
+            };
+            apply_schema_version(self.catalog_id, snapshot_id, &ddl_tables, &mut tx).await?;
 
             advance_catalog_head(self.catalog_id, snapshot_id, &mut tx).await?;
 

--- a/tests/it/batch_commit_postgres_tests.rs
+++ b/tests/it/batch_commit_postgres_tests.rs
@@ -1,0 +1,748 @@
+#![cfg(feature = "write-postgres")]
+//! Multi-table commits: `commit_batch_in_tx` / `PostgresMetadataWriter::commit_batch`.
+//!
+//! Covers:
+//! - N tables becoming visible at ONE snapshot, with one catalog-head advance
+//! - per-table entry sequencing (`Replace` then `Append`s share the snapshot)
+//! - `schema_version` decided once for the batch — the regression a naive
+//!   per-table loop introduces
+//! - `Truncate` as a metadata-only empty (no dummy data file)
+//! - a conflicting entry aborting the whole batch
+//! - the caller keeping ownership of the transaction (the embedder property)
+//! - request validation
+
+use datafusion_ducklake::metadata_writer::{
+    BatchEntry, BatchOp, ColumnDef, DataFileInfo, MetadataWriter, WriteMode,
+};
+use datafusion_ducklake::{
+    MulticatalogManager, PostgresMetadataWriter, commit_batch_in_tx, initialize_multicatalog_schema,
+};
+use sqlx::Row;
+use sqlx::postgres::{PgPool, PgPoolOptions};
+use testcontainers::ContainerAsync;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+async fn spin_up_postgres() -> anyhow::Result<(PgPool, ContainerAsync<Postgres>)> {
+    let container = Postgres::default().start().await?;
+    let port = container.get_host_port_ipv4(5432).await?;
+    let conn_str = format!("postgresql://postgres:postgres@127.0.0.1:{}/postgres", port);
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&conn_str)
+        .await?;
+    initialize_multicatalog_schema(&pool).await?;
+    Ok((pool, container))
+}
+
+fn cols() -> Vec<ColumnDef> {
+    vec![
+        ColumnDef::new("id", "int64", false).unwrap(),
+        ColumnDef::new("name", "varchar", true).unwrap(),
+    ]
+}
+
+/// Columns with one extra field, so a table written with `cols()` and then with
+/// these registers as a schema change.
+fn cols_widened() -> Vec<ColumnDef> {
+    let mut c = cols();
+    c.push(ColumnDef::new("email", "varchar", true).unwrap());
+    c
+}
+
+async fn writer_for(pool: &PgPool, catalog: &str) -> (PostgresMetadataWriter, i64) {
+    let mgr = MulticatalogManager::new(pool.clone());
+    let catalog_id = mgr.create_catalog(catalog).await.unwrap();
+    let writer = PostgresMetadataWriter::with_pool(pool.clone(), catalog_id)
+        .await
+        .unwrap();
+    writer.set_data_path("/data").unwrap();
+    (writer, catalog_id)
+}
+
+/// Plan one entry the way a caller would: reserve ids against the live catalog,
+/// then describe the file to register.
+fn entry(
+    writer: &PostgresMetadataWriter,
+    table: &str,
+    op: BatchOp,
+    columns: Vec<ColumnDef>,
+    file: Option<DataFileInfo>,
+) -> BatchEntry {
+    let mode = match op {
+        BatchOp::Append => WriteMode::Append,
+        BatchOp::Replace | BatchOp::Truncate => WriteMode::Replace,
+    };
+    let setup = writer
+        .begin_write_transaction("public", table, &columns, mode)
+        .unwrap();
+    BatchEntry {
+        schema_name: "public".to_string(),
+        table_name: table.to_string(),
+        table_id_hint: setup.table_id,
+        op,
+        file,
+        columns,
+        column_ids: setup.column_ids,
+        base_snapshot: setup.base_snapshot_id,
+    }
+}
+
+fn file(path: &str, records: i64) -> Option<DataFileInfo> {
+    Some(DataFileInfo::new(path, 1024, records))
+}
+
+async fn head(pool: &PgPool, catalog_id: i64) -> i64 {
+    sqlx::query(
+        "SELECT COALESCE(MAX(snapshot_id), 0) FROM ducklake_catalog_snapshot_map
+         WHERE catalog_id = $1",
+    )
+    .bind(catalog_id)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap()
+}
+
+async fn schema_version_of(pool: &PgPool, snapshot_id: i64) -> i64 {
+    sqlx::query("SELECT schema_version FROM ducklake_snapshot WHERE snapshot_id = $1")
+        .bind(snapshot_id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+        .try_get(0)
+        .unwrap()
+}
+
+/// Live data files of a table, as `(path, begin_snapshot)`.
+async fn live_files(pool: &PgPool, table_id: i64) -> Vec<(String, i64)> {
+    sqlx::query(
+        "SELECT path, begin_snapshot FROM ducklake_data_file
+         WHERE table_id = $1 AND end_snapshot IS NULL ORDER BY data_file_id",
+    )
+    .bind(table_id)
+    .fetch_all(pool)
+    .await
+    .unwrap()
+    .into_iter()
+    .map(|r| (r.try_get(0).unwrap(), r.try_get(1).unwrap()))
+    .collect()
+}
+
+async fn table_record_count(pool: &PgPool, table_id: i64) -> i64 {
+    sqlx::query("SELECT record_count FROM ducklake_table_stats WHERE table_id = $1")
+        .bind(table_id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+        .try_get(0)
+        .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn batch_commits_many_tables_at_one_snapshot() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let (writer, catalog_id) = writer_for(&pool, "prod").await;
+    let before = head(&pool, catalog_id).await;
+
+    let entries = vec![
+        entry(
+            &writer,
+            "orders",
+            BatchOp::Replace,
+            cols(),
+            file("orders/f1.parquet", 10),
+        ),
+        entry(
+            &writer,
+            "customers",
+            BatchOp::Replace,
+            cols(),
+            file("customers/f1.parquet", 20),
+        ),
+        entry(
+            &writer,
+            "events",
+            BatchOp::Replace,
+            cols(),
+            file("events/f1.parquet", 30),
+        ),
+    ];
+    let committed = writer.commit_batch(&entries).unwrap();
+
+    assert_eq!(committed.tables.len(), 3);
+    // One snapshot for the whole batch, and it is the new head — a single advance.
+    assert_eq!(head(&pool, catalog_id).await, committed.snapshot_id);
+    assert!(committed.snapshot_id > before);
+    let mapped: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_catalog_snapshot_map
+         WHERE catalog_id = $1 AND snapshot_id > $2",
+    )
+    .bind(catalog_id)
+    .bind(before)
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap();
+    assert_eq!(mapped, 1, "a batch maps exactly one new snapshot");
+
+    // Every table's file carries the shared snapshot as its begin.
+    for table in &committed.tables {
+        let files = live_files(&pool, table.table_id).await;
+        assert_eq!(
+            files.len(),
+            1,
+            "{} should have one live file",
+            table.table_name
+        );
+        assert_eq!(
+            files[0].1, committed.snapshot_id,
+            "{} should begin at the batch snapshot",
+            table.table_name
+        );
+    }
+    let counts: Vec<i64> = committed.tables.iter().map(|t| t.record_count).collect();
+    assert_eq!(
+        counts,
+        vec![10, 20, 30],
+        "reported in first-appearance order"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn batch_replace_then_appends_share_the_snapshot() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let (writer, catalog_id) = writer_for(&pool, "prod").await;
+
+    // Seed a generation to be superseded.
+    let seed = vec![entry(
+        &writer,
+        "orders",
+        BatchOp::Replace,
+        cols(),
+        file("orders/old.parquet", 5),
+    )];
+    let seeded = writer.commit_batch(&seed).unwrap();
+    let table_id = seeded.tables[0].table_id;
+
+    // replace, append, append — all in one batch, one snapshot.
+    let setup = writer
+        .begin_write_transaction("public", "orders", &cols(), WriteMode::Replace)
+        .unwrap();
+    let mk = |op: BatchOp, path: &str, records: i64| BatchEntry {
+        schema_name: "public".to_string(),
+        table_name: "orders".to_string(),
+        table_id_hint: setup.table_id,
+        op,
+        file: file(path, records),
+        columns: cols(),
+        column_ids: setup.column_ids.clone(),
+        base_snapshot: setup.base_snapshot_id,
+    };
+    let committed = writer
+        .commit_batch(&[
+            mk(BatchOp::Replace, "orders/f1.parquet", 1),
+            mk(BatchOp::Append, "orders/f2.parquet", 2),
+            mk(BatchOp::Append, "orders/f3.parquet", 3),
+        ])
+        .unwrap();
+
+    assert_eq!(
+        committed.tables.len(),
+        1,
+        "three entries on one table report as one table"
+    );
+    assert_eq!(committed.tables[0].record_count, 6);
+
+    // The prior generation is retired; the batch's own three files survive — the
+    // `begin_snapshot < S` guard must not eat them.
+    let files = live_files(&pool, table_id).await;
+    let paths: Vec<&str> = files.iter().map(|(p, _)| p.as_str()).collect();
+    assert_eq!(
+        paths,
+        vec!["orders/f1.parquet", "orders/f2.parquet", "orders/f3.parquet"]
+    );
+    assert!(
+        files
+            .iter()
+            .all(|(_, begin)| *begin == committed.snapshot_id)
+    );
+    let retired: i64 = sqlx::query(
+        "SELECT end_snapshot FROM ducklake_data_file
+         WHERE table_id = $1 AND path = 'orders/old.parquet'",
+    )
+    .bind(table_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap();
+    assert_eq!(retired, committed.snapshot_id);
+    assert_eq!(table_record_count(&pool, table_id).await, 6);
+    assert_eq!(head(&pool, catalog_id).await, committed.snapshot_id);
+}
+
+/// The regression a per-table `schema_version` decision introduces.
+///
+/// Within one unmapped snapshot every table reads the same `MAX`-over-mapped
+/// predecessor, so a DDL table writes `prev + 1` and a DML table ordered after it
+/// writes `prev` straight back — losing the bump. The version has to be decided once
+/// over the union of tables.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn batch_bumps_schema_version_once_with_ddl_before_dml() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let (writer, catalog_id) = writer_for(&pool, "prod").await;
+
+    // Seed `existing` so a same-columns write against it is pure DML.
+    let seeded = writer
+        .commit_batch(&[entry(
+            &writer,
+            "existing",
+            BatchOp::Replace,
+            cols(),
+            file("existing/f0.parquet", 1),
+        )])
+        .unwrap();
+    let baseline = schema_version_of(&pool, seeded.snapshot_id).await;
+
+    // DDL first (brand-new table), DML second (same columns as seeded). Ordering the
+    // DML last is what exposes a per-table decision.
+    let committed = writer
+        .commit_batch(&[
+            entry(
+                &writer,
+                "fresh",
+                BatchOp::Replace,
+                cols(),
+                file("fresh/f1.parquet", 1),
+            ),
+            entry(
+                &writer,
+                "existing",
+                BatchOp::Append,
+                cols(),
+                file("existing/f1.parquet", 1),
+            ),
+        ])
+        .unwrap();
+
+    assert_eq!(
+        committed.schema_version,
+        baseline + 1,
+        "a batch containing any DDL bumps exactly once, and a later DML entry must \
+         not lower it back"
+    );
+    assert_eq!(
+        schema_version_of(&pool, committed.snapshot_id).await,
+        baseline + 1,
+        "the persisted snapshot must agree with the reported version"
+    );
+
+    // Dense: one row for the table that changed, none for the one that didn't.
+    let ddl_rows: Vec<(i64, i64)> = sqlx::query(
+        "SELECT table_id, schema_version FROM ducklake_schema_versions
+         WHERE begin_snapshot = $1",
+    )
+    .bind(committed.snapshot_id)
+    .fetch_all(&pool)
+    .await
+    .unwrap()
+    .into_iter()
+    .map(|r| (r.try_get(0).unwrap(), r.try_get(1).unwrap()))
+    .collect();
+    let fresh = committed
+        .tables
+        .iter()
+        .find(|t| t.table_name == "fresh")
+        .unwrap();
+    assert_eq!(ddl_rows, vec![(fresh.table_id, baseline + 1)]);
+    assert!(fresh.schema_changed);
+    assert!(
+        !committed
+            .tables
+            .iter()
+            .find(|t| t.table_name == "existing")
+            .unwrap()
+            .schema_changed
+    );
+    assert_eq!(head(&pool, catalog_id).await, committed.snapshot_id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn batch_carries_schema_version_forward_when_no_table_changed() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let (writer, _catalog_id) = writer_for(&pool, "prod").await;
+
+    let seeded = writer
+        .commit_batch(&[entry(
+            &writer,
+            "orders",
+            BatchOp::Replace,
+            cols(),
+            file("orders/f0.parquet", 1),
+        )])
+        .unwrap();
+    let baseline = schema_version_of(&pool, seeded.snapshot_id).await;
+
+    let committed = writer
+        .commit_batch(&[entry(
+            &writer,
+            "orders",
+            BatchOp::Append,
+            cols(),
+            file("orders/f1.parquet", 1),
+        )])
+        .unwrap();
+    assert_eq!(
+        committed.schema_version, baseline,
+        "a DML-only batch carries the version forward"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn batch_bumps_once_for_several_changed_tables() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let (writer, _catalog_id) = writer_for(&pool, "prod").await;
+
+    // Two brand-new tables in one batch: both DDL, but one version for the snapshot.
+    let committed = writer
+        .commit_batch(&[
+            entry(
+                &writer,
+                "a",
+                BatchOp::Replace,
+                cols(),
+                file("a/f1.parquet", 1),
+            ),
+            entry(
+                &writer,
+                "b",
+                BatchOp::Replace,
+                cols(),
+                file("b/f1.parquet", 1),
+            ),
+        ])
+        .unwrap();
+    assert_eq!(committed.schema_version, 1);
+    let rows: i64 =
+        sqlx::query("SELECT COUNT(*) FROM ducklake_schema_versions WHERE begin_snapshot = $1")
+            .bind(committed.snapshot_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .try_get(0)
+            .unwrap();
+    assert_eq!(rows, 2, "one row per changed table, sharing the version");
+
+    // A widening batch bumps once more, not once per table.
+    let next = writer
+        .commit_batch(&[
+            entry(
+                &writer,
+                "a",
+                BatchOp::Replace,
+                cols_widened(),
+                file("a/f2.parquet", 1),
+            ),
+            entry(
+                &writer,
+                "b",
+                BatchOp::Replace,
+                cols_widened(),
+                file("b/f2.parquet", 1),
+            ),
+        ])
+        .unwrap();
+    assert_eq!(next.schema_version, 2, "dense: exactly one bump");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn batch_truncate_empties_a_table_without_a_data_file() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let (writer, catalog_id) = writer_for(&pool, "prod").await;
+
+    let seeded = writer
+        .commit_batch(&[entry(
+            &writer,
+            "stale",
+            BatchOp::Replace,
+            cols(),
+            file("stale/f0.parquet", 7),
+        )])
+        .unwrap();
+    let table_id = seeded.tables[0].table_id;
+    assert_eq!(live_files(&pool, table_id).await.len(), 1);
+
+    // Truncate alongside a normal load, so the batch has a reason to exist.
+    let committed = writer
+        .commit_batch(&[
+            entry(&writer, "stale", BatchOp::Truncate, cols(), None),
+            entry(
+                &writer,
+                "fresh",
+                BatchOp::Replace,
+                cols(),
+                file("fresh/f1.parquet", 3),
+            ),
+        ])
+        .unwrap();
+
+    assert!(
+        live_files(&pool, table_id).await.is_empty(),
+        "truncate retires every live file"
+    );
+    assert_eq!(table_record_count(&pool, table_id).await, 0);
+    // No dummy zero-row file was registered for the truncated table.
+    let files_at_snapshot: i64 = sqlx::query(
+        "SELECT COUNT(*) FROM ducklake_data_file WHERE table_id = $1 AND begin_snapshot = $2",
+    )
+    .bind(table_id)
+    .bind(committed.snapshot_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .try_get(0)
+    .unwrap();
+    assert_eq!(files_at_snapshot, 0);
+    assert_eq!(
+        committed
+            .tables
+            .iter()
+            .find(|t| t.table_name == "stale")
+            .unwrap()
+            .record_count,
+        0
+    );
+    // The table loaded alongside it is unaffected.
+    let fresh = committed
+        .tables
+        .iter()
+        .find(|t| t.table_name == "fresh")
+        .unwrap();
+    assert_eq!(live_files(&pool, fresh.table_id).await.len(), 1);
+    assert_eq!(head(&pool, catalog_id).await, committed.snapshot_id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn batch_aborts_entirely_when_one_entry_conflicts() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let (writer, catalog_id) = writer_for(&pool, "prod").await;
+
+    let seeded = writer
+        .commit_batch(&[entry(
+            &writer,
+            "orders",
+            BatchOp::Replace,
+            cols(),
+            file("orders/f0.parquet", 4),
+        )])
+        .unwrap();
+    let orders_id = seeded.tables[0].table_id;
+
+    // Plan a Replace against a stale base, then move the table on so the base is
+    // genuinely behind.
+    let mut stale = entry(
+        &writer,
+        "orders",
+        BatchOp::Replace,
+        cols(),
+        file("orders/f_stale.parquet", 1),
+    );
+    stale.base_snapshot = seeded.snapshot_id - 1;
+
+    let head_before = head(&pool, catalog_id).await;
+    let err = writer
+        .commit_batch(&[
+            entry(
+                &writer,
+                "customers",
+                BatchOp::Replace,
+                cols(),
+                file("customers/f1.parquet", 9),
+            ),
+            stale,
+        ])
+        .expect_err("a conflicting entry must abort the batch");
+    assert!(
+        matches!(err, datafusion_ducklake::DuckLakeError::Conflict(_)),
+        "expected Conflict, got {err:?}"
+    );
+
+    // Nothing from the batch survived — not even the entry that preceded the
+    // conflicting one.
+    assert_eq!(head(&pool, catalog_id).await, head_before);
+    let files = live_files(&pool, orders_id).await;
+    assert_eq!(
+        files.iter().map(|(p, _)| p.as_str()).collect::<Vec<_>>(),
+        vec!["orders/f0.parquet"],
+        "the seeded generation is untouched"
+    );
+    let customers_exists: Option<i64> = sqlx::query_scalar(
+        "SELECT t.table_id FROM ducklake_table t WHERE t.table_name = 'customers'",
+    )
+    .fetch_optional(&pool)
+    .await
+    .unwrap();
+    assert!(
+        customers_exists.is_none(),
+        "the first entry's table must not exist after the abort"
+    );
+}
+
+/// The embedder property: the caller's transaction is still theirs afterwards, so
+/// their own metadata commits atomically with the DuckLake commit.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn caller_metadata_commits_with_the_batch() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let (writer, catalog_id) = writer_for(&pool, "prod").await;
+    sqlx::query("CREATE TABLE app_loads (commit_id TEXT PRIMARY KEY, snapshot_id BIGINT NOT NULL)")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let entries = vec![entry(
+        &writer,
+        "orders",
+        BatchOp::Replace,
+        cols(),
+        file("orders/f1.parquet", 12),
+    )];
+
+    let mut tx = pool.begin().await.unwrap();
+    let committed = commit_batch_in_tx(&mut tx, catalog_id, 30_000, &entries)
+        .await
+        .unwrap();
+    // The caller writes its own bookkeeping in the SAME transaction.
+    sqlx::query("INSERT INTO app_loads (commit_id, snapshot_id) VALUES ($1, $2)")
+        .bind("load-1")
+        .bind(committed.snapshot_id)
+        .execute(&mut *tx)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    assert_eq!(head(&pool, catalog_id).await, committed.snapshot_id);
+    let recorded: i64 = sqlx::query("SELECT snapshot_id FROM app_loads WHERE commit_id = 'load-1'")
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .try_get(0)
+        .unwrap();
+    assert_eq!(recorded, committed.snapshot_id);
+}
+
+/// The other half of the same property: rolling back takes the DuckLake commit with
+/// it, so there is no committed-but-unrecorded snapshot to reconcile.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn rolling_back_the_caller_transaction_discards_the_batch() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let (writer, catalog_id) = writer_for(&pool, "prod").await;
+    let head_before = head(&pool, catalog_id).await;
+
+    let entries = vec![entry(
+        &writer,
+        "orders",
+        BatchOp::Replace,
+        cols(),
+        file("orders/f1.parquet", 12),
+    )];
+
+    let mut tx = pool.begin().await.unwrap();
+    let committed = commit_batch_in_tx(&mut tx, catalog_id, 30_000, &entries)
+        .await
+        .unwrap();
+    tx.rollback().await.unwrap();
+
+    assert_eq!(
+        head(&pool, catalog_id).await,
+        head_before,
+        "the head must not have advanced"
+    );
+    let snapshot_exists: Option<i64> =
+        sqlx::query_scalar("SELECT snapshot_id FROM ducklake_snapshot WHERE snapshot_id = $1")
+            .bind(committed.snapshot_id)
+            .fetch_optional(&pool)
+            .await
+            .unwrap();
+    assert!(snapshot_exists.is_none(), "the snapshot row is gone");
+    let table_exists: Option<i64> =
+        sqlx::query_scalar("SELECT table_id FROM ducklake_table WHERE table_name = 'orders'")
+            .fetch_optional(&pool)
+            .await
+            .unwrap();
+    assert!(table_exists.is_none(), "the table was never created");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn batch_rejects_malformed_requests() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let (writer, _catalog_id) = writer_for(&pool, "prod").await;
+
+    assert!(
+        writer.commit_batch(&[]).is_err(),
+        "an empty batch is rejected"
+    );
+
+    // Truncate must not carry a file.
+    let mut bad = entry(&writer, "t", BatchOp::Truncate, cols(), None);
+    bad.file = file("t/f1.parquet", 1);
+    assert!(writer.commit_batch(&[bad]).is_err());
+
+    // Append/Replace require one.
+    let missing = entry(&writer, "t", BatchOp::Append, cols(), None);
+    assert!(writer.commit_batch(&[missing]).is_err());
+
+    // column_ids must be 1:1 with columns.
+    let mut ragged = entry(
+        &writer,
+        "t",
+        BatchOp::Replace,
+        cols(),
+        file("t/f1.parquet", 1),
+    );
+    ragged.column_ids.pop();
+    assert!(writer.commit_batch(&[ragged]).is_err());
+
+    // Only the FIRST entry for a table may retire it.
+    let first = entry(
+        &writer,
+        "t",
+        BatchOp::Replace,
+        cols(),
+        file("t/f1.parquet", 1),
+    );
+    let mut second = first.clone();
+    second.op = BatchOp::Replace;
+    second.file = file("t/f2.parquet", 1);
+    assert!(
+        writer.commit_batch(&[first.clone(), second]).is_err(),
+        "a later Replace on the same table is rejected"
+    );
+
+    // Entries for one table must agree on columns.
+    let mut divergent = first.clone();
+    divergent.op = BatchOp::Append;
+    divergent.columns = cols_widened();
+    divergent.column_ids.push(999);
+    assert!(writer.commit_batch(&[first, divergent]).is_err());
+
+    // A rejected batch writes nothing.
+    let orphan: Option<i64> =
+        sqlx::query_scalar("SELECT table_id FROM ducklake_table WHERE table_name = 't'")
+            .fetch_optional(&pool)
+            .await
+            .unwrap();
+    assert!(orphan.is_none());
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -17,6 +17,7 @@
 
 mod append_with_deletes_postgres_tests;
 mod append_with_deletes_tests;
+mod batch_commit_postgres_tests;
 mod cdc_cumulative_delete_tests;
 mod cdc_differential_tests;
 mod cdc_rowid_tests;


### PR DESCRIPTION
A DuckLake snapshot versions the whole catalog — it carries no `table_id`, and
`ducklake_snapshot_changes` records a comma-separated list of per-table
modifications against a single `snapshot_id` — but every write path in
`MetadataWriter` commits exactly one table, in its own transaction. So N tables
means N snapshots, N `lock_catalog` acquisitions, and N points at which a reader
can observe a partially-applied set. There is no way to make a group of tables
become visible together, even though the format is built for it.

This adds that, and makes the commit joinable to a transaction the caller already
owns.

## `commit_batch_in_tx`

```rust
pub async fn commit_batch_in_tx(
    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
    catalog_id: i64,
    lock_timeout_ms: u32,
    entries: &[BatchEntry],
) -> Result<BatchCommit>;
```

One `lock_catalog`, one allocated snapshot that every row begins at, one
`schema_version` decision, one `advance_catalog_head` last. Entries are grouped by
`(schema, table)` in first-appearance order and applied in list order within a
table: the first entry for a table may `Append`/`Replace`/`Truncate`, the rest must
be `Append`, since retiring inside the same snapshot would discard rows the batch
just added. `replace, append, append` on one table therefore retires the prior
generation and registers all three files — the retirement's `begin_snapshot < S`
guard spares the batch's own.

`Truncate` empties a table as metadata only, with no zero-row data file. It rides
the `Replace` path for the conflict check and stat zeroing, and additionally ends
live delete files — a data-file-only retirement would leave delete rows counting
deletions against files that no longer exist.

`PostgresMetadataWriter::commit_batch` is the self-contained form for callers with
no transaction of their own.

## Why it takes the caller's transaction

It does **not** commit `tx`, and leaves it usable afterwards. An application
embedding this crate typically keeps its own metadata in Postgres — a table
registry, generation pointers, load bookkeeping. Today it cannot commit that
metadata atomically with the DuckLake commit, so it needs a two-phase protocol
plus reconciliation machinery to recover the window between the DuckLake commit
and its own. When the two share a database, that window is avoidable outright:
one transaction covers both, and a failure rolls back everything.

`sqlx` is already part of the public surface (`MulticatalogManager::new(pool:
PgPool)`, `PostgresMetadataWriter::with_pool(pool: PgPool, …)`), so accepting a
`&mut Transaction` extends an existing pattern rather than introducing one.

Data files are registered by reference and belong to the caller: this never
deletes one, including on the failure path — the ownership rule #215 sets out for
`register_existing_data_file`.

## Prerequisite refactor (first commit)

`finalize_snapshot` allocated its own snapshot id and wrote `schema_version`
inline, so it could only ever run once per snapshot. It is split into
`allocate_snapshot`, `finalize_table_in_snapshot` (one table, against an
already-allocated snapshot; returns `is_ddl` rather than acting on it), and
`apply_schema_version`. The five callers — `register_data_file`,
`register_data_files`, `register_existing_data_file`,
`register_data_file_with_deletes`, `publish_snapshot` — drive the three in
sequence.

No SQL changed. The only ordering deltas are that `schema_version` is written
after the column writes rather than before (nothing in between reads it) and the
snapshot row is allocated before the `Replace` conflict check rather than after
(an abort rolls it back, burning only a sequence value; no comparison uses
unmapped ids).

**One correctness point this encodes.** `schema_version` is a per-catalog dense
counter computed as `MAX` over *mapped* snapshots. Within one unmapped commit
every table reads the same `prev_max`, so a per-table decision has a DDL table
write `prev_max + 1` and a table ordered after it write `prev_max` straight back,
losing the bump. It is now decided once over the union of tables, with one
`ducklake_schema_versions` row per changed table — equivalent to the old
behaviour when there is one table.

Two extractions are now shared rather than duplicated: `register_files_for_table`
(the per-table registration `register_data_files` already performed) and
`retire_live_delete_files` (from `commit_truncate`, where its guard is a no-op and
in a batch is required).

`ColumnDef` gains `PartialEq`/`Eq` so a batch can require that every entry for a
table describes the same columns.

## Tests

`tests/it/batch_commit_postgres_tests.rs` — N tables at one snapshot with a single
head advance; `replace,append,append` sharing the snapshot; the `schema_version`
regression above (DDL entry followed by a DML entry); carry-forward when nothing
changed; one bump across several changed tables; `Truncate` with no data file; a
conflicting entry aborting the whole batch including the table registered before
it; caller metadata committing with the batch; rollback discarding it; and request
validation.

## Scope

Postgres/multicatalog only, behind the existing `write-postgres` /
`multicatalog-postgres` features. Mirroring into the SQLite/DuckDB/MySQL writers
is straightforward but not required by the model here — happy to add it if backend
parity is wanted in the same change.

Deliberately untouched: the other snapshot-allocation sites (`set_delete_file`,
`commit_positional_deletes`, `commit_compaction`, `commit_truncate`,
`retire_appends_since`) repeat the carry-forward pattern and could use
`apply_schema_version` too, but converting them serves no caller here and only
widens the diff. Likewise, `changes_made` is still only written by
`commit_compaction`; populating it for ordinary and batch commits is a reasonable
follow-up.