### PR TITLE
Let consumers configure object store and PostgreSQL TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `TableChangesTable`, `TableInsertionsTable` and `TableDeletionsTable` accept the table's columns
   through a new `with_columns` builder. No signature changed; without it the columns are read from
   the metadata provider on each scan.
+- **BREAKING**: PostgreSQL metadata features no longer select a TLS provider. Consumers that need
+  TLS must also enable one of `tls-native-tls`, `tls-rustls-aws-lc-rs`, or `tls-rustls-ring`.
+  Without one, SQLx rejects connections that require TLS and may try plaintext when `sslmode`
+  prefers TLS. No catalog or data migration is needed.
+- **BREAKING**: S3 support is no longer selected by the library. Consumers using
+  `object_store::aws` must enable `object_store/aws` in their application or register another
+  `ObjectStore` implementation with DataFusion. Local filesystem support remains available through
+  DataFusion without extra configuration. No catalog or data migration is needed.
 - `TableWriteSession::finish_with_deletes` no longer refuses a session that produced more than one appended file; it commits them all in the snapshot that carries the deletes (#214).
 
 ### Fixed

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -25,6 +25,10 @@ below) where tables are created via `DuckLakeTableWriter` and then appended to w
 | PostgreSQL |  ✅  |  ✅   |      ✅       | `metadata-postgres`, `write-postgres`, `multicatalog-postgres` |
 | MySQL      |  ✅  |  ❌   |      ❌       | `metadata-mysql`                                       |
 
+The listed PostgreSQL features do not select a TLS provider. Plain local connections work without
+one. For TLS, also enable one of `tls-native-tls`, `tls-rustls-aws-lc-rs`, or
+`tls-rustls-ring`.
+
 PostgreSQL has **two** writers, both behind `write-postgres`:
 
 | Writer | Layout | Spec-compliant | SQL `CREATE TABLE`/CTAS | Read back with |
@@ -60,9 +64,16 @@ multiple independent DuckLake catalogs. Reading multiple catalogs requires
 | Store                       | Supported | Notes                                              |
 |-----------------------------|:---------:|----------------------------------------------------|
 | Local filesystem            |    ✅     | Available by default via DataFusion's object store |
-| S3-compatible (S3, MinIO)   |    ✅     | Register with `RuntimeEnv::register_object_store`  |
+| S3-compatible (S3, MinIO)   |    ✅     | Enable `object_store/aws` in the application       |
 | Google Cloud Storage        |    ❌     | Not currently wired up                             |
 | Azure Blob Storage          |    ❌     | Not currently wired up                             |
+
+Applications configure `object_store` directly for local files, S3, or MinIO, or register another
+compatible `ObjectStore` implementation with DataFusion, including an OpenDAL‑backed connector.
+DuckLake enables the filesystem and AWS providers only for its own tests and examples.
+
+Enabling `object_store/aws` also enables Ring through its HTTP client. If another dependency enables
+AWS‑LC, install the intended process‑wide Rustls `CryptoProvider` before creating TLS clients.
 
 ---
 
@@ -79,6 +90,9 @@ multiple independent DuckLake catalogs. Reading multiple catalogs requires
 | `write-sqlite`           | Write to SQLite catalogs (`write` + `metadata-sqlite`)                   |         |
 | `write-postgres`         | Write to PostgreSQL catalogs (`write` + `metadata-postgres` + multi-catalog) |     |
 | `multicatalog-postgres`  | Read multiple catalogs from one PostgreSQL store                         |         |
+| `tls-native-tls`         | Use native TLS for SQLx PostgreSQL connections                           |         |
+| `tls-rustls-aws-lc-rs`   | Use Rustls with AWS‑LC for SQLx PostgreSQL connections                   |         |
+| `tls-rustls-ring`        | Use Rustls with Ring for SQLx PostgreSQL connections                     |         |
 | `encryption`             | Parquet Modular Encryption (PME) reads                                   |         |
 | `skip-tests-with-docker` | CI-only: skip tests that require Docker                                  |         |
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,6 +1375,16 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -2666,6 +2676,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3727,6 +3752,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework 2.11.1",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3857,10 +3899,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags 2.9.4",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "ordered-float"
@@ -4649,7 +4729,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.4.0",
 ]
 
 [[package]]
@@ -4785,12 +4865,25 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.9.4",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b369d18893388b345804dc0007963c99b7d665ae71d275812d828c6f089640"
 dependencies = [
  "bitflags 2.9.4",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -5186,6 +5279,7 @@ dependencies = [
  "indexmap 2.14.0",
  "log",
  "memchr",
+ "native-tls",
  "percent-encoding",
  "rustls 0.23.37",
  "serde",
@@ -6171,9 +6265,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ datafusion = "54"
 datafusion-datasource = "54"
 arrow = "58"
 parquet = { version = "58", features = ["async"] }
-object_store = { version = "0.13", features = ["aws"] }
+object_store = { version = "0.13", default-features = false }
 url = "2.5"
 percent-encoding = "2"
 async-trait = "0.1"
@@ -51,6 +51,7 @@ duckdb = { version = "1.4.1", optional = true }
 sqlx = { version = "0.9", features = ["runtime-tokio"], optional = true }
 
 [dev-dependencies]
+object_store = { version = "0.13", features = ["aws", "fs"] }
 testcontainers = "0.23"
 testcontainers-modules = { version = "0.11", features = ["minio", "postgres", "mysql"] }
 tempfile = "3.14"
@@ -68,12 +69,15 @@ skip-tests-with-docker = []
 
 # Metadata provider backends
 metadata-duckdb = ["dep:duckdb"]
-metadata-postgres = ["dep:sqlx", "sqlx/postgres", "sqlx/chrono", "sqlx/tls-rustls-ring"]
+metadata-postgres = ["dep:sqlx", "sqlx/postgres", "sqlx/chrono"]
 # `mysql-rsa` keeps non-TLS `caching_sha2_password`/`sha256_password` auth working
 # (MySQL 8's default). sqlx bundled RSA unconditionally through 0.8; 0.9 split it
 # into an opt-in feature, and without it those connections fail at connect time.
 metadata-mysql = ["dep:sqlx", "sqlx/mysql", "sqlx/mysql-rsa", "sqlx/chrono"]
 metadata-sqlite = ["dep:sqlx", "sqlx/sqlite", "sqlx/chrono"]
+tls-native-tls = ["sqlx?/tls-native-tls"]
+tls-rustls-aws-lc-rs = ["sqlx?/tls-rustls-aws-lc-rs"]
+tls-rustls-ring = ["sqlx?/tls-rustls-ring"]
 
 # Compile DuckDB C++ from source and statically bundle it. Enabled by default.
 # Consumers who want to dynamically link against a system libduckdb can disable

--- a/README.md
+++ b/README.md
@@ -33,16 +33,22 @@ Add the crate:
 cargo add datafusion-ducklake
 ```
 
-The default build includes the DuckDB catalog backend, statically bundled. Other
-backends and write support are opt-in via feature flags — see
-[COMPATIBILITY.md](COMPATIBILITY.md) for the full matrix.
+The default build includes the statically bundled DuckDB catalog backend. Applications configure
+their object store implementation directly. Other catalog backends and write support are opt‑in
+via feature flags. See [COMPATIBILITY.md](COMPATIBILITY.md) for the full matrix.
 
 ```toml
 # Cargo.toml — read PostgreSQL catalogs
 # (for the experimental multi-catalog write path, use features = ["write-postgres"])
-[dependencies]
-datafusion-ducklake = { version = "0.5", features = ["metadata-postgres"] }
+[dependencies.datafusion-ducklake]
+version = "0.6"
+default-features = false
+features = ["metadata-postgres", "tls-rustls-aws-lc-rs"]
 ```
+
+`metadata-postgres`, `multicatalog-postgres`, and `write-postgres` do not select a TLS provider.
+Plain local connections work without one. For TLS, also enable one of `tls-native-tls`,
+`tls-rustls-aws-lc-rs`, or `tls-rustls-ring` on `datafusion-ducklake`.
 
 The examples below also use `datafusion`, `object_store`, and `url` directly — add them
 to your `[dependencies]` as well (this crate does not re-export them). The write example
@@ -55,6 +61,15 @@ Run a query against an existing PostgreSQL catalog with the bundled example:
 cargo run --example basic_query --features metadata-postgres -- \
   "postgresql://user:password@localhost:5432/database" "SELECT * FROM main.users"
 ```
+
+Configure `object_store` directly for local, S3, or MinIO data files. Applications can instead
+register another DataFusion `ObjectStore`, such as an OpenDAL‑backed connector.
+
+DataFusion enables local filesystem support. S3 and MinIO applications must enable
+`object_store/aws` themselves. That feature enables Ring through its HTTP client. If another
+dependency enables AWS‑LC, install the intended process‑wide Rustls
+[`CryptoProvider`](https://docs.rs/rustls/0.23/rustls/crypto/struct.CryptoProvider.html) before
+creating TLS clients.
 
 (The example also accepts DuckDB, SQLite, and MySQL connection strings with the matching
 `metadata-*` feature — see [COMPATIBILITY.md](COMPATIBILITY.md).)

--- a/tests/it/postgres_metadata_provider_test.rs
+++ b/tests/it/postgres_metadata_provider_test.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "metadata-postgres")]
+#![cfg(all(feature = "metadata-postgres", feature = "metadata-duckdb"))]
 //! PostgreSQL metadata provider tests
 //!
 //! This test suite verifies the PostgreSQL metadata provider implementation,


### PR DESCRIPTION
### Summary

Stop selecting object store implementations and a PostgreSQL TLS provider in DuckLake's normal
dependency graph. The library continues to use the `ObjectStore` trait, while applications choose
the matching `object_store` implementation or register another DataFusion connector such as
OpenDAL. PostgreSQL support remains behind the existing metadata and write features, but applications
now choose their SQLx TLS provider directly.

DuckLake's tests and examples enable the filesystem and AWS implementations through a dev
dependency. This keeps their existing coverage without adding those implementations to downstream
builds.

### Design

- Keep `object_store` available without default features because DuckLake's library code depends on
  the interface, not a concrete provider.
- Let applications configure `object_store` directly. DuckLake has no filesystem‑specific or
  AWS‑specific library code that needs a forwarding feature.
- Keep `metadata-postgres`, `multicatalog-postgres`, and `write-postgres` independent from TLS.
  Applications choose Ring, AWS‑LC, native TLS, or no TLS through their own SQLx dependency.
- Enable `object_store/aws` and `object_store/fs` only as dev dependencies so examples and tests
  retain their current providers.
- Gate tests on DuckLake capabilities, not dependency features. The PostgreSQL metadata provider
  suite also requires `metadata-duckdb` because it imports the DuckDB provider and shared fixtures.

### Changes

- Disable default features on the normal `object_store` dependency.
- Enable AWS and filesystem support on the `object_store` dev dependency.
- Remove `sqlx/tls-rustls-ring` from `metadata-postgres`.
- Make the PostgreSQL metadata provider test gate match its DuckDB dependency.
- Update the README, compatibility matrix, changelog, and lockfile for consumer‑owned providers.

### Consumer configuration

An application can combine filesystem storage with AWS‑LC PostgreSQL TLS without enabling either
provider through DuckLake:

```toml
datafusion-ducklake = { version = "0.6", default-features = false, features = ["write-postgres", "write-sqlite"] }
object_store = { version = "0.13", default-features = false, features = ["fs"] }
sqlx = { version = "0.9", default-features = false, features = ["postgres", "runtime-tokio", "tls-rustls-aws-lc-rs"] }
```

Applications using OpenDAL can omit concrete `object_store` providers and register an
`object_store_opendal` adapter with DataFusion.

### Commit and branch

- Branch: `fix/object-store-aws-opt-in`.
- Commit: `e6a3ff319813a45ed66978d3b1fecb4046524cf8 Let consumers configure object store and PostgreSQL TLS`.
- Base: `cf72534d08e4a75a6d51d9e7810ab9b8fbf4f14c` (`origin/main`, including PR #230).
- Shape: exactly one commit ahead of `origin/main`.
- Remote: `faysou:fix/object-store-aws-opt-in`.
- PR: [datafusion-contrib/datafusion-ducklake#247](https://github.com/datafusion-contrib/datafusion-ducklake/pull/247).

### Verification

- Default, provider‑free, PostgreSQL metadata, and PostgreSQL write `cargo check --locked`
  configurations passed.
- Default, `metadata-postgres`, and `write-postgres` normal dependency graphs have no reverse
  dependency on Ring.
- `cargo test --locked --no-default-features --features metadata-postgres --test it --no-run` passed,
  proving the narrow test target compiles with capability gates and no DuckDB provider.
- `postgres_metadata_provider_test::test_get_current_snapshot` passed against a disposable
  PostgreSQL container with no SQLx TLS provider selected by DuckLake.
- `cargo fmt --all -- --check` passed.
- `cargo metadata --locked --no-deps --format-version 1` passed.
- `git diff --check origin/main` passed.
