### PR TITLE
fix(read): declare nested field ids in read schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `TableWriteSession::finish_with_deletes` no longer refuses a session that produced more than one appended file; it commits them all in the snapshot that carries the deletes (#214).
 
 ### Fixed
+- `types::build_read_schema_with_field_id_mapping` declares the `PARQUET:field_id` of every nested
+  node the data file tags — list elements, struct children, map key/value, at any depth. A nested
+  node's field id is part of its parent's Arrow type, so a read schema that omitted it disagreed with
+  the batches the parquet reader produces from the very file it describes ("column types must match
+  schema types"). Callers that pair that schema with arrow-rs themselves hit the error directly;
+  scans through this crate's `TableProvider` were unaffected, because DataFusion's parquet opener
+  casts a metadata-only difference away. Files without nested field ids (external, or written before
+  nested nodes were tagged) are still described without them, and the table's catalog schema stays
+  free of storage metadata. Dropping the ids on the way out is a relabel rather than a conversion, so
+  a scan over a nested column keeps its filter and limit pushdown.
 - A write upgrades legacy single‑row `list<T>` metadata to recursive list and element rows without
   changing the existing list column ID or invalidating historical snapshots.
 - Reads null‑fill fields added inside structs, including non‑nullable fields and structs nested in

--- a/src/column_rename.rs
+++ b/src/column_rename.rs
@@ -75,6 +75,13 @@ impl ColumnRenameExec {
 
     /// Returns whether this node only renames columns without casting,
     /// projecting, or synthesizing values.
+    ///
+    /// Nested field metadata is ignored: a read schema describes the file's
+    /// nested nodes with the `PARQUET:field_id` the file tags them with, so it
+    /// differs from the catalog type by metadata alone even when the values are
+    /// identical. Dropping that metadata on the way out is a zero-copy relabel,
+    /// not a conversion, so it must not cost the scan its filter and limit
+    /// pushdown.
     pub fn is_pure_type_preserving_rename(&self) -> bool {
         let input_schema = self.input.schema();
         input_schema.fields().len() == self.output_schema.fields().len()
@@ -83,7 +90,7 @@ impl ColumnRenameExec {
                 .iter()
                 .zip(self.output_schema.fields())
                 .all(|(input, output)| {
-                    input.data_type() == output.data_type()
+                    types_equal_ignoring_field_metadata(input.data_type(), output.data_type())
                         && self
                             .reverse_mapping
                             .get(output.name())
@@ -286,6 +293,53 @@ impl Stream for ColumnRenameStream {
 impl RecordBatchStream for ColumnRenameStream {
     fn schema(&self) -> SchemaRef {
         Arc::clone(&self.output_schema)
+    }
+}
+
+/// Compare two Arrow types, ignoring the metadata carried by nested fields.
+///
+/// Names, nullability and value types still have to match at every level. All
+/// nested field metadata is disregarded, not only the `PARQUET:field_id` this
+/// exists for: metadata annotates a node, it never decides what its values are,
+/// so a difference confined to it is a relabel rather than a conversion. The
+/// read path attaches no other nested metadata.
+///
+/// Types with no nested fields, and the container types the read path never
+/// produces (dictionaries, unions, run-end encoding), fall back to strict
+/// equality.
+pub(crate) fn types_equal_ignoring_field_metadata(
+    left: &arrow::datatypes::DataType,
+    right: &arrow::datatypes::DataType,
+) -> bool {
+    use arrow::datatypes::{DataType, Field};
+
+    fn fields_equal(left: &Field, right: &Field) -> bool {
+        left.name() == right.name()
+            && left.is_nullable() == right.is_nullable()
+            && types_equal_ignoring_field_metadata(left.data_type(), right.data_type())
+    }
+
+    match (left, right) {
+        (DataType::List(left), DataType::List(right))
+        | (DataType::LargeList(left), DataType::LargeList(right))
+        | (DataType::ListView(left), DataType::ListView(right))
+        | (DataType::LargeListView(left), DataType::LargeListView(right)) => {
+            fields_equal(left, right)
+        },
+        (DataType::FixedSizeList(left, left_size), DataType::FixedSizeList(right, right_size)) => {
+            left_size == right_size && fields_equal(left, right)
+        },
+        (DataType::Map(left, left_sorted), DataType::Map(right, right_sorted)) => {
+            left_sorted == right_sorted && fields_equal(left, right)
+        },
+        (DataType::Struct(left), DataType::Struct(right)) => {
+            left.len() == right.len()
+                && left
+                    .iter()
+                    .zip(right.iter())
+                    .all(|(left, right)| fields_equal(left, right))
+        },
+        _ => left == right,
     }
 }
 
@@ -528,6 +582,91 @@ mod tests {
         let column = pushed[0][0].predicate.downcast_ref::<Column>().unwrap();
         assert_eq!(column.name(), "old_col");
         assert_eq!(column.index(), 0);
+    }
+
+    /// A read schema tags a nested column's children with the field ids the file
+    /// records; the catalog schema does not. Stripping that metadata on the way
+    /// out is a relabel, not a cast, so the scan keeps its pushdown.
+    #[test]
+    fn nested_field_metadata_alone_still_allows_pushdown() {
+        let element = |metadata: Option<(&str, &str)>| {
+            let field = Field::new("element", DataType::Float32, true);
+            match metadata {
+                Some((key, value)) => {
+                    field.with_metadata(HashMap::from([(key.to_string(), value.to_string())]))
+                },
+                None => field,
+            }
+        };
+        let input_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, true),
+            Field::new(
+                "v",
+                DataType::List(Arc::new(element(Some(("PARQUET:field_id", "3"))))),
+                true,
+            ),
+        ]));
+        let output_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, true),
+            Field::new("v", DataType::List(Arc::new(element(None))), true),
+        ]));
+        let input: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(input_schema));
+        let exec = ColumnRenameExec::new(input, output_schema, HashMap::new());
+        let filter: Arc<dyn PhysicalExpr> = Arc::new(Column::new("id", 0));
+
+        assert!(exec.is_pure_type_preserving_rename());
+        assert!(exec.supports_limit_pushdown());
+        let description = exec
+            .gather_filters_for_pushdown(
+                FilterPushdownPhase::Pre,
+                vec![filter],
+                &ConfigOptions::new(),
+            )
+            .unwrap();
+        assert!(matches!(
+            description.parent_filters()[0][0].discriminant,
+            PushedDown::Yes
+        ));
+    }
+
+    /// The relaxation is metadata-only: a nested child renamed or retyped is
+    /// still a real conversion and must block pushdown.
+    #[test]
+    fn nested_child_name_or_type_difference_blocks_pushdown() {
+        let list = |child: Field| DataType::List(Arc::new(child));
+        let cases = [
+            (
+                list(Field::new("element", DataType::Float32, true)),
+                list(Field::new("item", DataType::Float32, true)),
+            ),
+            (
+                list(Field::new("element", DataType::Float32, true)),
+                list(Field::new("element", DataType::Float64, true)),
+            ),
+            (
+                list(Field::new("element", DataType::Float32, false)),
+                list(Field::new("element", DataType::Float32, true)),
+            ),
+        ];
+
+        for (input_type, output_type) in cases {
+            let input: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(Arc::new(Schema::new(
+                vec![Field::new("v", input_type.clone(), true)],
+            ))));
+            let exec = ColumnRenameExec::new(
+                input,
+                Arc::new(Schema::new(vec![Field::new(
+                    "v",
+                    output_type.clone(),
+                    true,
+                )])),
+                HashMap::new(),
+            );
+            assert!(
+                !exec.is_pure_type_preserving_rename(),
+                "{input_type:?} -> {output_type:?} is a conversion, not a relabel"
+            );
+        }
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -803,13 +803,30 @@ fn read_data_type_with_field_id_mapping(
             arrow_field_names,
             match_by_id,
         )?;
-        Ok(Arc::new(
-            field
-                .clone()
-                .with_name(name)
-                .with_data_type(data_type)
-                .with_nullable(field.is_nullable() || is_absent),
-        ))
+        // A nested node's field id is part of the Arrow *type* of its parent
+        // (`DataType::List`/`Struct`/`Map` embed whole child `Field`s, metadata
+        // included), so it takes part in every array/batch type check. The
+        // physical file tags each nested node with its DuckLake field id, so the
+        // read schema must declare the same id or batches the parquet reader
+        // produces for the file do not match the schema the reader was handed.
+        // Only stamp what the file actually carries: a node matched by name
+        // (`match_by_id == false`, an external file with no ids) or one absent
+        // from the file has no id to declare. Top-level fields are deliberately
+        // left bare — their metadata is not part of any type, they are resolved
+        // by name, and stamping them would make every read schema differ from
+        // the catalog schema.
+        let field_metadata_id = (match_by_id && !is_absent).then(|| field_id.to_string());
+        let mut read_field = field
+            .clone()
+            .with_name(name)
+            .with_data_type(data_type)
+            .with_nullable(field.is_nullable() || is_absent);
+        if let Some(id) = field_metadata_id {
+            let mut metadata = read_field.metadata().clone();
+            metadata.insert(PARQUET_FIELD_ID_META_KEY.to_string(), id);
+            read_field = read_field.with_metadata(metadata);
+        }
+        Ok(Arc::new(read_field))
     }
 
     fn rewrite_type(
@@ -1207,6 +1224,325 @@ mod tests {
         };
 
         assert_eq!(fields[0].name(), "__ducklake_absent_field_4");
+    }
+
+    /// Collect `(dotted path, field id)` for every nested node of `data_type`,
+    /// reading the id from the node's `PARQUET:field_id` metadata. Nodes without
+    /// the metadata are reported with `None` so a missing id is visible in the
+    /// assertion rather than silently skipped.
+    fn nested_field_ids(data_type: &DataType) -> Vec<(String, Option<String>)> {
+        fn walk(prefix: &str, field: &Field, out: &mut Vec<(String, Option<String>)>) {
+            let path = format!("{prefix}.{}", field.name());
+            out.push((
+                path.clone(),
+                field.metadata().get(PARQUET_FIELD_ID_META_KEY).cloned(),
+            ));
+            collect(&path, field.data_type(), out);
+        }
+        fn collect(prefix: &str, data_type: &DataType, out: &mut Vec<(String, Option<String>)>) {
+            match data_type {
+                DataType::List(child)
+                | DataType::LargeList(child)
+                | DataType::FixedSizeList(child, _) => walk(prefix, child, out),
+                DataType::Struct(children) => {
+                    for child in children {
+                        walk(prefix, child, out);
+                    }
+                },
+                // The Map wrapper ("entries"/"key_value") is a synthetic parquet
+                // group with no DuckLake column and no field id; descend through
+                // it without recording it.
+                DataType::Map(entries, _) => collect(prefix, entries.data_type(), out),
+                _ => {},
+            }
+        }
+
+        let mut out = Vec::new();
+        collect("", data_type, &mut out);
+        out
+    }
+
+    /// Columns for a table shaped
+    /// `v LIST<FLOAT>, s STRUCT<label VARCHAR, score INT>, m MAP<VARCHAR, INT>, nn LIST<LIST<INT>>`,
+    /// with catalog ids assigned depth-first (1..12) the way DuckLake assigns them.
+    fn nested_test_columns() -> Vec<DuckLakeTableColumn> {
+        vec![
+            DuckLakeTableColumn {
+                column_id: 1,
+                column_name: "v".to_string(),
+                column_type: "list".to_string(),
+                is_nullable: true,
+                data_type: Some(DataType::List(Arc::new(Field::new(
+                    "item",
+                    DataType::Float32,
+                    true,
+                )))),
+                nested_column_ids: vec![2],
+            },
+            DuckLakeTableColumn {
+                column_id: 3,
+                column_name: "s".to_string(),
+                column_type: "struct".to_string(),
+                is_nullable: true,
+                data_type: Some(DataType::Struct(
+                    vec![
+                        Arc::new(Field::new("label", DataType::Utf8View, true)),
+                        Arc::new(Field::new("score", DataType::Int32, true)),
+                    ]
+                    .into(),
+                )),
+                nested_column_ids: vec![4, 5],
+            },
+            DuckLakeTableColumn {
+                column_id: 6,
+                column_name: "m".to_string(),
+                column_type: "map".to_string(),
+                is_nullable: true,
+                data_type: Some(DataType::Map(
+                    Arc::new(Field::new(
+                        "entries",
+                        DataType::Struct(
+                            vec![
+                                Arc::new(Field::new("key", DataType::Utf8View, false)),
+                                Arc::new(Field::new("value", DataType::Int32, true)),
+                            ]
+                            .into(),
+                        ),
+                        false,
+                    )),
+                    false,
+                )),
+                nested_column_ids: vec![7, 8],
+            },
+            DuckLakeTableColumn {
+                column_id: 9,
+                column_name: "nn".to_string(),
+                column_type: "list".to_string(),
+                is_nullable: true,
+                data_type: Some(DataType::List(Arc::new(Field::new(
+                    "item",
+                    DataType::List(Arc::new(Field::new("item", DataType::Int32, true))),
+                    true,
+                )))),
+                nested_column_ids: vec![10, 11],
+            },
+        ]
+    }
+
+    /// The file schema a DuckLake writer produces for [`nested_test_columns`]:
+    /// every semantic node tagged with its field id, list children named
+    /// `element`, and no id on the Map wrapper group.
+    fn nested_test_file_schema() -> Schema {
+        let id = |id: i32| HashMap::from([(PARQUET_FIELD_ID_META_KEY.to_string(), id.to_string())]);
+        Schema::new(vec![
+            Field::new(
+                "v",
+                DataType::List(Arc::new(
+                    Field::new("element", DataType::Float32, true).with_metadata(id(2)),
+                )),
+                true,
+            )
+            .with_metadata(id(1)),
+            Field::new(
+                "s",
+                DataType::Struct(
+                    vec![
+                        Arc::new(Field::new("label", DataType::Utf8, true).with_metadata(id(4))),
+                        Arc::new(Field::new("score", DataType::Int32, true).with_metadata(id(5))),
+                    ]
+                    .into(),
+                ),
+                true,
+            )
+            .with_metadata(id(3)),
+            Field::new(
+                "m",
+                DataType::Map(
+                    Arc::new(Field::new(
+                        "key_value",
+                        DataType::Struct(
+                            vec![
+                                Arc::new(
+                                    Field::new("key", DataType::Utf8, false).with_metadata(id(7)),
+                                ),
+                                Arc::new(
+                                    Field::new("value", DataType::Int32, true).with_metadata(id(8)),
+                                ),
+                            ]
+                            .into(),
+                        ),
+                        false,
+                    )),
+                    false,
+                ),
+                true,
+            )
+            .with_metadata(id(6)),
+            Field::new(
+                "nn",
+                DataType::List(Arc::new(
+                    Field::new(
+                        "element",
+                        DataType::List(Arc::new(
+                            Field::new("element", DataType::Int32, true).with_metadata(id(11)),
+                        )),
+                        true,
+                    )
+                    .with_metadata(id(10)),
+                )),
+                true,
+            )
+            .with_metadata(id(9)),
+        ])
+    }
+
+    fn nested_test_parquet_field_ids() -> HashMap<i32, String> {
+        HashMap::from([
+            (1, "v".to_string()),
+            (2, "element".to_string()),
+            (3, "s".to_string()),
+            (4, "label".to_string()),
+            (5, "score".to_string()),
+            (6, "m".to_string()),
+            (7, "key".to_string()),
+            (8, "value".to_string()),
+            (9, "nn".to_string()),
+            (10, "element".to_string()),
+            (11, "element".to_string()),
+        ])
+    }
+
+    /// A nested node's `PARQUET:field_id` is part of its parent's Arrow *type*,
+    /// so it takes part in every batch type check. The read schema describes the
+    /// physical file to the parquet reader, and DuckLake tags every nested node
+    /// in the file with its field id — so the read schema must declare the same
+    /// ids for List elements, Struct children and Map key/value at every depth.
+    #[test]
+    fn test_read_schema_declares_nested_field_ids() {
+        let (read_schema, _) = build_read_schema_with_field_id_mapping(
+            &nested_test_columns(),
+            &nested_test_parquet_field_ids(),
+            Some(&nested_test_file_schema()),
+        )
+        .unwrap();
+
+        let ids: Vec<(String, Option<String>)> = read_schema
+            .fields()
+            .iter()
+            .flat_map(|field| nested_field_ids(field.data_type()))
+            .collect();
+        assert_eq!(
+            ids,
+            vec![
+                (".element".to_string(), Some("2".to_string())),
+                (".label".to_string(), Some("4".to_string())),
+                (".score".to_string(), Some("5".to_string())),
+                (".key".to_string(), Some("7".to_string())),
+                (".value".to_string(), Some("8".to_string())),
+                (".element".to_string(), Some("10".to_string())),
+                (".element.element".to_string(), Some("11".to_string())),
+            ],
+            "every nested node must declare the field id the file records for it"
+        );
+
+        // The Map wrapper is a synthetic parquet group, not a DuckLake column: it
+        // must stay untagged, matching what the writer emits.
+        let DataType::Map(entries, _) = read_schema.field(2).data_type() else {
+            panic!("m must remain a map");
+        };
+        assert!(
+            !entries.metadata().contains_key(PARQUET_FIELD_ID_META_KEY),
+            "the map wrapper group has no DuckLake column and must carry no field id"
+        );
+
+        // Top-level fields are matched by name and their metadata is not part of
+        // any Arrow type, so they stay bare.
+        for field in read_schema.fields() {
+            assert!(
+                !field.metadata().contains_key(PARQUET_FIELD_ID_META_KEY),
+                "top-level field '{}' must not be tagged",
+                field.name()
+            );
+        }
+    }
+
+    /// An external / legacy file whose nested nodes carry no field ids is matched
+    /// structurally. Declaring ids the file does not have would be the same
+    /// divergence in the opposite direction, so nothing is stamped.
+    #[test]
+    fn test_read_schema_omits_nested_field_ids_for_file_without_them() {
+        let file_schema = Schema::new(vec![
+            Field::new(
+                "v",
+                DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+                true,
+            ),
+            Field::new(
+                "s",
+                DataType::Struct(
+                    vec![
+                        Arc::new(Field::new("label", DataType::Utf8, true)),
+                        Arc::new(Field::new("score", DataType::Int32, true)),
+                    ]
+                    .into(),
+                ),
+                true,
+            ),
+        ]);
+        let columns = nested_test_columns()[..2].to_vec();
+        // A file written before nested nodes were tagged: top-level ids only.
+        let parquet_field_ids = HashMap::from([(1, "v".to_string()), (3, "s".to_string())]);
+
+        let (read_schema, _) = build_read_schema_with_field_id_mapping(
+            &columns,
+            &parquet_field_ids,
+            Some(&file_schema),
+        )
+        .unwrap();
+
+        let ids: Vec<(String, Option<String>)> = read_schema
+            .fields()
+            .iter()
+            .flat_map(|field| nested_field_ids(field.data_type()))
+            .collect();
+        assert_eq!(
+            ids,
+            vec![
+                (".item".to_string(), None),
+                (".label".to_string(), None),
+                (".score".to_string(), None),
+            ],
+            "a file without nested field ids must not be described as having them"
+        );
+    }
+
+    /// A nested field the file predates reads as NULL under a synthetic name.
+    /// There is no physical node to describe, so it gets no field id either.
+    #[test]
+    fn test_read_schema_omits_field_id_for_absent_nested_field() {
+        let mut parquet_field_ids = nested_test_parquet_field_ids();
+        parquet_field_ids.remove(&5); // `score` was added after this file was written
+
+        let (read_schema, _) = build_read_schema_with_field_id_mapping(
+            &nested_test_columns()[1..2],
+            &parquet_field_ids,
+            Some(&nested_test_file_schema()),
+        )
+        .unwrap();
+
+        let DataType::Struct(fields) = read_schema.field(0).data_type() else {
+            panic!("s must remain a struct");
+        };
+        assert_eq!(
+            fields[0].metadata().get(PARQUET_FIELD_ID_META_KEY),
+            Some(&"4".to_string()),
+            "a present nested field keeps its id"
+        );
+        assert_eq!(fields[1].name(), "__ducklake_absent_field_5");
+        assert!(
+            !fields[1].metadata().contains_key(PARQUET_FIELD_ID_META_KEY),
+            "a nested field absent from the file has no physical node to tag"
+        );
     }
 
     #[test]

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -41,6 +41,7 @@ mod multicatalog_postgres_tests;
 mod multicatalog_provider_tests;
 mod mysql_metadata_provider_test;
 mod mysql_metadata_writer_test;
+mod nested_field_id_schema_tests;
 mod numeric_metadata_validation_tests;
 mod object_store_integration_test;
 mod partition_tests;

--- a/tests/it/nested_field_id_schema_tests.rs
+++ b/tests/it/nested_field_id_schema_tests.rs
@@ -1,0 +1,487 @@
+//! The read schema a nested column is scanned with must declare the field ids
+//! the physical file carries.
+//!
+//! DuckLake tags every semantic node of a nested column with its own field id —
+//! a List element, each Struct child, a Map's key and value, at any depth — while
+//! the synthetic parquet wrapper groups (`list`, `key_value`) stay untagged. A
+//! nested node's `PARQUET:field_id` lives in its parent's Arrow *type*
+//! (`DataType::List`/`Struct`/`Map` embed whole `Field`s, metadata included), so
+//! it takes part in every array and record-batch type check. A read schema that
+//! omits it therefore disagrees with the batches the parquet reader produces from
+//! the very file it describes, and a caller pairing the two gets
+//! "column types must match schema types".
+//!
+//! Field ids are the only part of that agreement these tests establish. The read
+//! schema is type-identical to the file for a nested column that contains neither
+//! a MAP nor a string; two known differences remain outside the scope of this
+//! module. Both are older than this fix, and both surface as the same
+//! "column types must match schema types" error:
+//!
+//! - **Map wrapper name** — the read schema keeps the wrapper group the catalog
+//!   built, named `entries`, while this crate's writer and DuckLake itself name
+//!   it `key_value`. Present since MAP support arrived in #230.
+//! - **Nested VARCHAR** — a string is served as `Utf8View` while parquet stores
+//!   `Utf8` (#160, predating #230). DataFusion coerces top-level fields only, so
+//!   the difference stands for a string inside a List, Struct or Map.
+//!
+//! This crate's own scan absorbs both — `ColumnRenameExec` relabels the wrapper,
+//! and the cast `ParquetOpener` inserts widens the string — so they are invisible
+//! to a query and visible only to a caller driving arrow-rs from
+//! `build_read_schema_with_field_id_mapping` directly. The fixtures below are
+//! integral and float throughout so that neither masks the field-id comparison.
+
+#![cfg(all(feature = "write-sqlite", feature = "metadata-sqlite"))]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arrow::array::{Array, Float32Array, Int32Array, ListArray, MapArray, StructArray};
+use arrow::buffer::{OffsetBuffer, ScalarBuffer};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use datafusion::parquet::arrow::PARQUET_FIELD_ID_META_KEY;
+use datafusion::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use datafusion::prelude::*;
+use object_store::local::LocalFileSystem;
+use tempfile::TempDir;
+
+use datafusion_ducklake::metadata_provider::MetadataProvider;
+use datafusion_ducklake::types::{
+    build_read_schema_with_field_id_mapping, extract_parquet_field_ids,
+};
+use datafusion_ducklake::{
+    DuckLakeCatalog, DuckLakeTableWriter, MetadataWriter, SqliteMetadataProvider,
+    SqliteMetadataWriter,
+};
+
+/// `id INT, v FLOAT[], s STRUCT<a INT, b INT>, m MAP<INT, INT>, nn INT[][]`.
+///
+/// Every column is integral or float on purpose: the read path serves strings as
+/// `Utf8View` while parquet stores `Utf8`, and that deliberate difference would
+/// mask the field-id comparison this test is about.
+fn nested_batch() -> RecordBatch {
+    let v = ListArray::new(
+        Arc::new(Field::new("element", DataType::Float32, true)),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0_i32, 2, 3])),
+        Arc::new(Float32Array::from(vec![1.0_f32, 2.0, 3.0])),
+        None,
+    );
+    let s = StructArray::new(
+        vec![
+            Arc::new(Field::new("a", DataType::Int32, true)),
+            Arc::new(Field::new("b", DataType::Int32, true)),
+        ]
+        .into(),
+        vec![Arc::new(Int32Array::from(vec![10, 20])), Arc::new(Int32Array::from(vec![30, 40]))],
+        None,
+    );
+    let entry_fields = vec![
+        Arc::new(Field::new("key", DataType::Int32, false)),
+        Arc::new(Field::new("value", DataType::Int32, true)),
+    ];
+    let m = MapArray::new(
+        Arc::new(Field::new(
+            "entries",
+            DataType::Struct(entry_fields.clone().into()),
+            false,
+        )),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0_i32, 2, 3])),
+        StructArray::new(
+            entry_fields.into(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(Int32Array::from(vec![7, 8, 9])),
+            ],
+            None,
+        ),
+        None,
+        false,
+    );
+    let inner = ListArray::new(
+        Arc::new(Field::new("element", DataType::Int32, true)),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0_i32, 2, 3, 4])),
+        Arc::new(Int32Array::from(vec![1, 2, 3, 4])),
+        None,
+    );
+    let nn = ListArray::new(
+        Arc::new(Field::new("element", inner.data_type().clone(), true)),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0_i32, 2, 3])),
+        Arc::new(inner),
+        None,
+    );
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("v", v.data_type().clone(), true),
+        Field::new("s", s.data_type().clone(), true),
+        Field::new("m", m.data_type().clone(), true),
+        Field::new("nn", nn.data_type().clone(), true),
+    ]));
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2])),
+            Arc::new(v),
+            Arc::new(s),
+            Arc::new(m),
+            Arc::new(nn),
+        ],
+    )
+    .unwrap()
+}
+
+/// Write [`nested_batch`] as a DuckLake table and return the catalog directory
+/// plus the single parquet file it produced.
+async fn write_nested_table() -> (TempDir, std::path::PathBuf) {
+    let temp_dir = TempDir::new().unwrap();
+    let data_path = temp_dir.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+    let writer = SqliteMetadataWriter::new_with_init(&format!(
+        "sqlite:{}?mode=rwc",
+        temp_dir.path().join("test.db").display()
+    ))
+    .await
+    .unwrap();
+    writer.set_data_path(data_path.to_str().unwrap()).unwrap();
+
+    DuckLakeTableWriter::new(
+        Arc::new(writer),
+        Arc::new(LocalFileSystem::new()) as Arc<dyn object_store::ObjectStore>,
+    )
+    .unwrap()
+    .write_table("main", "nested", &[nested_batch()])
+    .await
+    .unwrap();
+
+    let path = std::fs::read_dir(data_path.join("main").join("nested"))
+        .unwrap()
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .find(|path| path.extension().is_some_and(|ext| ext == "parquet"))
+        .expect("a parquet file was written");
+    (temp_dir, path)
+}
+
+/// The crate's read schema for the written file: what it hands the parquet
+/// reader as that file's schema.
+async fn read_schema_for(
+    temp_dir: &TempDir,
+    file_schema: &Schema,
+    parquet_field_ids: &HashMap<i32, String>,
+) -> Schema {
+    let provider = SqliteMetadataProvider::new(&format!(
+        "sqlite:{}",
+        temp_dir.path().join("test.db").display()
+    ))
+    .await
+    .unwrap();
+    let snapshot = provider.get_current_snapshot().unwrap();
+    let table_id = provider.list_all_tables(snapshot).unwrap()[0]
+        .table
+        .table_id;
+    let columns = provider.get_table_structure(table_id, snapshot).unwrap();
+    build_read_schema_with_field_id_mapping(&columns, parquet_field_ids, Some(file_schema))
+        .unwrap()
+        .0
+}
+
+/// Every parquet node, depth first, as `(name, field id)` — `None` for the
+/// synthetic wrapper groups DuckLake leaves untagged.
+fn parquet_nodes(path: &std::path::Path) -> Vec<(String, Option<i32>)> {
+    fn collect(
+        node: &datafusion::parquet::schema::types::Type,
+        out: &mut Vec<(String, Option<i32>)>,
+    ) {
+        let info = node.get_basic_info();
+        out.push((node.name().to_string(), info.has_id().then(|| info.id())));
+        if node.is_group() {
+            for child in node.get_fields() {
+                collect(child, out);
+            }
+        }
+    }
+
+    let builder =
+        ParquetRecordBatchReaderBuilder::try_new(std::fs::File::open(path).unwrap()).unwrap();
+    let mut out = Vec::new();
+    for field in builder
+        .metadata()
+        .file_metadata()
+        .schema_descr()
+        .root_schema()
+        .get_fields()
+    {
+        collect(field, &mut out);
+    }
+    out
+}
+
+/// `(dotted path, field id)` for every nested node of `data_type`, reading the id
+/// from `PARQUET:field_id`. Untagged nodes are reported as `None` so a missing id
+/// shows up in the comparison instead of vanishing. The Map wrapper is descended
+/// through, not recorded: it is a parquet group with no DuckLake column.
+fn nested_field_ids(data_type: &DataType) -> Vec<(String, Option<String>)> {
+    fn walk(prefix: &str, field: &Field, out: &mut Vec<(String, Option<String>)>) {
+        let path = format!("{prefix}.{}", field.name());
+        out.push((
+            path.clone(),
+            field.metadata().get(PARQUET_FIELD_ID_META_KEY).cloned(),
+        ));
+        collect(&path, field.data_type(), out);
+    }
+    fn collect(prefix: &str, data_type: &DataType, out: &mut Vec<(String, Option<String>)>) {
+        match data_type {
+            DataType::List(child)
+            | DataType::LargeList(child)
+            | DataType::FixedSizeList(child, _) => walk(prefix, child, out),
+            DataType::Struct(children) => {
+                for child in children {
+                    walk(prefix, child, out);
+                }
+            },
+            DataType::Map(entries, _) => collect(prefix, entries.data_type(), out),
+            _ => {},
+        }
+    }
+
+    let mut out = Vec::new();
+    collect("", data_type, &mut out);
+    out
+}
+
+fn schema_nested_field_ids(schema: &Schema) -> Vec<(String, Option<String>)> {
+    schema
+        .fields()
+        .iter()
+        .flat_map(|field| {
+            nested_field_ids(field.data_type())
+                .into_iter()
+                .map(|(path, id)| (format!("{}{path}", field.name()), id))
+        })
+        .collect()
+}
+
+/// The written file is the reference: DuckLake numbers every semantic node in one
+/// depth-first sequence and leaves the wrapper groups untagged.
+#[tokio::test(flavor = "multi_thread")]
+async fn written_file_tags_every_nested_node_and_no_wrapper() {
+    let (_temp_dir, path) = write_nested_table().await;
+
+    assert_eq!(
+        parquet_nodes(&path),
+        vec![
+            ("id".to_string(), Some(1)),
+            ("v".to_string(), Some(2)),
+            ("list".to_string(), None),
+            ("element".to_string(), Some(3)),
+            ("s".to_string(), Some(4)),
+            ("a".to_string(), Some(5)),
+            ("b".to_string(), Some(6)),
+            ("m".to_string(), Some(7)),
+            ("key_value".to_string(), None),
+            ("key".to_string(), Some(8)),
+            ("value".to_string(), Some(9)),
+            ("nn".to_string(), Some(10)),
+            ("list".to_string(), None),
+            ("element".to_string(), Some(11)),
+            ("list".to_string(), None),
+            ("element".to_string(), Some(12)),
+        ],
+        "field ids must run depth-first across the whole schema, with the \
+         synthetic list/key_value groups untagged"
+    );
+}
+
+/// Regression: the read schema must declare the same nested field ids the file
+/// carries, for List elements, Struct children, Map key/value, and at every depth.
+#[tokio::test(flavor = "multi_thread")]
+async fn read_schema_declares_the_nested_field_ids_the_file_carries() {
+    let (temp_dir, path) = write_nested_table().await;
+    let builder =
+        ParquetRecordBatchReaderBuilder::try_new(std::fs::File::open(&path).unwrap()).unwrap();
+    let file_schema = builder.schema().as_ref().clone();
+    let field_ids = extract_parquet_field_ids(builder.metadata());
+
+    let read_schema = read_schema_for(&temp_dir, &file_schema, &field_ids).await;
+
+    assert_eq!(
+        schema_nested_field_ids(&read_schema),
+        schema_nested_field_ids(&file_schema),
+        "the read schema must describe the file's nested nodes, field ids included"
+    );
+    // Spelled out, so a future change that "fixes" a mismatch by stripping ids
+    // from both sides fails here.
+    assert_eq!(
+        schema_nested_field_ids(&read_schema),
+        vec![
+            ("v.element".to_string(), Some("3".to_string())),
+            ("s.a".to_string(), Some("5".to_string())),
+            ("s.b".to_string(), Some("6".to_string())),
+            ("m.key".to_string(), Some("8".to_string())),
+            ("m.value".to_string(), Some("9".to_string())),
+            ("nn.element".to_string(), Some("11".to_string())),
+            ("nn.element.element".to_string(), Some("12".to_string())),
+        ],
+    );
+
+    // The Map wrapper group carries no id in the file and must carry none here.
+    let DataType::Map(entries, _) = read_schema.field(3).data_type() else {
+        panic!("m must remain a map");
+    };
+    assert!(
+        !entries.metadata().contains_key(PARQUET_FIELD_ID_META_KEY),
+        "the map wrapper group has no DuckLake column and must stay untagged"
+    );
+}
+
+/// Regression, as a caller sees it: batches the parquet reader produces from a
+/// data file must validate against the schema the crate describes that file with.
+#[tokio::test(flavor = "multi_thread")]
+async fn file_batches_validate_against_the_crate_read_schema() {
+    let (temp_dir, path) = write_nested_table().await;
+    let builder =
+        ParquetRecordBatchReaderBuilder::try_new(std::fs::File::open(&path).unwrap()).unwrap();
+    let file_schema = builder.schema().as_ref().clone();
+    let field_ids = extract_parquet_field_ids(builder.metadata());
+    let read_schema = read_schema_for(&temp_dir, &file_schema, &field_ids).await;
+
+    // `m` is excluded: the read schema names the Map wrapper group `entries`
+    // where the file names it `key_value`. That difference sits in the Arrow type
+    // too, but it is not about field ids and predates them — the scan reconciles
+    // it in `ColumnRenameExec`.
+    let projection: Vec<usize> = (0..read_schema.fields().len())
+        .filter(|index| read_schema.field(*index).name() != "m")
+        .collect();
+    let projected = Arc::new(read_schema.project(&projection).unwrap());
+
+    let mut reader = builder.build().unwrap();
+    let raw = reader.next().unwrap().unwrap();
+    let columns: Vec<_> = projection
+        .iter()
+        .map(|index| Arc::clone(raw.column(*index)))
+        .collect();
+
+    RecordBatch::try_new(projected, columns)
+        .expect("a batch read from the file must match the file's read schema");
+}
+
+/// The other direction: the fix must not push parquet field ids into the table's
+/// public schema. The catalog schema stays free of them and the scan keeps
+/// emitting batches that validate against it.
+#[tokio::test(flavor = "multi_thread")]
+async fn scan_output_still_matches_the_catalog_schema() {
+    let (temp_dir, _path) = write_nested_table().await;
+
+    let provider = SqliteMetadataProvider::new(&format!(
+        "sqlite:{}",
+        temp_dir.path().join("test.db").display()
+    ))
+    .await
+    .unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog("test", Arc::new(DuckLakeCatalog::new(provider).unwrap()));
+    let table = ctx
+        .catalog("test")
+        .unwrap()
+        .schema("main")
+        .unwrap()
+        .table("nested")
+        .await
+        .unwrap()
+        .unwrap();
+    let advertised = table.schema();
+
+    assert!(
+        schema_nested_field_ids(&advertised)
+            .iter()
+            .all(|(_, id)| id.is_none()),
+        "the catalog schema is the logical one; storage field ids do not belong \
+         in it: {advertised:#?}"
+    );
+
+    let batches = ctx
+        .sql("SELECT * FROM test.main.nested")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 2);
+    for batch in &batches {
+        RecordBatch::try_new(Arc::clone(&advertised), batch.columns().to_vec())
+            .expect("scan output must validate against the advertised table schema");
+    }
+}
+
+/// Declaring the ids makes a struct column's read schema differ from the catalog
+/// schema by metadata alone, which routes the scan through `ColumnRenameExec`.
+/// That must not cost the scan its predicate pushdown: the difference is a
+/// relabel, not a conversion.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_struct_column_keeps_its_predicate_pushdown() {
+    let temp_dir = TempDir::new().unwrap();
+    let data_path = temp_dir.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+    let writer = SqliteMetadataWriter::new_with_init(&format!(
+        "sqlite:{}?mode=rwc",
+        temp_dir.path().join("test.db").display()
+    ))
+    .await
+    .unwrap();
+    writer.set_data_path(data_path.to_str().unwrap()).unwrap();
+
+    let s = StructArray::new(
+        vec![Arc::new(Field::new("a", DataType::Int32, true))].into(),
+        vec![Arc::new(Int32Array::from(vec![10, 20]))],
+        None,
+    );
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, true),
+        Field::new("s", s.data_type().clone(), true),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![Arc::new(Int32Array::from(vec![1, 2])), Arc::new(s)],
+    )
+    .unwrap();
+    DuckLakeTableWriter::new(
+        Arc::new(writer),
+        Arc::new(LocalFileSystem::new()) as Arc<dyn object_store::ObjectStore>,
+    )
+    .unwrap()
+    .write_table("main", "structs", &[batch])
+    .await
+    .unwrap();
+
+    let provider = SqliteMetadataProvider::new(&format!(
+        "sqlite:{}",
+        temp_dir.path().join("test.db").display()
+    ))
+    .await
+    .unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog("test", Arc::new(DuckLakeCatalog::new(provider).unwrap()));
+
+    let explained = ctx
+        .sql("EXPLAIN SELECT * FROM test.main.structs WHERE id = 2")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let plan = arrow::util::pretty::pretty_format_batches(&explained)
+        .unwrap()
+        .to_string();
+    assert!(
+        plan.contains("predicate=id@0 = 2"),
+        "the filter must still reach the parquet scan:\n{plan}"
+    );
+
+    let rows = ctx
+        .sql("SELECT id FROM test.main.structs WHERE id = 2")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(rows.iter().map(RecordBatch::num_rows).sum::<usize>(), 1);
+}


### PR DESCRIPTION
## The defect

At `cf72534` the crate cannot read back a `List` column it wrote itself. Write a table with a
`FLOAT[]` column, hand the file's read schema and the file to arrow-rs, and pairing the two fails:

```
column types must match schema types,
  expected List(Float32, field: 'element')
  but found List(Float32, field: 'element', metadata: {"PARQUET:field_id": "3"})
  at column index 1
```

The writer tags every semantic nested node of a data file with its `PARQUET:field_id` — a List
element, each Struct child, a Map's key and value, at any depth. The per-file read schema
(`types::build_read_schema_with_field_id_mapping`, via `read_data_type_with_field_id_mapping`)
declared none of them.

That difference is not cosmetic. A nested node's metadata lives inside its parent's Arrow
`DataType` — `DataType::List`/`Struct`/`Map` embed whole child `Field`s, metadata included — so it
participates in every array and record-batch type check. The schema that is supposed to *describe*
a file therefore disagrees with the batches the parquet reader produces from that very file.

## Who is affected

Callers of the public helper `types::build_read_schema_with_field_id_mapping` who drive arrow-rs
with the schema it returns. That is where this was reported from.

Query results were never wrong, and no scan through this crate's `TableProvider` ever failed:
DataFusion's `ParquetOpener` inserts a `CastExpr` wherever a logical and a physical field differ,
and casting a delta that is metadata-only yields the target type unchanged. The crate's own scan
path absorbed the mismatch silently, which is why this survived to a downstream consumer.

## Regression from #230

#230 (`feat: support recursive DuckLake column types`) started tagging nested nodes on write
without extending the read schema to match. Bisect is clean:

```
613220f  perf(read): skip empty data files when pruning (#244)   clean
1a0a35d  feat: support recursive DuckLake column types (#230)    broken
```

## The fix

Stamp the id the file records onto each nested node of the read schema, and only there
(`src/types.rs`, `rewrite_field`). The read schema is the correct side to change: it exists to
describe one physical file, so it should carry what that file carries. Official DuckLake assigns
field ids recursively in exactly the same depth-first order, and leaves the synthetic parquet
wrapper groups untagged — verified by writing the same table with both writers and diffing
`parquet_schema()` (see "Manual testing" below); the two id sequences are identical.

Deliberately *not* stamped:

- **Files matched by name** (`match_by_id == false`) — an external file, or one written before
  nested nodes were tagged, has no physical node to describe.
- **A nested field the file predates** (`is_absent`) — it is null-filled, so there is nothing in
  the file to point at.
- **The map wrapper group** — a synthetic parquet group with no DuckLake column behind it.
- **Top-level fields** — their metadata is not part of any Arrow `DataType`, they are resolved by
  name, and stamping them would make every read schema differ from the catalog schema.

The catalog schema is untouched, so query output still carries no storage metadata.

## Pushdown regression, caught in review

Declaring the ids leaves a struct column's read schema differing from the catalog schema by
metadata alone, which routes the scan through `ColumnRenameExec`. Its purity check
(`is_pure_type_preserving_rename`) gates filter and limit pushdown and compared types strictly, so
the fix as first written silently cost a struct column its predicate pushdown.

Dropping the metadata in `ColumnRenameExec` is a zero-copy relabel, not a conversion, so the check
now uses `types_equal_ignoring_field_metadata` (`src/column_rename.rs`): names, nullability and
value types must still match at every level; nested field metadata does not. Metadata annotates a
node and never decides what its values are, so a difference confined to it cannot change what a
pushed-down filter or limit means.

## Two known gaps, neither introduced here

The read schema is now type-identical to the file for a nested column containing neither a MAP nor
a string. Two differences remain, both surfacing as the same "column types must match schema types"
error, and both out of scope here:

- **Map wrapper name.** The read schema keeps the wrapper group the catalog built, named `entries`;
  this crate's writer and DuckLake itself name it `key_value`. Present since MAP support arrived in
  #230.
- **Nested `Utf8View`.** A string is served as `Utf8View` while parquet stores `Utf8` (#160).
  DataFusion coerces top-level fields only, so the difference stands for a string inside a List,
  Struct or Map.

Both are absorbed by this crate's own scan — `ColumnRenameExec` relabels the wrapper, the cast
`ParquetOpener` inserts widens the string — so, like the field-id gap, they are invisible to a
query and visible only to a caller driving arrow-rs directly. They are documented in the test
module rather than fixed, so the invariant the tests establish is not overstated.

## Test coverage

Regression tests. The two integration tests below were run against this branch with `src/types.rs`
and `src/column_rename.rs` reverted to `HEAD~1`, and both fail there:

- `nested_field_id_schema_tests::read_schema_declares_the_nested_field_ids_the_file_carries` — the
  read schema must carry the file's ids, asserted both as "equal to the file's ids" and spelled out
  literally, so a future change that "fixes" a mismatch by stripping ids from both sides fails here.
  Pre-fix: every nested node comes back `None` against the file's `3, 5, 6, 8, 9, 11, 12`.
- `nested_field_id_schema_tests::file_batches_validate_against_the_crate_read_schema` — the defect
  as the reporter hit it: batches the parquet reader produces must construct a `RecordBatch` against
  the schema the crate describes that file with. Pre-fix, this is where the error at the top of this
  description comes from.
- `types::tests::test_read_schema_declares_nested_field_ids` (unit) — the same property at the unit
  level, on a synthetic file schema: List elements, Struct children, Map key/value, and both levels
  of a nested list.

Guards — these pass with the pre-fix source too; they pin down behaviour this change could have
broken:

- `types::tests::test_read_schema_omits_nested_field_ids_for_file_without_them` and
  `test_read_schema_omits_field_id_for_absent_nested_field` — the two "nothing to describe" cases
  stay untagged.
- `nested_field_id_schema_tests::written_file_tags_every_nested_node_and_no_wrapper` — pins the
  writer's numbering, which is the reference the read schema is matched against.
- `nested_field_id_schema_tests::scan_output_still_matches_the_catalog_schema` — storage metadata
  must not leak into the table's advertised schema.
- `column_rename::tests::nested_field_metadata_alone_still_allows_pushdown` and
  `nested_child_name_or_type_difference_blocks_pushdown`, plus
  `nested_field_id_schema_tests::a_struct_column_keeps_its_predicate_pushdown` — the pushdown
  regression above, both directions: metadata-only differences stay pure, a real name or type
  difference does not.

The integration module is `#![cfg(all(feature = "write-sqlite", feature = "metadata-sqlite"))]`, so
it runs in both CI test invocations: `--features "skip-tests-with-docker write-sqlite"` (macOS) and
`--features "duckdb-bundled encryption metadata-mysql metadata-postgres metadata-sqlite
write-sqlite"` (the full single-catalog suite). The unit tests in `src/types.rs` and
`src/column_rename.rs` are ungated and run in every job.

All gates pass: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D
warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`, and both test
invocations.

## Manual testing

**Cross-tool field ids.** The same logical table (`INT`, `FLOAT[]`, `STRUCT<INT, VARCHAR>`,
`INT[][]`) written by this crate and by DuckDB's DuckLake extension produces byte-identical field-id
assignment, including the untagged wrapper groups:

```
                 this crate                     DuckDB
name          type        field_id   |   name          type        field_id
id            INT32       1          |   id            INT32       1
v             (LIST)      2          |   v             (LIST)      2
  list        (REPEATED)  -          |     list        (REPEATED)  -
  element     FLOAT       3          |     element     FLOAT       3
s             (group)     4          |   s             (group)     4
  a           INT32       5          |     a           INT32       5
  b           BYTE_ARRAY  6          |     b           BYTE_ARRAY  6
nn            (LIST)      7          |   nn            (LIST)      7
  list        (REPEATED)  -          |     list        (REPEATED)  -
  element     (LIST)      8          |     element     (LIST)      8
    list      (REPEATED)  -          |       list      (REPEATED)  -
    element   INT32       9          |       element   INT32       9
```

DuckDB reads the crate-written data file back correctly:

```
┌───────┬─────────────────┬──────────────────────────────┬───────────────┐
│  id   │        v        │              s               │      nn       │
├───────┼─────────────────┼──────────────────────────────┼───────────────┤
│     1 │ [1.5, 2.5, 3.5] │ {'a': 10, 'b': alpha}        │ [[1, 2], [3]] │
│     2 │ [4.5, 5.5]      │ {'a': 20, 'b': beta}         │ [[4, 5]]      │
└───────┴─────────────────┴──────────────────────────────┴───────────────┘
```

**Catalog-level interop is blocked in both directions, for reasons unrelated to this change.**
Stated so the result above is not read as more than it is:

- DuckDB attaching a catalog this crate wrote fails on catalog-schema drift — this crate implements
  an older spec revision: `Referenced column "next_catalog_id" not found` on `ducklake_snapshot`,
  and after shimming that in, `Referenced column "schema_uuid" not found`.
- This crate reading a catalog DuckDB wrote fails first in the SQLite provider (`no such column:
  sv.table_id` — this crate's `ducklake_schema_versions` carries a `table_id` column that official
  DuckLake's does not) and then, once that is shimmed away, in arrow-rs: `Parquet error: Column
  order length mismatch` on the DuckDB-written file.

Both are orthogonal to field ids, which is why the check above was done at the parquet level, where
field ids actually live.

**A real server, end to end.** A downstream server that embeds this crate was built against this
branch with no source changes (a Cargo `patch` override), run against a throwaway Postgres DuckLake
metadata store, and driven over its HTTP API: create a database, declare a managed table, load rows
with a `List<Float64>` column and a `Struct<Int64, Utf8>` column, read them back.

```
query: SELECT * FROM main.vecs ORDER BY id
{"columns":["id","v","s"],
 "rows":[[1,[1.5,2.5,3.5],{"a":10,"b":"alpha"}],
         [2,[4.5,5.5],{"a":20,"b":"beta"}]],
 "row_count":2}

query: SELECT id, v[1] AS first_v, s.b FROM main.vecs WHERE id = 2
{"rows":[[2,4.5,"beta"]],"row_count":1}
```

The catalog recorded the recursive column model (`element` under `v`, `a`/`b` under `s`, each with
`parent_column` set), and the filtered nested projection confirms the pushdown path is intact on a
live server. The `Utf8` struct child also exercises the nested-string gap above and is served
correctly, since the scan casts it.
