### PR TITLE
Add snapshot time travel selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,7 +226,8 @@ runtime.register_object_store(&Url::parse("s3://ducklake-data/")?, s3);
 ### Current Limitations
 - Writes are supported on SQLite and PostgreSQL only; DuckDB and MySQL are read-only
 - No `UPDATE` / `DELETE` operations yet (delete files are read but not written)
-- No SQL-level time travel (`AS OF`); a catalog binds to one snapshot, selectable programmatically via `DuckLakeCatalog::with_snapshot`
+- No SQL `AS OF` syntax; use `DuckLakeCatalog::with_snapshot`,
+  `DuckLakeCatalog::with_snapshot_at`, or `ducklake_table_at` for snapshot selection
 - Complex types (nested lists, structs, maps) have minimal support (many cases return errors)
 - Partitioning (`identity` + temporal `year`/`month`/`day`/`hour`) is supported: read + pruning on
   all backends, and partitioned writes on every writable backend, declared via

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -214,10 +214,12 @@ Known edges:
 ## Limitations
 
 - **Write backends:** DuckDB and MySQL are read-only; writes require SQLite or PostgreSQL.
-- **No SQL-level time travel:** a catalog is bound to a single snapshot. You *can* select
-  the snapshot programmatically — `DuckLakeCatalog::with_snapshot(provider, snapshot_id)`
-  binds to a specific one, and querying another point in time means creating another
-  catalog. What's missing is SQL-level historical querying (`AS OF`) within one handle.
+- **No `AS OF` syntax:** select a catalog snapshot by ID with
+  `DuckLakeCatalog::with_snapshot`, by UTC timestamp with
+  `DuckLakeCatalog::with_snapshot_at`, or select one table per query with
+  `ducklake_table_at`. Timestamp selection uses the latest snapshot at or before the
+  requested time. For snapshots with the same timestamp, an as‑of or change‑data end
+  bound selects the highest ID, while a change‑data start bound selects the lowest ID.
 - **One mutation per session, then re-open the catalog.** Because a catalog pins its
   snapshot at creation and never refreshes, a `SessionContext` observes a single generation
   for its lifetime. After an `UPDATE`/`DELETE`/`INSERT` commits, the same session keeps

--- a/README.md
+++ b/README.md
@@ -274,8 +274,8 @@ A few highlights worth knowing up front:
 
 - Reads work on DuckDB, SQLite, PostgreSQL, and MySQL; **writes are SQLite/PostgreSQL only**.
 - Object stores: local filesystem and S3-compatible (S3, MinIO).
-- Snapshots can be selected programmatically (`DuckLakeCatalog::with_snapshot`), but there
-  is no SQL-level time travel (`AS OF`) yet.
+- Snapshots can be selected through `DuckLakeCatalog` or per query with
+  `ducklake_table_at`; DataFusion does not support `AS OF` syntax.
 - Table partitioning: read + file pruning on all backends; partitioned writes on SQLite.
 - Data inlined by DuckDB's ducklake extension is **not read** — see COMPATIBILITY.md for
   the `COUNT(*)` undercount caveat and how to avoid it.

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::Result;
 use crate::information_schema::InformationSchemaProvider;
-use crate::metadata_provider::MetadataProvider;
+use crate::metadata_provider::{MetadataProvider, resolve_snapshot_at_or_before};
 use crate::path_resolver::{parse_object_store_url, resolve_path};
 use crate::schema::DuckLakeSchema;
 use datafusion::catalog::{CatalogProvider, SchemaProvider};
@@ -88,6 +88,17 @@ impl DuckLakeCatalog {
             #[cfg(feature = "write")]
             write_config: None,
         })
+    }
+
+    /// Create a read-only catalog bound to the latest snapshot at or before a
+    /// UTC timestamp. When snapshots share a timestamp, selects the highest
+    /// snapshot ID so every commit recorded at that instant is visible.
+    pub fn with_snapshot_at(
+        provider: Arc<dyn MetadataProvider>,
+        timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Self> {
+        let snapshot_id = resolve_snapshot_at_or_before(provider.as_ref(), timestamp.naive_utc())?;
+        Self::with_snapshot(provider, snapshot_id)
     }
 
     /// Create a catalog with write support.

--- a/src/metadata_provider.rs
+++ b/src/metadata_provider.rs
@@ -349,6 +349,98 @@ pub struct SnapshotMetadata {
     pub timestamp: Option<String>,
 }
 
+pub(crate) fn parse_snapshot_timestamp(raw: &str) -> Option<chrono::NaiveDateTime> {
+    let mut timestamp = raw.trim();
+    for suffix in ["Z", " UTC", "+00:00", "+00"] {
+        if let Some(stripped) = timestamp.strip_suffix(suffix) {
+            timestamp = stripped.trim();
+            break;
+        }
+    }
+    for format in ["%Y-%m-%d %H:%M:%S%.f", "%Y-%m-%dT%H:%M:%S%.f"] {
+        if let Ok(parsed) = chrono::NaiveDateTime::parse_from_str(timestamp, format) {
+            return Some(parsed);
+        }
+    }
+    chrono::NaiveDate::parse_from_str(timestamp, "%Y-%m-%d")
+        .ok()
+        .and_then(|date| date.and_hms_opt(0, 0, 0))
+}
+
+pub(crate) fn resolve_snapshot_at_or_before(
+    provider: &dyn MetadataProvider,
+    timestamp: chrono::NaiveDateTime,
+) -> Result<i64> {
+    resolve_snapshot_at(provider, timestamp, false)
+}
+
+pub(crate) fn resolve_snapshot_at_or_after(
+    provider: &dyn MetadataProvider,
+    timestamp: chrono::NaiveDateTime,
+) -> Result<i64> {
+    resolve_snapshot_at(provider, timestamp, true)
+}
+
+fn resolve_snapshot_at(
+    provider: &dyn MetadataProvider,
+    timestamp: chrono::NaiveDateTime,
+    at_or_after: bool,
+) -> Result<i64> {
+    let mut best: Option<(chrono::NaiveDateTime, i64)> = None;
+    for snapshot in provider.list_snapshots()? {
+        let Some(candidate_time) = snapshot
+            .timestamp
+            .as_deref()
+            .and_then(parse_snapshot_timestamp)
+        else {
+            continue;
+        };
+        if (at_or_after && candidate_time < timestamp)
+            || (!at_or_after && candidate_time > timestamp)
+        {
+            continue;
+        }
+        let replace = match best {
+            None => true,
+            Some((best_time, best_id)) if at_or_after => {
+                candidate_time < best_time
+                    || (candidate_time == best_time && snapshot.snapshot_id < best_id)
+            },
+            Some((best_time, best_id)) => {
+                candidate_time > best_time
+                    || (candidate_time == best_time && snapshot.snapshot_id > best_id)
+            },
+        };
+        if replace {
+            best = Some((candidate_time, snapshot.snapshot_id));
+        }
+    }
+    best.map(|(_, snapshot_id)| snapshot_id).ok_or_else(|| {
+        crate::error::DuckLakeError::InvalidSnapshot(format!(
+            "No snapshot found {} timestamp {timestamp}",
+            if at_or_after {
+                "at or after"
+            } else {
+                "at or before"
+            }
+        ))
+    })
+}
+
+pub(crate) fn require_snapshot(provider: &dyn MetadataProvider, snapshot_id: i64) -> Result<i64> {
+    if provider
+        .list_snapshots()?
+        .iter()
+        .any(|snapshot| snapshot.snapshot_id == snapshot_id)
+    {
+        Ok(snapshot_id)
+    } else {
+        Err(crate::error::DuckLakeError::InvalidSnapshot(format!(
+            "Snapshot {snapshot_id} does not exist"
+        )))
+    }
+}
+
 /// Metadata for a schema in the DuckLake catalog
 #[derive(Debug, Clone)]
 pub struct SchemaMetadata {

--- a/src/table_functions.rs
+++ b/src/table_functions.rs
@@ -7,8 +7,12 @@ use datafusion::logical_expr::Expr;
 use std::sync::Arc;
 
 use crate::information_schema::{FilesTable, SnapshotsTable, TableInfoTable};
-use crate::metadata_provider::MetadataProvider;
+use crate::metadata_provider::{
+    MetadataProvider, parse_snapshot_timestamp, require_snapshot, resolve_snapshot_at_or_after,
+    resolve_snapshot_at_or_before,
+};
 use crate::path_resolver::{parse_object_store_url, resolve_path};
+use crate::table::DuckLakeTable;
 use crate::table_changes::{TableChangesTable, TableInsertionsTable};
 use crate::table_deletions::TableDeletionsTable;
 use crate::types::build_arrow_schema;
@@ -83,6 +87,86 @@ impl TableFunctionImpl for DucklakeListFilesFunction {
 }
 
 #[derive(Debug)]
+pub struct DucklakeTableAtFunction {
+    provider: Arc<dyn MetadataProvider>,
+}
+
+impl DucklakeTableAtFunction {
+    pub fn new(provider: Arc<dyn MetadataProvider>) -> Self {
+        Self {
+            provider,
+        }
+    }
+}
+
+impl TableFunctionImpl for DucklakeTableAtFunction {
+    fn call(&self, exprs: &[Expr]) -> DataFusionResult<Arc<dyn TableProvider>> {
+        const FN_NAME: &str = "ducklake_table_at";
+        if exprs.len() != 3 {
+            return plan_err!(
+                "{FN_NAME}() requires 3 arguments: \
+                 {FN_NAME}('schema', 'table', version_or_timestamp)"
+            );
+        }
+        let string_arg = |expr: &Expr, name: &str| match expr {
+            Expr::Literal(ScalarValue::Utf8(Some(value)), _) => Ok(value.clone()),
+            _ => plan_err!("{name} of {FN_NAME}() must be a string literal"),
+        };
+        let schema_name = string_arg(&exprs[0], "schema")?;
+        let table_name = string_arg(&exprs[1], "table")?;
+        let snapshot_id = resolve_snapshot_bound(
+            &self.provider,
+            &exprs[2],
+            FN_NAME,
+            "version_or_timestamp",
+            false,
+        )?;
+        require_snapshot(self.provider.as_ref(), snapshot_id)
+            .map_err(|error| datafusion::error::DataFusionError::Plan(error.to_string()))?;
+
+        let schema = self
+            .provider
+            .get_schema_by_name(&schema_name, snapshot_id)
+            .map_err(|error| datafusion::error::DataFusionError::External(Box::new(error)))?
+            .ok_or_else(|| {
+                datafusion::error::DataFusionError::Plan(format!(
+                    "Schema '{schema_name}' does not exist at snapshot {snapshot_id}"
+                ))
+            })?;
+        let table = self
+            .provider
+            .get_table_by_name(schema.schema_id, &table_name, snapshot_id)
+            .map_err(|error| datafusion::error::DataFusionError::External(Box::new(error)))?
+            .ok_or_else(|| {
+                datafusion::error::DataFusionError::Plan(format!(
+                    "Table '{schema_name}.{table_name}' does not exist at snapshot {snapshot_id}"
+                ))
+            })?;
+        let data_path = self
+            .provider
+            .get_data_path()
+            .map_err(|error| datafusion::error::DataFusionError::External(Box::new(error)))?;
+        let (object_store_url, catalog_path) = parse_object_store_url(&data_path)
+            .map_err(|error| datafusion::error::DataFusionError::External(Box::new(error)))?;
+        let schema_path = resolve_path(&catalog_path, &schema.path, schema.path_is_relative)
+            .map_err(|error| datafusion::error::DataFusionError::External(Box::new(error)))?;
+        let table_path = resolve_path(&schema_path, &table.path, table.path_is_relative)
+            .map_err(|error| datafusion::error::DataFusionError::External(Box::new(error)))?;
+        let provider = DuckLakeTable::new(
+            table.table_id,
+            table.table_name,
+            Arc::clone(&self.provider),
+            snapshot_id,
+            Arc::new(object_store_url),
+            table_path,
+        )
+        .map_err(|error| datafusion::error::DataFusionError::External(Box::new(error)))?;
+
+        Ok(Arc::new(provider))
+    }
+}
+
+#[derive(Debug)]
 pub struct DucklakeTableChangesFunction {
     provider: Arc<dyn MetadataProvider>,
 }
@@ -112,32 +196,11 @@ fn parse_table_name(table_name: &str) -> (&str, &str) {
     }
 }
 
-/// Parse a snapshot-time string as stored by the catalog backends. Accepts
-/// `YYYY-MM-DD HH:MM:SS[.fff]` / `YYYY-MM-DDTHH:MM:SS[.fff]` / `YYYY-MM-DD`,
-/// with an optional trailing `Z`, ` UTC`, `+00` or `+00:00` (times are UTC).
-fn parse_snapshot_timestamp(raw: &str) -> Option<chrono::NaiveDateTime> {
-    let mut t = raw.trim();
-    for suffix in ["Z", " UTC", "+00:00", "+00"] {
-        if let Some(stripped) = t.strip_suffix(suffix) {
-            t = stripped.trim();
-            break;
-        }
-    }
-    for fmt in ["%Y-%m-%d %H:%M:%S%.f", "%Y-%m-%dT%H:%M:%S%.f"] {
-        if let Ok(ts) = chrono::NaiveDateTime::parse_from_str(t, fmt) {
-            return Some(ts);
-        }
-    }
-    chrono::NaiveDate::parse_from_str(t, "%Y-%m-%d")
-        .ok()
-        .and_then(|d| d.and_hms_opt(0, 0, 0))
-}
-
 /// Resolve a snapshot bound argument: an integer snapshot id, or a timestamp
 /// (a string literal or a `TIMESTAMP '...'` cast) resolved against the
-/// catalog's snapshot times — a START bound resolves to the FIRST snapshot
+/// catalog's snapshot times: a START bound resolves to the FIRST snapshot
 /// at-or-after the timestamp, an END bound to the LAST snapshot at-or-before
-/// it, matching official DuckLake's `AT (TIMESTAMP => ...)` semantics.
+/// it.
 fn resolve_snapshot_bound(
     provider: &Arc<dyn MetadataProvider>,
     expr: &Expr,
@@ -201,37 +264,13 @@ fn resolve_snapshot_bound(
         },
     };
 
-    let snapshots = provider
-        .list_snapshots()
-        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
-    let mut best: Option<i64> = None;
-    for s in &snapshots {
-        let Some(t) = s.timestamp.as_deref().and_then(parse_snapshot_timestamp) else {
-            continue;
-        };
-        let candidate = if is_start {
-            t >= ts
-        } else {
-            t <= ts
-        };
-        if candidate {
-            best = Some(match best {
-                None => s.snapshot_id,
-                Some(b) if is_start => b.min(s.snapshot_id),
-                Some(b) => b.max(s.snapshot_id),
-            });
-        }
-    }
-    best.ok_or_else(|| {
-        datafusion::error::DataFusionError::Plan(format!(
-            "{fn_name}(): no snapshot {} timestamp {ts}",
-            if is_start {
-                "at or after"
-            } else {
-                "at or before"
-            },
-        ))
-    })
+    let resolved = if is_start {
+        resolve_snapshot_at_or_after(provider.as_ref(), ts)
+    } else {
+        resolve_snapshot_at_or_before(provider.as_ref(), ts)
+    };
+    resolved
+        .map_err(|error| datafusion::error::DataFusionError::Plan(format!("{fn_name}(): {error}")))
 }
 
 /// Parse the common `('schema.table', start, end)` argument list of the CDC
@@ -413,6 +452,10 @@ pub fn register_ducklake_functions(
         Arc::new(DucklakeListFilesFunction::new(provider.clone())),
     );
     ctx.register_udtf(
+        "ducklake_table_at",
+        Arc::new(DucklakeTableAtFunction::new(provider.clone())),
+    );
+    ctx.register_udtf(
         "ducklake_table_changes",
         Arc::new(DucklakeTableChangesFunction::new(provider.clone())),
     );
@@ -428,7 +471,7 @@ pub fn register_ducklake_functions(
 
 #[cfg(test)]
 mod snapshot_bound_tests {
-    use super::parse_snapshot_timestamp;
+    use crate::metadata_provider::parse_snapshot_timestamp;
 
     #[test]
     fn parses_backend_snapshot_time_formats() {

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -65,5 +65,6 @@ mod sqllogictest_runner;
 mod table_changes_tests;
 mod table_deletions_repartition_tests;
 mod table_tests;
+mod time_travel_tests;
 mod type_promotion_tests;
 mod write_tests;

--- a/tests/it/time_travel_tests.rs
+++ b/tests/it/time_travel_tests.rs
@@ -1,0 +1,182 @@
+//! Snapshot selection by version and timestamp.
+
+#![cfg(all(feature = "write-sqlite", feature = "metadata-sqlite"))]
+
+use std::sync::Arc;
+
+use arrow::array::Int32Array;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use chrono::{TimeZone, Utc};
+use datafusion::prelude::SessionContext;
+use datafusion_ducklake::{
+    DuckLakeCatalog, DuckLakeTableWriter, SqliteMetadataProvider, SqliteMetadataWriter,
+    register_ducklake_functions,
+};
+use object_store::local::LocalFileSystem;
+use sqlx::SqlitePool;
+use tempfile::TempDir;
+
+fn id_batch(ids: &[i32]) -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+    RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(ids.to_vec()))]).unwrap()
+}
+
+async fn ids(context: &SessionContext, sql: &str) -> Vec<i32> {
+    let batches = context.sql(sql).await.unwrap().collect().await.unwrap();
+    let mut values = Vec::new();
+    for batch in batches {
+        let array = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        values.extend((0..array.len()).map(|index| array.value(index)));
+    }
+    values
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn version_timestamp_and_same_second_cdc_select_snapshots() {
+    let temp = TempDir::new().unwrap();
+    let database = temp.path().join("catalog.db");
+    let data = temp.path().join("data");
+    std::fs::create_dir(&data).unwrap();
+    let connection = format!("sqlite:{}?mode=rwc", database.display());
+    let writer = Arc::new(
+        SqliteMetadataWriter::new_with_init(&connection)
+            .await
+            .unwrap(),
+    );
+    datafusion_ducklake::MetadataWriter::set_data_path(writer.as_ref(), data.to_str().unwrap())
+        .unwrap();
+    let initial = DuckLakeTableWriter::new(
+        writer.clone(),
+        Arc::new(LocalFileSystem::new()) as Arc<dyn object_store::ObjectStore>,
+    )
+    .unwrap()
+    .write_table("main", "t", &[id_batch(&[1, 2, 3])])
+    .await
+    .unwrap();
+
+    let provider = SqliteMetadataProvider::new(&connection).await.unwrap();
+    let writable = DuckLakeCatalog::with_writer(Arc::new(provider), writer).unwrap();
+    let write_context = SessionContext::new();
+    write_context.register_catalog("lake", Arc::new(writable));
+    write_context
+        .sql("DELETE FROM lake.main.t WHERE id = 2")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let pool = SqlitePool::connect(&connection).await.unwrap();
+    let delete_snapshot: i64 = sqlx::query_scalar("SELECT MAX(snapshot_id) FROM ducklake_snapshot")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert!(delete_snapshot > initial.snapshot_id);
+    sqlx::query("UPDATE ducklake_snapshot SET snapshot_time = ? WHERE snapshot_id = ?")
+        .bind("2026-08-01 12:00:00.000000")
+        .bind(initial.snapshot_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE ducklake_snapshot SET snapshot_time = ? WHERE snapshot_id = ?")
+        .bind("2026-08-01 13:00:00.000000")
+        .bind(delete_snapshot)
+        .execute(&pool)
+        .await
+        .unwrap();
+    pool.close().await;
+
+    let current_provider = SqliteMetadataProvider::new(&connection).await.unwrap();
+    let current = SessionContext::new();
+    current.register_catalog(
+        "lake",
+        Arc::new(DuckLakeCatalog::new(current_provider).unwrap()),
+    );
+    assert_eq!(
+        ids(&current, "SELECT id FROM lake.main.t ORDER BY id").await,
+        vec![1, 3]
+    );
+
+    let timestamp = Utc
+        .with_ymd_and_hms(2026, 8, 1, 12, 30, 0)
+        .single()
+        .unwrap();
+    let timestamp_provider = Arc::new(SqliteMetadataProvider::new(&connection).await.unwrap());
+    let timestamp_catalog =
+        DuckLakeCatalog::with_snapshot_at(timestamp_provider, timestamp).unwrap();
+    let timestamp_context = SessionContext::new();
+    timestamp_context.register_catalog("past", Arc::new(timestamp_catalog));
+    assert_eq!(
+        ids(&timestamp_context, "SELECT id FROM past.main.t ORDER BY id").await,
+        vec![1, 2, 3]
+    );
+    let invalid_catalog_provider =
+        Arc::new(SqliteMetadataProvider::new(&connection).await.unwrap());
+    let before_first = Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).single().unwrap();
+    assert!(
+        DuckLakeCatalog::with_snapshot_at(invalid_catalog_provider, before_first)
+            .unwrap_err()
+            .to_string()
+            .contains("No snapshot found at or before timestamp")
+    );
+
+    let pool = SqlitePool::connect(&connection).await.unwrap();
+    sqlx::query("UPDATE ducklake_snapshot SET snapshot_time = ? WHERE snapshot_id = ?")
+        .bind("2026-08-01 12:00:00.000000")
+        .bind(delete_snapshot)
+        .execute(&pool)
+        .await
+        .unwrap();
+    pool.close().await;
+
+    let function_provider = Arc::new(SqliteMetadataProvider::new(&connection).await.unwrap());
+    let function_context = SessionContext::new();
+    register_ducklake_functions(&function_context, function_provider);
+    let by_version = ids(
+        &function_context,
+        &format!(
+            "SELECT id FROM ducklake_table_at('main', 't', {}) ORDER BY id",
+            initial.snapshot_id
+        ),
+    )
+    .await;
+    let by_timestamp = ids(
+        &function_context,
+        "SELECT id FROM ducklake_table_at(\
+         'main', 't', TIMESTAMP '2026-08-01 12:00:00') ORDER BY id",
+    )
+    .await;
+    let deleted_through_timestamp = ids(
+        &function_context,
+        &format!(
+            "SELECT id FROM ducklake_table_deletions(\
+             'main.t', {}, TIMESTAMP '2026-08-01 12:00:00') ORDER BY id",
+            initial.snapshot_id
+        ),
+    )
+    .await;
+    assert_eq!(by_version, vec![1, 2, 3]);
+    assert_eq!(by_timestamp, vec![1, 3]);
+    assert_eq!(deleted_through_timestamp, vec![2]);
+
+    let invalid_version = function_context
+        .sql("SELECT * FROM ducklake_table_at('main', 't', 999999)")
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(invalid_version.contains("Snapshot 999999 does not exist"));
+    let invalid_timestamp = function_context
+        .sql(
+            "SELECT * FROM ducklake_table_at(\
+             'main', 't', TIMESTAMP '2020-01-01 00:00:00')",
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(invalid_timestamp.contains("No snapshot found at or before timestamp"));
+}


### PR DESCRIPTION
### Summary

Add read‑only DuckLake time travel through both catalog binding and a per‑query DataFusion table
function. `DuckLakeCatalog::with_snapshot_at` pins a catalog to the latest snapshot at or before a
UTC timestamp. `ducklake_table_at('schema', 'table', version_or_timestamp)` selects one table at a
snapshot ID or timestamp without moving or replacing the registered catalog.

Snapshot timestamps now resolve by their parsed time instead of assuming snapshot IDs always
encode time order. Equal timestamps resolve by bound direction: a start bound selects the lowest
snapshot ID, while an end or as‑of bound selects the highest ID so it includes every commit
recorded at that instant. Existing change‑data table functions use the same resolver, so all
timestamp bounds share one ordering and error surface.

### Selection flow

```mermaid
flowchart LR
    Input["Snapshot ID or UTC timestamp"] --> Resolve["Resolve and validate snapshot"]
    Resolve --> Catalog["Pin DuckLakeCatalog"]
    Resolve --> Function["ducklake_table_at"]
    Function --> Schema["Resolve schema and table at snapshot"]
    Schema --> Provider["Build read-only DuckLakeTable"]
    Catalog --> CatalogQuery["Query historical catalog"]
    Provider --> TableQuery["Query one historical table"]
```

### Public surface

| Surface | Selection | Scope | Mutation |
| ------- | --------- | ----- | -------- |
| `DuckLakeCatalog::with_snapshot_at(provider, timestamp)` | Latest snapshot at or before a typed UTC timestamp. | Every table reached through the catalog handle. | None; the handle stays pinned. |
| `ducklake_table_at('schema', 'table', snapshot_id)` | Exact validated snapshot ID. | One table in one query. | None; registered catalogs are unchanged. |
| `ducklake_table_at('schema', 'table', timestamp)` | Latest snapshot at or before the timestamp literal. | One table in one query. | None; registered catalogs are unchanged. |

### Commit and branch

- Branch: `ducklake-time-travel-pr`.
- Time-travel commit: `eff5af4 feat: add snapshot time travel selection`.
- Main base: `0ae7b7ecf281301ad78c269b4275a22ee0e0a47c` (`origin/main`).
- Shape: exactly one commit ahead of `origin/main`.
- Remote: `faysou:ducklake-time-travel-pr`.
- Working dependency branch: `ac8f5d8` on `ducklake-working-independent-prs-2`.
- PR: [datafusion-ducklake#236](https://github.com/datafusion-contrib/datafusion-ducklake/pull/236).

### Verification

- `cargo fmt --all -- --check`: passed on the rebased branch.
- `CARGO_BUILD_JOBS=8 cargo check --all-targets --all-features`: passed on the rebased branch.
- Time‑travel integration: 1 test passed. It proves nearest eligible timestamp ordering,
  direction‑specific equal‑timestamp selection, same‑second SQLite CDC end bounds, historical
  visibility before a delete, current visibility after the delete, and invalid ID and timestamp
  errors.
- `git diff --check`: passed.

### Specification proof

| DuckLake rule | Implementation invariant | Discriminating proof |
| ------------- | ------------------------ | -------------------- |
| [Time travel](https://ducklake.select/docs/stable/duckdb/usage/time_travel) allows a snapshot to be selected by timestamp or explicit snapshot identifier. | The catalog API accepts a typed UTC timestamp, while `ducklake_table_at` accepts an integer ID or DataFusion timestamp literal and uses the same snapshot resolver. | An exact initial ID returns the pre‑delete rows, while the tied timestamp selects the later delete snapshot. |
| [Timestamp time travel](https://ducklake.select/docs/stable/duckdb/usage/time_travel) reads the database state recorded for a requested point in time. | Resolution parses every available snapshot time and chooses the greatest time that is not later than the requested time. It does not infer time order from the snapshot ID. | Snapshots at 12:00 and 13:00 are queried at 12:30; the result contains the row deleted by the 13:00 snapshot. |
| SQLite stores `snapshot_time` at whole‑second resolution. | Equal timestamps select the lowest ID for a start bound and the highest ID for an end or as‑of bound. | A CDC deletion query ending at the shared timestamp returns the row deleted by the later snapshot. |
| [`ducklake_snapshot`](https://ducklake.select/docs/stable/specification/tables/ducklake_snapshot) stores a unique `snapshot_id` and the creation `snapshot_time` for every valid snapshot. | Exact ID selection first verifies that the ID exists. Timestamp selection returns a structured invalid‑snapshot error when no valid snapshot exists at or before the target. | ID `999999` and a timestamp before the first snapshot both fail with exact snapshot‑selection errors instead of constructing an empty or inconsistent table. |
| [Snapshots](https://ducklake.select/docs/stable/duckdb/usage/snapshots) represent consistent database states whose changes can include data deletion. | A selected snapshot is copied into the catalog or table provider and remains fixed for all schema, table, file, and delete‑file lookups in that query. | Current selection returns `[1, 3]`, while the pinned pre‑delete catalog and per‑query table both return `[1, 2, 3]`. |
| [Time travel selects a historical snapshot](https://ducklake.select/docs/stable/duckdb/usage/time_travel) without changing that snapshot's recorded state. | `ducklake_table_at` resolves schema and table metadata at the chosen snapshot, then creates one read‑only `DuckLakeTable`; it does not mutate the registered catalog or metadata provider. | The test queries the current catalog and both historical table‑function forms from separate contexts without moving any catalog snapshot. |

### Reference implementation

The official metadata manager resolves an exact `version` directly and resolves timestamp bounds
with `<=` or `>=`, ordering toward the nearest eligible snapshot and erroring when none exists
([snapshot selection](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_metadata_manager.cpp#L4414-L4449)).
Transactions cache the resulting snapshot for a consistent query
([transaction cache](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_transaction.cpp#L1613-L1647)),
and table scans obtain the snapshot selected by their `AT` clause
([scan binding](https://github.com/duckdb/ducklake/blob/7c0eafc80413c311aabd47c71044f3b1318cc342/src/storage/ducklake_table_entry.cpp#L359-L365)).
The branch follows the same bounds and pinning rules. The reference query has no secondary order
for equal timestamps, so the branch defines the edge case explicitly: a start bound selects the
lowest snapshot ID, while an end or as‑of bound selects the highest. `ducklake_table_at` supplies
equivalent per‑query selection without extending DataFusion's SQL grammar.

### Upstream readiness

The local branch is reviewable as one commit directly on current `origin/main`. The working
dependency branch carries this exact change after recursive column support.

### Review boundary

This branch owns read‑only snapshot selection by timestamp, exact per‑query table selection, shared
timestamp parsing, and invalid selection errors. It does not add SQL `AT (VERSION => ...)` syntax,
refresh writable session pins, retry write conflicts, expire snapshots, change metadata, or add
non‑UTC offset parsing tracked by
[datafusion-ducklake#237](https://github.com/datafusion-contrib/datafusion-ducklake/issues/237).
