### PR TITLE
fix(cdc): resolve change-feed columns by field id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `DuckLakeTable::file_has_embedded_rowid` is now public, and available without the write features. `resolve_positions` is only valid for files that have never been rewritten, and `files_matching` cannot identify those from catalog metadata alone — nor should it silently withhold them, since a keyed mutation that never sees a file holding its key inserts a duplicate. This is the check a caller runs on each returned file to refuse a rewritten one loudly instead; the crate's own DELETE uses it the same way.
 
 ### Changed
+- **BREAKING**: `ducklake_table_changes`, `ducklake_table_insertions` and
+  `ducklake_table_deletions` resolve each data file's columns **by field id**, as of the window's
+  end snapshot, instead of by current name — matching official DuckLake. Output changes, silently,
+  on any table whose columns were renamed or dropped and re-added:
+  - a renamed column returned NULL for rows in files written before the rename, and now returns
+    those rows' values;
+  - a column dropped and re-added under the same name returned the DROPPED column's values for
+    rows in files written before the re-add, and now returns NULL there (the re-added column has
+    its own field id, and those files predate it);
+  - two columns whose names were swapped returned each other's values, and now return their own;
+  - a field renamed inside a `STRUCT` behaves the same way as a top-level one.
+
+  The fix is **not retroactive**: it changes what the feeds return from now on, and nothing in the
+  catalog was damaged, so no repair tooling is needed — but anything derived from earlier feed
+  output on an affected table is still wrong. **Re-derive anything built from change-feed output on
+  a table whose columns were renamed, or dropped and re-added.** To find those tables, look for a
+  `column_id` with more than one row, or a name shared by two `column_id`s:
+
+  ```sql
+  SELECT table_id, column_id, count(*) AS generations
+  FROM ducklake_column GROUP BY table_id, column_id HAVING count(*) > 1;
+
+  SELECT table_id, column_name, count(DISTINCT column_id) AS ids
+  FROM ducklake_column GROUP BY table_id, column_name HAVING count(DISTINCT column_id) > 1;
+  ```
+
+  Field ids come from each file's parquet footer, so the feeds now read one footer per data file —
+  the insert-only feed previously read none — and each per-file scan carries one more plan node.
+  On a table with **encrypted** files the footers cannot be read, so a feed whose window spans a
+  rename or a drop-and-re-add is refused with an error rather than served by name. That refusal is
+  conservative and catches some column changes that would have been safe to match by name, and only
+  `ducklake_table_changes` / `ducklake_table_insertions` give the explanatory error; see
+  COMPATIBILITY.md.
+- `TableChangesTable`, `TableInsertionsTable` and `TableDeletionsTable` accept the table's columns
+  through a new `with_columns` builder. No signature changed; without it the columns are read from
+  the metadata provider on each scan.
 - `TableWriteSession::finish_with_deletes` no longer refuses a session that produced more than one appended file; it commits them all in the snapshot that carries the deletes (#214).
 
 ### Fixed
@@ -34,6 +70,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   changing the existing list column ID or invalidating historical snapshots.
 - Reads null‑fill fields added inside structs, including non‑nullable fields and structs nested in
   lists, while preserving field‑ID‑based nested renames and drops.
+- The CDC table functions resolve the TABLE and its schema at the window's end snapshot, not at the
+  catalog's current snapshot. A window over a table that was dropped afterwards failed with
+  "Table 'main.t' not found in catalog" even though every snapshot in the window still had the
+  table; it now returns that window's changes, and a window whose end snapshot is past the drop
+  reports that the table does not exist at that snapshot — matching official DuckLake. One window
+  changes the other way: a window ending BEFORE the table was created used to resolve the table at
+  the current snapshot and return an empty feed, and now reports that the table does not exist at
+  that snapshot. Official DuckLake errors on that window too, so this is convergence rather than a
+  new restriction (#196).
+- A `SELECT` over a table whose struct child was added or renamed by DDL no longer fails with
+  "Cannot cast nullable struct field … to non-nullable field". DuckLake records such a child as
+  non-nullable while the physical parquet node stays optional, and a file written before the change
+  does not carry the child at all; `build_read_schema_with_field_id_mapping` now relaxes nested
+  nullability exactly as the sibling `build_arrow_schema` does. Map keys stay non-nullable. The read
+  schema is then type-identical to the catalog schema, so the rename layer above the scan is a
+  relabel and filters and limits reach the parquet reader's pruning on tables with nested columns.
 
 ## [0.6.0] - 2026-07-20
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -240,6 +240,27 @@ Known edges:
   per-row snapshot column cannot be read). Non-encrypted catalogs emit the full
   official change-set (inserts, deletes, update pre/postimages, merged-file rows at
   their origin snapshots).
+- **Change feeds over an encrypted table whose columns evolved are refused.** A change
+  feed resolves each data file's columns by field id, read from that file's parquet
+  footer, so a column renamed (or dropped and re-added under the same name) after a file
+  was written still reads that file's values. The encrypted path holds no key for those
+  footers, and the only thing left to match on — the column name — is exactly what the
+  rename changed. Rather than hand back another column's values, the feed errors when
+  the table's columns changed between the oldest data file in the window and the
+  window's end snapshot. A window whose files all predate the change is unaffected, and
+  so is reading the table itself. Two details worth knowing:
+  - **The check is deliberately conservative, and refuses more than it must.** A column's
+    identity is its name plus its resolved type, and the type is what carries a nested
+    field's name — so widening a column with `ALTER … TYPE`, or adding or renaming a field
+    inside an existing `STRUCT`, also trips it, even though matching those by name would
+    have been correct. Adding a new top-level column, and dropping one outright, do not
+    trip it: the added name is in no older file, and nobody asks for the dropped one.
+  - **Only `ducklake_table_changes` and `ducklake_table_insertions` refuse with that
+    explanation.** `ducklake_table_deletions` has no encryption support at all: it reads
+    the deleted rows' source data file with no key, so on an encrypted table it fails with
+    a raw parquet decryption error rather than a message about column evolution. That feed
+    did not work on encrypted tables before either — the failure has moved from read time
+    to plan time.
 - **Partition pruning covers `identity` + `year` only.** `month`/`day`/`hour`/`bucket(N)`
   partition transforms are read correctly but fail open (files are always kept, never
   mis-dropped); only whole-value (`identity`) and calendar-year ranges prune files.

--- a/src/table.rs
+++ b/src/table.rs
@@ -707,6 +707,174 @@ struct FileReadConfig {
     row_group_count: usize,
 }
 
+/// What one file's parquet footer says: the field-id → physical-name map, the
+/// arrow schema the reader derives from it, and the row-group boundaries.
+///
+/// This is the ONLY place the crate parses a data file's footer for read
+/// planning, so field-id resolution cannot drift between the table scan and the
+/// change feeds.
+pub(crate) struct ParquetFooterFacts {
+    /// `field_id → physical column name`, at every nesting depth.
+    pub(crate) field_ids: HashMap<i32, String>,
+    /// The arrow schema the parquet reader derives for this file.
+    pub(crate) arrow_schema: SchemaRef,
+    /// Per-row-group starting physical row position (prefix sums of
+    /// `row_groups[i].num_rows()`).
+    pub(crate) row_group_starts: Vec<i64>,
+    /// Number of row groups (`row_group_starts.len()`).
+    pub(crate) row_group_count: usize,
+}
+
+/// A file's footer resolved against a table's CURRENT columns: the schema to
+/// scan it with (each column under the physical name THIS file gives it, or a
+/// guaranteed-absent name when the file predates the column), the renames back
+/// to the catalog names, and the reserved embedded columns it carries.
+#[derive(Debug, Clone)]
+pub(crate) struct ParquetFileLayout {
+    /// One field per current column, in catalog order, under its physical name.
+    /// Carries no embedded columns — each read path appends the ones it wants.
+    pub(crate) read_schema: SchemaRef,
+    /// `physical name → catalog name`, for the columns whose names differ.
+    pub(crate) name_mapping: HashMap<String, String>,
+    /// `Some(parquet_column_name)` if the file embeds the rowid column (tagged
+    /// with [`ROW_ID_PARQUET_FIELD_ID`]).
+    pub(crate) embedded_rowid_parquet_name: Option<String>,
+    /// `Some(parquet_column_name)` if the file embeds the per-row snapshot-id
+    /// column ([`SNAPSHOT_ID_PARQUET_FIELD_ID`]) — i.e. it is a merged partial
+    /// file.
+    pub(crate) embedded_snapshot_parquet_name: Option<String>,
+    /// True if the file carries a data column that is NOT in the table's current
+    /// schema — a column dropped since the file was written.
+    pub(crate) drops_current_columns: bool,
+    pub(crate) row_group_starts: Vec<i64>,
+    pub(crate) row_group_count: usize,
+}
+
+/// Read `resolved_path`'s parquet footer once. `encryption_key` is the file's
+/// DuckLake encryption key when it has one; it is only usable with the
+/// `encryption` feature, and this function cannot open an encrypted file
+/// without it.
+pub(crate) async fn read_parquet_footer_facts(
+    state: &dyn Session,
+    object_store_url: &ObjectStoreUrl,
+    resolved_path: &str,
+    encryption_key: Option<&str>,
+) -> DataFusionResult<ParquetFooterFacts> {
+    let object_store = state.runtime_env().object_store(object_store_url)?;
+    let object_path = ObjectPath::from(resolved_path);
+    let reader = ParquetObjectReader::new(object_store, object_path);
+
+    #[cfg(feature = "encryption")]
+    let builder = {
+        use parquet::arrow::arrow_reader::ArrowReaderOptions;
+        let options = match encryption_key {
+            Some(key) if !key.is_empty() => {
+                let key_bytes = crate::encryption::DuckLakeEncryptionFactory::decode_key(key)?;
+                let decryption_props =
+                    parquet::encryption::decrypt::FileDecryptionProperties::builder(key_bytes)
+                        .build()
+                        .map_err(|e| {
+                            DataFusionError::Execution(format!(
+                                "Failed to create decryption properties: {}",
+                                e
+                            ))
+                        })?;
+                ArrowReaderOptions::new().with_file_decryption_properties(decryption_props)
+            },
+            _ => ArrowReaderOptions::new(),
+        };
+        ParquetRecordBatchStreamBuilder::new_with_options(reader, options)
+            .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))?
+    };
+
+    #[cfg(not(feature = "encryption"))]
+    let builder = {
+        // Without the feature there is no decryption to configure.
+        let _ = encryption_key;
+        ParquetRecordBatchStreamBuilder::new(reader)
+            .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))?
+    };
+
+    let field_ids = extract_parquet_field_ids(builder.metadata());
+
+    // Per-row-group starting positions (prefix sums of num_rows), read from the
+    // footer we already have open. Drives row-group-aligned scan partitioning on
+    // positional paths.
+    let row_groups = builder.metadata().row_groups();
+    let row_group_count = row_groups.len();
+    let mut row_group_starts = Vec::with_capacity(row_group_count);
+    let mut row_acc: i64 = 0;
+    for rg in row_groups {
+        row_group_starts.push(row_acc);
+        row_acc = row_acc.saturating_add(rg.num_rows());
+    }
+
+    Ok(ParquetFooterFacts {
+        field_ids,
+        arrow_schema: builder.schema().clone(),
+        row_group_starts,
+        row_group_count,
+    })
+}
+
+/// Resolve one file's columns against `columns` by field id.
+///
+/// `fallback_schema` is used verbatim for a file that carries no field ids at
+/// all (an external or pre-DuckLake parquet file), where names are the only
+/// thing to match on.
+pub(crate) async fn read_parquet_file_layout(
+    state: &dyn Session,
+    object_store_url: &ObjectStoreUrl,
+    resolved_path: &str,
+    encryption_key: Option<&str>,
+    columns: &[DuckLakeTableColumn],
+    fallback_schema: &SchemaRef,
+) -> DataFusionResult<Arc<ParquetFileLayout>> {
+    let facts =
+        read_parquet_footer_facts(state, object_store_url, resolved_path, encryption_key).await?;
+
+    let (read_schema, name_mapping) = if facts.field_ids.is_empty() {
+        (fallback_schema.clone(), HashMap::new())
+    } else {
+        let (schema, mapping) = build_read_schema_with_field_id_mapping(
+            columns,
+            &facts.field_ids,
+            Some(facts.arrow_schema.as_ref()),
+        )
+        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        (Arc::new(schema), mapping)
+    };
+
+    // Does the file carry a data column no longer in the current schema? Any
+    // parquet field-id that is neither a reserved embedded column nor one of the
+    // current catalog `column_id`s is a since-dropped column. Compaction uses
+    // this to refuse merging a file whose data would be lost.
+    let current_column_ids: HashSet<i32> = columns
+        .iter()
+        .flat_map(|column| {
+            std::iter::once(column.column_id).chain(column.nested_column_ids.iter().copied())
+        })
+        .map(|column_id| column_id as i32)
+        .collect();
+    let drops_current_columns = facts.field_ids.keys().any(|fid| {
+        *fid != ROW_ID_PARQUET_FIELD_ID
+            && *fid != SNAPSHOT_ID_PARQUET_FIELD_ID
+            && !current_column_ids.contains(fid)
+    });
+
+    Ok(Arc::new(ParquetFileLayout {
+        read_schema,
+        name_mapping,
+        embedded_rowid_parquet_name: facts.field_ids.get(&ROW_ID_PARQUET_FIELD_ID).cloned(),
+        embedded_snapshot_parquet_name: facts.field_ids.get(&SNAPSHOT_ID_PARQUET_FIELD_ID).cloned(),
+        drops_current_columns,
+        row_group_starts: facts.row_group_starts,
+        row_group_count: facts.row_group_count,
+    }))
+}
+
 /// DuckLake table provider
 ///
 /// Represents a table within a DuckLake schema and provides access to data via Parquet files.
@@ -1902,101 +2070,28 @@ impl DuckLakeTable {
             }
         }
 
-        let object_store = state
-            .runtime_env()
-            .object_store(self.object_store_url.as_ref())?;
-        let object_path = ObjectPath::from(resolved_path.as_str());
-        let reader = ParquetObjectReader::new(object_store, object_path);
-
         #[cfg(feature = "encryption")]
-        let builder = {
-            use parquet::arrow::arrow_reader::ArrowReaderOptions;
-            let options = if let Some(ref key) = file.encryption_key {
-                if !key.is_empty() {
-                    let key_bytes = crate::encryption::DuckLakeEncryptionFactory::decode_key(key)?;
-                    let decryption_props =
-                        parquet::encryption::decrypt::FileDecryptionProperties::builder(key_bytes)
-                            .build()
-                            .map_err(|e| {
-                                DataFusionError::Execution(format!(
-                                    "Failed to create decryption properties: {}",
-                                    e
-                                ))
-                            })?;
-                    ArrowReaderOptions::new().with_file_decryption_properties(decryption_props)
-                } else {
-                    ArrowReaderOptions::new()
-                }
-            } else {
-                ArrowReaderOptions::new()
-            };
-            ParquetRecordBatchStreamBuilder::new_with_options(reader, options)
-                .await
-                .map_err(|e| DataFusionError::External(Box::new(e)))?
-        };
-
+        let encryption_key = file.encryption_key.as_deref();
         #[cfg(not(feature = "encryption"))]
-        let builder = ParquetRecordBatchStreamBuilder::new(reader)
-            .await
-            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        let encryption_key = None;
 
-        let field_id_map = extract_parquet_field_ids(builder.metadata());
+        let layout = read_parquet_file_layout(
+            state,
+            self.object_store_url.as_ref(),
+            &resolved_path,
+            encryption_key,
+            &self.columns,
+            &self.physical_schema,
+        )
+        .await?;
 
-        // Per-row-group starting positions (prefix sums of num_rows), read from
-        // the footer we already have open. Drives row-group-aligned scan
-        // partitioning on positional paths.
-        let row_groups = builder.metadata().row_groups();
-        let row_group_count = row_groups.len();
-        let mut row_group_starts = Vec::with_capacity(row_group_count);
-        let mut row_acc: i64 = 0;
-        for rg in row_groups {
-            row_group_starts.push(row_acc);
-            row_acc = row_acc.saturating_add(rg.num_rows());
-        }
-
-        // Standard read_schema + name_mapping for physical columns.
-        let (physical_read_schema, mut name_mapping) = if field_id_map.is_empty() {
-            (self.physical_schema.as_ref().clone(), HashMap::new())
-        } else {
-            let (s, m) = build_read_schema_with_field_id_mapping(
-                &self.columns,
-                &field_id_map,
-                Some(builder.schema().as_ref()),
-            )
-            .map_err(|e| DataFusionError::External(Box::new(e)))?;
-            (s, m)
-        };
-
-        // Detect the embedded rowid column by reserved field-id.
-        let embedded_rowid_parquet_name = field_id_map.get(&ROW_ID_PARQUET_FIELD_ID).cloned();
-        // Detect the embedded per-row snapshot-id column (marks a partial file).
-        let embedded_snapshot_parquet_name =
-            field_id_map.get(&SNAPSHOT_ID_PARQUET_FIELD_ID).cloned();
-        // Does the file carry a data column no longer in the current schema? Any
-        // parquet field-id that is neither a reserved embedded column nor one of
-        // the current catalog `column_id`s is a since-dropped column. Compaction
-        // uses this to refuse merging a file whose data would be lost.
-        let current_column_ids: std::collections::HashSet<i32> = self
-            .columns
-            .iter()
-            .flat_map(|column| {
-                std::iter::once(column.column_id).chain(column.nested_column_ids.iter().copied())
-            })
-            .map(|column_id| column_id as i32)
-            .collect();
-        let drops_current_columns = field_id_map.keys().any(|fid| {
-            *fid != ROW_ID_PARQUET_FIELD_ID
-                && *fid != SNAPSHOT_ID_PARQUET_FIELD_ID
-                && !current_column_ids.contains(fid)
-        });
-
-        let read_schema = if let Some(ref parquet_name) = embedded_rowid_parquet_name {
+        let mut name_mapping = layout.name_mapping.clone();
+        let read_schema = if let Some(ref parquet_name) = layout.embedded_rowid_parquet_name {
             // Append the embedded rowid column to read_schema under its
             // parquet name; ParquetExec will project it by name from the
             // file. We add a `parquet_name → "rowid"` rename so the user
             // sees the column as `rowid` (only needed if the names differ).
-            let mut fields: Vec<Arc<Field>> =
-                physical_read_schema.fields().iter().cloned().collect();
+            let mut fields: Vec<Arc<Field>> = layout.read_schema.fields().iter().cloned().collect();
             fields.push(Arc::new(Field::new(
                 parquet_name.clone(),
                 DataType::Int64,
@@ -2007,17 +2102,17 @@ impl DuckLakeTable {
             }
             Arc::new(Schema::new(fields))
         } else {
-            Arc::new(physical_read_schema)
+            layout.read_schema.clone()
         };
 
         let cfg = Arc::new(FileReadConfig {
             read_schema,
             name_mapping,
-            embedded_rowid_parquet_name,
-            embedded_snapshot_parquet_name,
-            drops_current_columns,
-            row_group_starts,
-            row_group_count,
+            embedded_rowid_parquet_name: layout.embedded_rowid_parquet_name.clone(),
+            embedded_snapshot_parquet_name: layout.embedded_snapshot_parquet_name.clone(),
+            drops_current_columns: layout.drops_current_columns,
+            row_group_starts: layout.row_group_starts.clone(),
+            row_group_count: layout.row_group_count,
         });
 
         {

--- a/src/table_changes.rs
+++ b/src/table_changes.rs
@@ -10,12 +10,12 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 
 use arrow::array::{Array, ArrayRef, BooleanArray, Int64Array, StringArray, UInt32Array};
 use arrow::compute::take;
-use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use arrow::datatypes::{DataType, Field, FieldRef, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use datafusion::catalog::Session;
@@ -35,18 +35,17 @@ use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
 };
 use futures::{Stream, StreamExt};
-use object_store::path::Path as ObjectPath;
-use parquet::arrow::ParquetRecordBatchStreamBuilder;
-use parquet::arrow::async_reader::ParquetObjectReader;
 
-use crate::metadata_provider::{DataFileChange, MetadataProvider};
+use crate::column_rename::ColumnRenameExec;
+use crate::metadata_provider::{DataFileChange, DuckLakeTableColumn, MetadataProvider};
 use crate::path_resolver::resolve_path;
 use crate::positional_source::PositionalFileSource;
-use crate::row_id::{
-    FileRowNumberExec, ROW_ID_PARQUET_FIELD_ID, ROW_POS_COLUMN_NAME, SNAPSHOT_ID_PARQUET_FIELD_ID,
+use crate::row_id::{FileRowNumberExec, ROW_POS_COLUMN_NAME, SNAPSHOT_ID_PARQUET_FIELD_ID};
+use crate::table::{
+    ParquetFileLayout, delete_file_schema, read_parquet_file_layout, read_parquet_footer_facts,
+    validated_file_size, validated_record_count,
 };
-use crate::table::{delete_file_schema, validated_file_size, validated_record_count};
-use crate::types::extract_parquet_field_ids;
+use crate::types::ABSENT_FIELD_PREFIX;
 
 #[cfg(feature = "encryption")]
 use crate::encryption::EncryptionFactoryBuilder;
@@ -89,15 +88,94 @@ impl fmt::Display for ChangeType {
     }
 }
 
-/// Physical names of a data file's embedded CDC columns, when present.
-#[derive(Debug, Clone, Default)]
-struct EmbeddedCdcNames {
-    /// `_ducklake_internal_row_id` under its physical name (field id
-    /// [`ROW_ID_PARQUET_FIELD_ID`]).
-    rowid: Option<String>,
-    /// `_ducklake_internal_snapshot_id` under its physical name (field id
-    /// [`SNAPSHOT_ID_PARQUET_FIELD_ID`]).
-    snapshot: Option<String>,
+/// Present a per-file CDC scan under the catalog schema: `table_fields` resolved
+/// by field id and coerced to their catalog types, then whatever internal columns
+/// the scan appended (embedded rowid, embedded per-row snapshot, physical
+/// position) passed through unchanged, by name.
+///
+/// The wrap is decided against a target that does NOT depend on the file, because
+/// a union's branches must all end up with the SAME output schema: `UnionExec`
+/// validates the field count only, adopts the first branch's names, and panics on
+/// a type mismatch. Wrapping "only the files that need renaming" would emit the
+/// pre-rename column name for the others.
+///
+/// Two latent hazards, both shared with the ordinary table scan, which presents
+/// its positional reads the same way:
+///
+/// - A NOT NULL top-level column that an older file does not carry is read as an
+///   all-NULL array and then presented under the non-nullable catalog field, which
+///   `record_batch_with_schema` rejects. DuckDB's own extension cannot create that
+///   state (`ADD COLUMN … NOT NULL` is refused as "Adding columns with constraints
+///   not yet supported"), but this crate's writer and third-party implementations
+///   can.
+/// - The internal column names are not reserved: nothing stops a table column from
+///   being called [`ROW_POS_COLUMN_NAME`], and nothing stops an older file from
+///   physically carrying a column called `__ducklake_absent_field_<id>`. Either
+///   makes two fields of one schema share a name, and the by-name lookup then
+///   binds the first — reading the table column where the position was meant, or
+///   real data where a null-fill was meant. Reserving the names belongs with the
+///   writer's name validation, not here.
+pub(crate) fn present_catalog_schema(
+    scan: Arc<dyn ExecutionPlan>,
+    table_fields: &[FieldRef],
+    name_mapping: &HashMap<String, String>,
+) -> Arc<dyn ExecutionPlan> {
+    let scan_schema = scan.schema();
+    debug_assert!(scan_schema.fields().len() >= table_fields.len());
+    let mut fields: Vec<FieldRef> = table_fields.to_vec();
+    fields.extend(
+        scan_schema
+            .fields()
+            .iter()
+            .skip(table_fields.len())
+            .cloned(),
+    );
+    let output_schema: SchemaRef = Arc::new(Schema::new(fields));
+    if !name_mapping.is_empty() || scan_schema != output_schema {
+        Arc::new(ColumnRenameExec::new(
+            scan,
+            output_schema,
+            name_mapping.clone(),
+        ))
+    } else {
+        scan
+    }
+}
+
+/// Refuse a column list that disagrees with the table schema built from it.
+///
+/// Every CDC read path locates a scan batch's internal columns (embedded rowid,
+/// embedded per-row snapshot, physical position) by arithmetic on `table_len`,
+/// while the per-file read schema is built from the column list. If the list is
+/// LONGER, those indices address data columns and the feed reports a data value
+/// as a rowid — wrong answers, no error. Both come from one
+/// `get_table_structure` call inside the table functions, so this is
+/// unreachable there; the providers' constructors and `with_columns` are
+/// public, and this is the boundary check for a caller that pairs a schema with
+/// the wrong columns.
+pub(crate) fn check_column_count(table_len: usize, columns_len: usize) -> DataFusionResult<()> {
+    if table_len != columns_len {
+        return Err(DataFusionError::External(
+            format!(
+                "change feed built with {columns_len} column(s) but a {table_len}-field table \
+                 schema; the schema and the column list must describe the same table"
+            )
+            .into(),
+        ));
+    }
+    Ok(())
+}
+
+/// Index of a read-schema column the file actually carries. A CDC-columns-only
+/// projection (`SELECT snapshot_id FROM …`, `COUNT(*)`) reads one data column
+/// purely for its row count, and a column the file predates is materialised as a
+/// null array rather than read from it.
+fn row_count_probe_index(read_schema: &Schema) -> usize {
+    read_schema
+        .fields()
+        .iter()
+        .position(|f| !f.name().starts_with(ABSENT_FIELD_PREFIX))
+        .unwrap_or(0)
 }
 
 /// Positions of the CDC metadata columns in the feed's output schema. They
@@ -357,6 +435,14 @@ pub struct TableChangesTable {
     table_schema: SchemaRef,
     /// Combined schema: table columns + snapshot_id + change_type
     output_schema: SchemaRef,
+    /// The table's columns as of `end_snapshot`, carrying the field ids each data
+    /// file's columns are resolved by. Set via [`Self::with_columns`]; fetched
+    /// from the metadata provider on demand when it is not.
+    columns: Option<Arc<Vec<DuckLakeTableColumn>>>,
+    /// Per-file read layout, memoized by resolved path. A file inserted and then
+    /// deleted inside the window is reached from both sides of the feed, and a
+    /// delete's source data file can be reached by several delete records.
+    layout_cache: Mutex<HashMap<String, Arc<ParquetFileLayout>>>,
     /// When set, the delete side is never read: every row added in the window
     /// surfaces as `insert` (the `ducklake_table_insertions` feed).
     insertions_only: bool,
@@ -393,8 +479,22 @@ impl TableChangesTable {
             table_path,
             table_schema,
             output_schema,
+            columns: None,
+            layout_cache: Mutex::new(HashMap::new()),
             insertions_only: false,
         }
+    }
+
+    /// Supply the table's columns as of the window's end snapshot.
+    ///
+    /// A data file records each column under the name it had when the file was
+    /// written, tagged with the column's field id, so the feed resolves columns by
+    /// field id rather than by name. Without this the columns are fetched from the
+    /// metadata provider on each scan; passing them in avoids that query when the
+    /// caller already holds them.
+    pub fn with_columns(mut self, columns: Vec<DuckLakeTableColumn>) -> Self {
+        self.columns = Some(Arc::new(columns));
+        self
     }
 
     /// Turn this feed into `ducklake_table_insertions`: the delete side is
@@ -404,6 +504,56 @@ impl TableChangesTable {
     pub fn insertions_only(mut self) -> Self {
         self.insertions_only = true;
         self
+    }
+
+    /// The table's columns as of the window's end snapshot: whatever
+    /// [`Self::with_columns`] was given, else a fresh metadata read.
+    fn resolve_columns(&self) -> DataFusionResult<Arc<Vec<DuckLakeTableColumn>>> {
+        match &self.columns {
+            Some(columns) => Ok(Arc::clone(columns)),
+            None => {
+                let columns = self
+                    .provider
+                    .get_table_structure(self.table_id, self.end_snapshot)
+                    .map_err(|e| DataFusionError::External(Box::new(e)))?;
+                Ok(Arc::new(columns))
+            },
+        }
+    }
+
+    /// The read layout of one data file, memoized by resolved path.
+    async fn file_layout(
+        &self,
+        state: &dyn Session,
+        columns: &[DuckLakeTableColumn],
+        path: &str,
+        is_relative: bool,
+    ) -> DataFusionResult<Arc<ParquetFileLayout>> {
+        let resolved = resolve_path(&self.table_path, path, is_relative)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        {
+            let cache = self.layout_cache.lock().unwrap();
+            if let Some(layout) = cache.get(&resolved) {
+                return Ok(Arc::clone(layout));
+            }
+        }
+        // No encryption key: this path never reaches an encrypted file (see the
+        // guard in `scan`), and a footer it cannot decrypt is not readable here.
+        let layout = read_parquet_file_layout(
+            state,
+            self.object_store_url.as_ref(),
+            &resolved,
+            None,
+            columns,
+            &self.table_schema,
+        )
+        .await?;
+        self.layout_cache
+            .lock()
+            .unwrap()
+            .entry(resolved)
+            .or_insert_with(|| Arc::clone(&layout));
+        Ok(layout)
     }
 
     /// Analyze projection and split into table columns and CDC columns.
@@ -490,22 +640,26 @@ impl TableChangesTable {
         Arc::new(Schema::new(fields))
     }
 
-    /// Build a ParquetExec wrapped with PrependCDCColumnsExec for a single file
+    /// Build a ParquetExec wrapped with PrependCDCColumnsExec for a single file.
+    /// `layout` is `None` only for an encrypted file, whose footer this path
+    /// cannot decrypt: its columns are then matched by name against the catalog
+    /// schema (see the guard in [`TableProvider::scan`]).
     #[cfg(feature = "encryption")]
     async fn build_exec_for_file(
         &self,
         state: &dyn Session,
         data_file: &DataFileChange,
+        layout: Option<&ParquetFileLayout>,
         proj_info: &ProjectionInfo,
         encryption_factory: &Option<Arc<dyn EncryptionFactory>>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let read_schema = self.file_read_schema(layout);
         let parquet_source = if let Some(factory) = encryption_factory {
-            ParquetSource::new(self.table_schema.clone())
-                .with_encryption_factory(Arc::clone(factory))
+            ParquetSource::new(read_schema).with_encryption_factory(Arc::clone(factory))
         } else {
-            ParquetSource::new(self.table_schema.clone())
+            ParquetSource::new(read_schema)
         };
-        self.build_exec_for_file_impl(state, data_file, proj_info, parquet_source)
+        self.build_exec_for_file_impl(state, data_file, layout, proj_info, parquet_source)
             .await
     }
 
@@ -515,15 +669,22 @@ impl TableChangesTable {
         &self,
         state: &dyn Session,
         data_file: &DataFileChange,
+        layout: Option<&ParquetFileLayout>,
         proj_info: &ProjectionInfo,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
-        self.build_exec_for_file_impl(
-            state,
-            data_file,
-            proj_info,
-            ParquetSource::new(self.table_schema.clone()),
-        )
-        .await
+        let parquet_source = ParquetSource::new(self.file_read_schema(layout));
+        self.build_exec_for_file_impl(state, data_file, layout, proj_info, parquet_source)
+            .await
+    }
+
+    /// The schema to scan one data file's table columns with: the file's own
+    /// field-id-resolved read schema, or the catalog schema when there is no
+    /// layout (an encrypted file).
+    fn file_read_schema(&self, layout: Option<&ParquetFileLayout>) -> SchemaRef {
+        match layout {
+            Some(layout) => Arc::clone(&layout.read_schema),
+            None => Arc::clone(&self.table_schema),
+        }
     }
 
     /// Internal implementation for building a ParquetExec wrapped with PrependCDCColumnsExec
@@ -531,6 +692,7 @@ impl TableChangesTable {
         &self,
         _state: &dyn Session,
         data_file: &DataFileChange,
+        layout: Option<&ParquetFileLayout>,
         proj_info: &ProjectionInfo,
         parquet_source: ParquetSource,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
@@ -557,7 +719,7 @@ impl TableChangesTable {
         // Determine what to read from Parquet
         let parquet_projection = if proj_info.table_indices.is_empty() {
             // Only CDC columns requested - read minimal data for row counts
-            Some(vec![0])
+            Some(vec![row_count_probe_index(&self.file_read_schema(layout))])
         } else {
             Some(proj_info.table_indices.clone())
         };
@@ -576,11 +738,25 @@ impl TableChangesTable {
         let file_scan_config = builder.build();
 
         // Use DataSourceExec directly to preserve our ParquetSource with encryption factory
-        let parquet_exec: Arc<dyn ExecutionPlan> =
+        let mut parquet_exec: Arc<dyn ExecutionPlan> =
             DataSourceExec::from_data_source(file_scan_config);
 
         // Determine if we should skip input columns (only CDC columns requested)
         let skip_input_columns = proj_info.table_indices.is_empty();
+
+        // Present the projected catalog fields, so every file's branch of the
+        // union below carries the same schema and `PrependCDCColumnsExec` can
+        // build batches under it. Nothing to present when the table columns are
+        // dropped anyway (a CDC-columns-only projection).
+        if !skip_input_columns {
+            let table_fields: Vec<FieldRef> = proj_info
+                .table_indices
+                .iter()
+                .map(|&i| Arc::clone(&self.table_schema.fields()[i]))
+                .collect();
+            let name_mapping = layout.map(|l| l.name_mapping.clone()).unwrap_or_default();
+            parquet_exec = present_catalog_schema(parquet_exec, &table_fields, &name_mapping);
+        }
 
         // Build output schema for PrependCDCColumnsExec
         let cdc_exec_schema = if skip_input_columns {
@@ -617,59 +793,55 @@ impl TableChangesTable {
         )))
     }
 
-    /// Read a file's parquet footer and return the physical names of its
-    /// embedded CDC columns: the row-id column ([`ROW_ID_PARQUET_FIELD_ID`],
-    /// present on UPDATE / non-adjacent-compaction outputs) and the per-row
-    /// snapshot-id column ([`SNAPSHOT_ID_PARQUET_FIELD_ID`], present on
-    /// compaction-merged partial files).
-    async fn detect_embedded_cdc_names(
+    /// Read a DELETE file's footer and return the physical name of its embedded
+    /// per-row snapshot column ([`SNAPSHOT_ID_PARQUET_FIELD_ID`]) when present.
+    /// Current-spec delete files are cumulative and carry one.
+    ///
+    /// A delete file holds `(file_path, pos[, snapshot])`, none of it table
+    /// columns, so it needs the raw footer rather than a read layout.
+    async fn detect_delete_file_snapshot_name(
         &self,
         state: &dyn Session,
         path: &str,
         is_relative: bool,
-    ) -> DataFusionResult<EmbeddedCdcNames> {
+    ) -> DataFusionResult<Option<String>> {
         let resolved = resolve_path(&self.table_path, path, is_relative)
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
-        let object_store = state
-            .runtime_env()
-            .object_store(self.object_store_url.as_ref())?;
-        let reader = ParquetObjectReader::new(object_store, ObjectPath::from(resolved.as_str()));
-        let builder = ParquetRecordBatchStreamBuilder::new(reader)
-            .await
-            .map_err(|e| DataFusionError::External(Box::new(e)))?;
-        let field_ids = extract_parquet_field_ids(builder.metadata());
-        Ok(EmbeddedCdcNames {
-            rowid: field_ids.get(&ROW_ID_PARQUET_FIELD_ID).cloned(),
-            snapshot: field_ids.get(&SNAPSHOT_ID_PARQUET_FIELD_ID).cloned(),
-        })
+        let facts =
+            read_parquet_footer_facts(state, self.object_store_url.as_ref(), &resolved, None)
+                .await?;
+        Ok(facts.field_ids.get(&SNAPSHOT_ID_PARQUET_FIELD_ID).cloned())
     }
 
-    /// The read schema for a data file: the table columns, plus the embedded
-    /// rowid / per-row snapshot columns (under their physical names) when
-    /// present, in that order.
+    /// The read schema for a data file: its table columns under the physical names
+    /// THIS file gives them, plus the embedded rowid / per-row snapshot columns
+    /// when present, in that order.
     fn read_schema_with_embedded(
         &self,
+        layout: &ParquetFileLayout,
         rowid_name: &Option<String>,
         snapshot_name: &Option<String>,
     ) -> SchemaRef {
         match (rowid_name, snapshot_name) {
-            (None, None) => self.table_schema.clone(),
+            (None, None) => Arc::clone(&layout.read_schema),
             (rowid, snapshot) => {
-                let mut fields: Vec<Field> = self
-                    .table_schema
-                    .fields()
-                    .iter()
-                    .map(|f| f.as_ref().clone())
-                    .collect();
+                let mut fields: Vec<FieldRef> =
+                    layout.read_schema.fields().iter().cloned().collect();
                 if let Some(name) = rowid {
-                    fields.push(Field::new(name, DataType::Int64, true));
+                    fields.push(Arc::new(Field::new(name, DataType::Int64, true)));
                 }
                 if let Some(name) = snapshot {
-                    fields.push(Field::new(name, DataType::Int64, true));
+                    fields.push(Arc::new(Field::new(name, DataType::Int64, true)));
                 }
                 Arc::new(Schema::new(fields))
             },
         }
+    }
+
+    /// The catalog fields the per-file scans of the correlated feed present, so
+    /// every one of them hands `correlate_changes` the same table columns.
+    fn catalog_table_fields(&self) -> Vec<FieldRef> {
+        self.table_schema.fields().iter().cloned().collect()
     }
 
     /// Scan of an inserted data file for the correlated feed. A file with an
@@ -678,10 +850,14 @@ impl TableChangesTable {
     /// (`PositionalFileSource` + `FileRowNumberExec`) so its rowid can be
     /// synthesized as `row_id_start + position` — but only when `need_rowid`;
     /// otherwise it is a plain scan with no position column.
+    ///
+    /// Either way the plan is presented under the catalog schema, ABOVE
+    /// `FileRowNumberExec` so the position column it appends passes straight
+    /// through.
     fn build_insert_scan(
         &self,
         data_file: &DataFileChange,
-        embedded: &EmbeddedCdcNames,
+        layout: &ParquetFileLayout,
         need_rowid_resolution: bool,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         let resolved = resolve_path(
@@ -702,11 +878,12 @@ impl TableChangesTable {
         }
         // The per-row snapshot column is read only for partial (merged) files.
         let snapshot_name = if data_file.partial_max.is_some() {
-            embedded.snapshot.clone()
+            layout.embedded_snapshot_parquet_name.clone()
         } else {
             None
         };
-        let read_schema = self.read_schema_with_embedded(&embedded.rowid, &snapshot_name);
+        let embedded_rowid = &layout.embedded_rowid_parquet_name;
+        let read_schema = self.read_schema_with_embedded(layout, embedded_rowid, &snapshot_name);
         let plain_scan = |pf: PartitionedFile, schema: SchemaRef| {
             let builder = FileScanConfigBuilder::new(
                 self.object_store_url.as_ref().clone(),
@@ -715,10 +892,10 @@ impl TableChangesTable {
             .with_file_group(FileGroup::new(vec![pf]));
             DataSourceExec::from_data_source(builder.build())
         };
-        match &embedded.rowid {
+        let scan: Arc<dyn ExecutionPlan> = match embedded_rowid {
             // Postimage / rewrite / non-adjacent merge: rowid IS the embedded
             // column — a plain scan.
-            Some(_) => Ok(plain_scan(pf, read_schema)),
+            Some(_) => plain_scan(pf, read_schema),
             // No embedded rowid but resolution required (rowid projected, or a
             // partial file whose real rowids feed the update correlation): scan
             // positionally to synthesize rowid = row_id_start + position.
@@ -729,11 +906,16 @@ impl TableChangesTable {
                         .with_file_group(FileGroup::new(vec![pf]))
                         .with_partitioned_by_file_group(true);
                 let scan = DataSourceExec::from_data_source(builder.build());
-                Ok(Arc::new(FileRowNumberExec::new(scan, vec![0])))
+                Arc::new(FileRowNumberExec::new(scan, vec![0]))
             },
             // Plain insert, rowid not needed: a plain scan, no positions.
-            None => Ok(plain_scan(pf, read_schema)),
-        }
+            None => plain_scan(pf, read_schema),
+        };
+        Ok(present_catalog_schema(
+            scan,
+            &self.catalog_table_fields(),
+            &layout.name_mapping,
+        ))
     }
 
     /// Positional scan of a delete's source data file: table columns, the
@@ -746,6 +928,7 @@ impl TableChangesTable {
         resolved_path: &str,
         size_bytes: i64,
         footer_size: i64,
+        layout: &ParquetFileLayout,
         embedded_name: &Option<String>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         let mut pf = PartitionedFile::new(
@@ -757,13 +940,17 @@ impl TableChangesTable {
         {
             pf = pf.with_metadata_size_hint(hint);
         }
-        let read_schema = self.read_schema_with_embedded(embedded_name, &None);
+        let read_schema = self.read_schema_with_embedded(layout, embedded_name, &None);
         let source = PositionalFileSource::wrap(Arc::new(ParquetSource::new(read_schema)));
         let builder = FileScanConfigBuilder::new(self.object_store_url.as_ref().clone(), source)
             .with_file_group(FileGroup::new(vec![pf]))
             .with_partitioned_by_file_group(true);
         let scan = DataSourceExec::from_data_source(builder.build());
-        Ok(Arc::new(FileRowNumberExec::new(scan, vec![0])))
+        Ok(present_catalog_schema(
+            Arc::new(FileRowNumberExec::new(scan, vec![0])),
+            &self.catalog_table_fields(),
+            &layout.name_mapping,
+        ))
     }
 
     /// Scan of a positional delete file (the standard `(file_path, pos)` schema);
@@ -806,6 +993,90 @@ impl TableChangesTable {
         Ok(DataSourceExec::from_data_source(builder.build()))
     }
 
+    /// Refuse the feed when an encrypted table's columns changed identity between
+    /// the oldest data file in the window and the window's end.
+    ///
+    /// Encrypted files' footers cannot be decrypted on this path, so their columns
+    /// can only be matched by name — correct only while every in-window file
+    /// records the columns under the names the end snapshot uses. A rename or a
+    /// drop-and-re-add breaks that, and a by-name read would then return NULL or
+    /// another column's values with no indication anything was wrong. Adding a
+    /// column, and dropping one outright, stay safe: the new name is in no older
+    /// file (so it null-fills) and the dropped one is asked for by nobody.
+    ///
+    /// The identity below is coarser than "was a column renamed", so this
+    /// refuses strictly more than it has to: a type widened by `ALTER … TYPE`
+    /// and a struct child added inside an existing column both change it, and
+    /// both would in fact read correctly by name. Erring toward refusal is the
+    /// point — the alternative on this path is silently wrong values — but a
+    /// finer check (compare names per field id, ignore the rest) would let those
+    /// two through if they turn out to matter. `COMPATIBILITY.md` says so.
+    #[cfg(feature = "encryption")]
+    fn reject_evolved_encrypted_table(
+        &self,
+        columns: &[DuckLakeTableColumn],
+        data_files: &[DataFileChange],
+    ) -> DataFusionResult<()> {
+        let Some(oldest) = data_files.iter().map(|f| f.begin_snapshot).min() else {
+            return Ok(());
+        };
+        if oldest >= self.end_snapshot {
+            return Ok(());
+        }
+        let then = self
+            .provider
+            .get_table_structure(self.table_id, oldest)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+        // A column's identity is its name plus its resolved type — the type is
+        // what carries a NESTED field's name, so a renamed struct child shows up
+        // here too.
+        let identity = |column: &DuckLakeTableColumn| -> DataFusionResult<(String, String)> {
+            let data_type = column
+                .data_type()
+                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+            Ok((column.column_name.clone(), format!("{data_type:?}")))
+        };
+        let mut then_by_id: HashMap<i64, (String, String)> = HashMap::new();
+        let mut then_names: HashSet<String> = HashSet::new();
+        for column in &then {
+            then_by_id.insert(column.column_id, identity(column)?);
+            then_names.insert(column.column_name.clone());
+        }
+
+        let mut evolved = false;
+        for column in columns {
+            evolved = match then_by_id.get(&column.column_id) {
+                Some(previous) => *previous != identity(column)?,
+                // A column id the older snapshot did not have: safe unless its
+                // name did exist back then under a different id — that is a drop
+                // and re-add, and a by-name read would find the dropped column's
+                // data in the older files.
+                None => then_names.contains(&column.column_name),
+            };
+            if evolved {
+                break;
+            }
+        }
+
+        if evolved {
+            return Err(DataFusionError::External(
+                format!(
+                    "table {} has encrypted data files and its columns changed between \
+                     snapshot {oldest} and snapshot {}: a column was renamed, or dropped and \
+                     re-added under the same name. Change feeds resolve columns by field id, \
+                     which requires reading each file's parquet footer, and an encrypted \
+                     footer cannot be read here — so the feed would return another column's \
+                     values. Query a snapshot window whose files all predate the change, or \
+                     read the table directly.",
+                    self.table_id, self.end_snapshot
+                )
+                .into(),
+            ));
+        }
+        Ok(())
+    }
+
     /// Build the correlated change feed: pair a same-snapshot delete + insert
     /// that share a rowid into `update_preimage` (old) + `update_postimage`
     /// (new); surface unmatched inserts as `insert` and unmatched deletes as
@@ -814,24 +1085,34 @@ impl TableChangesTable {
     async fn build_correlated_changes(
         &self,
         state: &dyn Session,
+        columns: &[DuckLakeTableColumn],
         data_files: &[DataFileChange],
         delete_files: &[crate::metadata_provider::DeleteFileChange],
-        embedded_names: &[EmbeddedCdcNames],
+        layouts: &[Arc<ParquetFileLayout>],
         projection: Option<&Vec<usize>>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         let table_len = self.table_schema.fields().len();
+        // Both come from the same column list, and the index arithmetic below
+        // (which column of a scan batch is the embedded rowid, the embedded
+        // snapshot, the position) assumes they agree. A disagreement would
+        // silently misalign every per-file scan — with more columns than
+        // `table_len` the internal-column indices land on DATA columns and the
+        // feed emits a data value as a rowid. Unreachable through the table
+        // functions, which derive both from one `get_table_structure` call, but
+        // the constructor and `with_columns` are public: refuse loudly.
+        check_column_count(table_len, columns.len())?;
         // Whether the caller wants the rowid column (at ROWID_IDX among the
         // leading CDC columns). When it does not, plain inserts skip the
         // positional scan and rowid synthesis entirely.
         let need_rowid = projection.is_none_or(|idx| idx.contains(&ROWID_IDX));
 
         let mut insert_units = Vec::with_capacity(data_files.len());
-        for (df, names) in data_files.iter().zip(embedded_names.iter()) {
+        for (df, layout) in data_files.iter().zip(layouts.iter()) {
             // Column layout of the scan batch after the `table_len` table
             // columns: [embedded rowid?][embedded snapshot? (partial files
             // only)][position? (appended by FileRowNumberExec)].
             let is_partial = df.partial_max.is_some();
-            if is_partial && names.snapshot.is_none() {
+            if is_partial && layout.embedded_snapshot_parquet_name.is_none() {
                 return Err(DataFusionError::External(
                     format!(
                         "data file {} is a merged partial file (partial_max set) but carries \
@@ -846,22 +1127,23 @@ impl TableChangesTable {
             // correlation (a placeholder could false-pair), so rowid is
             // resolved for them even when it is not projected.
             let resolve_rowid = need_rowid || is_partial;
-            let has_embedded_rowid = names.rowid.is_some();
+            let has_embedded_rowid = layout.embedded_rowid_parquet_name.is_some();
             let mut next_idx = table_len;
             let embedded_col_idx = has_embedded_rowid.then(|| {
                 let i = next_idx;
                 next_idx += 1;
                 i
             });
-            let snapshot_col_idx = (is_partial && names.snapshot.is_some()).then(|| {
-                let i = next_idx;
-                next_idx += 1;
-                i
-            });
+            let snapshot_col_idx = (is_partial && layout.embedded_snapshot_parquet_name.is_some())
+                .then(|| {
+                    let i = next_idx;
+                    next_idx += 1;
+                    i
+                });
             let pos_col_idx = (!has_embedded_rowid && resolve_rowid).then_some(next_idx);
             insert_units.push(InsertUnit {
                 snapshot_id: df.begin_snapshot,
-                scan: self.build_insert_scan(df, names, resolve_rowid)?,
+                scan: self.build_insert_scan(df, layout, resolve_rowid)?,
                 embedded_col_idx,
                 snapshot_col_idx,
                 pos_col_idx,
@@ -882,18 +1164,22 @@ impl TableChangesTable {
                     dfc.data_file_path_is_relative,
                 )
                 .map_err(|e| DataFusionError::External(Box::new(e)))?;
-                let old_embedded = self
-                    .detect_embedded_cdc_names(
+                // The source data file can predate the window (and any rename in
+                // it), so its columns need resolving by field id too.
+                let source_layout = self
+                    .file_layout(
                         state,
+                        columns,
                         &dfc.data_file_path,
                         dfc.data_file_path_is_relative,
                     )
-                    .await?
-                    .rowid;
+                    .await?;
+                let old_embedded = source_layout.embedded_rowid_parquet_name.clone();
                 let data_scan = self.build_delete_data_scan(
                     &resolved,
                     dfc.data_file_size_bytes,
                     dfc.data_file_footer_size.unwrap_or(0),
+                    &source_layout,
                     &old_embedded,
                 )?;
                 // A cumulative (current-spec) delete file embeds each row's
@@ -902,13 +1188,12 @@ impl TableChangesTable {
                 // the delta-vs-previous model.
                 let snapshot_name = match &dfc.current_delete_path {
                     Some(p) => {
-                        self.detect_embedded_cdc_names(
+                        self.detect_delete_file_snapshot_name(
                             state,
                             p,
                             dfc.current_delete_path_is_relative.unwrap_or(true),
                         )
                         .await?
-                        .snapshot
                     },
                     None => None,
                 };
@@ -1009,6 +1294,11 @@ impl TableProvider for TableChangesTable {
         // Analyze projection to determine what to read
         let proj_info = self.analyze_projection(projection);
 
+        // The columns as of the window's END snapshot, carrying the field ids the
+        // per-file read schemas are built from — official DuckLake resolves a
+        // change feed against exactly that generation of the schema.
+        let columns = self.resolve_columns()?;
+
         // Get data files added between snapshots (INSERT changes)
         let data_files = self
             .provider
@@ -1085,27 +1375,29 @@ impl TableProvider for TableChangesTable {
                 use datafusion::physical_plan::empty::EmptyExec;
                 return Ok(Arc::new(EmptyExec::new(proj_info.output_schema)));
             }
+            // Without the footers there are no field ids to resolve columns by,
+            // and matching by name is wrong once a column has been renamed or
+            // dropped and re-added.
+            #[cfg(feature = "encryption")]
+            self.reject_evolved_encrypted_table(&columns, &data_files)?;
         }
         let any_partial = data_files.iter().any(|f| f.partial_max.is_some());
 
         if (proj_info.need_rowid || !delete_files.is_empty() || any_partial) && !any_encrypted {
-            let mut embedded_names: Vec<EmbeddedCdcNames> = Vec::with_capacity(data_files.len());
+            let mut layouts: Vec<Arc<ParquetFileLayout>> = Vec::with_capacity(data_files.len());
             for data_file in &data_files {
-                embedded_names.push(
-                    self.detect_embedded_cdc_names(
-                        state,
-                        &data_file.path,
-                        data_file.path_is_relative,
-                    )
-                    .await?,
+                layouts.push(
+                    self.file_layout(state, &columns, &data_file.path, data_file.path_is_relative)
+                        .await?,
                 );
             }
             return self
                 .build_correlated_changes(
                     state,
+                    &columns,
                     &data_files,
                     &delete_files,
-                    &embedded_names,
+                    &layouts,
                     projection,
                 )
                 .await;
@@ -1132,16 +1424,33 @@ impl TableProvider for TableChangesTable {
             }
         };
 
-        // Build execution plan for each file with projection pushdown
+        // Build execution plan for each file with projection pushdown. Each
+        // file's columns are resolved by field id — except on an encrypted
+        // catalog, whose footers this path cannot read (the query has already
+        // been refused above if that table's columns evolved).
         let mut execs: Vec<Arc<dyn ExecutionPlan>> = Vec::with_capacity(data_files.len());
         for data_file in &data_files {
+            let layout = if any_encrypted {
+                None
+            } else {
+                Some(
+                    self.file_layout(state, &columns, &data_file.path, data_file.path_is_relative)
+                        .await?,
+                )
+            };
             #[cfg(feature = "encryption")]
             let exec = self
-                .build_exec_for_file(state, data_file, &proj_info, &encryption_factory)
+                .build_exec_for_file(
+                    state,
+                    data_file,
+                    layout.as_deref(),
+                    &proj_info,
+                    &encryption_factory,
+                )
                 .await?;
             #[cfg(not(feature = "encryption"))]
             let exec = self
-                .build_exec_for_file(state, data_file, &proj_info)
+                .build_exec_for_file(state, data_file, layout.as_deref(), &proj_info)
                 .await?;
             execs.push(exec);
         }
@@ -1913,6 +2222,13 @@ impl TableInsertionsTable {
             inner,
             output_schema,
         }
+    }
+
+    /// Supply the table's columns as of the window's end snapshot; see
+    /// [`TableChangesTable::with_columns`].
+    pub fn with_columns(mut self, columns: Vec<DuckLakeTableColumn>) -> Self {
+        self.inner = self.inner.with_columns(columns);
+        self
     }
 
     /// Map an index of this feed's schema — `(snapshot_id, rowid, table

--- a/src/table_deletions.rs
+++ b/src/table_deletions.rs
@@ -21,11 +21,11 @@
 //! deletions were silently missed or mis-attributed (issue #178).
 
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use arrow::array::{Array, ArrayRef, Int64Array, StringArray, UInt32Array};
 use arrow::compute::take;
-use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use arrow::datatypes::{DataType, Field, FieldRef, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use datafusion::catalog::Session;
@@ -48,18 +48,16 @@ use datafusion::physical_plan::{
 };
 use futures::stream::BoxStream;
 use futures::{StreamExt, TryStreamExt};
-use object_store::path::Path as ObjectPath;
-use parquet::arrow::ParquetRecordBatchStreamBuilder;
-use parquet::arrow::async_reader::ParquetObjectReader;
 
-use crate::metadata_provider::{DeleteFileChange, MetadataProvider};
+use crate::metadata_provider::{DeleteFileChange, DuckLakeTableColumn, MetadataProvider};
 use crate::path_resolver::resolve_path;
 use crate::positional_source::PositionalFileSource;
-use crate::row_id::{
-    FileRowNumberExec, ROW_ID_PARQUET_FIELD_ID, ROW_POS_COLUMN_NAME, SNAPSHOT_ID_PARQUET_FIELD_ID,
+use crate::row_id::{FileRowNumberExec, ROW_POS_COLUMN_NAME, SNAPSHOT_ID_PARQUET_FIELD_ID};
+use crate::table::{
+    ParquetFileLayout, read_parquet_file_layout, read_parquet_footer_facts, validated_file_size,
+    validated_record_count,
 };
-use crate::table::{validated_file_size, validated_record_count};
-use crate::types::extract_parquet_field_ids;
+use crate::table_changes::{check_column_count, present_catalog_schema};
 
 /// Delete file schema: (file_path: VARCHAR, pos: INT64)
 fn delete_file_schema() -> SchemaRef {
@@ -88,6 +86,13 @@ pub struct TableDeletionsTable {
     table_schema: SchemaRef,
     /// Combined schema: snapshot_id + rowid + change_type + table columns
     output_schema: SchemaRef,
+    /// The table's columns as of `end_snapshot`, carrying the field ids each data
+    /// file's columns are resolved by. Set via [`Self::with_columns`]; fetched
+    /// from the metadata provider on demand when it is not.
+    columns: Option<Arc<Vec<DuckLakeTableColumn>>>,
+    /// Per-file read layout, memoized by resolved path: several delete records in
+    /// one window can share a source data file.
+    layout_cache: Mutex<HashMap<String, Arc<ParquetFileLayout>>>,
 }
 
 impl TableDeletionsTable {
@@ -122,7 +127,69 @@ impl TableDeletionsTable {
             table_path,
             table_schema,
             output_schema,
+            columns: None,
+            layout_cache: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Supply the table's columns as of the window's end snapshot.
+    ///
+    /// A data file records each column under the name it had when the file was
+    /// written, tagged with the column's field id, so the feed resolves columns by
+    /// field id rather than by name. Without this the columns are fetched from the
+    /// metadata provider on each scan; passing them in avoids that query when the
+    /// caller already holds them.
+    pub fn with_columns(mut self, columns: Vec<DuckLakeTableColumn>) -> Self {
+        self.columns = Some(Arc::new(columns));
+        self
+    }
+
+    /// The table's columns as of the window's end snapshot: whatever
+    /// [`Self::with_columns`] was given, else a fresh metadata read.
+    fn resolve_columns(&self) -> DataFusionResult<Arc<Vec<DuckLakeTableColumn>>> {
+        match &self.columns {
+            Some(columns) => Ok(Arc::clone(columns)),
+            None => {
+                let columns = self
+                    .provider
+                    .get_table_structure(self.table_id, self.end_snapshot)
+                    .map_err(|e| DataFusionError::External(Box::new(e)))?;
+                Ok(Arc::new(columns))
+            },
+        }
+    }
+
+    /// The read layout of one data file, memoized by resolved path.
+    async fn file_layout(
+        &self,
+        state: &dyn Session,
+        columns: &[DuckLakeTableColumn],
+        path: &str,
+        is_relative: bool,
+    ) -> DataFusionResult<Arc<ParquetFileLayout>> {
+        let resolved = resolve_path(&self.table_path, path, is_relative)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        {
+            let cache = self.layout_cache.lock().unwrap();
+            if let Some(layout) = cache.get(&resolved) {
+                return Ok(Arc::clone(layout));
+            }
+        }
+        let layout = read_parquet_file_layout(
+            state,
+            self.object_store_url.as_ref(),
+            &resolved,
+            None,
+            columns,
+            &self.table_schema,
+        )
+        .await?;
+        self.layout_cache
+            .lock()
+            .unwrap()
+            .entry(resolved)
+            .or_insert_with(|| Arc::clone(&layout));
+        Ok(layout)
     }
 
     /// Build execution plan for a single delete file entry. `need_rowid` gates
@@ -131,6 +198,7 @@ impl TableDeletionsTable {
     async fn build_exec_for_delete_entry(
         &self,
         state: &dyn Session,
+        columns: &[DuckLakeTableColumn],
         need_rowid: bool,
         delete_file: &DeleteFileChange,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
@@ -198,19 +266,32 @@ impl TableDeletionsTable {
             _ => None,
         };
 
-        // Detect the source file's embedded rowid column (present on UPDATE /
-        // compaction outputs). When present, a deleted row's rowid is that
-        // embedded value — NOT `row_id_start + position`, which would key the
-        // delete differently from the row's insert/update_postimage. Only probe
-        // when the rowid is actually requested.
+        // Resolve the source data file's columns by field id: it can be older than
+        // the window, and older than any rename in it. This footer read is
+        // unconditional — the embedded-rowid probe it replaces happened only when
+        // the rowid was projected, but the column names have to be resolved either
+        // way.
         let table_len = self.table_schema.fields().len();
-        let embedded_name = if need_rowid {
-            self.detect_embedded_rowid_name(
+        // Both come from the same column list; the index arithmetic below assumes
+        // they agree, and a disagreement would misalign every scan batch
+        // silently — see [`check_column_count`].
+        check_column_count(table_len, columns.len())?;
+        let layout = self
+            .file_layout(
                 state,
+                columns,
                 &delete_file.data_file_path,
                 delete_file.data_file_path_is_relative,
             )
-            .await?
+            .await?;
+
+        // The source file's embedded rowid column (present on UPDATE / compaction
+        // outputs). When present, a deleted row's rowid is that embedded value —
+        // NOT `row_id_start + position`, which would key the delete differently
+        // from the row's insert/update_postimage. Only read it when the rowid is
+        // actually requested.
+        let embedded_name = if need_rowid {
+            layout.embedded_rowid_parquet_name.clone()
         } else {
             None
         };
@@ -224,6 +305,7 @@ impl TableDeletionsTable {
             &data_file_path,
             delete_file.data_file_size_bytes,
             delete_file.data_file_footer_size.unwrap_or(0),
+            &layout,
             &embedded_name,
         )?;
 
@@ -248,51 +330,25 @@ impl TableDeletionsTable {
         })))
     }
 
-    /// Read the source file's footer and return the physical name of its embedded
-    /// row-id column ([`ROW_ID_PARQUET_FIELD_ID`]) when present. Such a file is an
-    /// UPDATE / compaction output whose logical rowids come from that column.
-    async fn detect_embedded_rowid_name(
-        &self,
-        state: &dyn Session,
-        path: &str,
-        is_relative: bool,
-    ) -> DataFusionResult<Option<String>> {
-        self.parquet_field_id_name(state, path, is_relative, ROW_ID_PARQUET_FIELD_ID)
-            .await
-    }
-
     /// Read a DELETE file's footer and return the physical name of its embedded
     /// per-row snapshot column ([`SNAPSHOT_ID_PARQUET_FIELD_ID`]) when present.
     /// Current-spec delete files are cumulative and carry one; each row's value
     /// is the snapshot at which that position was deleted.
+    ///
+    /// A delete file holds `(file_path, pos[, snapshot])`, none of it table
+    /// columns, so it needs the raw footer rather than a read layout.
     async fn detect_delete_file_snapshot_name(
         &self,
         state: &dyn Session,
         path: &str,
         is_relative: bool,
     ) -> DataFusionResult<Option<String>> {
-        self.parquet_field_id_name(state, path, is_relative, SNAPSHOT_ID_PARQUET_FIELD_ID)
-            .await
-    }
-
-    async fn parquet_field_id_name(
-        &self,
-        state: &dyn Session,
-        path: &str,
-        is_relative: bool,
-        field_id: i32,
-    ) -> DataFusionResult<Option<String>> {
         let resolved = resolve_path(&self.table_path, path, is_relative)
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
-        let object_store = state
-            .runtime_env()
-            .object_store(self.object_store_url.as_ref())?;
-        let reader = ParquetObjectReader::new(object_store, ObjectPath::from(resolved.as_str()));
-        let builder = ParquetRecordBatchStreamBuilder::new(reader)
-            .await
-            .map_err(|e| DataFusionError::External(Box::new(e)))?;
-        let field_ids = extract_parquet_field_ids(builder.metadata());
-        Ok(field_ids.get(&field_id).cloned())
+        let facts =
+            read_parquet_footer_facts(state, self.object_store_url.as_ref(), &resolved, None)
+                .await?;
+        Ok(facts.field_ids.get(&SNAPSHOT_ID_PARQUET_FIELD_ID).cloned())
     }
 
     /// Build a ParquetExec for a delete file. When `snapshot_name` is `Some`,
@@ -345,11 +401,15 @@ impl TableDeletionsTable {
     /// and [`FileRowNumberExec`] guarantee true physical positions, so deleted
     /// rows are matched to the delete file's `pos` set regardless of how the
     /// file is read (issue #178).
+    /// The table columns are read under the physical names THIS file gives them
+    /// and presented back under the catalog schema, above [`FileRowNumberExec`] so
+    /// the position column passes through.
     fn build_data_file_scan(
         &self,
         path: &str,
         size_bytes: i64,
         footer_size: i64,
+        layout: &ParquetFileLayout,
         embedded_name: &Option<String>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         let mut pf = PartitionedFile::new(path, validated_file_size(size_bytes, path)?);
@@ -361,16 +421,12 @@ impl TableDeletionsTable {
 
         let read_schema = match embedded_name {
             Some(name) => {
-                let mut fields: Vec<Field> = self
-                    .table_schema
-                    .fields()
-                    .iter()
-                    .map(|f| f.as_ref().clone())
-                    .collect();
-                fields.push(Field::new(name, DataType::Int64, true));
+                let mut fields: Vec<FieldRef> =
+                    layout.read_schema.fields().iter().cloned().collect();
+                fields.push(Arc::new(Field::new(name, DataType::Int64, true)));
                 Arc::new(Schema::new(fields))
             },
-            None => self.table_schema.clone(),
+            None => Arc::clone(&layout.read_schema),
         };
 
         let source = PositionalFileSource::wrap(Arc::new(ParquetSource::new(read_schema)));
@@ -378,7 +434,12 @@ impl TableDeletionsTable {
             .with_file_group(FileGroup::new(vec![pf]))
             .with_partitioned_by_file_group(true);
         let scan = DataSourceExec::from_data_source(builder.build());
-        Ok(Arc::new(FileRowNumberExec::new(scan, vec![0])))
+        let table_fields: Vec<FieldRef> = self.table_schema.fields().iter().cloned().collect();
+        Ok(present_catalog_schema(
+            Arc::new(FileRowNumberExec::new(scan, vec![0])),
+            &table_fields,
+            &layout.name_mapping,
+        ))
     }
 }
 
@@ -432,11 +493,16 @@ impl TableProvider for TableDeletionsTable {
         // cannot be synthesized (no embedded rowid and a NULL row_id_start).
         let need_rowid = projection.is_none_or(|indices| indices.contains(&1));
 
+        // The columns as of the window's END snapshot, carrying the field ids the
+        // per-file read schemas are built from — official DuckLake resolves a
+        // change feed against exactly that generation of the schema.
+        let columns = self.resolve_columns()?;
+
         // Build execution plan for each delete entry
         let mut execs: Vec<Arc<dyn ExecutionPlan>> = Vec::with_capacity(delete_files.len());
         for delete_file in &delete_files {
             let exec = self
-                .build_exec_for_delete_entry(state, need_rowid, delete_file)
+                .build_exec_for_delete_entry(state, &columns, need_rowid, delete_file)
                 .await?;
             execs.push(exec);
         }

--- a/src/table_functions.rs
+++ b/src/table_functions.rs
@@ -185,6 +185,9 @@ struct CdcTableContext {
     object_store_url: datafusion::execution::object_store::ObjectStoreUrl,
     table_path: String,
     table_schema: Arc<arrow::datatypes::Schema>,
+    /// The columns the `table_schema` was built from, carrying the field ids each
+    /// data file's columns are resolved by.
+    columns: Vec<crate::metadata_provider::DuckLakeTableColumn>,
 }
 
 /// Split `'schema.table'` (defaulting to schema `main`).
@@ -306,26 +309,29 @@ fn parse_cdc_args(
         );
     }
 
+    // A change feed reports against the schema as of the window's END snapshot —
+    // the table and its schema included, not only its columns. Resolving them at
+    // the CURRENT snapshot instead makes a window over a since-dropped table
+    // unreadable, even though every snapshot in it still has the table, and makes
+    // a window that predates a table's creation resolve to a table it should not
+    // see. Official DuckLake resolves at the end snapshot and reports "does not
+    // exist at version N" beyond it.
     let (schema_name, table_name_only) = parse_table_name(&table_name);
-    let snapshot_id = provider
-        .get_current_snapshot()
-        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
     let schema = provider
-        .get_schema_by_name(schema_name, snapshot_id)
+        .get_schema_by_name(schema_name, end_snapshot)
         .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?
         .ok_or_else(|| {
             datafusion::error::DataFusionError::Plan(format!(
-                "Schema '{}' not found in catalog",
-                schema_name
+                "Schema '{schema_name}' does not exist at snapshot {end_snapshot}"
             ))
         })?;
     let table = provider
-        .get_table_by_name(schema.schema_id, table_name_only, snapshot_id)
+        .get_table_by_name(schema.schema_id, table_name_only, end_snapshot)
         .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?
         .ok_or_else(|| {
             datafusion::error::DataFusionError::Plan(format!(
-                "Table '{}.{}' not found in catalog",
-                schema_name, table_name_only
+                "Table '{schema_name}.{table_name_only}' does not exist at snapshot \
+                 {end_snapshot}"
             ))
         })?;
     let data_path = provider
@@ -353,6 +359,7 @@ fn parse_cdc_args(
             object_store_url,
             table_path,
             table_schema,
+            columns,
         },
     ))
 }
@@ -361,15 +368,18 @@ impl TableFunctionImpl for DucklakeTableChangesFunction {
     fn call(&self, exprs: &[Expr]) -> DataFusionResult<Arc<dyn TableProvider>> {
         let (start_snapshot, end_snapshot, ctx) =
             parse_cdc_args(&self.provider, exprs, "ducklake_table_changes")?;
-        Ok(Arc::new(TableChangesTable::new(
-            self.provider.clone(),
-            ctx.table_id,
-            start_snapshot,
-            end_snapshot,
-            Arc::new(ctx.object_store_url),
-            ctx.table_path,
-            ctx.table_schema,
-        )))
+        Ok(Arc::new(
+            TableChangesTable::new(
+                self.provider.clone(),
+                ctx.table_id,
+                start_snapshot,
+                end_snapshot,
+                Arc::new(ctx.object_store_url),
+                ctx.table_path,
+                ctx.table_schema,
+            )
+            .with_columns(ctx.columns),
+        ))
     }
 }
 
@@ -390,15 +400,18 @@ impl TableFunctionImpl for DucklakeTableDeletionsFunction {
     fn call(&self, exprs: &[Expr]) -> DataFusionResult<Arc<dyn TableProvider>> {
         let (start_snapshot, end_snapshot, ctx) =
             parse_cdc_args(&self.provider, exprs, "ducklake_table_deletions")?;
-        Ok(Arc::new(TableDeletionsTable::new(
-            self.provider.clone(),
-            ctx.table_id,
-            start_snapshot,
-            end_snapshot,
-            Arc::new(ctx.object_store_url),
-            ctx.table_path,
-            ctx.table_schema,
-        )))
+        Ok(Arc::new(
+            TableDeletionsTable::new(
+                self.provider.clone(),
+                ctx.table_id,
+                start_snapshot,
+                end_snapshot,
+                Arc::new(ctx.object_store_url),
+                ctx.table_path,
+                ctx.table_schema,
+            )
+            .with_columns(ctx.columns),
+        ))
     }
 }
 
@@ -422,15 +435,18 @@ impl TableFunctionImpl for DucklakeTableInsertionsFunction {
     fn call(&self, exprs: &[Expr]) -> DataFusionResult<Arc<dyn TableProvider>> {
         let (start_snapshot, end_snapshot, ctx) =
             parse_cdc_args(&self.provider, exprs, "ducklake_table_insertions")?;
-        Ok(Arc::new(TableInsertionsTable::new(
-            self.provider.clone(),
-            ctx.table_id,
-            start_snapshot,
-            end_snapshot,
-            Arc::new(ctx.object_store_url),
-            ctx.table_path,
-            ctx.table_schema,
-        )))
+        Ok(Arc::new(
+            TableInsertionsTable::new(
+                self.provider.clone(),
+                ctx.table_id,
+                start_snapshot,
+                end_snapshot,
+                Arc::new(ctx.object_store_url),
+                ctx.table_path,
+                ctx.table_schema,
+            )
+            .with_columns(ctx.columns),
+        ))
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -629,6 +629,11 @@ pub fn build_arrow_schema(columns: &[DuckLakeTableColumn]) -> Result<Schema> {
     Ok(Schema::new(fields?))
 }
 
+/// Prefix of the synthetic name a read schema gives a column the file does not
+/// carry, so the scan null-fills it instead of matching a same-named column that
+/// happens to be present.
+pub(crate) const ABSENT_FIELD_PREFIX: &str = "__ducklake_absent_field_";
+
 fn read_compatible_data_type(data_type: &DataType, nullable_struct_fields: bool) -> DataType {
     let rewrite_field = |field: &Arc<Field>, nullable: bool| {
         Arc::new(
@@ -792,7 +797,7 @@ fn read_data_type_with_field_id_mapping(
                 .unwrap_or(parquet_name)
                 .clone()
         } else if match_by_id {
-            format!("__ducklake_absent_field_{field_id}")
+            format!("{ABSENT_FIELD_PREFIX}{field_id}")
         } else {
             field.name().clone()
         };
@@ -912,6 +917,13 @@ fn read_data_type_with_field_id_mapping(
 /// renamed columns. A current column whose field_id is absent from a file that
 /// otherwise carries field_ids is read as an all-NULL column (the file predates
 /// the column, or it was dropped then re-added under the same name).
+///
+/// Nested nullability is relaxed exactly as [`build_arrow_schema`] relaxes it: a
+/// field added inside a struct, or renamed there, is recorded non-nullable in the
+/// catalog while the physical node stays optional, and a file written before the
+/// change does not carry it at all. Map keys stay non-nullable — a map's entries
+/// are structurally non-null, and relaxing them makes a `MAP` column's arrays
+/// disagree with the schema describing them.
 pub fn build_read_schema_with_field_id_mapping(
     current_columns: &[DuckLakeTableColumn],
     parquet_field_ids: &HashMap<i32, String>,
@@ -923,7 +935,10 @@ pub fn build_read_schema_with_field_id_mapping(
     let fields: Result<Vec<Field>> = current_columns
         .iter()
         .map(|col| {
-            let mut data_type = col.data_type()?;
+            // Relax nested nullability BEFORE the field ids are stamped on:
+            // the rewrite neither adds nor removes a node, so the
+            // `nested_column_ids` iterator stays aligned with the type.
+            let mut data_type = read_compatible_data_type(&col.data_type()?, true);
             let field_id = i32::try_from(col.column_id).map_err(|_| {
                 DuckLakeError::Internal(format!(
                     "column_id {} for column '{}' exceeds i32 range for Parquet field_id",
@@ -950,7 +965,7 @@ pub fn build_read_schema_with_field_id_mapping(
                 } else if parquet_field_ids.is_empty() {
                     (col.column_name.clone(), false, false) // external/legacy file
                 } else {
-                    (format!("__ducklake_absent_field_{}", field_id), true, true)
+                    (format!("{ABSENT_FIELD_PREFIX}{field_id}"), true, true)
                 };
 
             if !is_absent && !col.nested_column_ids.is_empty() {
@@ -2534,5 +2549,86 @@ mod tests {
         assert!(!types_compatible("foobar", "int32"));
         assert!(!types_compatible("int32", "foobar"));
         assert!(!types_compatible("foobar", "bazqux"));
+    }
+
+    /// A struct child the catalog records NON-nullable — what DDL that adds or
+    /// renames a nested field writes — must read as nullable, so the read schema
+    /// stays type-identical to the catalog schema the provider advertises. When
+    /// they differ the scan has to cast, and casting a nullable physical child to
+    /// a non-nullable logical one is refused outright.
+    #[test]
+    fn test_read_schema_relaxes_nested_nullability_like_catalog_schema() {
+        let columns = vec![DuckLakeTableColumn {
+            column_id: 1,
+            column_name: "s".to_string(),
+            column_type: "struct<a:int32,b:int32>".to_string(),
+            is_nullable: true,
+            data_type: Some(DataType::Struct(
+                vec![
+                    Arc::new(Field::new("a", DataType::Int32, true)),
+                    Arc::new(Field::new("b", DataType::Int32, false)),
+                ]
+                .into(),
+            )),
+            nested_column_ids: vec![2, 3],
+        }];
+        let parquet_field_ids =
+            HashMap::from([(1, "s".to_string()), (2, "a".to_string()), (3, "b".to_string())]);
+
+        let (read_schema, _) =
+            build_read_schema_with_field_id_mapping(&columns, &parquet_field_ids, None).unwrap();
+        let DataType::Struct(fields) = read_schema.field(0).data_type() else {
+            panic!("s must remain a struct");
+        };
+        assert!(fields[1].is_nullable(), "child `b` must read as nullable");
+
+        let catalog_schema = build_arrow_schema(&columns).unwrap();
+        assert!(
+            crate::column_rename::types_equal_ignoring_field_metadata(
+                read_schema.field(0).data_type(),
+                catalog_schema.field(0).data_type(),
+            ),
+            "read {:?} != catalog {:?}",
+            read_schema.field(0).data_type(),
+            catalog_schema.field(0).data_type(),
+        );
+    }
+
+    /// A MAP's key is structurally non-null. The relaxation must not reach it:
+    /// a nullable key makes the arrays a `MAP` column produces disagree with the
+    /// schema they are read under.
+    #[test]
+    fn test_read_schema_keeps_map_key_non_nullable() {
+        let entries = Field::new(
+            "entries",
+            DataType::Struct(
+                vec![
+                    Arc::new(Field::new("key", DataType::Utf8, false)),
+                    Arc::new(Field::new("value", DataType::Int32, true)),
+                ]
+                .into(),
+            ),
+            false,
+        );
+        let columns = vec![DuckLakeTableColumn {
+            column_id: 1,
+            column_name: "m".to_string(),
+            column_type: "map<varchar,int32>".to_string(),
+            is_nullable: true,
+            data_type: Some(DataType::Map(Arc::new(entries), false)),
+            nested_column_ids: vec![2, 3],
+        }];
+        let parquet_field_ids =
+            HashMap::from([(1, "m".to_string()), (2, "key".to_string()), (3, "value".to_string())]);
+
+        let (read_schema, _) =
+            build_read_schema_with_field_id_mapping(&columns, &parquet_field_ids, None).unwrap();
+        let DataType::Map(entries, _) = read_schema.field(0).data_type() else {
+            panic!("m must remain a map");
+        };
+        let DataType::Struct(fields) = entries.data_type() else {
+            panic!("map entries must be a struct");
+        };
+        assert!(!fields[0].is_nullable(), "map key must stay non-nullable");
     }
 }

--- a/tests/it/cdc_differential_tests.rs
+++ b/tests/it/cdc_differential_tests.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "metadata-duckdb")]
-//! Differential CDC conformance tests (#179).
+//! Differential CDC conformance tests.
 //!
 //! Each test builds a DuckLake catalog, runs the OFFICIAL DuckDB ducklake
 //! extension's change feeds (`ducklake_table_changes` / `ducklake_table_deletions`)
@@ -20,8 +20,13 @@
 //!   official's; the deletions list must be official's with `change_type`
 //!   inserted after `(snapshot_id, rowid)`.
 //!
-//! Not yet covered (tracked in #179): encrypted (PME) catalogs, compaction
-//! rewrites, schema evolution between snapshots.
+//! Schema evolution between snapshots IS covered, at the bottom of this file:
+//! renames (top-level, nested, and a cycle), a column dropped and re-added under
+//! the same name, and a column added between the queried snapshots — over both
+//! plan shapes and all three feeds. Encrypted (PME) catalogs cannot be diffed
+//! here at all (the extension writing these fixtures does not encrypt), and
+//! compaction REWRITES — as opposed to the adjacent-file merges two scenarios
+//! below do exercise — are still uncovered.
 
 use std::collections::HashSet;
 use std::path::Path;
@@ -877,4 +882,622 @@ async fn diff_timestamp_bounds() -> DataFusionResult<()> {
     );
     assert_feeds_match("timestamp-bounded table_changes", &official, &by_timestamp);
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Schema evolution between snapshots
+// ---------------------------------------------------------------------------
+//
+// A data file records each column under the physical name it had when the file
+// was written, tagged with the column's field id. Official DuckLake resolves a
+// change feed's columns BY FIELD ID against the schema as of the window's END
+// snapshot, so a column renamed after a file was written still reads that
+// file's values, and a column dropped and re-added under the same name reads as
+// NULL for files that predate the re-add. Resolving by name instead returns
+// NULL, another column's values, or — in a rename cycle — silently swapped
+// ones.
+//
+// These are all COLUMN-level: every scenario keeps the table itself alive
+// throughout. Resolving the table and schema at the right snapshot is a separate
+// concern, and one these tests do not reach.
+
+/// Rendered cells of one query result, sorted row-wise.
+type ProjectedRows = Vec<Vec<String>>;
+
+/// The rows of an arbitrary projection, rendered to the canonical strings and
+/// sorted. Used where [`CanonRow`] cannot represent the projection: a feed
+/// queried WITHOUT `rowid` — the projection that selects the insert-only plan
+/// shape — and nested values extracted with engine-specific SQL.
+fn official_projection(conn: &duckdb::Connection, sql: &str) -> DataFusionResult<ProjectedRows> {
+    let mut stmt = conn.prepare(sql).map_err(box_err)?;
+    let mut rows: ProjectedRows = stmt
+        .query_map([], |row| {
+            let mut out = Vec::new();
+            let mut i = 0;
+            while let Ok(v) = row.get::<usize, Value>(i) {
+                out.push(duckdb_cell(&v));
+                i += 1;
+            }
+            Ok(out)
+        })
+        .map_err(box_err)?
+        .collect::<Result<_, _>>()
+        .map_err(box_err)?;
+    rows.sort();
+    Ok(rows)
+}
+
+/// The crate-side counterpart of [`official_projection`].
+async fn crate_projection(ctx: &SessionContext, sql: &str) -> DataFusionResult<ProjectedRows> {
+    let batches = ctx.sql(sql).await?.collect().await?;
+    let mut rows: ProjectedRows = Vec::new();
+    for batch in &batches {
+        for r in 0..batch.num_rows() {
+            rows.push(
+                (0..batch.num_columns())
+                    .map(|c| arrow_cell(batch, c, r))
+                    .collect(),
+            );
+        }
+    }
+    rows.sort();
+    Ok(rows)
+}
+
+/// Diff a projection over every snapshot window of the catalog built by
+/// `statements` whose END snapshot is at least `min_end`. `official_sql` and
+/// `crate_sql` are templates with `{a}` / `{b}` window placeholders; they differ
+/// only where the two dialects do (the table function's argument form).
+///
+/// Both engines resolve a feed's columns as of the window's end snapshot, so a
+/// projection naming a column that some DDL statement introduced is unbindable
+/// in windows that end before it: `min_end` is the snapshot from which every
+/// projected name exists. Windows below it are covered by the whole-row
+/// comparison in [`assert_cdc_conformance`], which projects no names of its own.
+async fn assert_projection_conformance(
+    statements: &[&str],
+    min_end: i64,
+    official_sql: &str,
+    crate_sql: &str,
+) -> DataFusionResult<()> {
+    let tmp = TempDir::new().map_err(box_err)?;
+    let path = tmp.path().join("diff.ducklake");
+    write_catalog(&path, statements)?;
+
+    let fill = |template: &str, a: i64, b: i64| {
+        template
+            .replace("{a}", &a.to_string())
+            .replace("{b}", &b.to_string())
+    };
+
+    let mut expected: Vec<((i64, i64), ProjectedRows)> = Vec::new();
+    {
+        let conn = official_connection(&path)?;
+        for (a, b) in windows(&snapshot_ids(&conn)?) {
+            if b < min_end {
+                continue;
+            }
+            let rows = official_projection(&conn, &fill(official_sql, a, b))?;
+            expected.push(((a, b), rows));
+        }
+    }
+    assert!(
+        !expected.is_empty(),
+        "min_end {min_end} excluded every snapshot window"
+    );
+
+    let ctx = crate_context(&path).await?;
+    for ((a, b), want) in expected {
+        let sql = fill(crate_sql, a, b);
+        let got = crate_projection(&ctx, &sql).await?;
+        assert_eq!(got, want, "window [{a},{b}] diverges from official: {sql}");
+    }
+    Ok(())
+}
+
+/// One file written before a top-level rename, one after.
+const RENAME: &[&str] = &[
+    "CREATE TABLE c.t(id INTEGER, nm VARCHAR);",
+    "INSERT INTO c.t VALUES (1, 'a'), (2, 'b');",
+    "ALTER TABLE c.t RENAME COLUMN nm TO name;",
+    "INSERT INTO c.t VALUES (3, 'c');",
+];
+
+/// A rename with deletes on both sides of it: the second DELETE's source data
+/// file predates the rename, so the deleted rows' old values are only reachable
+/// by field id.
+const RENAME_WITH_DELETES: &[&str] = &[
+    "CREATE TABLE c.t(id INTEGER, nm VARCHAR);",
+    "INSERT INTO c.t VALUES (1, 'a'), (2, 'b');",
+    "DELETE FROM c.t WHERE id = 1;",
+    "ALTER TABLE c.t RENAME COLUMN nm TO name;",
+    "INSERT INTO c.t VALUES (3, 'c');",
+    "DELETE FROM c.t WHERE id = 2;",
+];
+
+/// `note` is dropped and re-added under the same name, so the old and the new
+/// column share a name and differ only by field id.
+const DROP_THEN_READD: &[&str] = &[
+    "CREATE TABLE c.t(id INTEGER, note VARCHAR);",
+    "INSERT INTO c.t VALUES (1, 'old-1'), (2, 'old-2');",
+    "ALTER TABLE c.t DROP COLUMN note;",
+    "ALTER TABLE c.t ADD COLUMN note VARCHAR;",
+    "INSERT INTO c.t VALUES (3, 'new-3');",
+];
+
+/// A top-level rename: rows written before it must still surface their values.
+#[tokio::test]
+async fn diff_renamed_column() -> DataFusionResult<()> {
+    assert_cdc_conformance("t", RENAME).await
+}
+
+/// The same rename with deletes around it, so `delete` rows and the deletions
+/// feed read a pre-rename source file.
+#[tokio::test]
+async fn diff_renamed_column_with_deletes() -> DataFusionResult<()> {
+    assert_cdc_conformance("t", RENAME_WITH_DELETES).await
+}
+
+/// Projecting `rowid` away selects a different plan for `ducklake_table_changes`
+/// and `ducklake_table_insertions` (one scan per file, unioned, with the CDC
+/// columns prepended) and skips the rowid resolution in
+/// `ducklake_table_deletions`. Each builds its own read schema, so one plan
+/// shape proves nothing about the other.
+#[tokio::test]
+async fn diff_renamed_column_without_rowid_projection() -> DataFusionResult<()> {
+    // `name` exists from the rename (snapshot 3 of RENAME, 4 of
+    // RENAME_WITH_DELETES) on.
+    assert_projection_conformance(
+        RENAME,
+        3,
+        "SELECT snapshot_id, change_type, name \
+         FROM ducklake_table_changes('c', 'main', 't', {a}, {b})",
+        "SELECT snapshot_id, change_type, name FROM ducklake_table_changes('main.t', {a}, {b})",
+    )
+    .await?;
+    assert_projection_conformance(
+        RENAME,
+        3,
+        "SELECT snapshot_id, name FROM ducklake_table_insertions('c', 'main', 't', {a}, {b})",
+        "SELECT snapshot_id, name FROM ducklake_table_insertions('main.t', {a}, {b})",
+    )
+    .await?;
+    assert_projection_conformance(
+        RENAME_WITH_DELETES,
+        4,
+        "SELECT snapshot_id, name FROM ducklake_table_deletions('c', 'main', 't', {a}, {b})",
+        "SELECT snapshot_id, name FROM ducklake_table_deletions('main.t', {a}, {b})",
+    )
+    .await
+}
+
+/// A dropped, then re-added, column name. Resolving by name reads the dropped
+/// column's data out of the old files; the re-added column must read as NULL
+/// there. Which of the two the window even sees depends on its END snapshot, so
+/// this is asserted over every window rather than against one hard-coded shape.
+#[tokio::test]
+async fn diff_dropped_then_readded_column() -> DataFusionResult<()> {
+    assert_cdc_conformance("t", DROP_THEN_READD).await
+}
+
+/// The same, on the insert-only plan shape.
+#[tokio::test]
+async fn diff_dropped_then_readded_column_without_rowid_projection() -> DataFusionResult<()> {
+    assert_projection_conformance(
+        DROP_THEN_READD,
+        1,
+        "SELECT snapshot_id, change_type, id \
+         FROM ducklake_table_changes('c', 'main', 't', {a}, {b})",
+        "SELECT snapshot_id, change_type, id FROM ducklake_table_changes('main.t', {a}, {b})",
+    )
+    .await?;
+    // Between the DROP (snapshot 3) and the re-ADD (4) there is no `note`
+    // column at all, so project it only from the re-add on.
+    assert_projection_conformance(
+        DROP_THEN_READD,
+        4,
+        "SELECT snapshot_id, change_type, id, note \
+         FROM ducklake_table_changes('c', 'main', 't', {a}, {b})",
+        "SELECT snapshot_id, change_type, id, note \
+         FROM ducklake_table_changes('main.t', {a}, {b})",
+    )
+    .await
+}
+
+/// A rename CYCLE: `x` and `y` swap names. Resolving by name does not lose a
+/// value here, it returns the OTHER column's — the same row shape, silently
+/// wrong.
+///
+/// Only windows ending at or after the last rename (snapshot 5) can be diffed:
+/// the extension writing this catalog leaves the intermediate generations
+/// overlapping (`x` spans snapshots 1-5 while `tmp` spans 3-5 under the SAME
+/// column id), so its own `ducklake_table_changes` fails with "Column with name
+/// x already exists" for a window that ends mid-cycle.
+#[tokio::test]
+async fn diff_renamed_column_cycle() -> DataFusionResult<()> {
+    assert_projection_conformance(
+        &[
+            "CREATE TABLE c.t(x VARCHAR, y VARCHAR);",
+            "INSERT INTO c.t VALUES ('in-x', 'in-y');",
+            "ALTER TABLE c.t RENAME COLUMN x TO tmp;",
+            "ALTER TABLE c.t RENAME COLUMN y TO x;",
+            "ALTER TABLE c.t RENAME COLUMN tmp TO y;",
+            "INSERT INTO c.t VALUES ('post-x', 'post-y');",
+        ],
+        5,
+        "SELECT snapshot_id, rowid, change_type, x, y \
+         FROM ducklake_table_changes('c', 'main', 't', {a}, {b})",
+        "SELECT snapshot_id, rowid, change_type, x, y \
+         FROM ducklake_table_changes('main.t', {a}, {b})",
+    )
+    .await
+}
+
+/// A column added between the queried snapshots and renamed after that: files
+/// written before the ADD carry no such field id at all, files between ADD and
+/// RENAME carry it under the old name.
+#[tokio::test]
+async fn diff_column_added_then_renamed() -> DataFusionResult<()> {
+    assert_cdc_conformance(
+        "t",
+        &[
+            "CREATE TABLE c.t(id INTEGER);",
+            "INSERT INTO c.t VALUES (1);",
+            "ALTER TABLE c.t ADD COLUMN c INTEGER;",
+            "INSERT INTO c.t VALUES (2, 20);",
+            "ALTER TABLE c.t RENAME COLUMN c TO cc;",
+            "INSERT INTO c.t VALUES (3, 30);",
+        ],
+    )
+    .await
+}
+
+/// An UPDATE before the rename. Its rewritten file embeds the row ids, which
+/// takes a different scan branch from a plain insert — the `update_postimage`
+/// rows come from that branch.
+#[tokio::test]
+async fn diff_renamed_column_after_update() -> DataFusionResult<()> {
+    assert_cdc_conformance(
+        "t",
+        &[
+            "CREATE TABLE c.t(id INTEGER, nm VARCHAR);",
+            "INSERT INTO c.t VALUES (1, 'a'), (2, 'b');",
+            "UPDATE c.t SET nm = 'B' WHERE id = 2;",
+            "ALTER TABLE c.t RENAME COLUMN nm TO name;",
+            "INSERT INTO c.t VALUES (3, 'c');",
+        ],
+    )
+    .await
+}
+
+/// A rename of a field INSIDE a struct. Nested nodes carry their own field ids,
+/// so a fix that resolves only top-level columns still loses this one.
+#[tokio::test]
+async fn diff_renamed_nested_field() -> DataFusionResult<()> {
+    let statements = &[
+        "CREATE TABLE c.t(id INTEGER, s STRUCT(a INTEGER, b INTEGER));",
+        "INSERT INTO c.t VALUES (1, {'a': 10, 'b': 20});",
+        "ALTER TABLE c.t RENAME COLUMN s.b TO bb;",
+        "INSERT INTO c.t VALUES (2, {'a': 30, 'bb': 40});",
+    ];
+    // `s.bb` exists from the rename (snapshot 3) on.
+    assert_projection_conformance(
+        statements,
+        3,
+        "SELECT snapshot_id, change_type, id, s['a'], s['bb'] \
+         FROM ducklake_table_changes('c', 'main', 't', {a}, {b})",
+        "SELECT snapshot_id, change_type, id, s['a'], s['bb'] \
+         FROM ducklake_table_changes('main.t', {a}, {b})",
+    )
+    .await?;
+    assert_projection_conformance(
+        statements,
+        3,
+        "SELECT snapshot_id, rowid, id, s['a'], s['bb'] \
+         FROM ducklake_table_insertions('c', 'main', 't', {a}, {b})",
+        "SELECT snapshot_id, rowid, id, s['a'], s['bb'] \
+         FROM ducklake_table_insertions('main.t', {a}, {b})",
+    )
+    .await
+}
+
+/// A rename over a COMPACTION-MERGED file: its rows span several snapshots
+/// (attributed per row by an embedded snapshot column) and it predates the
+/// rename.
+///
+/// Only windows whose start does not exceed the merged file's `begin_snapshot`
+/// live-diff against the installed extension — the same 1.4-era gap
+/// `diff_compacted_inserts` documents (windows starting past it exclude the
+/// merged file entirely).
+#[tokio::test]
+async fn diff_renamed_column_over_compacted_file() -> DataFusionResult<()> {
+    let tmp = TempDir::new().map_err(box_err)?;
+    let path = tmp.path().join("compact_rename.ducklake");
+    write_catalog(
+        &path,
+        &[
+            "CREATE TABLE c.t(id INTEGER, nm VARCHAR);",
+            "INSERT INTO c.t VALUES (1, 'a');",
+            "INSERT INTO c.t VALUES (2, 'b');",
+            "CALL ducklake_merge_adjacent_files('c');",
+            "ALTER TABLE c.t RENAME COLUMN nm TO name;",
+            "INSERT INTO c.t VALUES (3, 'c');",
+        ],
+    )?;
+    // Snapshots: 1 = CREATE, 2/3 = inserts, 4 = merge, 5 = rename, 6 = insert.
+    let live_windows = [(0, 6), (1, 6), (2, 6), (2, 3)];
+    let mut official: Vec<((i64, i64), CanonFeed)> = Vec::new();
+    {
+        let conn = official_connection(&path)?;
+        for (a, b) in live_windows {
+            official.push((
+                (a, b),
+                official_feed(
+                    &conn,
+                    &format!("SELECT * FROM ducklake_table_changes('c', 'main', 't', {a}, {b})"),
+                    true,
+                )?,
+            ));
+        }
+    }
+    let ctx = crate_context(&path).await?;
+    for ((a, b), official_changes) in official {
+        let crate_changes = crate_feed(
+            &ctx,
+            &format!("SELECT * FROM ducklake_table_changes('main.t', {a}, {b})"),
+            true,
+        )
+        .await?;
+        assert_feeds_match(
+            &format!("compacted + renamed table_changes window [{a},{b}]"),
+            &official_changes,
+            &crate_changes,
+        );
+    }
+    Ok(())
+}
+
+/// GUARD (passes before the field-id fix). Every field a CDC feed advertises —
+/// at every nesting depth — must carry EMPTY metadata.
+///
+/// A read schema describes a file's nested nodes with the `PARQUET:field_id`
+/// the file tags them with. That metadata is part of the parent's Arrow type, so
+/// leaking it into a feed's output makes the feed's own batches disagree with
+/// the schema it advertises ("expected List(Float32) but found
+/// List(Float32, field: 'element', metadata: {\"PARQUET:field_id\": \"3\"})").
+#[tokio::test]
+async fn cdc_output_fields_carry_no_parquet_metadata() -> DataFusionResult<()> {
+    use arrow::datatypes::{DataType, Field};
+
+    fn assert_bare(field: &Field, path: &str, feed: &str) {
+        assert!(
+            field.metadata().is_empty(),
+            "{feed}: field {path} carries metadata {:?}",
+            field.metadata()
+        );
+        match field.data_type() {
+            DataType::List(child)
+            | DataType::LargeList(child)
+            | DataType::FixedSizeList(child, _)
+            | DataType::Map(child, _) => {
+                assert_bare(child, &format!("{path}.{}", child.name()), feed)
+            },
+            DataType::Struct(children) => {
+                for child in children {
+                    assert_bare(child, &format!("{path}.{}", child.name()), feed);
+                }
+            },
+            _ => {},
+        }
+    }
+
+    let tmp = TempDir::new().map_err(box_err)?;
+    let path = tmp.path().join("bare.ducklake");
+    write_catalog(
+        &path,
+        &[
+            "CREATE TABLE c.t(id INTEGER, v FLOAT[], s STRUCT(a INTEGER), m MAP(VARCHAR, INTEGER));",
+            "INSERT INTO c.t VALUES (1, [1.5, 2.5], {'a': 10}, MAP(['k'], [7]));",
+            "ALTER TABLE c.t RENAME COLUMN v TO vals;",
+            "INSERT INTO c.t VALUES (2, [3.5], {'a': 20}, MAP(['j'], [8]));",
+            "DELETE FROM c.t WHERE id = 1;",
+        ],
+    )?;
+    let ctx = crate_context(&path).await?;
+    for feed in ["ducklake_table_changes", "ducklake_table_insertions", "ducklake_table_deletions"]
+    {
+        let batches = ctx
+            .sql(&format!("SELECT * FROM {feed}('main.t', 0, 1000)"))
+            .await?
+            .collect()
+            .await?;
+        assert!(!batches.is_empty(), "{feed} produced no batches");
+        for batch in &batches {
+            for field in batch.schema().fields() {
+                assert_bare(field, field.name(), feed);
+            }
+            // The batch's own arrays must agree with that schema, which is what
+            // the metadata check is really about.
+            RecordBatch::try_new(batch.schema(), batch.columns().to_vec())
+                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+        }
+    }
+    Ok(())
+}
+
+/// GUARD (passes before the field-id fix). List / struct / map values must
+/// round-trip through all three feeds unchanged: the read schema now describes
+/// nested nodes, and a nested value re-wrapped under the wrong type is exactly
+/// how the reported arrow error is produced. No DDL here — the point is that the
+/// ordinary case keeps working.
+#[tokio::test]
+async fn diff_nested_values_round_trip() -> DataFusionResult<()> {
+    let statements = &[
+        "CREATE TABLE c.t(id INTEGER, v FLOAT[], s STRUCT(a INTEGER), m MAP(VARCHAR, INTEGER));",
+        "INSERT INTO c.t VALUES (1, [1.5, 2.5], {'a': 10}, MAP(['k'], [7]));",
+        "INSERT INTO c.t VALUES (2, [3.5], {'a': 20}, MAP(['k'], [8]));",
+        "UPDATE c.t SET id = 12 WHERE id = 2;",
+        "DELETE FROM c.t WHERE id = 1;",
+    ];
+    // `m['k']` is not usable on either side of the diff: a MAP column's key is
+    // served as `Utf8` while a string literal is `Utf8View`, and the lookup will
+    // not compare the two (an ordinary `SELECT` hits this too, so it is not a CDC
+    // question). `map_extract` reaches the value on both engines.
+    let projection = "snapshot_id, rowid, id, v[1], s['a'], map_extract(m, 'k')[1]";
+    assert_projection_conformance(
+        statements,
+        1,
+        &format!(
+            "SELECT {projection}, change_type \
+             FROM ducklake_table_changes('c', 'main', 't', {{a}}, {{b}})"
+        ),
+        &format!(
+            "SELECT {projection}, change_type \
+             FROM ducklake_table_changes('main.t', {{a}}, {{b}})"
+        ),
+    )
+    .await?;
+    for feed in ["ducklake_table_insertions", "ducklake_table_deletions"] {
+        assert_projection_conformance(
+            statements,
+            1,
+            &format!("SELECT {projection} FROM {feed}('c', 'main', 't', {{a}}, {{b}})"),
+            &format!("SELECT {projection} FROM {feed}('main.t', {{a}}, {{b}})"),
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+/// GUARD (passes before the field-id fix). A struct child added by DDL is
+/// recorded NON-nullable in the catalog while the parquet node stays optional;
+/// the feed must read it as NULL for files that predate it rather than failing
+/// the nullability check.
+#[tokio::test]
+async fn diff_struct_child_added_by_ddl() -> DataFusionResult<()> {
+    assert_projection_conformance(
+        &[
+            "CREATE TABLE c.t(id INTEGER, s STRUCT(a INTEGER));",
+            "INSERT INTO c.t VALUES (1, {'a': 10});",
+            "ALTER TABLE c.t ADD COLUMN s.b INTEGER;",
+            "INSERT INTO c.t VALUES (2, {'a': 30, 'b': 40});",
+        ],
+        // `s.b` exists from the ADD (snapshot 3) on.
+        3,
+        "SELECT snapshot_id, change_type, id, s['a'], s['b'] \
+         FROM ducklake_table_changes('c', 'main', 't', {a}, {b})",
+        "SELECT snapshot_id, change_type, id, s['a'], s['b'] \
+         FROM ducklake_table_changes('main.t', {a}, {b})",
+    )
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// The window's end snapshot resolves the TABLE, not only its columns
+// ---------------------------------------------------------------------------
+
+/// A change feed reports against the schema as of the window's END snapshot, and
+/// that includes the table itself: a window over a table that was dropped LATER
+/// must still be served, in a catalog that has since moved on. Past the drop the
+/// table is gone and the query is refused — official DuckLake says "does not
+/// exist at version N".
+#[tokio::test]
+async fn diff_window_over_since_dropped_table() -> DataFusionResult<()> {
+    let tmp = TempDir::new().map_err(box_err)?;
+    let path = tmp.path().join("dropped.ducklake");
+    write_catalog(
+        &path,
+        &[
+            // 1 = CREATE t, 2/3 = inserts, 4 = DROP t, 5 = CREATE other,
+            // 6 = insert into other.
+            "CREATE TABLE c.t(id INTEGER);",
+            "INSERT INTO c.t VALUES (1);",
+            "INSERT INTO c.t VALUES (2);",
+            "DROP TABLE c.t;",
+            "CREATE TABLE c.other(x INTEGER);",
+            "INSERT INTO c.other VALUES (9);",
+        ],
+    )?;
+
+    let live_windows = [(0, 3), (1, 3), (2, 2), (3, 3), (1, 1)];
+    let mut official: Vec<((i64, i64), CanonFeed)> = Vec::new();
+    {
+        let conn = official_connection(&path)?;
+        for (a, b) in live_windows {
+            official.push((
+                (a, b),
+                official_feed(
+                    &conn,
+                    &format!("SELECT * FROM ducklake_table_changes('c', 'main', 't', {a}, {b})"),
+                    true,
+                )?,
+            ));
+        }
+        // Past the drop the table does not exist at the window's end snapshot.
+        for (a, b) in [(4, 4), (1, 6)] {
+            assert!(
+                official_feed(
+                    &conn,
+                    &format!("SELECT * FROM ducklake_table_changes('c', 'main', 't', {a}, {b})"),
+                    true,
+                )
+                .is_err(),
+                "official must refuse window [{a},{b}] over a dropped table"
+            );
+        }
+    }
+
+    let ctx = crate_context(&path).await?;
+    for ((a, b), official_changes) in official {
+        let crate_changes = crate_feed(
+            &ctx,
+            &format!("SELECT * FROM ducklake_table_changes('main.t', {a}, {b})"),
+            true,
+        )
+        .await?;
+        assert_feeds_match(
+            &format!("since-dropped table_changes window [{a},{b}]"),
+            &official_changes,
+            &crate_changes,
+        );
+    }
+    for (a, b) in [(4, 4), (1, 6)] {
+        let error = match ctx
+            .sql(&format!(
+                "SELECT * FROM ducklake_table_changes('main.t', {a}, {b})"
+            ))
+            .await
+        {
+            Ok(df) => df.collect().await.err(),
+            Err(e) => Some(e),
+        };
+        let message = error
+            .map(|e| e.to_string())
+            .unwrap_or_else(|| String::from("<no error>"));
+        assert!(
+            message.contains("does not exist at snapshot"),
+            "window [{a},{b}] over a dropped table: unexpected outcome: {message}"
+        );
+    }
+    Ok(())
+}
+
+/// GUARD (passes before the field-id fix). A column widened by `ALTER … TYPE`
+/// after a file was written. The per-file read schema declares the column's
+/// CURRENT type, so the narrower values the older file physically holds have to be
+/// widened on the way out — the one evolution case that already worked by name,
+/// and which must keep working now that the schema is built per file.
+#[tokio::test]
+async fn diff_promoted_column_type() -> DataFusionResult<()> {
+    assert_cdc_conformance(
+        "t",
+        &[
+            "CREATE TABLE c.t(id INTEGER, n INTEGER);",
+            "INSERT INTO c.t VALUES (1, 10);",
+            "ALTER TABLE c.t ALTER COLUMN n TYPE BIGINT;",
+            "INSERT INTO c.t VALUES (2, 20);",
+            "DELETE FROM c.t WHERE id = 1;",
+        ],
+    )
+    .await
 }

--- a/tests/it/encryption_tests.rs
+++ b/tests/it/encryption_tests.rs
@@ -106,9 +106,11 @@ fn create_catalog_with_encrypted_file(
             end_snapshot BIGINT
         );
 
-        -- Column table
+        -- Column table. A column id has one row per generation — a rename closes
+        -- the previous row and opens another under the SAME id — so it is no more
+        -- a primary key here than it is in a real catalog.
         CREATE TABLE ducklake_column (
-            column_id BIGINT PRIMARY KEY,
+            column_id BIGINT NOT NULL,
             table_id BIGINT NOT NULL,
             column_name VARCHAR NOT NULL,
             column_type VARCHAR NOT NULL,
@@ -130,6 +132,8 @@ fn create_catalog_with_encrypted_file(
             encryption_key VARCHAR,
             record_count BIGINT,
             row_id_start BIGINT,
+            partial_max BIGINT,
+            mapping_id BIGINT,
             begin_snapshot BIGINT NOT NULL,
             end_snapshot BIGINT
         );
@@ -145,6 +149,7 @@ fn create_catalog_with_encrypted_file(
             footer_size BIGINT,
             encryption_key VARCHAR,
             delete_count BIGINT,
+            partial_max BIGINT,
             begin_snapshot BIGINT NOT NULL,
             end_snapshot BIGINT
         );
@@ -380,5 +385,77 @@ async fn test_read_encrypted_parquet_with_wrong_key_fails() -> anyhow::Result<()
         println!("Got expected error: {}", exec_result.unwrap_err());
     }
 
+    Ok(())
+}
+
+/// Record a rename of the `name` column in a second snapshot, the way a real
+/// catalog does: the existing generation is closed and another one opens under the
+/// SAME column id, so the id is the stable key and the name is not.
+fn rename_column_in_second_snapshot(catalog_path: &Path) -> anyhow::Result<()> {
+    let conn = duckdb::Connection::open(catalog_path)?;
+    conn.execute("INSERT INTO ducklake_snapshot (snapshot_id) VALUES (2)", [])?;
+    conn.execute(
+        "UPDATE ducklake_column SET end_snapshot = 2 WHERE column_id = 2",
+        [],
+    )?;
+    conn.execute(
+        "INSERT INTO ducklake_column
+           (column_id, table_id, column_name, column_type, column_order, begin_snapshot)
+         VALUES (2, 1, 'display_name', 'VARCHAR', 1, 2)",
+        [],
+    )?;
+    Ok(())
+}
+
+async fn encrypted_changes_context(catalog_path: &Path) -> anyhow::Result<SessionContext> {
+    let ctx = SessionContext::new();
+    let provider = DuckdbMetadataProvider::new(catalog_path.to_str().unwrap())?;
+    let provider_arc: Arc<dyn MetadataProvider> =
+        Arc::new(DuckdbMetadataProvider::new(catalog_path.to_str().unwrap())?);
+    ctx.register_catalog("ducklake", Arc::new(DuckLakeCatalog::new(provider)?));
+    datafusion_ducklake::register_ducklake_functions(&ctx, provider_arc);
+    Ok(ctx)
+}
+
+/// A change feed resolves each file's columns by field id, which means reading the
+/// file's parquet footer — and the change-feed path holds no key for an encrypted
+/// footer. On a table whose columns were renamed (or dropped and re-added) it must
+/// therefore REFUSE the query: matching by name instead would hand back another
+/// column's values, or NULL, with nothing to indicate it.
+#[tokio::test]
+async fn test_change_feed_refuses_evolved_encrypted_table() -> anyhow::Result<()> {
+    let temp_dir = TempDir::new()?;
+    let parquet_path = temp_dir.path().join("encrypted_data.parquet");
+    let catalog_path = temp_dir.path().join("catalog.duckdb");
+    let file_size = create_encrypted_parquet_file(&parquet_path, TEST_ENCRYPTION_KEY)?;
+    let key = std::str::from_utf8(TEST_ENCRYPTION_KEY)?;
+    create_catalog_with_encrypted_file(&catalog_path, &parquet_path, file_size, key)?;
+    rename_column_in_second_snapshot(&catalog_path)?;
+
+    let ctx = encrypted_changes_context(&catalog_path).await?;
+
+    // A window ending at the rename cannot be served.
+    let error = match ctx
+        .sql("SELECT * FROM ducklake_table_changes('main.encrypted_users', 1, 2)")
+        .await
+    {
+        Ok(df) => df.collect().await.expect_err("must refuse the window"),
+        Err(e) => e,
+    };
+    let message = error.to_string();
+    assert!(
+        message.contains("encrypted data files") && message.contains("changed between"),
+        "unexpected error: {message}"
+    );
+
+    // A window that predates the rename is unaffected: every file records the
+    // columns under the names that window's end snapshot uses.
+    let batches = ctx
+        .sql("SELECT * FROM ducklake_table_changes('main.encrypted_users', 1, 1)")
+        .await?
+        .collect()
+        .await?;
+    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(rows, 3, "the pre-rename window must still be readable");
     Ok(())
 }

--- a/tests/it/renamed_columns_tests.rs
+++ b/tests/it/renamed_columns_tests.rs
@@ -609,3 +609,137 @@ async fn test_drop_readd_column_reads_null_for_pre_drop_rows() -> Result<()> {
     );
     Ok(())
 }
+
+/// A struct whose child was touched by DDL: DuckLake records the child as
+/// NON-nullable in the catalog while the parquet node stays optional, and files
+/// written before the DDL do not carry the child at all.
+///
+/// Both `ADD COLUMN s.<child>` and `RENAME COLUMN s.<child>` rewrite the child's
+/// catalog row this way.
+fn create_catalog_evolved_struct_child(catalog_path: &Path, rename: bool) -> Result<()> {
+    let conn = duckdb::Connection::open_in_memory()?;
+    crate::common::ensure_ducklake_installed();
+    conn.execute("LOAD ducklake;", [])?;
+    let ducklake_path = format!("ducklake:{}", catalog_path.display());
+    conn.execute(&format!("ATTACH '{}' AS test_catalog;", ducklake_path), [])?;
+    if rename {
+        conn.execute(
+            "CREATE TABLE test_catalog.t (id INT, s STRUCT(a INT, b INT));",
+            [],
+        )?;
+        conn.execute(
+            "INSERT INTO test_catalog.t VALUES (1, {'a': 10, 'b': 20});",
+            [],
+        )?;
+        conn.execute("ALTER TABLE test_catalog.t RENAME COLUMN s.b TO bb;", [])?;
+        conn.execute(
+            "INSERT INTO test_catalog.t VALUES (2, {'a': 30, 'bb': 40});",
+            [],
+        )?;
+    } else {
+        conn.execute("CREATE TABLE test_catalog.t (id INT, s STRUCT(a INT));", [])?;
+        conn.execute("INSERT INTO test_catalog.t VALUES (1, {'a': 10});", [])?;
+        conn.execute("ALTER TABLE test_catalog.t ADD COLUMN s.b INT;", [])?;
+        conn.execute(
+            "INSERT INTO test_catalog.t VALUES (2, {'a': 30, 'b': 40});",
+            [],
+        )?;
+    }
+    Ok(())
+}
+
+async fn evolved_struct_context(catalog_path: &Path) -> Result<SessionContext> {
+    let provider = DuckdbMetadataProvider::new(catalog_path.to_str().unwrap())?;
+    let catalog = DuckLakeCatalog::new(provider)?;
+    let ctx = SessionContext::new();
+    ctx.register_catalog("ducklake", Arc::new(catalog));
+    Ok(ctx)
+}
+
+/// The child's catalog nullability must not be enforced against the file: an
+/// ordinary `SELECT` over a table whose struct child was added or renamed by DDL
+/// has to read the child as NULL where the file predates it, not fail the scan.
+#[tokio::test]
+async fn test_scan_reads_struct_child_touched_by_ddl() -> Result<()> {
+    for (rename, child, expected) in [
+        (
+            false,
+            "b",
+            vec![(1, Some(10), None), (2, Some(30), Some(40))],
+        ),
+        (
+            true,
+            "bb",
+            vec![(1, Some(10), Some(20)), (2, Some(30), Some(40))],
+        ),
+    ] {
+        let temp_dir = TempDir::new()?;
+        let catalog_path = temp_dir.path().join("evolved_struct.ducklake");
+        create_catalog_evolved_struct_child(&catalog_path, rename)?;
+        let ctx = evolved_struct_context(&catalog_path).await?;
+        let batches = ctx
+            .sql(&format!(
+                "SELECT id, s['a'], s['{child}'] FROM ducklake.main.t ORDER BY id"
+            ))
+            .await?
+            .collect()
+            .await?;
+        let mut got: Vec<(i32, Option<i32>, Option<i32>)> = Vec::new();
+        for b in &batches {
+            let cell = |col: usize, row: usize| {
+                let a = b.column(col).as_any().downcast_ref::<Int32Array>().unwrap();
+                (!a.is_null(row)).then(|| a.value(row))
+            };
+            for row in 0..b.num_rows() {
+                got.push((
+                    b.column(0)
+                        .as_any()
+                        .downcast_ref::<Int32Array>()
+                        .unwrap()
+                        .value(row),
+                    cell(1, row),
+                    cell(2, row),
+                ));
+            }
+        }
+        assert_eq!(got, expected, "rename={rename}");
+    }
+    Ok(())
+}
+
+/// A read schema that relaxes nested nullability the way the catalog schema does
+/// is type-identical to it, so the rename layer above the scan is a relabel and
+/// filters still reach the parquet reader's pruning.
+#[tokio::test]
+async fn test_filter_pushes_down_over_evolved_struct_column() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let catalog_path = temp_dir.path().join("evolved_struct_pushdown.ducklake");
+    create_catalog_evolved_struct_child(&catalog_path, true)?;
+    let ctx = evolved_struct_context(&catalog_path).await?;
+
+    // The struct column has to be IN the projection: with it projected away the
+    // rename layer only ever sees scalar fields, and pushdown never depended on
+    // the nested types at all.
+    let plan = ctx
+        .sql("EXPLAIN SELECT id, s FROM ducklake.main.t WHERE id = 2")
+        .await?
+        .collect()
+        .await?;
+    let rendered = arrow::util::pretty::pretty_format_batches(&plan)?.to_string();
+    assert!(
+        rendered.contains("predicate=id@0 = 2"),
+        "the filter must reach the scan, plan was:\n{rendered}"
+    );
+
+    let rows = ctx
+        .sql("SELECT id, s FROM ducklake.main.t WHERE id = 2")
+        .await?
+        .collect()
+        .await?;
+    let total: usize = rows.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(
+        total, 1,
+        "the pushed-down filter must keep the matching row"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## The defect

Every CDC read schema was hand-built from the catalog's **current** column names, so a data file's
columns were matched **by name, at every depth**. A data file written before a `RENAME` records the
column under its old name, so the match failed and the feed invented a NULL. A file written before a
column was dropped and re-added under the same name records the *dropped* column under that name, so
the match succeeded on the wrong column and the feed served stale data.

Concretely, `CREATE TABLE t(id INTEGER, nm VARCHAR)` → insert `a`, `b` → `RENAME COLUMN nm TO name`
→ insert `c`:

```
             base scan          ducklake_table_changes (before)   after
  id=1       name = a           name = NULL                       name = a
  id=2       name = b           name = NULL                       name = b
  id=3       name = c           name = c                          name = c
```

Drop-then-re-add of `note` leaked the dropped column's values (`old-1`, `old-2`) where the reference
returns NULL — the exact hazard the `__ducklake_absent_field_N` sentinel exists to prevent.

The worst case is a **rename cycle**, where nothing looks wrong at all. `t(x VARCHAR, y VARCHAR)`,
one row `('in-x','in-y')`, then `x→tmp`, `y→x`, `tmp→y`:

```
             base scan                    change feed (before)
  x          in-y                         in-x
  y          in-x                         in-y
```

Same row count, same shape, no NULLs, no error, no warning — the two columns' values silently
swapped relative to what the table itself returns. Anything downstream keyed on those values was
wrong with no signal.

A nested rename (`RENAME COLUMN s.b TO bb`) loses the value the same way: nested nodes carry their
own field ids, so resolving only top-level columns is not enough.

## What official DuckLake does

It resolves columns **by field id as of the window's end snapshot**, and the field id — not the name
— is the stable key. Verified against the extension: for `t(id INTEGER, v FLOAT[])` it tags `id`=1,
`v`=2, `element`=3 and leaves the `list` wrapper untagged; after a rename, `ducklake_column` holds
**two rows for one `column_id`** (`nm` and `name`).

The end-snapshot part matters and is not a detail:

```
  scenario            window   official returns
  rename nm→name      (1,2)    column named nm,   values a,b
  rename nm→name      (1,4)    column named name, values a,b,c
  drop + re-add note  (1,2)    old-1, old-2       (the pre-drop generation)
  drop + re-add note  (1,3)    column absent entirely
  drop + re-add note  (1,4)    NULL               (the re-added generation)
```

So "always NULL after a re-add" would be just as wrong as the old behaviour. Every test here
parameterises the window rather than hard-coding one answer.

## Scope of the change

Three independent hand-built read schemas were the bug, and all three are replaced:

- `table_changes.rs` `read_schema_with_embedded` — the **correlated** path (`build_insert_scan`,
  `build_delete_data_scan`), including the embedded-rowid postimage arm that `update_postimage` rows
  come from.
- `table_changes.rs` `build_exec_for_file*` — the **insert-only / encrypted** path, which passed
  `self.table_schema` straight to `ParquetSource`.
- `table_deletions.rs` `build_data_file_scan` — an independent third copy.

That covers all three feeds (`ducklake_table_changes`, `ducklake_table_insertions`, which wraps the
changes provider, and `ducklake_table_deletions`) on **both** plan shapes — with `rowid` projected
(`TableChangesExec`) and without (`UnionExec` / `PrependCDCColumnsExec`) — plus compaction-merged
partial files, whose index arithmetic the merged-file test now pins.

Each feed now resolves one read schema per data file through the same field-id function the table
scan uses, then presents the result back under the catalog schema via `ColumnRenameExec`. Two
things worth flagging for review:

- The rename layer is wrapped **unconditionally** against a file-independent target schema. The
  tempting "only wrap files that actually need renaming" optimisation is wrong twice over:
  `UnionExec::try_new` validates **field count only** (names and types are unchecked, child 0's
  names are adopted, and a type mismatch *panics* rather than erroring), so an unwrapped branch
  quietly emits the pre-rename column name.
- The layout is memoized per resolved path. That also removes a pre-existing double footer read on
  the correlated path, where a file inserted and deleted in the same window was read twice. The
  insert-only path, which previously read no footers, now reads one per data file — a deliberate
  plan-time cost, called out in the changelog.

## Nested-child nullability (and a main-scan bug it fixes)

DuckLake records a struct child that DDL **added or renamed** as non-nullable while the physical
parquet node stays OPTIONAL. `build_arrow_schema` already relaxed this;
`build_read_schema_with_field_id_mapping` did not — so the **ordinary `SELECT`** already failed
outright on any table with an evolved struct child, independent of CDC:

```
Cannot cast column 's' from Struct("a": Int32, "b": Int32)
  to Struct("a": Int32, "b": non-null Int32):
  Cannot cast nullable struct field 'b' to non-nullable field
```

The relaxation is applied in the **shared** function rather than inside CDC, which fixes that main
scan too, is strictly more permissive, and matches what the sibling public `build_arrow_schema`
already returned. A blanket relaxation would have been unsound: map entries are passed
`nullable_struct_fields = false` deliberately, and forcing map keys nullable breaks a
`MAP<VARCHAR,INT>` column at execute time instead. Map keys stay non-nullable.

Side effect, with its own test: the read schema is now type-identical to the catalog schema, so
`types_equal_ignoring_field_metadata` matches on struct columns and `is_pure_type_preserving_rename()`
becomes true where it was false. Filters and limits therefore reach the parquet reader's pruning
through the rename layer on tables with nested columns — pushdown that was silently lost there
before.

## Encrypted tables: refused, not guessed

Field-id resolution needs the file's parquet footer, and the encrypted CDC path holds no key for it.
The only thing left to match on is the column name, which is exactly what a rename changed. Rather
than hand back another column's values, a feed over an encrypted table whose columns changed
identity between the oldest in-window data file and the window's end **errors**. Two boundaries a
reviewer should hold me to, both now documented in `COMPATIBILITY.md`:

- **The check is coarser than "was a column renamed", so it refuses more than it must.** Column
  identity is name + resolved type (the type is what carries a nested field's name), so widening a
  column with `ALTER … TYPE`, or adding/renaming a field inside an existing `STRUCT`, also trips it —
  even though matching those by name is correct, and *was* served before this change. Erring toward
  refusal is the intent, since the alternative on this path is silently wrong values, but it is a
  real behaviour change for encrypted tables. A finer check (compare names per field id, ignore the
  rest) would let those two through if it turns out to matter. Adding a new top-level column and
  dropping one outright do not trip it.
- **Only `ducklake_table_changes` and `ducklake_table_insertions` refuse with that explanation.**
  `ducklake_table_deletions` has no encryption support at all — it reads the deleted rows' source
  data file with no key — so on an encrypted table it fails with a raw parquet decryption error
  instead. Not a regression (that feed already failed on encrypted tables), but the failure has
  moved from read time to plan time, and the message is unhelpful. Documented rather than papered
  over.

## Issues

**Closes #196.** The table-level twin of the same bug: the CDC table functions resolved the *table*
and its schema at the catalog's current snapshot, so a window over a since-dropped table failed with
`Table 'main.t' not found in catalog` even though every snapshot in the window still had it. Now
resolved at the window's end snapshot. Test: `diff_window_over_since_dropped_table` diffs the live
windows against official and asserts both engines refuse the windows past the drop.

One window moves the other way, and the changelog says so: a window ending **before** the table was
created used to return an empty feed and now reports that the table does not exist at that snapshot.
Official errors on that window too, so this is convergence, not a new restriction. (The differential
harness's `windows()` deliberately keeps `end >= 1` for exactly this reason.)

**Refs #7** — schema evolution in CDC is now largely covered, but **not closed**, because two cases
remain:

- Evolved **encrypted** tables refuse by design (above). That is a decision, not an omission, but it
  is not conformance.
- A **mid-cycle rename window** cannot be served by either engine. The reference leaves the
  intermediate generations overlapping in `ducklake_column` — in the cycle scenario `x` spans
  snapshots 1-5 while `tmp` spans 3-5 under the *same* column id — so official's own
  `ducklake_table_changes` fails with `Column with name x already exists`, and this crate refuses
  with `DuckLake column metadata contains duplicate column ids`. Both refuse; neither returns rows.
  The cycle test therefore diffs only windows ending at or after the last rename.

## Tests

18 new integration tests. **14 fail on the base commit**; the other 4 are labelled `GUARD` in their
doc comments and pass before the fix by design — they exist to stop regressions, not to prove the
bug:

- `cdc_output_fields_carry_no_parquet_metadata` — asserts no CDC output field, **at any depth**,
  carries `PARQUET:field_id`. This is the guard against the naive version of this fix, which
  reproduces a real arrow error (`expected List(Float32) but found List(Float32, field: 'element',
  metadata: {"PARQUET:field_id": "3"})`) for callers who drive arrow-rs from a schema the crate
  hands out.
- `diff_nested_values_round_trip` — list / struct / map through all three feeds.
- `diff_struct_child_added_by_ddl` — the nullability scenario through CDC.
- `diff_promoted_column_type` — `ALTER … TYPE` widening, the one evolution case that already worked
  by name and must keep working now that the schema is per-file.

The failing 14 cover top-level renames (with deletes, and without a `rowid` projection to force the
other plan shape), drop-then-re-add on both plan shapes, the rename cycle, a column added between
the queried snapshots then renamed, a rename after an `UPDATE` (the embedded-rowid postimage arm), a
nested rename, a rename over a compaction-merged file, the since-dropped-table window, the encrypted
refusal, and the two main-scan tests (evolved struct child reads; filter pushdown over it).

The CDC ones live in the existing **differential harness**, which runs the official DuckDB ducklake
extension and this crate over the identical catalog and diffs canonicalized rows, rowids,
snapshot_ids and change_types across **every** snapshot window. So "is this what the reference does?"
is answered by execution rather than by hand-written expectations — it is what caught the
end-snapshot semantics above. The harness header previously listed schema evolution as its known gap
and cited #179 (since closed); it now describes what is covered and no longer cites it.

## Breaking / operational notes

Marked **BREAKING** in the changelog under `### Changed`, because output changes silently on any
table whose columns were renamed or dropped-and-re-added: a renamed column goes NULL → real value, a
re-added name goes stale value → NULL, swapped names stop swapping. Nothing errors, so a consumer
relying on the old output gets different answers without notice. Plan shape also changes (one extra
node per file group), so anything snapshot-testing CDC `EXPLAIN` output will diff.

The fix is **not retroactive**. Nothing in the catalog was damaged and no repair tooling is needed,
but state already derived from earlier feed output on an affected table is still wrong, so the entry
tells users to **re-derive anything built from change-feed output** on such a table. The exposure
query is in the changelog:

```sql
SELECT table_id, column_id, count(*) AS generations
FROM ducklake_column GROUP BY table_id, column_id HAVING count(*) > 1;

SELECT table_id, column_name, count(DISTINCT column_id) AS ids
FROM ducklake_column GROUP BY table_id, column_name HAVING count(DISTINCT column_id) > 1;
```

The first finds renames, the second drop-and-re-adds.

**No version bump here.** The BREAKING entry sits under `## [Unreleased]`, which is enough to
justify the next minor when you cut it. This repo's convention is a dedicated release commit that
bumps `Cargo.toml` and promotes `Unreleased` → the new heading together (as `52830c1
chore(release): 0.6.0` did), so that stays your separate step rather than being half-done here.

## Reviewing

Four gates, all clean:

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
cargo test --features "skip-tests-with-docker write-sqlite"
cargo test --features "duckdb-bundled encryption metadata-mysql metadata-postgres metadata-sqlite write-sqlite"
```

Reported by a downstream consumer of the crate.
