### PR TITLE
perf(build): disable DataFusion default features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,12 @@ jobs:
         if: steps.changes.outputs.code == 'true'
         run: cargo clippy ${{ runner.os == 'Linux' && '--workspace' || '' }} --all-targets --all-features --no-deps -- -D warnings
 
+      # `--lib` excludes dev dependencies, so their DataFusion defaults and
+      # object_store `aws`/`fs` features cannot mask production dependencies.
+      - name: Check library without dev dependencies
+        if: steps.changes.outputs.code == 'true' && runner.os == 'Linux'
+        run: cargo check --locked --lib --no-default-features
+
       # macOS only. This step used to run on Linux too, as
       # `cargo test --features write-sqlite` — but `--features` keeps the default
       # features on, so that feature set (metadata-duckdb + duckdb-bundled +

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ exclude = ["datafusion-ducklake.iml", "target", "tests/test_data"]
 autotests = false
 
 [dependencies]
-datafusion = "54"
-datafusion-datasource = "54"
+datafusion = { version = "54", default-features = false, features = ["parquet", "recursive_protection", "sql"] }
+datafusion-datasource = { version = "54", default-features = false }
 arrow = "58"
 parquet = { version = "58", features = ["async"] }
 object_store = { version = "0.13", default-features = false }
@@ -51,6 +51,7 @@ duckdb = { version = "1.4.1", optional = true }
 sqlx = { version = "0.9", features = ["runtime-tokio"], optional = true }
 
 [dev-dependencies]
+datafusion = "54"
 object_store = { version = "0.13", features = ["aws", "fs"] }
 testcontainers = "0.23"
 testcontainers-modules = { version = "0.11", features = ["minio", "postgres", "mysql"] }


### PR DESCRIPTION
### Summary

Stop enabling DataFusion's full default feature set for every datafusion-ducklake consumer. The
library uses DataFusion's Parquet and SQL modules and keeps recursive stack protection, while
optional scalar‑function packages and compressed CSV/JSON input are application choices.

The test suite keeps DataFusion's defaults through a dev dependency. This preserves sqllogictest
coverage without leaking the broader feature set into downstream builds.

The required build job also checks the library without dev dependencies. This prevents DataFusion
defaults and the `object_store` development features from masking accidental production feature
requirements.

### Changes

- Disable default features on the normal `datafusion` dependency and enable `parquet`,
  `recursive_protection`, and `sql` explicitly.
- Disable default features on the normal `datafusion-datasource` dependency, removing its default
  `compression` feature from consumers.
- Enable DataFusion defaults in dev builds so unit, integration, sqllogic, and documentation tests
  retain their existing function surface.
- Add a required library‑only build without crate defaults or dev dependencies.

### Consumer impact

Cargo features remain additive. Applications can enable any additional DataFusion function package
they use, while applications that need only DuckLake's library surface no longer compile unrelated
function packages by default. Recursive planner and expression traversal remain protected against
stack overflow.

This change does not alter DuckLake data, metadata, or query semantics. It only moves ownership of
optional DataFusion capabilities to the consuming application.

### Verification

- `cargo check --locked --lib --no-default-features` passed with the existing read‑only dead‑code
  warnings.
- `cargo metadata --locked --no-deps --format-version 1` passed.
- The non‑dev dependency tree includes `recursive` and excludes the `object_store` AWS feature.
- The GitHub Actions workflow parsed as YAML.
- `git diff --check` passed.
