### PR TITLE
perf(write): batch per-column stat inserts, and trace the write path

### DIFF
--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -915,6 +915,12 @@ async fn recompute_table_column_stats(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[tracing::instrument(
+    name = "ducklake.finalize_snapshot",
+    level = "info",
+    skip_all,
+    fields(catalog_id, schema_name, table_name)
+)]
 async fn finalize_snapshot(
     catalog_id: i64,
     schema_name: &str,
@@ -1878,6 +1884,12 @@ impl MetadataWriter for PostgresMetadataWriter {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(
+        name = "ducklake.register_data_files",
+        level = "info",
+        skip_all,
+        fields(table_id, schema_name, table_name, files = files.len(), columns = columns.len())
+    )]
     fn register_data_files_with_commit_metadata(
         &self,
         table_id: i64,
@@ -4079,6 +4091,12 @@ impl MetadataWriter for PostgresMetadataWriter {
         })
     }
 
+    #[tracing::instrument(
+        name = "ducklake.begin_write_transaction",
+        level = "info",
+        skip_all,
+        fields(schema_name, table_name, columns = columns.len())
+    )]
     fn begin_write_transaction(
         &self,
         schema_name: &str,

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -708,31 +708,53 @@ async fn schedule_compaction_files(
 /// the catalog id, not the schema id).
 /// Persist the harvested per-column stats for a just-registered data file
 /// (per-file zone maps). See the SQLite writer's equivalent for the rationale.
+///
+/// Sent as one `UNNEST` insert rather than a statement per column: this runs on
+/// every commit, and against a networked Postgres the round trip dominates the
+/// work — a wide table otherwise pays one round trip per column. Passing the
+/// columns as arrays (rather than a generated `VALUES` list) keeps the bind
+/// count fixed at nine, so a table cannot approach Postgres's 65535-parameter
+/// ceiling however many columns it has.
 async fn insert_file_column_stats(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     table_id: i64,
     data_file_id: i64,
     column_stats: &[ColumnStat],
 ) -> Result<()> {
-    for stat in column_stats {
-        sqlx::query(
-            "INSERT INTO ducklake_file_column_stats
-                 (data_file_id, table_id, column_id, column_size_bytes,
-                  value_count, null_count, min_value, max_value, contains_nan, extra_stats)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NULL)",
-        )
-        .bind(data_file_id)
-        .bind(table_id)
-        .bind(stat.column_id)
-        .bind(stat.column_size_bytes)
-        .bind(stat.value_count)
-        .bind(stat.null_count)
-        .bind(stat.min_value.as_deref())
-        .bind(stat.max_value.as_deref())
-        .bind(stat.contains_nan)
-        .execute(&mut **tx)
-        .await?;
+    if column_stats.is_empty() {
+        return Ok(());
     }
+
+    let column_ids: Vec<i64> = column_stats.iter().map(|s| s.column_id).collect();
+    let sizes: Vec<Option<i64>> = column_stats.iter().map(|s| s.column_size_bytes).collect();
+    let value_counts: Vec<Option<i64>> = column_stats.iter().map(|s| s.value_count).collect();
+    let null_counts: Vec<Option<i64>> = column_stats.iter().map(|s| s.null_count).collect();
+    let mins: Vec<Option<String>> = column_stats.iter().map(|s| s.min_value.clone()).collect();
+    let maxes: Vec<Option<String>> = column_stats.iter().map(|s| s.max_value.clone()).collect();
+    let nans: Vec<Option<bool>> = column_stats.iter().map(|s| s.contains_nan).collect();
+
+    sqlx::query(
+        "INSERT INTO ducklake_file_column_stats
+             (data_file_id, table_id, column_id, column_size_bytes,
+              value_count, null_count, min_value, max_value, contains_nan, extra_stats)
+         SELECT $1, $2, u.column_id, u.column_size_bytes,
+                u.value_count, u.null_count, u.min_value, u.max_value, u.contains_nan, NULL
+         FROM UNNEST($3::bigint[], $4::bigint[], $5::bigint[], $6::bigint[],
+                     $7::text[], $8::text[], $9::boolean[])
+              AS u(column_id, column_size_bytes, value_count, null_count,
+                   min_value, max_value, contains_nan)",
+    )
+    .bind(data_file_id)
+    .bind(table_id)
+    .bind(&column_ids)
+    .bind(&sizes)
+    .bind(&value_counts)
+    .bind(&null_counts)
+    .bind(&mins)
+    .bind(&maxes)
+    .bind(&nans)
+    .execute(&mut **tx)
+    .await?;
     Ok(())
 }
 
@@ -862,21 +884,33 @@ async fn recompute_table_column_stats(
         .bind(table_id)
         .execute(&mut **tx)
         .await?;
-    for g in globals {
-        sqlx::query(
-            "INSERT INTO ducklake_table_column_stats
-                 (table_id, column_id, contains_null, contains_nan, min_value, max_value, extra_stats)
-             VALUES ($1, $2, $3, $4, $5, $6, NULL)",
-        )
-        .bind(table_id)
-        .bind(g.column_id)
-        .bind(g.contains_null)
-        .bind(g.contains_nan)
-        .bind(g.min_value)
-        .bind(g.max_value)
-        .execute(&mut **tx)
-        .await?;
+    if globals.is_empty() {
+        return Ok(());
     }
+
+    // One `UNNEST` insert rather than a statement per column, for the same
+    // reason as the per-file stats above: this replace runs on every commit.
+    let column_ids: Vec<i64> = globals.iter().map(|g| g.column_id).collect();
+    let contains_null: Vec<Option<bool>> = globals.iter().map(|g| g.contains_null).collect();
+    let contains_nan: Vec<Option<bool>> = globals.iter().map(|g| g.contains_nan).collect();
+    let mins: Vec<Option<String>> = globals.iter().map(|g| g.min_value.clone()).collect();
+    let maxes: Vec<Option<String>> = globals.iter().map(|g| g.max_value.clone()).collect();
+
+    sqlx::query(
+        "INSERT INTO ducklake_table_column_stats
+             (table_id, column_id, contains_null, contains_nan, min_value, max_value, extra_stats)
+         SELECT $1, u.column_id, u.contains_null, u.contains_nan, u.min_value, u.max_value, NULL
+         FROM UNNEST($2::bigint[], $3::boolean[], $4::boolean[], $5::text[], $6::text[])
+              AS u(column_id, contains_null, contains_nan, min_value, max_value)",
+    )
+    .bind(table_id)
+    .bind(&column_ids)
+    .bind(&contains_null)
+    .bind(&contains_nan)
+    .bind(&mins)
+    .bind(&maxes)
+    .execute(&mut **tx)
+    .await?;
     Ok(())
 }
 

--- a/src/table_writer.rs
+++ b/src/table_writer.rs
@@ -1550,6 +1550,7 @@ impl RollingFileWriter {
 
 /// Write the parquet footer and flush the staging file to disk, releasing its
 /// descriptor. Synchronous, so a streaming write needs no await to roll a file.
+#[tracing::instrument(name = "ducklake.finalize_open_file", level = "info", skip_all)]
 fn finalize_open_file(file: OpenFile) -> Result<StagedFile> {
     let staged = file.writer.into_inner()?;
     // `into_inner` flushes the buffered footer bytes to the OS file; dropping the
@@ -1569,6 +1570,7 @@ fn finalize_open_file(file: OpenFile) -> Result<StagedFile> {
 /// Upload a finished staging file and harvest its per-column stats, returning the
 /// [`DataFileInfo`] for the catalog commit (relative path; the caller stamps any
 /// partition). On failure the multipart upload is aborted so no partial object is left.
+#[tracing::instrument(name = "ducklake.upload_staged_file", level = "info", skip_all)]
 async fn upload_staged_file(
     staged: StagedFile,
     object_store: &Arc<dyn ObjectStore>,
@@ -1970,6 +1972,7 @@ impl TableWriteSession {
         self.object_path.as_ref()
     }
 
+    #[tracing::instrument(name = "ducklake.write_session_finish", level = "info", skip_all)]
     pub async fn finish(mut self) -> Result<WriteResult> {
         // Rolling: finish the in-progress file, upload every file this session
         // produced, and commit them in ONE snapshot.
@@ -2182,6 +2185,7 @@ impl TableWriteSession {
     /// Finalise + upload the staged parquet and return its [`DataFileInfo`],
     /// leaving the metadata commit to the caller. Shared by
     /// [`finish`](Self::finish) and [`finish_with_deletes`](Self::finish_with_deletes).
+    #[tracing::instrument(name = "ducklake.upload_staged", level = "info", skip_all)]
     async fn upload_staged(&mut self) -> Result<DataFileInfo> {
         let writer = self.writer.take().ok_or_else(|| {
             crate::error::DuckLakeError::Internal("Writer already closed".to_string())

--- a/tests/it/multicatalog_postgres_tests.rs
+++ b/tests/it/multicatalog_postgres_tests.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field};
 use datafusion_ducklake::metadata_writer::{
-    ColumnDef, DataFileInfo, MetadataWriter, SnapshotCommitMetadata, WriteMode,
+    ColumnDef, ColumnStat, DataFileInfo, MetadataWriter, SnapshotCommitMetadata, WriteMode,
 };
 use datafusion_ducklake::{
     DuckLakeError, DuckLakeTableWriter, MulticatalogManager, NullOrder, PartitionTransform,
@@ -5434,4 +5434,210 @@ async fn register_existing_data_file_rejects_mismatched_column_ids() {
         0,
         "nothing is committed on a validation failure"
     );
+}
+
+/// Per-column stats round-trip through the multicatalog writer with the right
+/// value on the right column.
+///
+/// Both stats tables are written one row per column from parallel arrays, so
+/// the failure this guards against is misalignment — every row present and the
+/// counts right, but a column carrying its neighbour's bounds. Each column here
+/// gets a deliberately distinct signature, and `sparse` carries NULL bounds
+/// with a non-NULL size, so a NULL landing in the wrong array shifts a value
+/// onto the wrong column instead of quietly disappearing.
+#[tokio::test(flavor = "multi_thread")]
+async fn postgres_file_and_table_column_stats_round_trip_per_column() {
+    let (pool, _container) = spin_up_postgres().await.unwrap();
+    let catalog_id = MulticatalogManager::new(pool.clone())
+        .create_catalog("column_stats_roundtrip")
+        .await
+        .unwrap();
+    let writer = PostgresMetadataWriter::with_pool(pool.clone(), catalog_id)
+        .await
+        .unwrap();
+
+    let columns = vec![
+        ColumnDef::new("id", "int64", false).unwrap(),
+        ColumnDef::new("label", "varchar", true).unwrap(),
+        ColumnDef::new("sparse", "varchar", true).unwrap(),
+    ];
+
+    let begin = writer
+        .begin_write_transaction("public", "stats", &columns, WriteMode::Replace)
+        .unwrap();
+
+    let stats = vec![
+        ColumnStat {
+            column_id: begin.column_ids[0],
+            min_value: Some("1".to_string()),
+            max_value: Some("900".to_string()),
+            null_count: Some(0),
+            value_count: Some(300),
+            contains_nan: None,
+            column_size_bytes: Some(1_111),
+        },
+        ColumnStat {
+            column_id: begin.column_ids[1],
+            min_value: Some("alpha".to_string()),
+            max_value: Some("omega".to_string()),
+            null_count: Some(7),
+            value_count: Some(293),
+            contains_nan: None,
+            column_size_bytes: Some(2_222),
+        },
+        // All-NULL column: bounds absent, size still present.
+        ColumnStat {
+            column_id: begin.column_ids[2],
+            min_value: None,
+            max_value: None,
+            null_count: Some(300),
+            value_count: Some(0),
+            contains_nan: None,
+            column_size_bytes: Some(3_333),
+        },
+    ];
+
+    writer
+        .register_data_file(
+            begin.table_id,
+            "public",
+            "stats",
+            begin.snapshot_id,
+            &DataFileInfo::new("stats.parquet", 4_096, 300).with_column_stats(stats),
+            WriteMode::Replace,
+            begin.base_snapshot_id,
+            &columns,
+            &begin.column_ids,
+        )
+        .unwrap();
+
+    let rows = sqlx::query(
+        "SELECT column_id, min_value, max_value, null_count, value_count, column_size_bytes
+         FROM ducklake_file_column_stats WHERE table_id = $1 ORDER BY column_id",
+    )
+    .bind(begin.table_id)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(rows.len(), 3, "one per-file stats row per column");
+
+    struct ExpectedFileStat {
+        min: Option<&'static str>,
+        max: Option<&'static str>,
+        nulls: i64,
+        values: i64,
+        size: i64,
+    }
+    let expected = [
+        ExpectedFileStat {
+            min: Some("1"),
+            max: Some("900"),
+            nulls: 0,
+            values: 300,
+            size: 1_111,
+        },
+        ExpectedFileStat {
+            min: Some("alpha"),
+            max: Some("omega"),
+            nulls: 7,
+            values: 293,
+            size: 2_222,
+        },
+        ExpectedFileStat {
+            min: None,
+            max: None,
+            nulls: 300,
+            values: 0,
+            size: 3_333,
+        },
+    ];
+    for (i, (row, want)) in rows.iter().zip(expected.iter()).enumerate() {
+        assert_eq!(
+            row.get::<i64, _>("column_id"),
+            begin.column_ids[i],
+            "column {i}: stats row is for the wrong column"
+        );
+        assert_eq!(
+            row.get::<Option<String>, _>("min_value").as_deref(),
+            want.min,
+            "column {i}: min_value"
+        );
+        assert_eq!(
+            row.get::<Option<String>, _>("max_value").as_deref(),
+            want.max,
+            "column {i}: max_value"
+        );
+        assert_eq!(
+            row.get::<Option<i64>, _>("null_count"),
+            Some(want.nulls),
+            "column {i}: null_count"
+        );
+        assert_eq!(
+            row.get::<Option<i64>, _>("value_count"),
+            Some(want.values),
+            "column {i}: value_count"
+        );
+        assert_eq!(
+            row.get::<Option<i64>, _>("column_size_bytes"),
+            Some(want.size),
+            "column {i}: column_size_bytes"
+        );
+    }
+
+    // The table-wide roll-up is rebuilt from those per-file rows on every
+    // commit, so it must land on the right columns too.
+    let rollup = sqlx::query(
+        "SELECT column_id, min_value, max_value, contains_null
+         FROM ducklake_table_column_stats WHERE table_id = $1 ORDER BY column_id",
+    )
+    .bind(begin.table_id)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(rollup.len(), 3, "one roll-up row per column");
+
+    struct ExpectedRollup {
+        min: Option<&'static str>,
+        max: Option<&'static str>,
+        contains_null: bool,
+    }
+    let want_rollup = [
+        ExpectedRollup {
+            min: Some("1"),
+            max: Some("900"),
+            contains_null: false,
+        },
+        ExpectedRollup {
+            min: Some("alpha"),
+            max: Some("omega"),
+            contains_null: true,
+        },
+        ExpectedRollup {
+            min: None,
+            max: None,
+            contains_null: true,
+        },
+    ];
+    for (i, (row, want)) in rollup.iter().zip(want_rollup.iter()).enumerate() {
+        assert_eq!(
+            row.get::<i64, _>("column_id"),
+            begin.column_ids[i],
+            "column {i}: roll-up row is for the wrong column"
+        );
+        assert_eq!(
+            row.get::<Option<String>, _>("min_value").as_deref(),
+            want.min,
+            "column {i}: roll-up min_value"
+        );
+        assert_eq!(
+            row.get::<Option<String>, _>("max_value").as_deref(),
+            want.max,
+            "column {i}: roll-up max_value"
+        );
+        assert_eq!(
+            row.get::<Option<bool>, _>("contains_null"),
+            Some(want.contains_null),
+            "column {i}: roll-up contains_null"
+        );
+    }
 }


### PR DESCRIPTION
Two commits: a perf change, and the instrumentation that shows why it was hard
to evaluate. 
---

## 1. Batch the per-column stat inserts

`ducklake_file_column_stats` and `ducklake_table_column_stats` were written one
statement per column, inside the commit transaction. Both now go as a single
`UNNEST` insert.

The columns travel as arrays rather than a generated `VALUES` list, so the bind
count is fixed at nine and six regardless of table width — a wide table can't
approach Postgres's 65535-parameter ceiling.

Resulting rows are unchanged: same values, same columns, same transaction. On a
ten-column write these two loops were 20 of the ~90 statements a commit issues,
and they run on *every* commit.

Measured through a downstream consumer, release build, serial writes into a
ten-column table, statements counted with `pg_stat_statements`:

| | statements/write |
|---|---|
| `main` | 86.0 |
| this branch | **68.0** |

Wall-clock did not move against a *loopback* Postgres — these are in-transaction
statements on a held connection, so 18 of them disappear below the noise floor.
The win is proportional to per-statement round-trip time, which loopback makes
~0. Against a networked catalog it should matter; I have not measured that
configuration and present it as rationale, not result.

### Tests

The multicatalog suite is excluded from CI, and nothing asserted the *contents*
of either table for this writer — value assertions existed only for the SQLite
and single-catalog Postgres writers. Adds
`postgres_file_and_table_column_stats_round_trip_per_column`, which gives each
column a distinct signature and includes a column with NULL bounds but a
non-NULL size, so a misaligned array shifts a value onto the wrong column rather
than vanishing. Verified it fails when the min/max array binds are swapped:

```
assertion `left == right` failed: column 0: min_value
  left: Some("900")
 right: Some("1")
```

---

## 2. Trace the write path

Tracing a single `POST .../loads` against a live deployment produced this:

| | |
|---|---|
| `handler_load_database_table` | **1,190 ms** |
| sum of all instrumented child spans | **131 ms (11%)** |
| **unaccounted, inside one opaque block** | **1,058 ms (89%)** |

Every catalog call, cache read and `publish_managed_load` is instrumented
downstream — but the write path in this crate is not, so 89% of a load is
invisible. A day spent optimising configuration, connection pools, indexes and
statement counts moved throughput not at all, because all of it addressed the
11%.

Adds spans on the two halves of a commit and on the object-store write:

```
ducklake.begin_write_transaction   catalog row lock, id reservation
ducklake.register_data_files       the commit transaction
ducklake.finalize_snapshot         snapshot, schema, column, stats rows
ducklake.write_session_finish      close and upload
ducklake.upload_staged_file        the object-store PUT
ducklake.upload_staged
ducklake.finalize_open_file        parquet close
```

`skip_all` throughout so no argument is recorded by accident; the only fields
emitted are ids, names and collection lengths. Level `info`, matching the
read-path spans already in the crate. No behaviour change.

---

## Scope

Both changes are limited to the multicatalog Postgres writer. The identical
insert-loop shape exists in `metadata_writer_postgres_single.rs` and
`metadata_writer_mysql.rs` (both networked, both would benefit) and in the SQLite
and DuckDB writers (in-process, no round trip to save). Happy to extend.

## Status

`cargo build`, `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` all clean.

The batching commit passed the multicatalog suite (86 tests) before the tracing
commit was added. **The suite has not been re-run since** — Docker on my machine
is currently failing to start testcontainers (`failed to create a container:
Timeout error`, every test, before any crate code runs), so the re-run is
blocked on infrastructure rather than on the change. The tracing commit adds
spans only. Worth a CI run or a second pair of eyes before merge.