### PR TITLE
fix(compaction): preserve partition assignment on the Postgres writer

### DIFF
--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -3572,6 +3572,12 @@ impl MetadataWriter for PostgresMetadataWriter {
                 let data_file_id: i64 = inserted.try_get(0)?;
                 insert_file_column_stats(&mut tx, table_id, data_file_id, &out.file.column_stats)
                     .await?;
+                // Carry the output's partition assignment over from its sources.
+                // Every file in a compaction group shares one partition, so the
+                // output belongs to exactly that partition; without this the
+                // merged file drops out of its partition and partition-value
+                // pruning is lost for good.
+                insert_partition_metadata(&mut tx, table_id, data_file_id, &out.file).await?;
             }
 
             // Recompute the visible stat totals from the surviving files (see the

--- a/tests/it/compaction_postgres_tests.rs
+++ b/tests/it/compaction_postgres_tests.rs
@@ -451,3 +451,301 @@ async fn rewrite_targets_explicit_postgres_data_files() {
         vec![(1, 10), (2, 20), (3, 30), (4, 40)],
     );
 }
+
+/// The Postgres counterpart of the SQLite
+/// `merge_only_within_a_partition_and_preserves_assignment` test.
+///
+/// Compaction of a PARTITIONED table must merge only within a partition AND carry
+/// each output's partition assignment over from its sources, on every metadata
+/// backend. Official DuckLake takes the merged file's partition straight from
+/// `source_files[0]` and writes the resulting `ducklake_file_partition_value` rows
+/// through its shared file-registration path, so an output that kept its rows but
+/// lost its partition row is not a representable state there.
+///
+/// This asserts on CATALOG state, not query results: a merged file that dropped its
+/// partition assignment still returns every row (zone maps keep pruning), so reads
+/// look healthy while partition-value pruning is silently and permanently gone.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn merge_preserves_partition_assignment_postgres() {
+    use datafusion_ducklake::partition::PartitionTransform;
+    use datafusion_ducklake::{ColumnDef, WriteMode};
+
+    let (pool, _container) = spin_up_postgres().await.unwrap();
+    let temp = TempDir::new().unwrap();
+    let data = temp.path().join("data");
+    std::fs::create_dir_all(&data).unwrap();
+    let store: ObjStore = Arc::new(LocalFileSystem::new());
+    let cat_name = "cat";
+    let cat = MulticatalogManager::new(pool.clone())
+        .create_catalog(cat_name)
+        .await
+        .unwrap();
+
+    // Create `public.t(id, val)` with no data, then partition it by `val`, so every
+    // data file that follows is written into a partition.
+    let writer = writer_for(&pool, cat, &data).await;
+    let cols = vec![
+        ColumnDef::from_arrow("id", &DataType::Int32, false).unwrap(),
+        ColumnDef::from_arrow("val", &DataType::Int32, false).unwrap(),
+    ];
+    let setup = writer
+        .begin_write_transaction("public", "t", &cols, WriteMode::Replace)
+        .unwrap();
+    writer
+        .publish_snapshot(
+            setup.table_id,
+            "public",
+            "t",
+            setup.snapshot_id,
+            WriteMode::Replace,
+            setup.base_snapshot_id,
+            &cols,
+            &setup.column_ids,
+        )
+        .unwrap();
+    writer
+        .set_partition_spec(
+            setup.table_id,
+            &[("val".to_string(), PartitionTransform::Identity)],
+        )
+        .unwrap();
+    let table_id = setup.table_id;
+
+    // Two appends, each landing rows in BOTH partitions (val=1 and val=2), so each
+    // append writes one small file per partition: four files over two origin
+    // snapshots. Spanning origin snapshots also drives the partial-data-file path,
+    // so each merged output carries a `partial_max` as well as its partition.
+    for id in [1, 2] {
+        DuckLakeTableWriter::new(writer_for(&pool, cat, &data).await, store.clone())
+            .unwrap()
+            .append_table("public", "t", &[batch(vec![id, id + 10], vec![1, 2])])
+            .await
+            .unwrap();
+    }
+    assert_eq!(
+        live_files(&pool, cat_name).await.len(),
+        4,
+        "two appends x two partitions = four files"
+    );
+
+    // Merge with a target large enough to bin everything that is legal to bin.
+    let result = with_writable_table(&pool, cat, cat_name, &data, |t, s| async move {
+        t.merge_adjacent_files(
+            &s,
+            MergeOptions {
+                target_file_size: 1 << 30,
+                max_merged_files: 1024,
+                min_file_size: 0,
+            },
+        )
+        .await
+    })
+    .await;
+    assert!(result.did_work(), "the small files must be compacted");
+    assert_eq!(result.files_processed, 4, "all four sources merged");
+    assert_eq!(
+        result.files_created, 2,
+        "one output per partition, never one across partitions"
+    );
+
+    // The load-bearing assertion: read the merged files' partition assignment back
+    // out of the catalog. One live file per partition, each with a non-NULL
+    // `partition_id` and its own `ducklake_file_partition_value` row.
+    let live_after: Vec<(Option<i64>, Option<String>, Option<i64>)> = sqlx::query(
+        "SELECT df.partition_id, fpv.partition_value, df.partial_max
+         FROM ducklake_data_file AS df
+         LEFT JOIN ducklake_file_partition_value AS fpv
+           ON fpv.data_file_id = df.data_file_id
+         WHERE df.table_id = $1 AND df.end_snapshot IS NULL
+         ORDER BY fpv.partition_value",
+    )
+    .bind(table_id)
+    .fetch_all(&pool)
+    .await
+    .unwrap()
+    .into_iter()
+    .map(|r| {
+        (
+            r.try_get::<Option<i64>, _>(0).unwrap(),
+            r.try_get::<Option<String>, _>(1).unwrap(),
+            r.try_get::<Option<i64>, _>(2).unwrap(),
+        )
+    })
+    .collect();
+
+    assert_eq!(
+        live_after.len(),
+        2,
+        "exactly one merged file per partition, each with exactly one partition \
+         value row: {live_after:?}"
+    );
+    let values: Vec<Option<String>> = live_after.iter().map(|(_, v, _)| v.clone()).collect();
+    assert_eq!(
+        values,
+        vec![Some("1".to_string()), Some("2".to_string())],
+        "each merged file keeps its own partition value: {live_after:?}"
+    );
+    for (partition_id, value, partial_max) in &live_after {
+        assert!(
+            partition_id.is_some(),
+            "a merged file of a partitioned table must keep its partition_id \
+             (value={value:?})"
+        );
+        assert!(
+            partial_max.is_some(),
+            "an output merged across origin snapshots is a partial file, and must \
+             carry its partition alongside partial_max (value={value:?})"
+        );
+    }
+
+    // Every partitioned live file agrees with the table's live partition spec, so a
+    // later merge pass still sees well-formed partition groups to bin within.
+    let spec_id = writer
+        .live_partition_spec(table_id)
+        .unwrap()
+        .expect("table is partitioned")
+        .partition_id;
+    for (partition_id, _, _) in &live_after {
+        assert_eq!(
+            *partition_id,
+            Some(spec_id),
+            "merged files must stay on the live partition spec"
+        );
+    }
+
+    // And the rows survive intact — this passes both before and after the fix,
+    // which is exactly why the catalog assertions above are the real test.
+    assert_eq!(
+        read_rows(&pool, cat_name, None).await,
+        vec![(1, 1), (2, 1), (11, 2), (12, 2)]
+    );
+}
+
+/// The Postgres counterpart of the SQLite `rewrite_preserves_partition_assignment`
+/// test. A delete-driven rewrite commits through the same `commit_compaction`
+/// output-registration path as a merge, so it lost the partition assignment in
+/// exactly the same way. The output holds a subset of one source file's rows, so it
+/// belongs to precisely that file's partition — official DuckLake takes the
+/// partition from `source_files[0]` on this path too.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn rewrite_preserves_partition_assignment_postgres() {
+    use datafusion_ducklake::partition::PartitionTransform;
+    use datafusion_ducklake::{ColumnDef, WriteMode};
+
+    let (pool, _container) = spin_up_postgres().await.unwrap();
+    let temp = TempDir::new().unwrap();
+    let data = temp.path().join("data");
+    std::fs::create_dir_all(&data).unwrap();
+    let store: ObjStore = Arc::new(LocalFileSystem::new());
+    let cat_name = "cat";
+    let cat = MulticatalogManager::new(pool.clone())
+        .create_catalog(cat_name)
+        .await
+        .unwrap();
+
+    let writer = writer_for(&pool, cat, &data).await;
+    let cols = vec![
+        ColumnDef::from_arrow("id", &DataType::Int32, false).unwrap(),
+        ColumnDef::from_arrow("val", &DataType::Int32, false).unwrap(),
+    ];
+    let setup = writer
+        .begin_write_transaction("public", "t", &cols, WriteMode::Replace)
+        .unwrap();
+    writer
+        .publish_snapshot(
+            setup.table_id,
+            "public",
+            "t",
+            setup.snapshot_id,
+            WriteMode::Replace,
+            setup.base_snapshot_id,
+            &cols,
+            &setup.column_ids,
+        )
+        .unwrap();
+    writer
+        .set_partition_spec(
+            setup.table_id,
+            &[("val".to_string(), PartitionTransform::Identity)],
+        )
+        .unwrap();
+    let table_id = setup.table_id;
+    let live_spec_id = writer
+        .live_partition_spec(table_id)
+        .unwrap()
+        .expect("table is partitioned")
+        .partition_id;
+
+    // One partition (val=1) holding ten rows, so the rewrite has a single source.
+    DuckLakeTableWriter::new(writer_for(&pool, cat, &data).await, store.clone())
+        .unwrap()
+        .append_table("public", "t", &[batch((1..=10).collect(), vec![1; 10])])
+        .await
+        .unwrap();
+
+    // Delete eight of ten rows, then rewrite past the 0.5 threshold.
+    {
+        let provider = MulticatalogProvider::with_pool(pool.clone(), cat_name)
+            .await
+            .unwrap();
+        let catalog =
+            DuckLakeCatalog::with_writer(Arc::new(provider), writer_for(&pool, cat, &data).await)
+                .unwrap();
+        let ctx = SessionContext::new();
+        ctx.register_catalog(cat_name, Arc::new(catalog));
+        ctx.sql(&format!("DELETE FROM {cat_name}.public.t WHERE id <= 8"))
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+    }
+    let result = with_writable_table(&pool, cat, cat_name, &data, |t, s| async move {
+        t.rewrite_data_files(
+            &s,
+            RewriteOptions {
+                delete_threshold: 0.5,
+                ..RewriteOptions::default()
+            },
+        )
+        .await
+    })
+    .await;
+    assert_eq!(result.files_created, 1, "the live rows are rewritten");
+
+    // The rewritten file keeps the partition it came from.
+    let (partition_id, value): (Option<i64>, Option<String>) = sqlx::query(
+        "SELECT df.partition_id, fpv.partition_value
+         FROM ducklake_data_file AS df
+         LEFT JOIN ducklake_file_partition_value AS fpv
+           ON fpv.data_file_id = df.data_file_id
+         WHERE df.table_id = $1 AND df.end_snapshot IS NULL",
+    )
+    .bind(table_id)
+    .fetch_one(&pool)
+    .await
+    .map(|r| {
+        (
+            r.try_get::<Option<i64>, _>(0).unwrap(),
+            r.try_get::<Option<String>, _>(1).unwrap(),
+        )
+    })
+    .unwrap();
+    assert_eq!(
+        partition_id,
+        Some(live_spec_id),
+        "the rewritten file must keep its partition_id"
+    );
+    assert_eq!(
+        value,
+        Some("1".to_string()),
+        "the rewritten file must keep its partition value"
+    );
+    // And the surviving rows read back.
+    assert_eq!(
+        read_rows(&pool, cat_name, None).await,
+        vec![(9, 1), (10, 1)]
+    );
+}


### PR DESCRIPTION
## Summary

`commit_compaction` registers each merged output file and its column statistics, but on the **Postgres** metadata writer it never writes the file's partition rows. Compacting a partitioned table therefore drops every merged file out of its partition.

The SQLite writer does not have this bug. One line brings Postgres in line with it.

## The asymmetry

| | writes `ducklake_file_partition_value`? |
|---|---|
| `metadata_writer_sqlite.rs:3486` (compaction output loop) | yes |
| `metadata_writer_postgres.rs:3485-3508` (same loop) | **no** — stops after `insert_file_column_stats` |

The Postgres writer *has* `insert_partition_metadata` (`:741`) and calls it from **every other** file-registration path — `:1707`, `:1874`, `:2487`, `:2798`, `:3050`. Compaction was the only omission, which makes this a gap rather than a decision.

The data was there and being discarded: `compaction.rs:497` and `:639` call `file.with_partition(pid, …)`, so `out.file.partition_id` and `partition_values` were populated before the loop threw them away. And `compaction.rs:285` documents the intended behaviour — *"A merged file inherits its sources' `partition_id` and partition values"* — so the code contradicted its own contract on one backend.

Only SQLite and Postgres override `commit_compaction`; the trait default (`metadata_writer.rs:1331`) errors as unsupported, so MySQL / postgres-single / DuckDB are unaffected.

## Broader than just merging

`rewrite_data_files` commits through the same `commit_compaction` (`compaction.rs:659`, `SourceRetirement::Retire`), so **delete-driven rewrite lost the partition assignment identically**. One fix covers both paths; there is a test for each, because SQLite already pinned both and Postgres pinned neither.

## Consequence

Reads stay correct — zone maps still prune — so nothing fails loudly. But partition-value pruning is permanently lost for every merged file, and a later compaction pass seeing assignment-less files could merge across former partition boundaries into something that can never be partition-pruned again. Since a table's layout is fixed at creation, that is not repairable in place.

## This converges on official DuckLake

The reference implementation does exactly what this change restores:

- `src/functions/ducklake_compaction_functions.cpp:543-544` — the merged output takes `source_files[0].file.partition_id` and `.partition_values`.
- `…:163-171` — those values are attached to every written output file.
- `src/storage/ducklake_metadata_manager.cpp:4118-4120` — partition rows are written in the same batch as `ducklake_data_file` and `ducklake_file_column_stats`.

DuckLake also treats the pairing as an invariant it actively checks (`ducklake_metadata_manager.cpp:3973-3975`):

```cpp
if (file.partition_id.IsValid() == file.partition_values.empty()) {
    throw InternalException("File should either not be partitioned, or have partition values");
}
```

**Note carefully what that does *not* catch, because it explains why this went unnoticed.** The check rejects *partitioned-without-values* and *values-without-partition*. The state this bug produced is `partition_id = NULL` **and** no values — the legal "not partitioned" branch. So a damaged file is indistinguishable from a file that was legitimately never partitioned (one written before the table gained its partition spec, say). Nothing asserts, nothing warns, and reads stay correct. The divergence is not that the crate produced an illegal state; it is that it silently produced an *unpartitioned* file where official DuckLake produces a partitioned one.

## The fix

One call at `metadata_writer_postgres.rs:3513`, after `insert_file_column_stats`, inside the same transaction as the data-file INSERT. Ordering relative to the stats call is irrelevant: disjoint tables, both after the row exists, both before commit.

`partial_max` needs no special handling. Merge candidates are grouped by partition identity, so a partial output still belongs to exactly one partition — `partial_max` expresses temporal visibility, not a second dimension. The merge test asserts `partial_max.is_some()` alongside the partition rather than leaving that to inference.

## Tests

Two, both against a real Postgres via testcontainers, asserting on **catalog state** rather than query results — the defining feature of this bug is that reads keep working while the metadata is wrong.

Verified pre-fix by reverting the call:

```
merge:   [(None, None, Some(4)), (None, None, Some(4))]   partition_id and partition_value both NULL
rewrite: left: None, right: Some(1)
```

Both pass after. Runtimes ~1.1–1.7s with a Postgres container starting, so they are exercising the real path.

## Note on CI coverage

These two tests are gated on `write-postgres`, which neither `cargo test` job enables — and that exclusion is **deliberate and documented** (`ci.yml:439-441`):

> Multicatalog (the runtimedb-specific layer, gated on `write-postgres`) is intentionally excluded here — its test files stay in-tree but don't run.

So this is not an oversight to fix in this PR. Flagging it only because it is the mechanism by which a Postgres-only write-path divergence could persist while the SQLite equivalent stayed green: nine test files sit behind that feature, including the pre-existing `compaction_postgres_tests.rs`. Locally the suite is 365 tests under the second CI job and 501 with `write-postgres` added.

The new tests are still compile- and clippy-gated via `--all-features --all-targets` (`ci.yml:195`), and would activate automatically if that axis were ever enabled.

For anyone who does want to run them: `cargo test --features "duckdb-bundled encryption metadata-mysql metadata-postgres metadata-sqlite write-sqlite write-postgres"` — note it surfaces 3 pre-existing failures in `postgres_single_catalog_write_tests` (e.g. `Plan("failed to resolve schema: main")`), confirmed pre-existing by stashing this change and re-running on a clean tree. Different writer, unrelated to this fix.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`, and both CI invocations — all clean. Plus an ad-hoc run with `write-postgres` where the two new tests and all 20 compaction tests pass.


