### PR TITLE
fix(write): record UTC statistics for timezone timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `TableWriteSession::finish_with_deletes` no longer refuses a session that produced more than one appended file; it commits them all in the snapshot that carries the deletes (#214).
 
 ### Fixed
+- Timezone-aware timestamp writes now record UTC min/max statistics for file pruning; catalogs
+  written before this change remain readable with absent bounds.
 - A keyed `DELETE` or `UPDATE` works on a data file that compaction has rewritten. The filtered
   delete path previously refused such a file outright — a v1 scope limit, documented as though
   position resolution depended on `rowid = row_id_start + physical position`. It does not:

--- a/src/stats_encode.rs
+++ b/src/stats_encode.rs
@@ -14,15 +14,14 @@
 //! ## Coverage
 //!
 //! Encoded exactly (min/max emitted): signed/unsigned integers, `BOOLEAN`,
-//! `FLOAT`/`DOUBLE`, `DECIMAL(p,s)` (128-bit), `DATE`, and `TIMESTAMP` without a
-//! time zone (all Arrow time units).
+//! `FLOAT`/`DOUBLE`, `DECIMAL(p,s)` (128-bit), `DATE`, and `TIMESTAMP` with or
+//! without a time zone (all Arrow time units). Timezone-bearing timestamps are
+//! normalized to UTC so their encoding is independent of the DuckDB session
+//! time zone.
 //!
 //! Deliberately **not** encoded yet — [`encode_scalar`] returns `None`, so the
 //! caller stores `min_value`/`max_value` as `NULL` and the file is never pruned on
 //! that column (spec-safe: DuckLake keeps files whose stats are NULL). Deferred:
-//! - `TIMESTAMP WITH TIME ZONE` — DuckDB renders it in the *session* time zone, so
-//!   the stored string is not deterministic without pinning a zone; deferred until
-//!   we settle on UTC rendering. See `[[timestamptz-stats]]`.
 //! - `TIME`, `BLOB`/`BINARY` (DuckLake never prunes on blobs anyway), `UUID`,
 //!   `INTERVAL`, `DECIMAL256`, and all nested types (`STRUCT`/`LIST`/`MAP`).
 //! - Over-long strings (see [`MAX_STRING_STAT_BYTES`]) — DuckDB truncates and
@@ -71,12 +70,18 @@ pub fn encode_scalar(value: &ScalarValue) -> Option<String> {
 
         ScalarValue::Date32(Some(days)) => encode_date32(*days),
 
-        // TIMESTAMP without a time zone. WITH time zone (`tz.is_some()`) is
-        // deferred — see `[[timestamptz-stats]]` in the module docs.
-        ScalarValue::TimestampSecond(Some(v), None) => encode_timestamp(*v, 1),
-        ScalarValue::TimestampMillisecond(Some(v), None) => encode_timestamp(*v, 1_000),
-        ScalarValue::TimestampMicrosecond(Some(v), None) => encode_timestamp(*v, 1_000_000),
-        ScalarValue::TimestampNanosecond(Some(v), None) => encode_timestamp(*v, 1_000_000_000),
+        ScalarValue::TimestampSecond(Some(v), timezone) => {
+            encode_timestamp(*v, 1, timezone.is_some())
+        },
+        ScalarValue::TimestampMillisecond(Some(v), timezone) => {
+            encode_timestamp(*v, 1_000, timezone.is_some())
+        },
+        ScalarValue::TimestampMicrosecond(Some(v), timezone) => {
+            encode_timestamp(*v, 1_000_000, timezone.is_some())
+        },
+        ScalarValue::TimestampNanosecond(Some(v), timezone) => {
+            encode_timestamp(*v, 1_000_000_000, timezone.is_some())
+        },
 
         // Strings — stored verbatim, subject to the length guard and the NUL
         // rule. A `\0` byte is dropped (→ SQL NULL) exactly as official DuckLake's
@@ -122,10 +127,10 @@ pub fn is_encodable_type(value: &ScalarValue) -> bool {
             | ScalarValue::Utf8View(_)
     ) || matches!(
         value,
-        ScalarValue::TimestampSecond(_, None)
-            | ScalarValue::TimestampMillisecond(_, None)
-            | ScalarValue::TimestampMicrosecond(_, None)
-            | ScalarValue::TimestampNanosecond(_, None)
+        ScalarValue::TimestampSecond(_, _)
+            | ScalarValue::TimestampMillisecond(_, _)
+            | ScalarValue::TimestampMicrosecond(_, _)
+            | ScalarValue::TimestampNanosecond(_, _)
     )
 }
 
@@ -486,9 +491,9 @@ fn encode_date32(days: i32) -> Option<String> {
     Some(date.format("%Y-%m-%d").to_string())
 }
 
-/// Encode a naive timestamp given its value in `units_per_second` sub-second
-/// units (1 = seconds, 1_000 = millis, 1_000_000 = micros, 1e9 = nanos).
-fn encode_timestamp(value: i64, units_per_second: i64) -> Option<String> {
+/// Encode a timestamp given its value in `units_per_second` sub-second units
+/// (1 = seconds, 1_000 = millis, 1_000_000 = micros, 1e9 = nanos).
+fn encode_timestamp(value: i64, units_per_second: i64, timezone: bool) -> Option<String> {
     let secs = value.div_euclid(units_per_second);
     let sub = value.rem_euclid(units_per_second); // 0..units_per_second
     // Convert the sub-second remainder to nanoseconds for chrono.
@@ -506,11 +511,15 @@ fn encode_timestamp(value: i64, units_per_second: i64) -> Option<String> {
         _ => String::new(),
     };
     let frac = frac.trim_end_matches('0');
-    if frac.is_empty() {
-        Some(base)
+    let mut encoded = if frac.is_empty() {
+        base
     } else {
-        Some(format!("{base}.{frac}"))
+        format!("{base}.{frac}")
+    };
+    if timezone {
+        encoded.push_str("+00");
     }
+    Some(encoded)
 }
 
 #[cfg(test)]
@@ -643,6 +652,17 @@ mod tests {
             ScalarValue::TimestampSecond(Some(-1), None),
             "1969-12-31 23:59:59",
         );
+        golden(
+            ScalarValue::TimestampMicrosecond(Some(-876_544), Some(Arc::from("UTC"))),
+            "1969-12-31 23:59:59.123456+00",
+        );
+        golden(
+            ScalarValue::TimestampNanosecond(
+                Some(1_578_227_696_123_456_789),
+                Some(Arc::from("America/New_York")),
+            ),
+            "2020-01-05 12:34:56.123456789+00",
+        );
     }
 
     #[test]
@@ -662,14 +682,7 @@ mod tests {
     fn nulls_and_unsupported_are_none() {
         assert_eq!(encode_scalar(&ScalarValue::Int32(None)), None);
         assert_eq!(encode_scalar(&ScalarValue::Float64(None)), None);
-        // Time / tz-timestamp / binary are deferred ⇒ None.
-        assert_eq!(
-            encode_scalar(&ScalarValue::TimestampMicrosecond(
-                Some(0),
-                Some(Arc::from("UTC"))
-            )),
-            None
-        );
+        // Time and binary are deferred ⇒ None.
         assert_eq!(
             encode_scalar(&ScalarValue::Binary(Some(vec![0xAB, 0x01]))),
             None
@@ -808,7 +821,7 @@ mod tests {
         assert!(is_encodable_type(&ScalarValue::TimestampMicrosecond(
             None, None
         )));
-        assert!(!is_encodable_type(&ScalarValue::TimestampMicrosecond(
+        assert!(is_encodable_type(&ScalarValue::TimestampMicrosecond(
             None,
             Some(Arc::from("UTC"))
         )));

--- a/tests/it/column_stats_tests.rs
+++ b/tests/it/column_stats_tests.rs
@@ -18,7 +18,11 @@ use arrow::array::{
 };
 use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 use arrow::record_batch::RecordBatch;
-use datafusion_ducklake::{DuckLakeTableWriter, MetadataWriter, SqliteMetadataWriter};
+use datafusion::prelude::SessionContext;
+use datafusion_ducklake::{
+    DuckLakeCatalog, DuckLakeTableWriter, MetadataWriter, SqliteMetadataProvider,
+    SqliteMetadataWriter,
+};
 use object_store::local::LocalFileSystem;
 use sqlx::{Row, SqlitePool};
 use tempfile::TempDir;
@@ -46,6 +50,11 @@ async fn crate_write_produces_duckdb_canonical_column_stats() {
         Field::new("id", DataType::Int32, false),
         Field::new("name", DataType::Utf8, true),
         Field::new("d", DataType::Date32, true),
+        Field::new(
+            "tsz",
+            DataType::Timestamp(TimeUnit::Microsecond, Some("America/New_York".into())),
+            false,
+        ),
     ]));
     let batch = RecordBatch::try_new(
         schema,
@@ -57,6 +66,14 @@ async fn crate_write_produces_duckdb_canonical_column_stats() {
                 Some(18266),
                 Some(18264),
             ])),
+            Arc::new(
+                TimestampMicrosecondArray::from(vec![
+                    -876_544,
+                    1_705_321_800_123_456,
+                    1_578_227_696_123_456,
+                ])
+                .with_timezone("America/New_York"),
+            ),
         ],
     )
     .unwrap();
@@ -112,6 +129,12 @@ async fn crate_write_produces_duckdb_canonical_column_stats() {
                 Some(0),
                 Some(3)
             ),
+            (
+                Some("1969-12-31 23:59:59.123456+00".to_string()),
+                Some("2024-01-15 12:30:00.123456+00".to_string()),
+                Some(0),
+                Some(3)
+            ),
         ],
         "per-file zone maps must match DuckDB-canonical encodings"
     );
@@ -130,7 +153,7 @@ async fn crate_write_produces_duckdb_canonical_column_stats() {
             .collect();
     assert_eq!(
         sizes.len(),
-        3,
+        4,
         "one column_size_bytes row per written column"
     );
     for (i, s) in sizes.iter().enumerate() {
@@ -172,9 +195,185 @@ async fn crate_write_produces_duckdb_canonical_column_stats() {
                 Some("2020-01-01".to_string()),
                 Some("2020-01-05".to_string())
             ),
+            (
+                Some(false),
+                Some("1969-12-31 23:59:59.123456+00".to_string()),
+                Some("2024-01-15 12:30:00.123456+00".to_string())
+            ),
         ],
         "table-wide roll-up must reflect the single file's bounds"
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn timestamptz_stats_prune_disjoint_file() {
+    let (_temp, db_url, low_values, _) = write_timestamptz_files().await;
+    let ctx = timestamptz_context(&db_url).await;
+    let sql = "SELECT tsz FROM test.main.t WHERE tsz < TIMESTAMP '2025-01-01 00:00:00+00:00'";
+    let plan = ctx
+        .sql(sql)
+        .await
+        .unwrap()
+        .create_physical_plan()
+        .await
+        .unwrap();
+    let display = datafusion::physical_plan::displayable(plan.as_ref())
+        .indent(true)
+        .to_string();
+    assert_eq!(
+        display.matches(".parquet").count(),
+        1,
+        "the disjoint 2030 file must be pruned:\n{display}",
+    );
+
+    let batches = ctx.sql(sql).await.unwrap().collect().await.unwrap();
+    assert_eq!(timestamp_values(&batches), low_values);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn timestamptz_catalog_without_bounds_remains_readable() {
+    let (_temp, db_url, low_values, high_values) = write_timestamptz_files().await;
+    let pool = SqlitePool::connect(&db_url).await.unwrap();
+    let file_rows = sqlx::query(
+        "UPDATE ducklake_file_column_stats
+         SET min_value = NULL, max_value = NULL
+         WHERE column_id IN
+             (SELECT column_id FROM ducklake_column WHERE column_name = 'tsz')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap()
+    .rows_affected();
+    let table_rows = sqlx::query(
+        "UPDATE ducklake_table_column_stats
+         SET min_value = NULL, max_value = NULL
+         WHERE column_id IN
+             (SELECT column_id FROM ducklake_column WHERE column_name = 'tsz')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap()
+    .rows_affected();
+    assert_eq!(file_rows, 2);
+    assert_eq!(table_rows, 1);
+    let file_bounds: Vec<(Option<String>, Option<String>)> = sqlx::query_as(
+        "SELECT min_value, max_value
+         FROM ducklake_file_column_stats
+         WHERE column_id IN
+             (SELECT column_id FROM ducklake_column WHERE column_name = 'tsz')
+         ORDER BY data_file_id",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    let table_bounds: (Option<String>, Option<String>) = sqlx::query_as(
+        "SELECT min_value, max_value
+         FROM ducklake_table_column_stats
+         WHERE column_id IN
+             (SELECT column_id FROM ducklake_column WHERE column_name = 'tsz')",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(file_bounds, vec![(None, None), (None, None)]);
+    assert_eq!(table_bounds, (None, None));
+
+    let ctx = timestamptz_context(&db_url).await;
+    let all = ctx
+        .sql("SELECT tsz FROM test.main.t ORDER BY tsz")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let mut expected = low_values.clone();
+    expected.extend(high_values);
+    assert_eq!(timestamp_values(&all), expected);
+
+    let sql = "SELECT tsz FROM test.main.t
+               WHERE tsz < TIMESTAMP '2025-01-01 00:00:00+00:00'
+               ORDER BY tsz";
+    let plan = ctx
+        .sql(sql)
+        .await
+        .unwrap()
+        .create_physical_plan()
+        .await
+        .unwrap();
+    let display = datafusion::physical_plan::displayable(plan.as_ref())
+        .indent(true)
+        .to_string();
+    assert_eq!(
+        display.matches(".parquet").count(),
+        2,
+        "files without timestamp bounds must not be pruned:\n{display}",
+    );
+    let filtered = ctx.sql(sql).await.unwrap().collect().await.unwrap();
+    assert_eq!(timestamp_values(&filtered), low_values);
+}
+
+async fn write_timestamptz_files() -> (TempDir, String, Vec<i64>, Vec<i64>) {
+    let temp = TempDir::new().unwrap();
+    let db_path = temp.path().join("stats.db");
+    let data_path = temp.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+
+    let db_url = format!("sqlite:{}", db_path.display());
+    let conn_str = format!("{db_url}?mode=rwc");
+    let writer = SqliteMetadataWriter::new_with_init(&conn_str)
+        .await
+        .unwrap();
+    writer.set_data_path(data_path.to_str().unwrap()).unwrap();
+
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "tsz",
+        DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+        false,
+    )]));
+    let low_values = vec![1_705_321_800_123_456, 1_705_321_800_123_457];
+    let low = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![Arc::new(TimestampMicrosecondArray::from(low_values.clone()).with_timezone("UTC"))],
+    )
+    .unwrap();
+    let high_values = vec![1_894_710_600_000_000, 1_894_710_600_000_001];
+    let high = RecordBatch::try_new(
+        schema,
+        vec![Arc::new(TimestampMicrosecondArray::from(high_values.clone()).with_timezone("UTC"))],
+    )
+    .unwrap();
+    let table_writer =
+        DuckLakeTableWriter::new(Arc::new(writer), Arc::new(LocalFileSystem::new())).unwrap();
+    table_writer.write_table("main", "t", &[low]).await.unwrap();
+    table_writer
+        .append_table("main", "t", &[high])
+        .await
+        .unwrap();
+    (temp, db_url, low_values, high_values)
+}
+
+async fn timestamptz_context(db_url: &str) -> SessionContext {
+    let provider = SqliteMetadataProvider::new(db_url).await.unwrap();
+    let catalog = DuckLakeCatalog::new(provider).unwrap();
+    let ctx = SessionContext::new();
+    ctx.register_catalog("test", Arc::new(catalog));
+    ctx
+}
+
+fn timestamp_values(batches: &[RecordBatch]) -> Vec<i64> {
+    batches
+        .iter()
+        .flat_map(|batch| {
+            batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<TimestampMicrosecondArray>()
+                .unwrap()
+                .values()
+                .iter()
+                .copied()
+        })
+        .collect()
 }
 
 /// Differential dump vs official DuckLake: writes the SAME diverse-typed data


### PR DESCRIPTION
### Summary

Record DuckLake file and table statistics for Arrow timestamps with timezone metadata. The writer
already maps timezone‑aware nanosecond timestamps to `timestamptz_ns` without losing precision, but
the statistics encoder previously omitted their min/max bounds. Queries therefore kept every file
when filtering on these columns.

The encoder now accepts any Arrow timezone annotation and renders its epoch instant in canonical
UTC. This keeps statistics stable across DuckDB session timezones while preserving the distinction
between timezone‑aware and timezone‑naive timestamps.

### Design

- Treat every non‑empty Arrow timezone annotation as instant semantics. The stored integer already
  measures time from the Unix epoch, so the annotation does not require a local‑time conversion.
- Render timezone‑aware bounds in UTC with a `+00` suffix. UTC keeps lexical ordering aligned with
  instant ordering across daylight‑saving transitions and makes equivalent annotations comparable.
- Preserve the source timestamp unit. Second, millisecond, microsecond, and nanosecond values retain
  their existing fractional precision and trailing‑zero behavior.
- Keep timezone‑naive timestamp encoding unchanged. These values remain wall‑clock timestamps with no
  offset suffix.

### Changes

- Encode timezone‑aware `ScalarValue` timestamp bounds instead of returning `None`.
- Classify timezone‑aware timestamp types as eligible for min/max statistics.
- Add exact UTC golden values for negative microsecond and nanosecond timestamps.
- Persist and assert file‑level and table‑level bounds from a non‑UTC Arrow annotation.
- Assert that DataFusion prunes a disjoint Parquet file using the new bounds.
- Reopen a catalog with the previous `NULL` timestamp bounds, read every value exactly, and prove
  filtered planning keeps both files rather than pruning from absent statistics.
- Document the fix in the Unreleased changelog.

### DuckLake conformance

| Spec area | DuckLake requirement | PR behavior | Status |
| --------- | -------------------- | ----------- | ------ |
| [`timestamptz`](https://ducklake.select/docs/stable/specification/data_types#primitive-types) | A timezone‑aware timestamp with microsecond precision. | Arrow second, millisecond, and microsecond timestamps with any timezone annotation remain `timestamptz`; the integer epoch instant is rendered in UTC. | Conforms |
| [Statistics encoding](https://ducklake.select/docs/stable/specification/data_types#type-encoding-for-statistics) | `timestamptz` bounds use an ISO 8601 timestamp with a UTC offset, such as `2024-01-15 12:30:00.123456+00`. | Aware bounds include `+00`; naive timestamp encodings remain unchanged. | Conforms |
| [`ducklake_file_column_stats`](https://ducklake.select/docs/stable/specification/tables/ducklake_file_column_stats) | `min_value` and `max_value` are string‑encoded lower and upper bounds for one file. | The writer persists exact UTC bounds and the integration test checks both values. | Conforms |
| [`ducklake_table_column_stats`](https://ducklake.select/docs/stable/specification/tables/ducklake_table_column_stats) | Table‑level `min_value` and `max_value` bound the full column. | The writer aggregates the same UTC representation and the integration test checks both values. | Conforms |
| [File pruning](https://ducklake.select/docs/stable/specification/queries#select-with-file-pruning) | Query planning may exclude files using per‑file min/max statistics. | The plan test proves a disjoint 2030 Parquet file is excluded from a 2024 timestamp filter. | Conforms |
| Nanosecond timezone timestamps | DuckLake 1.0 defines `timestamp_ns` and `timestamptz`, but not a timezone‑aware nanosecond type. | Existing `timestamptz_ns` support remains lossless and now records nine‑digit UTC bounds. | Extension |

### Compatibility

The DuckLake catalog continues to store `timestamptz` or `timestamptz_ns`, not an IANA timezone.
Data files retain their timestamp values and precision. Only previously absent catalog min/max
strings become populated, using the same UTC instant representation DuckLake exposes through Arrow.

This is a pre‑release catalog‑statistics format decision, not a Parquet timestamp format change.
Readers continue to support the previous form: `NULL` timezone bounds keep the file eligible for
scanning. The compatibility regression clears both file‑level and table‑level bounds, reopens the
catalog, reads all four timestamp values exactly, and verifies that filtering scans both files.

### Commit and branch

- Pull request: [datafusion-contrib/datafusion-ducklake#260](https://github.com/datafusion-contrib/datafusion-ducklake/pull/260).
- Branch: `fix/timestamptz-stats`.
- Base: `daf9bb4160c97dbf2ef0493efdeed9ea45bccb05` (`origin/main`).
- Commit: `6d4ef04831a96d9b8d9eab9b81e1141e8f94d5cf`.
- Shape: one focused commit on the latest upstream `main`.

### Verification

- `cargo test --no-default-features --features write-sqlite --lib stats_encode::tests::` passed.
- `cargo test --features "skip-tests-with-docker write-sqlite" --test it column_stats_tests` passed,
  11 tests, including canonical persisted statistics, timezone pruning, and the previous
  `NULL`‑bound catalog read.
- `cargo clippy --all-targets --all-features --no-deps -- -D warnings` passed.
- `cargo fmt --all -- --check` passed.
- `git diff --check` passed.
- GitHub CI passed on the previous head; the amended head will start a new run when published.
