### PR TITLE
fix(multicatalog): scope data paths by catalog

### DIFF
--- a/src/maintenance.rs
+++ b/src/maintenance.rs
@@ -11,10 +11,10 @@
 //! 2. **cleanup_old_files** ([`cleanup_old_files_sqlite`], [`cleanup_old_files_in_catalog`])
 //!    reads the scheduled rows, deletes the objects from the object store, and removes the rows.
 //! 3. **delete_orphaned_files** ([`delete_orphaned_files_sqlite`],
-//!    [`delete_orphaned_files_multicatalog`]) lists the data path, subtracts everything
-//!    referenced by the catalog (data files + delete files + still-scheduled-for-deletion),
-//!    and deletes whatever's left. Catches files left by aborted writes and by
-//!    `drop_catalog` (which hard-deletes catalog metadata without scheduling its files).
+//!    [`delete_orphaned_files_in_catalog`], [`delete_orphaned_files_multicatalog`]) lists a data
+//!    path, subtracts referenced data files, delete files, and files still scheduled for deletion,
+//!    and deletes whatever is left. The catalog-scoped form catches files left by aborted writes.
+//!    The global form also reclaims dropped-catalog files from retained data-path tombstones.
 //!
 //! The metadata writers deliberately hold no object store — physical I/O lives here so the
 //! catalog layer stays storage-agnostic (the object store comes from the caller, e.g. the
@@ -23,9 +23,13 @@
 use crate::Result;
 use crate::path_resolver::{parse_object_store_url, resolve_path};
 use chrono::{DateTime, Utc};
+#[cfg(feature = "write-postgres")]
+use datafusion::datasource::object_store::ObjectStoreUrl;
 use futures::TryStreamExt;
 use object_store::path::Path as ObjectPath;
 use object_store::{ObjectStore, ObjectStoreExt};
+#[cfg(feature = "write-postgres")]
+use std::collections::BTreeMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 
@@ -47,6 +51,13 @@ pub enum CleanupCriteria {
     All,
     /// Delete only files scheduled before this timestamp.
     OlderThan(DateTime<Utc>),
+}
+
+#[cfg(feature = "write-postgres")]
+struct DataPathGroup {
+    object_store_url: ObjectStoreUrl,
+    object_path: ObjectPath,
+    data_paths: Vec<String>,
 }
 
 /// Render a UTC timestamp as a SQL literal both backends parse and compare correctly.
@@ -163,7 +174,7 @@ pub async fn cleanup_old_files_in_catalog(
     criteria: CleanupCriteria,
     dry_run: bool,
 ) -> Result<Vec<String>> {
-    let data_path = mgr.get_data_path().await?;
+    let data_path = mgr.get_data_path_in_catalog(catalog_name).await?;
     let files = mgr
         .list_scheduled_for_deletion_in_catalog(catalog_name, &criteria)
         .await?;
@@ -265,18 +276,11 @@ pub async fn delete_orphaned_files_sqlite(
     run_orphan_cleanup(&data_path, referenced, object_store, criteria, dry_run).await
 }
 
-/// List the multicatalog's shared `data_path` and delete every `.parquet` not
-/// referenced by any catalog in the metadata DB.
+/// Sweep every registered multicatalog data path and delete unreferenced Parquet files.
 ///
-/// **Global, not per-catalog.** In our multicatalog Postgres model every catalog
-/// shares one `data_path`, so the natural unit for orphan reclamation is the
-/// whole data path. The referenced set is built across every catalog's data
-/// files, delete files, and still-pending scheduled-for-deletion rows. This
-/// closes the file-leak left by [`MulticatalogManager::drop_catalog`] — which
-/// hard-deletes catalog metadata in one shot, so its files become unreferenced
-/// rather than scheduled.
-///
-/// [`MulticatalogManager::drop_catalog`]: crate::multicatalog::MulticatalogManager::drop_catalog
+/// All roots must resolve to the same object-store authority because this API
+/// accepts one object store. Use [`delete_orphaned_files_in_data_path`] with the
+/// matching store when one metadata database spans multiple authorities.
 #[cfg(feature = "write-postgres")]
 pub async fn delete_orphaned_files_multicatalog(
     mgr: &crate::multicatalog::MulticatalogManager,
@@ -284,7 +288,172 @@ pub async fn delete_orphaned_files_multicatalog(
     criteria: CleanupCriteria,
     dry_run: bool,
 ) -> Result<Vec<String>> {
-    let data_path = mgr.get_data_path().await?;
-    let referenced = mgr.list_referenced_paths().await?;
-    run_orphan_cleanup(&data_path, referenced, object_store, criteria, dry_run).await
+    let data_path_groups = merge_data_path_groups(group_data_paths(mgr.list_data_paths().await?)?);
+    if data_path_groups.is_empty() {
+        return Err(crate::DuckLakeError::InvalidConfig(
+            "Missing required catalog metadata: 'data_path' not configured.".to_string(),
+        ));
+    }
+    let mut authority = None;
+    for group in &data_path_groups {
+        if authority
+            .as_ref()
+            .is_some_and(|expected| expected != &group.object_store_url)
+        {
+            return Err(crate::DuckLakeError::InvalidConfig(
+                "Multicatalog data paths span multiple object-store authorities; clean each path with delete_orphaned_files_in_data_path"
+                    .to_string(),
+            ));
+        }
+        authority = Some(group.object_store_url.clone());
+    }
+
+    let mut deleted = Vec::new();
+    for group in data_path_groups {
+        deleted.extend(
+            delete_orphaned_files_in_data_path_inner(
+                mgr,
+                &group,
+                Arc::clone(&object_store),
+                criteria.clone(),
+                dry_run,
+            )
+            .await?,
+        );
+    }
+    deleted.sort();
+    deleted.dedup();
+    Ok(deleted)
+}
+
+/// Delete orphaned Parquet files within one catalog's canonical data path.
+///
+/// The sweep includes every catalog root nested under that path because object-store listing is
+/// recursive. References from every included root are retained.
+#[cfg(feature = "write-postgres")]
+pub async fn delete_orphaned_files_in_catalog(
+    mgr: &crate::multicatalog::MulticatalogManager,
+    catalog_name: &str,
+    object_store: Arc<dyn ObjectStore>,
+    criteria: CleanupCriteria,
+    dry_run: bool,
+) -> Result<Vec<String>> {
+    let data_path = mgr.get_data_path_in_catalog(catalog_name).await?;
+    let group = registered_data_path_group(mgr, &data_path).await?;
+    delete_orphaned_files_in_data_path_inner(mgr, &group, object_store, criteria, dry_run).await
+}
+
+/// Delete orphaned Parquet files within one retained multicatalog data path.
+///
+/// `object_store` must serve the authority parsed from `data_path`. The object-store trait does not
+/// expose its authority for runtime validation.
+#[cfg(feature = "write-postgres")]
+pub async fn delete_orphaned_files_in_data_path(
+    mgr: &crate::multicatalog::MulticatalogManager,
+    data_path: &str,
+    object_store: Arc<dyn ObjectStore>,
+    criteria: CleanupCriteria,
+    dry_run: bool,
+) -> Result<Vec<String>> {
+    let group = registered_data_path_group(mgr, data_path).await?;
+    delete_orphaned_files_in_data_path_inner(mgr, &group, object_store, criteria, dry_run).await
+}
+
+#[cfg(feature = "write-postgres")]
+async fn delete_orphaned_files_in_data_path_inner(
+    mgr: &crate::multicatalog::MulticatalogManager,
+    group: &DataPathGroup,
+    object_store: Arc<dyn ObjectStore>,
+    criteria: CleanupCriteria,
+    dry_run: bool,
+) -> Result<Vec<String>> {
+    let clear_tombstone = !dry_run && matches!(&criteria, CleanupCriteria::All);
+    let dropped_before = mgr.current_timestamp().await?;
+    let mut referenced = Vec::new();
+    for data_path in &group.data_paths {
+        let (_, base_key) = parse_object_store_url(data_path)?;
+        for (path, relative) in mgr
+            .list_referenced_paths_in_data_paths(std::slice::from_ref(data_path))
+            .await?
+        {
+            referenced.push((resolve_path(&base_key, &path, relative)?, false));
+        }
+    }
+    let deleted = run_orphan_cleanup(
+        &group.data_paths[0],
+        referenced,
+        object_store,
+        criteria,
+        dry_run,
+    )
+    .await?;
+    if clear_tombstone {
+        mgr.clear_dropped_data_paths(&group.data_paths, dropped_before)
+            .await?;
+    }
+    Ok(deleted)
+}
+
+#[cfg(feature = "write-postgres")]
+async fn registered_data_path_group(
+    mgr: &crate::multicatalog::MulticatalogManager,
+    data_path: &str,
+) -> Result<DataPathGroup> {
+    let mut groups = group_data_paths(mgr.list_data_paths().await?)?;
+    let index = groups
+        .iter()
+        .position(|group| group.data_paths.iter().any(|path| path == data_path))
+        .ok_or_else(|| {
+            crate::DuckLakeError::InvalidConfig(format!(
+                "Data path {data_path:?} is not registered for multicatalog cleanup"
+            ))
+        })?;
+    let mut root = groups.remove(index);
+    for group in groups {
+        if group.object_store_url == root.object_store_url
+            && group.object_path.prefix_matches(&root.object_path)
+        {
+            root.data_paths.extend(group.data_paths);
+        }
+    }
+    Ok(root)
+}
+
+#[cfg(feature = "write-postgres")]
+fn group_data_paths(data_paths: Vec<String>) -> Result<Vec<DataPathGroup>> {
+    let mut groups = BTreeMap::new();
+    for data_path in data_paths {
+        let (object_store_url, base_key) = parse_object_store_url(&data_path)?;
+        let object_path = ObjectPath::from(base_key.trim_start_matches('/'));
+        groups
+            .entry((object_store_url, object_path))
+            .or_insert_with(Vec::new)
+            .push(data_path);
+    }
+    Ok(groups
+        .into_iter()
+        .map(
+            |((object_store_url, object_path), data_paths)| DataPathGroup {
+                object_store_url,
+                object_path,
+                data_paths,
+            },
+        )
+        .collect())
+}
+
+#[cfg(feature = "write-postgres")]
+fn merge_data_path_groups(groups: Vec<DataPathGroup>) -> Vec<DataPathGroup> {
+    let mut roots: Vec<DataPathGroup> = Vec::new();
+    for group in groups {
+        if let Some(root) = roots.iter_mut().find(|root| {
+            group.object_store_url == root.object_store_url
+                && group.object_path.prefix_matches(&root.object_path)
+        }) {
+            root.data_paths.extend(group.data_paths);
+        } else {
+            roots.push(group);
+        }
+    }
+    roots
 }

--- a/src/metadata_writer_postgres.rs
+++ b/src/metadata_writer_postgres.rs
@@ -223,8 +223,27 @@ pub(crate) const SQL_CREATE_MULTICATALOG_TABLES: &[&str] = &[
     r#"CREATE TABLE IF NOT EXISTS ducklake_catalog (
         catalog_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
         catalog_name VARCHAR NOT NULL UNIQUE,
+        data_path VARCHAR,
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     )"#,
+    r#"DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_attribute
+                WHERE attrelid = 'ducklake_catalog'::regclass
+                  AND attname = 'data_path'
+                  AND NOT attisdropped
+            ) THEN
+                ALTER TABLE ducklake_catalog ADD COLUMN data_path VARCHAR;
+                UPDATE ducklake_catalog AS catalog
+                SET data_path = (
+                    SELECT value FROM ducklake_metadata
+                    WHERE key = 'data_path' AND scope IS NULL
+                    LIMIT 1
+                )
+                WHERE catalog.data_path IS NULL;
+            END IF;
+        END $$"#,
     r#"CREATE TABLE IF NOT EXISTS ducklake_catalog_snapshot_map (
         catalog_id BIGINT NOT NULL,
         snapshot_id BIGINT NOT NULL,
@@ -261,6 +280,10 @@ pub(crate) const SQL_CREATE_MULTICATALOG_TABLES: &[&str] = &[
     )"#,
     r#"CREATE INDEX IF NOT EXISTS idx_scheduled_for_deletion_catalog
         ON ducklake_files_scheduled_for_deletion(catalog_id)"#,
+    r#"CREATE TABLE IF NOT EXISTS ducklake_dropped_data_path (
+        data_path VARCHAR PRIMARY KEY,
+        dropped_at TIMESTAMPTZ DEFAULT NOW()
+    )"#,
     r#"CREATE INDEX IF NOT EXISTS idx_catalog_snapshot_map_snapshot
         ON ducklake_catalog_snapshot_map(snapshot_id)"#,
     r#"CREATE INDEX IF NOT EXISTS idx_catalog_schema_map_schema
@@ -4023,35 +4046,33 @@ impl MetadataWriter for PostgresMetadataWriter {
 
     fn get_data_path(&self) -> Result<String> {
         block_on(async {
-            let row =
-                sqlx::query("SELECT value FROM ducklake_metadata WHERE key = $1 AND scope IS NULL")
-                    .bind("data_path")
-                    .fetch_optional(&self.pool)
+            let path: Option<String> =
+                sqlx::query_scalar("SELECT data_path FROM ducklake_catalog WHERE catalog_id = $1")
+                    .bind(self.catalog_id)
+                    .fetch_one(&self.pool)
                     .await?;
 
-            match row {
-                Some(r) => Ok(r.try_get(0)?),
-                None => Err(crate::error::DuckLakeError::InvalidConfig(
+            path.ok_or_else(|| {
+                crate::error::DuckLakeError::InvalidConfig(
                     "Missing required catalog metadata: 'data_path' not configured.".to_string(),
-                )),
-            }
+                )
+            })
         })
     }
 
     fn set_data_path(&self, path: &str) -> Result<()> {
-        // data_path is global per Phase 1. Reject silent overwrites — if it's
-        // already set to a different value, a concurrent tenant likely set it.
         block_on(async {
             let mut tx = self.pool.begin().await?;
+            lock_catalog(self.catalog_id, self.lock_timeout_ms, &mut tx).await?;
 
-            let existing: Option<String> = sqlx::query(
-                "SELECT value FROM ducklake_metadata
-                 WHERE key = 'data_path' AND scope IS NULL FOR UPDATE",
-            )
-            .fetch_optional(&mut *tx)
-            .await?
-            .map(|r| r.try_get(0))
-            .transpose()?;
+            let existing: Option<String> =
+                sqlx::query("SELECT data_path FROM ducklake_catalog WHERE catalog_id = $1")
+                    .bind(self.catalog_id)
+                    .fetch_optional(&mut *tx)
+                    .await?
+                    .map(|r| r.try_get(0))
+                    .transpose()?
+                    .flatten();
 
             match existing {
                 Some(cur) if cur == path => {
@@ -4060,20 +4081,18 @@ impl MetadataWriter for PostgresMetadataWriter {
                 },
                 Some(cur) => {
                     return Err(crate::error::DuckLakeError::InvalidConfig(format!(
-                        "data_path already set to {:?}, refusing to overwrite with {:?}",
-                        cur, path
+                        "data_path for catalog_id {} already set to {:?}, refusing to overwrite with {:?}",
+                        self.catalog_id, cur, path
                     )));
                 },
                 None => {},
             }
 
-            sqlx::query(
-                "INSERT INTO ducklake_metadata (key, value, scope)
-                 VALUES ('data_path', $1, NULL)",
-            )
-            .bind(path)
-            .execute(&mut *tx)
-            .await?;
+            sqlx::query("UPDATE ducklake_catalog SET data_path = $1 WHERE catalog_id = $2")
+                .bind(path)
+                .bind(self.catalog_id)
+                .execute(&mut *tx)
+                .await?;
 
             tx.commit().await?;
             Ok(())

--- a/src/multicatalog.rs
+++ b/src/multicatalog.rs
@@ -8,6 +8,7 @@ use crate::maintenance::{
     CleanupCriteria, ExpireCriteria, ExpiredSnapshot, ScheduledFile, format_sql_timestamp,
 };
 use crate::metadata_writer_postgres::execute_ddl_statements;
+use chrono::{DateTime, Utc};
 use sqlx::AssertSqlSafe;
 use sqlx::Row;
 use sqlx::postgres::{PgPool, PgRow};
@@ -153,11 +154,10 @@ impl MulticatalogManager {
     ///
     /// # What's NOT cleaned up
     ///
-    /// Data files on object storage are not removed here. Vacuum
-    /// reclaims them later, matching the crate's drop-without-commit
-    /// convention. Callers needing tighter storage cleanup should list
-    /// the data file paths before calling this and schedule their
-    /// removal externally.
+    /// Data files on object storage are not removed here. The catalog's
+    /// effective data path is retained so orphan cleanup can visit it after
+    /// the metadata rows are gone. Callers needing synchronous cleanup must
+    /// still arrange it around this metadata-only operation.
     pub async fn drop_catalog(&self, name: &str) -> Result<bool> {
         if name.trim().is_empty() {
             return Err(crate::DuckLakeError::InvalidConfig(
@@ -176,15 +176,16 @@ impl MulticatalogManager {
         // against the drop. If the row has already been deleted by a
         // parallel drop, we treat this call as a no-op.
         let row = sqlx::query(
-            "SELECT catalog_id FROM ducklake_catalog
+            "SELECT catalog_id, data_path
+             FROM ducklake_catalog
              WHERE catalog_name = $1 FOR UPDATE",
         )
         .bind(name)
         .fetch_optional(&mut *tx)
         .await?;
 
-        let catalog_id: i64 = match row {
-            Some(r) => r.try_get(0)?,
+        let (catalog_id, data_path): (i64, Option<String>) = match row {
+            Some(r) => (r.try_get("catalog_id")?, r.try_get("data_path")?),
             None => {
                 tx.commit().await?;
                 return Ok(false);
@@ -259,6 +260,22 @@ impl MulticatalogManager {
             .bind(catalog_id)
             .execute(&mut *tx)
             .await?;
+
+        sqlx::query("DELETE FROM ducklake_files_scheduled_for_deletion WHERE catalog_id = $1")
+            .bind(catalog_id)
+            .execute(&mut *tx)
+            .await?;
+
+        if let Some(data_path) = data_path {
+            sqlx::query(
+                "INSERT INTO ducklake_dropped_data_path (data_path)
+                 VALUES ($1)
+                 ON CONFLICT (data_path) DO UPDATE SET dropped_at = NOW()",
+            )
+            .bind(data_path)
+            .execute(&mut *tx)
+            .await?;
+        }
 
         // Finally the catalog row itself.
         sqlx::query("DELETE FROM ducklake_catalog WHERE catalog_id = $1")
@@ -470,7 +487,9 @@ impl MulticatalogManager {
         Ok(true)
     }
 
-    /// Read the global `data_path` (Phase 1: one `data_path` shared by all catalogs).
+    /// Read the legacy global `data_path` fallback.
+    ///
+    /// Use [`Self::get_data_path_in_catalog`] for a catalog-scoped root.
     pub async fn get_data_path(&self) -> Result<String> {
         let row =
             sqlx::query("SELECT value FROM ducklake_metadata WHERE key = $1 AND scope IS NULL")
@@ -483,6 +502,89 @@ impl MulticatalogManager {
                 "Missing required catalog metadata: 'data_path' not configured.".to_string(),
             )),
         }
+    }
+
+    /// Read the `data_path` for one catalog.
+    ///
+    /// Before the writer migration adds the catalog column, readers use the legacy global value.
+    pub async fn get_data_path_in_catalog(&self, catalog_name: &str) -> Result<String> {
+        let path: Option<String> =
+            if crate::multicatalog_provider::catalog_has_data_path(&self.pool).await? {
+                sqlx::query_scalar("SELECT data_path FROM ducklake_catalog WHERE catalog_name = $1")
+                    .bind(catalog_name)
+                    .fetch_optional(&self.pool)
+                    .await?
+                    .flatten()
+            } else {
+                sqlx::query_scalar(
+                    "SELECT metadata.value
+                 FROM ducklake_catalog AS catalog
+                 CROSS JOIN LATERAL (
+                     SELECT value FROM ducklake_metadata
+                     WHERE key = 'data_path' AND scope IS NULL LIMIT 1
+                 ) AS metadata
+                 WHERE catalog.catalog_name = $1",
+                )
+                .bind(catalog_name)
+                .fetch_optional(&self.pool)
+                .await?
+            };
+        path.ok_or_else(|| {
+            crate::DuckLakeError::InvalidConfig(format!(
+                "Missing required catalog metadata: 'data_path' not configured for catalog {catalog_name:?}."
+            ))
+        })
+    }
+
+    /// List every live, legacy, or dropped catalog root that may need orphan cleanup.
+    pub async fn list_data_paths(&self) -> Result<Vec<String>> {
+        let paths = if crate::multicatalog_provider::catalog_has_data_path(&self.pool).await? {
+            sqlx::query_scalar(
+                "SELECT data_path FROM (
+                     SELECT value AS data_path
+                     FROM ducklake_metadata
+                     WHERE key = 'data_path' AND scope IS NULL
+                     UNION
+                     SELECT data_path FROM ducklake_catalog
+                     UNION
+                     SELECT data_path FROM ducklake_dropped_data_path
+                 ) AS paths
+                 WHERE data_path IS NOT NULL
+                 ORDER BY data_path",
+            )
+            .fetch_all(&self.pool)
+            .await?
+        } else {
+            sqlx::query_scalar(
+                "SELECT value FROM ducklake_metadata
+                 WHERE key = 'data_path' AND scope IS NULL",
+            )
+            .fetch_all(&self.pool)
+            .await?
+        };
+        Ok(paths)
+    }
+
+    pub(crate) async fn current_timestamp(&self) -> Result<DateTime<Utc>> {
+        Ok(sqlx::query_scalar("SELECT NOW()")
+            .fetch_one(&self.pool)
+            .await?)
+    }
+
+    pub(crate) async fn clear_dropped_data_paths(
+        &self,
+        data_paths: &[String],
+        dropped_before: DateTime<Utc>,
+    ) -> Result<()> {
+        sqlx::query(
+            "DELETE FROM ducklake_dropped_data_path
+             WHERE data_path::TEXT = ANY($1) AND dropped_at <= $2",
+        )
+        .bind(data_paths)
+        .bind(dropped_before)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
     }
 
     /// Expire snapshots within a single catalog and GC the metadata they leave behind.
@@ -809,29 +911,37 @@ impl MulticatalogManager {
         Ok(())
     }
 
-    /// Every physical file referenced by **any** catalog in this metadata DB:
-    /// data files, delete files, and still-scheduled-for-deletion rows. Global
-    /// (no catalog filter) — orphan cleanup operates on the whole shared
-    /// `data_path` and must subtract every catalog's referenced files to avoid
-    /// deleting another catalog's data.
-    ///
-    /// Used by [`crate::maintenance::delete_orphaned_files_multicatalog`].
-    pub(crate) async fn list_referenced_paths(&self) -> Result<Vec<(String, bool)>> {
+    /// Every physical file referenced by a catalog whose effective `data_path`
+    /// matches one of `data_paths`. Canonical-root cleanup must preserve aliases.
+    pub(crate) async fn list_referenced_paths_in_data_paths(
+        &self,
+        data_paths: &[String],
+    ) -> Result<Vec<(String, bool)>> {
         let q = format!(
-            "SELECT {PG_RESOLVED_PATH} AS p, {PG_REL_FLAG} AS rel
+            "WITH root_catalog AS (
+                 SELECT catalog_id FROM ducklake_catalog
+                 WHERE data_path::TEXT = ANY($1)
+             )
+             SELECT {PG_RESOLVED_PATH} AS p, {PG_REL_FLAG} AS rel
              FROM ducklake_data_file df
              JOIN ducklake_table t ON t.table_id = df.table_id
              JOIN ducklake_schema s ON s.schema_id = t.schema_id
+             JOIN ducklake_catalog_schema_map m ON m.schema_id = s.schema_id
+             WHERE m.catalog_id IN (SELECT catalog_id FROM root_catalog)
              UNION ALL
              SELECT {PG_RESOLVED_PATH} AS p, {PG_REL_FLAG} AS rel
              FROM ducklake_delete_file df
              JOIN ducklake_table t ON t.table_id = df.table_id
              JOIN ducklake_schema s ON s.schema_id = t.schema_id
+             JOIN ducklake_catalog_schema_map m ON m.schema_id = s.schema_id
+             WHERE m.catalog_id IN (SELECT catalog_id FROM root_catalog)
              UNION ALL
              SELECT path AS p, path_is_relative AS rel
-             FROM ducklake_files_scheduled_for_deletion"
+             FROM ducklake_files_scheduled_for_deletion
+             WHERE catalog_id IN (SELECT catalog_id FROM root_catalog)"
         );
         let rows = sqlx::query(AssertSqlSafe(q.as_str()))
+            .bind(data_paths)
             .fetch_all(&self.pool)
             .await?;
         rows.into_iter()

--- a/src/multicatalog_provider.rs
+++ b/src/multicatalog_provider.rs
@@ -221,22 +221,28 @@ impl MetadataProvider for MulticatalogProvider {
     }
 
     fn get_data_path(&self) -> Result<String> {
-        // data_path is global per Phase 1 default.
         block_on(async {
-            let row =
-                sqlx::query("SELECT value FROM ducklake_metadata WHERE key = $1 AND scope IS NULL")
-                    .bind("data_path")
-                    .fetch_optional(&self.pool)
-                    .await?;
+            let path: Option<String> = if catalog_has_data_path(&self.pool).await? {
+                sqlx::query_scalar("SELECT data_path FROM ducklake_catalog WHERE catalog_id = $1")
+                    .bind(self.catalog_id)
+                    .fetch_one(&self.pool)
+                    .await?
+            } else {
+                sqlx::query_scalar(
+                    "SELECT value FROM ducklake_metadata
+                     WHERE key = 'data_path' AND scope IS NULL LIMIT 1",
+                )
+                .fetch_optional(&self.pool)
+                .await?
+            };
 
-            match row {
-                Some(r) => Ok(r.try_get(0)?),
-                None => Err(crate::error::DuckLakeError::InvalidConfig(
+            path.ok_or_else(|| {
+                crate::error::DuckLakeError::InvalidConfig(
                     "Missing required catalog metadata: 'data_path' not configured. \
                      The catalog may be uninitialized or corrupted."
                         .to_string(),
-                )),
-            }
+                )
+            })
         })
     }
 
@@ -1415,4 +1421,17 @@ WHERE data.table_id = $1
                 .collect()
         })
     }
+}
+
+pub(crate) async fn catalog_has_data_path(pool: &PgPool) -> Result<bool> {
+    Ok(sqlx::query_scalar(
+        "SELECT EXISTS (
+             SELECT 1 FROM pg_attribute
+             WHERE attrelid = 'ducklake_catalog'::regclass
+               AND attname = 'data_path'
+               AND NOT attisdropped
+         )",
+    )
+    .fetch_one(pool)
+    .await?)
 }

--- a/tests/it/multicatalog_hardening_tests.rs
+++ b/tests/it/multicatalog_hardening_tests.rs
@@ -12,9 +12,11 @@
 
 use std::sync::Arc;
 
+use datafusion_ducklake::metadata_provider::MetadataProvider;
 use datafusion_ducklake::metadata_writer::{ColumnDef, DataFileInfo, MetadataWriter, WriteMode};
 use datafusion_ducklake::{
-    MulticatalogManager, PostgresMetadataWriter, initialize_multicatalog_schema,
+    MulticatalogManager, MulticatalogProvider, PostgresMetadataWriter,
+    initialize_multicatalog_schema,
 };
 use sqlx::Row;
 use sqlx::postgres::{PgPool, PgPoolOptions};
@@ -380,24 +382,479 @@ async fn get_or_create_table_rejects_cross_catalog_schema_id() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
-async fn set_data_path_rejects_silent_overwrite() {
+async fn set_data_path_is_catalog_scoped_and_rejects_silent_overwrite() {
     let (pool, _c) = spin_up_postgres().await.unwrap();
     let mgr = MulticatalogManager::new(pool.clone());
-    let cat = mgr.create_catalog("pg_prod").await.unwrap();
-    let w = PostgresMetadataWriter::with_pool(pool.clone(), cat)
+    let cat_a = mgr.create_catalog("cat_a").await.unwrap();
+    let cat_b = mgr.create_catalog("cat_b").await.unwrap();
+    let writer_a = PostgresMetadataWriter::with_pool(pool.clone(), cat_a)
+        .await
+        .unwrap();
+    let writer_b = PostgresMetadataWriter::with_pool(pool.clone(), cat_b)
         .await
         .unwrap();
 
-    w.set_data_path("/data/a").unwrap();
-    // Same value is idempotent.
-    w.set_data_path("/data/a").unwrap();
-    // Different value rejected.
-    let err = w
+    writer_a.set_data_path("/data/a").unwrap();
+    writer_a.set_data_path("/data/a").unwrap();
+    let missing = writer_b
+        .get_data_path()
+        .expect_err("an unconfigured catalog must not inherit another root");
+    writer_b.set_data_path("/data/b").unwrap();
+    let err = writer_a
         .set_data_path("/data/b")
         .expect_err("must reject overwrite");
-    assert!(err.to_string().contains("already set"), "got: {}", err);
-    // Original value is untouched.
-    assert_eq!(w.get_data_path().unwrap(), "/data/a");
+    assert!(
+        err.to_string().contains("already set"),
+        "unexpected error: {err}"
+    );
+    assert!(missing.to_string().contains("not configured"));
+
+    let provider_a = MulticatalogProvider::with_pool_and_id(pool.clone(), cat_a)
+        .await
+        .unwrap();
+    let provider_b = MulticatalogProvider::with_pool_and_id(pool, cat_b)
+        .await
+        .unwrap();
+
+    assert_eq!(writer_a.get_data_path().unwrap(), "/data/a");
+    assert_eq!(writer_b.get_data_path().unwrap(), "/data/b");
+    assert_eq!(provider_a.get_data_path().unwrap(), "/data/a");
+    assert_eq!(provider_b.get_data_path().unwrap(), "/data/b");
+    assert_eq!(
+        mgr.get_data_path_in_catalog("cat_a").await.unwrap(),
+        "/data/a"
+    );
+    assert_eq!(
+        mgr.get_data_path_in_catalog("cat_b").await.unwrap(),
+        "/data/b"
+    );
+    let missing_global = mgr
+        .get_data_path()
+        .await
+        .expect_err("a fresh multicatalog store must not seed the legacy root");
+    assert!(missing_global.to_string().contains("not configured"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn legacy_data_path_is_backfilled_and_rejects_overwrite() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let catalog_id = mgr.create_catalog("legacy").await.unwrap();
+    sqlx::query("ALTER TABLE ducklake_catalog DROP COLUMN data_path")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO ducklake_metadata (key, value, scope)
+         VALUES ('data_path', '/data/legacy', NULL)",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    initialize_multicatalog_schema(&pool).await.unwrap();
+    let writer = PostgresMetadataWriter::with_pool(pool.clone(), catalog_id)
+        .await
+        .unwrap();
+    let error = writer
+        .set_data_path("/data/new")
+        .expect_err("the migrated path is already established");
+
+    assert!(error.to_string().contains("already set"));
+    assert_eq!(writer.get_data_path().unwrap(), "/data/legacy");
+
+    let fresh_id = mgr.create_catalog("fresh").await.unwrap();
+    initialize_multicatalog_schema(&pool).await.unwrap();
+    let fresh = PostgresMetadataWriter::with_pool(pool, fresh_id)
+        .await
+        .unwrap();
+    let missing = fresh
+        .get_data_path()
+        .expect_err("a post-migration catalog must remain unconfigured");
+    fresh.set_data_path("/data/fresh").unwrap();
+    assert!(missing.to_string().contains("not configured"));
+    assert_eq!(fresh.get_data_path().unwrap(), "/data/fresh");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn reader_uses_legacy_data_path_before_writer_migration() {
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let catalog_id = mgr.create_catalog("legacy_reader").await.unwrap();
+    sqlx::query("ALTER TABLE ducklake_catalog DROP COLUMN data_path")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO ducklake_metadata (key, value, scope)
+         VALUES ('data_path', '/data/legacy-reader', NULL)",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    let provider = MulticatalogProvider::with_pool_and_id(pool, catalog_id)
+        .await
+        .unwrap();
+
+    assert_eq!(provider.get_data_path().unwrap(), "/data/legacy-reader");
+    assert_eq!(
+        mgr.get_data_path_in_catalog("legacy_reader").await.unwrap(),
+        "/data/legacy-reader"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn global_orphan_cleanup_errors_without_data_path() {
+    use datafusion_ducklake::maintenance::{CleanupCriteria, delete_orphaned_files_multicatalog};
+    use object_store::ObjectStore;
+    use object_store::local::LocalFileSystem;
+
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool);
+    let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+    let error = delete_orphaned_files_multicatalog(&mgr, store, CleanupCriteria::All, false)
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("data_path' not configured"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn catalog_orphan_cleanup_keeps_shared_root_peer_files() {
+    use datafusion_ducklake::maintenance::{CleanupCriteria, delete_orphaned_files_in_catalog};
+    use object_store::ObjectStore;
+    use object_store::local::LocalFileSystem;
+    use tempfile::TempDir;
+
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat_a = mgr.create_catalog("cat_a").await.unwrap();
+    let cat_b = mgr.create_catalog("cat_b").await.unwrap();
+    let writer_a = PostgresMetadataWriter::with_pool(pool.clone(), cat_a)
+        .await
+        .unwrap();
+    let writer_b = PostgresMetadataWriter::with_pool(pool, cat_b)
+        .await
+        .unwrap();
+    let temp = TempDir::new().unwrap();
+    let data_path = temp.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+    writer_a.set_data_path(data_path.to_str().unwrap()).unwrap();
+    writer_b
+        .set_data_path(&format!("{}/", data_path.display()))
+        .unwrap();
+
+    for (writer, table, file) in [(&writer_a, "a", "a.parquet"), (&writer_b, "b", "b.parquet")] {
+        let setup = writer
+            .begin_write_transaction("public", table, &users_cols(), WriteMode::Replace)
+            .unwrap();
+        writer
+            .register_data_file(
+                setup.table_id,
+                "public",
+                table,
+                setup.snapshot_id,
+                &DataFileInfo::new(file, 100, 1),
+                WriteMode::Replace,
+                setup.base_snapshot_id,
+                &users_cols(),
+                &setup.column_ids,
+            )
+            .unwrap();
+    }
+
+    let a_file = data_path
+        .join(format!("cat_{cat_a}"))
+        .join("public/a/a.parquet");
+    let b_file = data_path
+        .join(format!("cat_{cat_b}"))
+        .join("public/b/b.parquet");
+    let orphan_file = data_path.join("orphan.parquet");
+    std::fs::create_dir_all(a_file.parent().unwrap()).unwrap();
+    std::fs::create_dir_all(b_file.parent().unwrap()).unwrap();
+    std::fs::write(&a_file, b"a").unwrap();
+    std::fs::write(&b_file, b"b").unwrap();
+    std::fs::write(&orphan_file, b"orphan").unwrap();
+
+    let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+    let deleted =
+        delete_orphaned_files_in_catalog(&mgr, "cat_a", store, CleanupCriteria::All, false)
+            .await
+            .unwrap();
+
+    assert_eq!(deleted, vec![orphan_file.to_string_lossy().into_owned()]);
+    assert!(a_file.exists());
+    assert!(b_file.exists());
+    assert!(!orphan_file.exists());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn global_orphan_cleanup_keeps_nested_root_files() {
+    use datafusion_ducklake::maintenance::{CleanupCriteria, delete_orphaned_files_multicatalog};
+    use object_store::ObjectStore;
+    use object_store::local::LocalFileSystem;
+    use tempfile::TempDir;
+
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat_a = mgr.create_catalog("parent").await.unwrap();
+    let cat_b = mgr.create_catalog("nested").await.unwrap();
+    let writer_a = PostgresMetadataWriter::with_pool(pool.clone(), cat_a)
+        .await
+        .unwrap();
+    let writer_b = PostgresMetadataWriter::with_pool(pool, cat_b)
+        .await
+        .unwrap();
+    let temp = TempDir::new().unwrap();
+    let root_a = temp.path().join("data");
+    let root_b = root_a.join("tenant");
+    std::fs::create_dir_all(&root_b).unwrap();
+    writer_a.set_data_path(root_a.to_str().unwrap()).unwrap();
+    writer_b.set_data_path(root_b.to_str().unwrap()).unwrap();
+
+    for (writer, table, file) in [(&writer_a, "a", "a.parquet"), (&writer_b, "b", "b.parquet")] {
+        let setup = writer
+            .begin_write_transaction("public", table, &users_cols(), WriteMode::Replace)
+            .unwrap();
+        writer
+            .register_data_file(
+                setup.table_id,
+                "public",
+                table,
+                setup.snapshot_id,
+                &DataFileInfo::new(file, 100, 1),
+                WriteMode::Replace,
+                setup.base_snapshot_id,
+                &users_cols(),
+                &setup.column_ids,
+            )
+            .unwrap();
+    }
+
+    let a_file = root_a
+        .join(format!("cat_{cat_a}"))
+        .join("public/a/a.parquet");
+    let b_file = root_b
+        .join(format!("cat_{cat_b}"))
+        .join("public/b/b.parquet");
+    let orphan_file = root_a.join("orphan.parquet");
+    std::fs::create_dir_all(a_file.parent().unwrap()).unwrap();
+    std::fs::create_dir_all(b_file.parent().unwrap()).unwrap();
+    std::fs::write(&a_file, b"a").unwrap();
+    std::fs::write(&b_file, b"b").unwrap();
+    std::fs::write(&orphan_file, b"orphan").unwrap();
+
+    let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+    let deleted = delete_orphaned_files_multicatalog(&mgr, store, CleanupCriteria::All, false)
+        .await
+        .unwrap();
+
+    assert_eq!(deleted, vec![orphan_file.to_string_lossy().into_owned()]);
+    assert!(a_file.exists());
+    assert!(b_file.exists());
+    assert!(!orphan_file.exists());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn global_orphan_cleanup_reclaims_dropped_distinct_root_catalog() {
+    use datafusion_ducklake::maintenance::{CleanupCriteria, delete_orphaned_files_multicatalog};
+    use object_store::ObjectStore;
+    use object_store::local::LocalFileSystem;
+    use tempfile::TempDir;
+
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat_a = mgr.create_catalog("cat_a").await.unwrap();
+    let cat_b = mgr.create_catalog("cat_b").await.unwrap();
+    let writer_a = PostgresMetadataWriter::with_pool(pool.clone(), cat_a)
+        .await
+        .unwrap();
+    let writer_b = PostgresMetadataWriter::with_pool(pool.clone(), cat_b)
+        .await
+        .unwrap();
+    let temp = TempDir::new().unwrap();
+    let root_a = temp.path().join("a");
+    let root_b = temp.path().join("b");
+    std::fs::create_dir_all(&root_a).unwrap();
+    std::fs::create_dir_all(&root_b).unwrap();
+    writer_a.set_data_path(root_a.to_str().unwrap()).unwrap();
+    writer_b.set_data_path(root_b.to_str().unwrap()).unwrap();
+
+    let setup = writer_b
+        .begin_write_transaction("public", "b", &users_cols(), WriteMode::Replace)
+        .unwrap();
+    writer_b
+        .register_data_file(
+            setup.table_id,
+            "public",
+            "b",
+            setup.snapshot_id,
+            &DataFileInfo::new("b.parquet", 100, 1),
+            WriteMode::Replace,
+            setup.base_snapshot_id,
+            &users_cols(),
+            &setup.column_ids,
+        )
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO ducklake_files_scheduled_for_deletion
+             (catalog_id, data_file_id, path, path_is_relative)
+         VALUES ($1, 999, 'scheduled.parquet', TRUE)",
+    )
+    .bind(cat_b)
+    .execute(&pool)
+    .await
+    .unwrap();
+    let b_file = root_b
+        .join(format!("cat_{cat_b}"))
+        .join("public/b/b.parquet");
+    std::fs::create_dir_all(b_file.parent().unwrap()).unwrap();
+    std::fs::write(&b_file, b"b").unwrap();
+
+    assert!(mgr.drop_catalog("cat_b").await.unwrap());
+    let scheduled: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ducklake_files_scheduled_for_deletion WHERE catalog_id = $1",
+    )
+    .bind(cat_b)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+    let deleted = delete_orphaned_files_multicatalog(&mgr, store, CleanupCriteria::All, false)
+        .await
+        .unwrap();
+
+    assert_eq!(scheduled, 0);
+    assert_eq!(deleted, vec![b_file.to_string_lossy().into_owned()]);
+    assert!(!b_file.exists());
+    assert_eq!(
+        mgr.list_data_paths().await.unwrap(),
+        vec![root_a.to_string_lossy().into_owned()],
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn global_orphan_cleanup_groups_dropped_path_aliases() {
+    use datafusion_ducklake::maintenance::{CleanupCriteria, delete_orphaned_files_multicatalog};
+    use object_store::ObjectStore;
+    use object_store::local::LocalFileSystem;
+    use tempfile::TempDir;
+
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let catalog_id = mgr.create_catalog("live").await.unwrap();
+    let writer = PostgresMetadataWriter::with_pool(pool.clone(), catalog_id)
+        .await
+        .unwrap();
+    let temp = TempDir::new().unwrap();
+    let data_path = temp.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+    writer.set_data_path(data_path.to_str().unwrap()).unwrap();
+
+    let setup = writer
+        .begin_write_transaction("public", "live", &users_cols(), WriteMode::Replace)
+        .unwrap();
+    writer
+        .register_data_file(
+            setup.table_id,
+            "public",
+            "live",
+            setup.snapshot_id,
+            &DataFileInfo::new("live.parquet", 100, 1),
+            WriteMode::Replace,
+            setup.base_snapshot_id,
+            &users_cols(),
+            &setup.column_ids,
+        )
+        .unwrap();
+    let data_path_alias = format!("{}/", data_path.display());
+    sqlx::query(
+        "INSERT INTO ducklake_dropped_data_path (data_path, dropped_at)
+         VALUES ($1, NOW() + INTERVAL '1 hour')",
+    )
+    .bind(&data_path_alias)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let live_file = data_path
+        .join(format!("cat_{catalog_id}"))
+        .join("public/live/live.parquet");
+    let orphan_file = data_path.join("orphan.parquet");
+    std::fs::create_dir_all(live_file.parent().unwrap()).unwrap();
+    std::fs::write(&live_file, b"live").unwrap();
+    std::fs::write(&orphan_file, b"orphan").unwrap();
+
+    let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+    let deleted = delete_orphaned_files_multicatalog(&mgr, store, CleanupCriteria::All, false)
+        .await
+        .unwrap();
+
+    assert_eq!(deleted, vec![orphan_file.to_string_lossy().into_owned()]);
+    assert!(live_file.exists());
+    assert!(!orphan_file.exists());
+    assert_eq!(
+        mgr.list_data_paths().await.unwrap(),
+        vec![data_path.to_string_lossy().into_owned(), data_path_alias.clone()],
+    );
+
+    sqlx::query(
+        "UPDATE ducklake_dropped_data_path
+         SET dropped_at = NOW() - INTERVAL '1 hour' WHERE data_path = $1",
+    )
+    .bind(&data_path_alias)
+    .execute(&pool)
+    .await
+    .unwrap();
+    let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+    let deleted = delete_orphaned_files_multicatalog(&mgr, store, CleanupCriteria::All, false)
+        .await
+        .unwrap();
+
+    assert!(deleted.is_empty());
+    assert_eq!(
+        mgr.list_data_paths().await.unwrap(),
+        vec![data_path.to_string_lossy().into_owned()],
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
+async fn global_orphan_cleanup_rejects_multiple_object_store_authorities() {
+    use datafusion_ducklake::maintenance::{CleanupCriteria, delete_orphaned_files_multicatalog};
+    use object_store::ObjectStore;
+    use object_store::local::LocalFileSystem;
+
+    let (pool, _c) = spin_up_postgres().await.unwrap();
+    let mgr = MulticatalogManager::new(pool.clone());
+    let cat_a = mgr.create_catalog("cat_a").await.unwrap();
+    let cat_b = mgr.create_catalog("cat_b").await.unwrap();
+    let writer_a = PostgresMetadataWriter::with_pool(pool.clone(), cat_a)
+        .await
+        .unwrap();
+    let writer_b = PostgresMetadataWriter::with_pool(pool, cat_b)
+        .await
+        .unwrap();
+    writer_a.set_data_path("s3://bucket-a/data").unwrap();
+    writer_b.set_data_path("s3://bucket-b/data").unwrap();
+    let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+
+    let error = delete_orphaned_files_multicatalog(&mgr, store, CleanupCriteria::All, false)
+        .await
+        .unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("multiple object-store authorities")
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/it/multicatalog_postgres_tests.rs
+++ b/tests/it/multicatalog_postgres_tests.rs
@@ -3932,7 +3932,7 @@ async fn delete_orphaned_files_reclaims_dropped_catalog_files() {
 /// Global sweep must NOT delete files referenced by ANY catalog. With two
 /// catalogs sharing `data_path` plus a stray, only the stray gets removed.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "pre-cat_{id} fixture layout + orphan-cleanup id collision; fixed with the maintenance rework"]
+#[cfg_attr(all(feature = "skip-tests-with-docker", target_os = "macos"), ignore)]
 async fn delete_orphaned_files_spares_files_referenced_by_any_catalog() {
     use datafusion_ducklake::maintenance::{CleanupCriteria, delete_orphaned_files_multicatalog};
     use datafusion_ducklake::metadata_writer::DataFileInfo;
@@ -3956,6 +3956,7 @@ async fn delete_orphaned_files_spares_files_referenced_by_any_catalog() {
     let data_path = temp.path().join("data");
     std::fs::create_dir_all(&data_path).unwrap();
     wa.set_data_path(data_path.to_str().unwrap()).unwrap();
+    wb.set_data_path(data_path.to_str().unwrap()).unwrap();
 
     // A and B each have one referenced data file.
     let sa = wa
@@ -3990,9 +3991,13 @@ async fn delete_orphaned_files_spares_files_referenced_by_any_catalog() {
     .unwrap();
 
     // Materialise the three files: A's referenced, B's referenced, one stray.
-    let a_file = data_path.join("public").join("t").join("a.parquet");
-    let b_file = data_path.join("public").join("u").join("b.parquet");
-    let stray = data_path.join("public").join("t").join("stray.parquet");
+    let a_file = data_path
+        .join(format!("cat_{cat_a}"))
+        .join("public/t/a.parquet");
+    let b_file = data_path
+        .join(format!("cat_{cat_b}"))
+        .join("public/u/b.parquet");
+    let stray = data_path.join("stray.parquet");
     std::fs::create_dir_all(a_file.parent().unwrap()).unwrap();
     std::fs::create_dir_all(b_file.parent().unwrap()).unwrap();
     std::fs::write(&a_file, b"a").unwrap();
@@ -4004,12 +4009,7 @@ async fn delete_orphaned_files_spares_files_referenced_by_any_catalog() {
         .await
         .unwrap();
 
-    assert_eq!(deleted.len(), 1, "only the stray is unreferenced");
-    assert!(
-        deleted[0].ends_with("public/t/stray.parquet"),
-        "got {:?}",
-        deleted[0]
-    );
+    assert_eq!(deleted, vec![stray.to_string_lossy().into_owned()]);
     assert!(!stray.exists());
     assert!(a_file.exists(), "A's referenced file survives");
     assert!(b_file.exists(), "B's referenced file survives");


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD041 -->

### Summary

Let PostgreSQL multicatalog users assign a distinct data root to each logical catalog. The writer
and provider are already bound to `catalog_id`, but their path methods used one global
`ducklake_metadata.data_path` row. A second catalog with a different root therefore failed during
initialization instead of remaining isolated.

DuckLake defines `data_path` as global within one logical catalog. The multicatalog extension now
stores that value on each `ducklake_catalog` row. Existing reader‑only deployments can still read
the standard global metadata row until a writer runs the migration.

### Changes

- Add `data_path` and backfill existing catalogs only when upgrading a registry that lacks the
  column.
- Leave catalogs created after migration unconfigured until they receive an explicit root.
- Let reader‑only deployments use the legacy global value before writer migration.
- Read and write paths through the writer and provider's bound `catalog_id`.
- Preserve same‑catalog idempotence and reject attempts to change an established root.
- Let different catalogs use different roots in the same PostgreSQL metadata database.
- Group raw path aliases by canonical object‑store authority and path before cleanup.
- Collapse nested roots into one parent sweep while resolving each catalog's references against its
  own root.
- Preserve every live catalog reference when catalogs share or nest roots.
- Retain dropped catalog roots until global orphan cleanup reclaims their files.
- Clear only tombstones that existed when reference collection began.
- Remove a dropped catalog's scheduled deletion rows with its other metadata.
- Sweep each canonical root once when one object store serves them, and reject a global sweep
  across multiple object‑store authorities before deleting anything.
- Add per‑path orphan cleanup for callers that supply a matching store for each authority.
- Preserve the missing‑root error when no catalog or legacy root is configured.
- Add PostgreSQL coverage for distinct paths, raw path aliases, nested roots, reader compatibility,
  one‑time migration, dropped roots, and object‑store authority validation.

### Path and cleanup flow

```mermaid
flowchart LR
    Legacy["Existing registry<br/>global data_path"] --> Migration{"Catalog table has<br/>data_path column?"}
    Migration -->|No| Backfill["Add column once<br/>backfill existing catalogs"]
    Migration -->|Yes| Current["Keep current catalog roots"]
    Current --> Registry["ducklake_catalog<br/>catalog_id + data_path"]
    Backfill --> Registry
    Fresh["Fresh catalog"] --> Explicit["Explicit data root"]
    Explicit --> Registry
    Legacy --> Reader["Reader-only fallback<br/>before migration"]
    Bound["Writer or provider<br/>bound catalog_id"] --> Registry
    Registry --> Selected["Selected catalog root"]
    Registry --> Roots["Registered raw roots"]
    Drop["drop_catalog"] -->|Retain effective root| Tombstone["ducklake_dropped_data_path<br/>tombstone"]
    Tombstone --> Roots
    Roots --> Canonical["Group aliases and<br/>collapse nested roots"]
    Canonical --> Authority{"One object-store<br/>authority?"}
    Authority -->|Yes| References["Resolve live references<br/>from every contained root"]
    Authority -->|No| PerPath["Per-path cleanup<br/>with matching object store"]
    PerPath --> References
    References --> Sweep["Sweep unreferenced files<br/>from each root"]
    Sweep --> Clear["Clear dropped-root tombstone<br/>after a full successful sweep"]
```

### DuckLake compatibility

The standard [`ducklake_metadata`](https://ducklake.select/docs/stable/specification/tables/ducklake_metadata)
table remains unchanged: `data_path` is still a global setting for a standard DuckLake catalog.
The new column belongs to the existing PostgreSQL multicatalog extension, whose
`ducklake_catalog` rows each represent one logical DuckLake catalog.

Existing multicatalog databases add the column and copy the legacy global value only when the
column is absent. Repeated initialization does not assign the legacy root to catalogs created after
that migration. Before migration, the read‑only provider detects the old schema and reads the global
value without requiring DDL rights. Fresh stores do not seed that row, so every new catalog must set
its own root.

Dropped roots live in a PostgreSQL multicatalog extension table until a full non‑dry‑run orphan
sweep succeeds. The global API accepts one object store and therefore requires all registered roots
to use the same authority. Deployments spanning authorities can call the per‑path API with the
matching store. Cleanup groups existing raw path variants such as `/lake` and `/lake/`, then folds
nested roots such as `/lake/tenant` into the parent sweep. It resolves references against each
catalog's own root before deleting files. A sweep clears only dropped‑root tombstones whose
timestamp predates reference collection, so a concurrent drop remains eligible for a later sweep.

Related to [datafusion-contrib/datafusion-ducklake#107](https://github.com/datafusion-contrib/datafusion-ducklake/issues/107).

### Verification

- `cargo check --locked --no-default-features --features multicatalog-postgres` passed with five
  pre‑existing dead‑code warnings outside this change.
- `cargo check --locked --no-default-features --features write-postgres` passed.
- The catalog‑path PostgreSQL test passed against two distinct catalog roots.
- The full multicatalog hardening module passed: 20 tests, including reader compatibility,
  migration reruns, nested roots, and live and dropped `/root` versus `/root/` aliases.
- The multicatalog provider module passed: 12 tests.
- The repaired global referenced‑file preservation test passed and is no longer ignored.
- `cargo clippy --locked --no-default-features --features write-postgres --all-targets --no-deps -- -D warnings` passed.
- `cargo fmt --all --check` passed.
- `git diff --check` passed.
