### PR TITLE
perf(read): skip empty data files when pruning

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -341,6 +341,25 @@ fn file_row_count(
     }
 }
 
+/// Whether the catalog *proves* this file holds no rows.
+///
+/// A file with no rows cannot hold a row matching any predicate, so it is safe to
+/// drop from a pruning candidate set without consulting its statistics — and worth
+/// dropping, because having no rows it also has no min/max, and a file with an
+/// absent bound suppresses pruning on that column for every file considered
+/// alongside it.
+///
+/// Only `Some(0)` is proof. `record_count` is optional in the catalog and some
+/// providers do not surface it at all, so `None` means "unknown", never "zero":
+/// treating it as zero would drop files full of live rows, silently losing them
+/// from a scan and — through
+/// [`files_matching`](DuckLakeTable::files_matching) — from a keyed mutation's
+/// view of the table. Unknown keeps the file, in line with the fail-open contract
+/// everywhere else in pruning.
+fn file_is_known_empty(file: &DuckLakeTableFile) -> bool {
+    file.max_row_count == Some(0)
+}
+
 fn build_datafusion_statistics(
     schema: &Schema,
     columns: &[DuckLakeTableColumn],
@@ -886,10 +905,22 @@ impl DuckLakeTable {
     /// its own statistics *prove* it cannot match. A file with no recorded
     /// statistics, an undecodable partition value, a NULL partition value, or a
     /// bound the catalog only knows approximately is always kept, and any error
-    /// building or evaluating the pruning predicate returns the complete file
-    /// list. Callers may therefore treat the result as "these files may match"
-    /// and must still evaluate `predicate` against the rows themselves; a
-    /// mutation that skipped that step could silently miss a row.
+    /// building or evaluating the pruning predicate discards the pruning done so
+    /// far and returns every file in the page — including files an earlier conjunct
+    /// had already excluded, since a failure part-way through leaves no basis for
+    /// trusting the exclusions that preceded it. Callers may therefore treat the
+    /// result as "these files may match" and must still evaluate `predicate`
+    /// against the rows themselves; a mutation that skipped that step could
+    /// silently miss a row.
+    ///
+    /// The one file dropped without consulting statistics is one the catalog
+    /// records as holding **no rows** (`record_count` of exactly 0): having no
+    /// rows, it cannot hold a matching one. That is a proof rather than an
+    /// estimate, so it is the one exclusion the error path above does *not* give
+    /// back — such a file is absent from the result whether or not pruning ran, and
+    /// whether or not it failed. A file whose row count the catalog leaves unset is
+    /// *not* treated as empty; unknown keeps the file, like every other unknown
+    /// here.
     ///
     /// How much it prunes depends on how completely the catalog describes the
     /// files. A file that carries no usable bound on a column the predicate
@@ -1184,14 +1215,32 @@ impl DuckLakeTable {
     /// current candidate set. Applying each conjunct repeatedly lets another
     /// conjunct first remove that file, then makes the suppressed column usable
     /// on the next pass. A file is only removed when its own statistics prove it
-    /// cannot match, and any pruning error keeps the complete input set.
+    /// cannot match, and any pruning error abandons the whole attempt: it returns
+    /// `candidates` — every input file bar the proven-empty ones — and so gives back
+    /// files an earlier conjunct had already excluded, rather than trusting
+    /// exclusions made before the failure.
+    ///
+    /// Files the catalog records as holding no rows are dropped up front by
+    /// [`file_is_known_empty`], before any statistics are consulted. A 0-row file
+    /// carries no min/max, so it would otherwise be the unusable bound described
+    /// above — suppressing its columns for a whole round. That exclusion rests on a
+    /// proof rather than on statistics, which is why `candidates` (not
+    /// `table_files`) is what both the no-predicates and the error path return: it
+    /// is the one narrowing no return path here gives back.
     fn prune_table_files_iteratively<'a>(
         &self,
         predicates: &[PruningPredicate],
         table_files: &'a [DuckLakeTableFile],
         file_statistics: &HashMap<i64, Arc<Statistics>>,
     ) -> Vec<&'a DuckLakeTableFile> {
-        let mut retained = table_files.iter().collect::<Vec<_>>();
+        // The candidate set every path below falls back to: the input minus the
+        // files proven empty. Dropping those is not a pruning decision that can be
+        // wrong, so it holds even when pruning is skipped entirely.
+        let candidates: Vec<&'a DuckLakeTableFile> = table_files
+            .iter()
+            .filter(|file| !file_is_known_empty(file))
+            .collect();
+        let mut retained = candidates.clone();
         if predicates.is_empty() {
             return retained;
         }
@@ -1203,7 +1252,7 @@ impl DuckLakeTable {
                     Ok(mask) => mask,
                     Err(e) => {
                         tracing::debug!(error = %e, "skipping plan-time file pruning");
-                        return table_files.iter().collect();
+                        return candidates;
                     },
                 };
                 debug_assert_eq!(mask.len(), retained.len());
@@ -3938,6 +3987,89 @@ mod tests {
         let predicate = physical_predicate(&table, col("id").eq(lit(105_i64)));
 
         assert_eq!(matching_ids(&table, &predicate)?, vec![1, 2, 3]);
+        Ok(())
+    }
+
+    /// A file the catalog records as holding no rows, and — the case that matters —
+    /// carrying no per-column statistics row at all.
+    ///
+    /// This is the shape that defeats pruning outright rather than merely costing
+    /// it a round. A 0-row file written by this crate normally does carry a
+    /// statistics row (`value_count` and `null_count` of 0, NULL bounds), and
+    /// DataFusion drops such a file unaided through the `null_count != row_count`
+    /// check it attaches to every comparison rewrite. With no statistics row there
+    /// is no such check to fire: nothing can drop the file, and its absent bounds
+    /// suppress the column for every file beside it, in every round. A statistics
+    /// harvest failure ([`crate::stats_collect::collect_column_stats`] yields no
+    /// rows) and a column added by later DDL both produce it.
+    fn empty_file_without_statistics(data_file_id: i64) -> DuckLakeFileMetadata {
+        let mut entry = fixture_file(data_file_id, None, None);
+        entry.file.max_row_count = Some(0);
+        entry
+    }
+
+    /// A file whose `record_count` the catalog leaves unset — what a provider that
+    /// does not surface one produces. Unknown, never empty.
+    fn file_with_unknown_row_count(
+        data_file_id: i64,
+        id_bounds: (i64, i64),
+    ) -> DuckLakeFileMetadata {
+        let mut entry = fixture_file(data_file_id, None, Some(id_bounds));
+        entry.file.max_row_count = None;
+        entry
+    }
+
+    /// A 0-row file with no statistics row of its own, alongside files whose
+    /// statistics are ideal. Its absent bounds are indistinguishable from those of
+    /// a file that simply has none, so unless it is excluded before statistics are
+    /// consulted it suppresses `id` for the whole candidate set — and, having no
+    /// statistics, it can never be dropped to lift that suppression on a later
+    /// round, so every file comes back.
+    ///
+    /// The control is
+    /// `files_matching_prunes_unpartitioned_files_by_column_statistics`: the same
+    /// three row-bearing files without the empty one, same predicate, same result.
+    #[test]
+    fn files_matching_prunes_around_an_empty_file_without_statistics() -> Result<()> {
+        let table = fixed_table(
+            vec![
+                fixture_file(1, None, Some((1, 10))),
+                fixture_file(2, None, Some((100, 110))),
+                fixture_file(3, None, Some((200, 210))),
+                empty_file_without_statistics(4),
+            ],
+            None,
+        )?;
+
+        let predicate = physical_predicate(&table, col("id").eq(lit(105_i64)));
+
+        assert_eq!(matching_ids(&table, &predicate)?, vec![2]);
+        Ok(())
+    }
+
+    /// Only a recorded row count of exactly 0 may drop a file. A catalog that
+    /// leaves `record_count` unset must never be read as "empty": that would
+    /// withhold a file holding live rows, and a keyed mutation that never sees the
+    /// file holding its key inserts a duplicate instead of superseding it, with no
+    /// error anywhere. Pinned because the mis-implementation is a one-token slip
+    /// (`max_row_count.unwrap_or(0) == 0`) that nothing else here would catch.
+    ///
+    /// File 2 carries the unknown count and is the only file whose bounds admit the
+    /// key, so reading unknown as empty collapses this result to nothing.
+    #[test]
+    fn files_matching_keeps_a_file_whose_row_count_is_unknown() -> Result<()> {
+        let table = fixed_table(
+            vec![
+                fixture_file(1, None, Some((1, 10))),
+                file_with_unknown_row_count(2, (100, 110)),
+                empty_file_without_statistics(3),
+            ],
+            None,
+        )?;
+
+        let predicate = physical_predicate(&table, col("id").eq(lit(105_i64)));
+
+        assert_eq!(matching_ids(&table, &predicate)?, vec![2]);
         Ok(())
     }
 

--- a/tests/it/empty_data_file_tests.rs
+++ b/tests/it/empty_data_file_tests.rs
@@ -1,0 +1,242 @@
+//! Reads over a table carrying a live data file with no rows.
+//!
+//! Such a file is ordinary: a write of only empty batches registers one, and the
+//! reference implementation emits one for partitioned output, so a catalog written
+//! elsewhere can contain them too. Pruning drops these files before it consults
+//! statistics — having no rows, they cannot hold a matching one — which means the
+//! scan planner never sees them either.
+//!
+//! These are no-regression guards for that exclusion, not reproductions of a bug:
+//! every assertion here holds both before and after it. What they pin is that
+//! removing a file from the candidate set cannot change what a read *returns* —
+//! neither the rows of a table that also holds real files, nor the shape of a table
+//! whose only live file is the empty one, where the exclusion empties the candidate
+//! set outright and the read must still answer with zero rows rather than fail, on
+//! the plain and the row-lineage planning paths alike.
+
+#![cfg(all(feature = "write-sqlite", feature = "metadata-sqlite"))]
+
+use std::sync::Arc;
+
+use arrow::array::Int32Array;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use datafusion::prelude::*;
+use object_store::local::LocalFileSystem;
+use tempfile::TempDir;
+
+use datafusion_ducklake::{
+    DuckLakeCatalog, DuckLakeTableWriter, MetadataWriter, SqliteMetadataProvider,
+    SqliteMetadataWriter,
+};
+
+fn table_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("val", DataType::Int32, false),
+    ]))
+}
+
+fn batch(ids: Vec<i32>, vals: Vec<i32>) -> RecordBatch {
+    RecordBatch::try_new(
+        table_schema(),
+        vec![Arc::new(Int32Array::from(ids)), Arc::new(Int32Array::from(vals))],
+    )
+    .unwrap()
+}
+
+fn conn_str(temp_dir: &TempDir) -> String {
+    format!(
+        "sqlite:{}?mode=rwc",
+        temp_dir.path().join("test.db").display()
+    )
+}
+
+fn object_store() -> Arc<dyn object_store::ObjectStore> {
+    Arc::new(LocalFileSystem::new())
+}
+
+/// Create the catalog and write `t`'s first data file from `batches`, which may be
+/// entirely empty — an all-empty write still registers a data file, with a
+/// `record_count` of 0.
+async fn seed_table(temp_dir: &TempDir, batches: &[RecordBatch]) {
+    let data_path = temp_dir.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+    let writer = SqliteMetadataWriter::new_with_init(&conn_str(temp_dir))
+        .await
+        .unwrap();
+    writer.set_data_path(data_path.to_str().unwrap()).unwrap();
+    DuckLakeTableWriter::new(Arc::new(writer), object_store())
+        .unwrap()
+        .write_table("main", "t", batches)
+        .await
+        .unwrap();
+}
+
+async fn append(temp_dir: &TempDir, batches: &[RecordBatch]) {
+    let writer = SqliteMetadataWriter::new(&conn_str(temp_dir))
+        .await
+        .unwrap();
+    DuckLakeTableWriter::new(Arc::new(writer), object_store())
+        .unwrap()
+        .append_table("main", "t", batches)
+        .await
+        .unwrap();
+}
+
+async fn read_only_session(temp_dir: &TempDir) -> SessionContext {
+    session(temp_dir, false).await
+}
+
+async fn session(temp_dir: &TempDir, row_lineage: bool) -> SessionContext {
+    let provider = SqliteMetadataProvider::new(&conn_str(temp_dir))
+        .await
+        .unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog(
+        "ducklake",
+        Arc::new(
+            DuckLakeCatalog::new(provider)
+                .unwrap()
+                .with_row_lineage(row_lineage),
+        ),
+    );
+    ctx
+}
+
+/// Every `id` the query returns, ascending.
+async fn query_ids(ctx: &SessionContext, sql: &str) -> Vec<i32> {
+    let batches = ctx.sql(sql).await.unwrap().collect().await.unwrap();
+    let mut ids: Vec<i32> = batches
+        .iter()
+        .flat_map(|b| {
+            let column = b
+                .column_by_name("id")
+                .expect("projection includes id")
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .expect("id is Int32")
+                .clone();
+            (0..column.len()).map(move |i| column.value(i))
+        })
+        .collect();
+    ids.sort_unstable();
+    ids
+}
+
+/// A table holding real files *and* an empty one reads exactly as it would
+/// without the empty file — unfiltered, filtered, and counted.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_scan_over_a_table_with_an_empty_file_returns_every_row() {
+    let temp_dir = TempDir::new().unwrap();
+    seed_table(&temp_dir, &[batch(vec![1, 2, 3], vec![10, 20, 30])]).await;
+    append(&temp_dir, &[batch(vec![101, 102, 103], vec![40, 50, 60])]).await;
+    // A live data file with no rows, sitting alongside the two above.
+    append(&temp_dir, &[RecordBatch::new_empty(table_schema())]).await;
+
+    let ctx = read_only_session(&temp_dir).await;
+
+    assert_eq!(
+        query_ids(&ctx, "SELECT id FROM ducklake.main.t").await,
+        vec![1, 2, 3, 101, 102, 103],
+        "the empty file must not cost the table any rows",
+    );
+    // A predicate that only one file's statistics admit: the row still comes back.
+    assert_eq!(
+        query_ids(&ctx, "SELECT id FROM ducklake.main.t WHERE id = 102").await,
+        vec![102],
+    );
+    // Answered from statistics rather than by reading files, so it is worth
+    // asserting separately: the empty file contributes 0 and must not shift it.
+    let counted = ctx
+        .sql("SELECT count(*) FROM ducklake.main.t")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(
+        counted[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .expect("count(*) is Int64")
+            .value(0),
+        6,
+    );
+}
+
+/// A table whose only live file is the empty one. Excluding it leaves nothing to
+/// scan at all, so this is the case where the exclusion could plausibly turn a
+/// legitimate zero-row read into a failure or a wrong-shaped result.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_table_whose_only_live_file_is_empty_reads_as_zero_rows() {
+    let temp_dir = TempDir::new().unwrap();
+    seed_table(&temp_dir, &[RecordBatch::new_empty(table_schema())]).await;
+
+    let ctx = read_only_session(&temp_dir).await;
+
+    let batches = ctx
+        .sql("SELECT id, val FROM ducklake.main.t")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(
+        batches.iter().map(RecordBatch::num_rows).sum::<usize>(),
+        0,
+        "an empty table reads as zero rows",
+    );
+    // The schema must still be the table's, not an artefact of having no file to
+    // derive one from.
+    let schema = ctx
+        .sql("SELECT id, val FROM ducklake.main.t")
+        .await
+        .unwrap()
+        .schema()
+        .as_arrow()
+        .clone();
+    assert_eq!(
+        schema
+            .fields()
+            .iter()
+            .map(|f| f.name().as_str())
+            .collect::<Vec<_>>(),
+        vec!["id", "val"],
+    );
+    assert_eq!(
+        query_ids(&ctx, "SELECT id FROM ducklake.main.t WHERE id = 1").await,
+        Vec::<i32>::new(),
+    );
+}
+
+/// The same shape read with row lineage on. Projecting the synthetic `rowid`
+/// takes a separate planning path — one scan per file, since each carries its own
+/// starting row id — with its own empty-plan branch. Excluding empty files is what
+/// makes that branch reachable for a table that does have a live file, so it is
+/// worth reading through rather than assuming it behaves like the path above.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_row_lineage_read_of_an_only_empty_table_reads_as_zero_rows() {
+    let temp_dir = TempDir::new().unwrap();
+    seed_table(&temp_dir, &[RecordBatch::new_empty(table_schema())]).await;
+
+    let ctx = session(&temp_dir, true).await;
+
+    let frame = ctx
+        .sql("SELECT id, val, rowid FROM ducklake.main.t")
+        .await
+        .unwrap();
+    let schema = frame.schema().as_arrow().clone();
+    assert_eq!(
+        schema
+            .fields()
+            .iter()
+            .map(|f| f.name().as_str())
+            .collect::<Vec<_>>(),
+        vec!["id", "val", "rowid"],
+        "the rowid projection must survive an empty candidate set",
+    );
+    let batches = frame.collect().await.unwrap();
+    assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 0,);
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -27,6 +27,7 @@ mod compaction_sqlite_tests;
 mod concurrent_tests;
 mod concurrent_write_tests;
 mod delete_filter_tests;
+mod empty_data_file_tests;
 mod encryption_tests;
 mod files_matching_tests;
 mod hybrid_asyncdb;


### PR DESCRIPTION
## Summary

A data file with **zero rows** is currently kept in the pruning candidate set, where it contributes an absent bound and forces an extra pruning round. A file with no rows cannot contain a row matching any predicate, so it can be excluded before statistics are consulted.

Related: #243 (there is currently no way to commit a table's schema without writing a 0-row data file, which is one way these arise).

## What this changes

Two things, and neither is a correctness fix — reads already return the right answer:

1. **Saves one pruning round** on any table carrying a 0-row file.
2. **Closes the residual case** where a 0-row file with *no per-column statistics row* defeats pruning outright.

## Why the common case already works

Worth stating plainly so this isn't read as a bigger claim than it is: a 0-row file normally **is** already pruned, and pruning is **not** broken today.

`PrunableStatistics` substitutes `ScalarValue::Null` for the missing min/max, and building the mixed-type array fails, so that column is unusable for the whole candidate set in that round. But DataFusion wraps every **binary** comparison rewrite in a `null_count != row_count` guard (`pruning_predicate.rs:1682` → `:2022` → `:1756`), which a 0-row file satisfies trivially (`0 == 0`) — so it is dropped on the very column whose bounds are unusable. `prune_table_files_iteratively` then sees the candidate set shrink and runs another round, now with usable bounds.

Measured on a SQLite-backed catalog with two row-bearing files plus one empty file:

```
ROUND 1  candidates=3 -> 2     (null-count guard drops the empty file)
ROUND 2  candidates=2 -> 1     (bounds now usable)
ROUND 3  candidates=1 -> 1     (stable)
```

Without the empty file the same fixture settles in two rounds. So the saving is exactly one round, plus the removal of a `Failed to convert min values to array` warning burst — around 100 occurrences per keyed mutation in the workload that prompted this.

## This matches official DuckLake

Worth stating explicitly, since the rule here is not to diverge from the reference implementation: **official DuckLake already drops zero-row files during filter pushdown.** It reaches the same place by a different statistic — `value_count` rather than `record_count` — in `ducklake_metadata_manager.cpp`:

```cpp
conditions += StringUtil::Format("(data.data_file_id NOT IN (SELECT data_file_id FROM %s) OR "
                                 "data.data_file_id IN (SELECT data_file_id FROM %s WHERE "
                                 "(value_count IS NULL OR value_count > 0) AND (%s(%s))))", ...);
```

A zero-row file that carries stats rows has `value_count = 0` and is excluded by any pushed-down min/max filter. So "skip empty files while pruning" is the reference behaviour, not an invention here.

This change prunes in two places the reference does not, and neither alters a row set:

- **the no-stats-row case** — official's `NOT IN` branch deliberately keeps a file with no stats row for the column; this drops it on `record_count == 0`. That is precisely the residual case above, and it is a strictly tighter narrowing of the same fail-open superset.
- **the no-predicate and error paths** — official includes empty files in an unfiltered scan. Zero rows either way.

Zero-row files are not hypothetical in the reference either: DuckLake's own `test/sql/compaction/repro_merge_adjacent_zero_output.test` asserts four live `ducklake_data_file` rows whose `record_count` sums to 0.

## The case that does not recover

The recovery above depends entirely on the empty file having an **`Exact` `null_count`** for the predicate's column. Where that is missing, the file has no usable statistic at all, nothing can prune it, the column stays suppressed in every round, and the loop exits after round one having pruned nothing:

```
WITHOUT a stats row -> [1, 2, 3, 4]     <- pruning fully defeated
WITH    a stats row -> [2]              <- ideal
BASELINE (no empty) -> [2]              <- ideal
```

Reachable at least three ways: `collect_column_stats` returns `Vec::new()` on any footer-harvest failure (`src/stats_collect.rs:85-95`), so this crate's own write path can produce such a file; schema evolution leaves a column with no stats row on files written before it (`src/table.rs:378-380`); and a foreign producer may simply omit them. Both of the first two are established by reading the code rather than by reproduction — flagging that rather than implying they were measured.

## Implementation

A 3-line `file_is_known_empty` (`max_row_count == Some(0)`, nothing else) plus a filter at the top of `prune_table_files_iteratively`. The filtered list becomes `candidates`, which is what both the no-predicates return and the pruning-error return hand back — an emptiness proof does not stop being a proof because pruning was skipped.

**`Some(0)` only.** `None` (a provider or older catalog that does not surface `max_row_count`) and `Some(n > 0)` both keep the file. Never treat `None` as zero: that would drop files holding real rows, which is silent data loss on a mutation path. The fail-open contract is preserved everywhere else — a file is dropped only when its own statistics prove it cannot match, and "zero rows" is exactly such a proof.

**Placement is in the pruning path, not `page_files_with_statistics`.** Both `scan` and `files_matching` collect encryption keys from the pre-filter page list (`src/table.rs:976`, `:2786`); narrowing that shared list would strand a key. `Replace` truncation is a commit-time catalog operation (`retire_prior_generation`), so nothing at read time needs the marker present in the live set.

## Tests

Five, all running under **both** CI feature sets — nothing local-only.

| Test | Verified by |
|---|---|
| `files_matching_prunes_around_an_empty_file_without_statistics` | **regression** — filter removed → `[1,2,3,4]` vs `[2]` |
| `files_matching_keeps_a_file_whose_row_count_is_unknown` | **guard** — `unwrap_or(0)` → `[]` vs `[2]`. The only test that catches that mis-implementation |
| `a_scan_over_a_table_with_an_empty_file_returns_every_row` | no-regression — over-broad filter → `[]` vs all rows |
| `a_table_whose_only_live_file_is_empty_reads_as_zero_rows` | no-regression (cannot detect over-reach; labelled as such) |
| `a_row_lineage_read_of_an_only_empty_table_reads_as_zero_rows` | added from review |

Each was confirmed to fail under a deliberate regression rather than by inspection.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`, and both CI test invocations — all clean on this commit, re-run immediately before pushing. Branch is on current `main` (`dfccf3e`); nothing to rebase.

