### PR TITLE
fix(write): percent-encode Hive partition directory names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,8 +64,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `TableWriteSession::finish_with_deletes` no longer refuses a session that produced more than one appended file; it commits them all in the snapshot that carries the deletes (#214).
 
 ### Fixed
+- Hive partition directory names are percent-encoded, matching official DuckLake byte for byte.
+  The previous mapping replaced every character outside `[A-Za-z0-9-_.:]` with `_`, so a partition
+  value containing a space, `+`, or `/` produced a directory name official never writes and which
+  could not be decoded back to the value — `ts=2024-01-15_12:30:00_00` where official writes
+  `ts=2024-01-15%2012%3A30%3A00%2B00`. Partition key names are now escaped on the same terms, as
+  official does. Only newly written files are affected: existing files are located by the path
+  recorded in `ducklake_data_file`, and pruning has always used the authoritative
+  `ducklake_file_partition_value`, so no catalog was damaged and no repair is needed.
 - Timezone-aware timestamp writes now record UTC min/max statistics for file pruning; catalogs
-  written before this change remain readable with absent bounds.
+  written before this change remain readable with absent bounds. This also lets an identity
+  partition key be a `timestamptz` column, which previously failed every `INSERT` with an
+  unsupported-value error because the partition value could not be encoded.
 - A keyed `DELETE` or `UPDATE` works on a data file that compaction has rewritten. The filtered
   delete path previously refused such a file outright — a v1 scope limit, documented as though
   position resolution depended on `rowid = row_id_start + physical position`. It does not:

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -353,20 +353,25 @@ impl PartitionWriteSpec {
 /// empty string when there are no keys (an unpartitioned file lives directly
 /// under the table directory).
 ///
-/// A `None` value (SQL NULL) uses DuckDB's `__HIVE_DEFAULT_PARTITION__` sentinel,
-/// matching official DuckLake's on-disk layout. The catalog
-/// (`ducklake_file_partition_value`) is the authoritative source for pruning, so
-/// this path is for human readability and interop only — values are sanitized for
-/// the filesystem without affecting correctness, and a sanitization collision
-/// between two distinct values is harmless (files carry distinct UUID names and
-/// distinct catalog values).
+/// A `None` value (SQL NULL) uses DuckDB's `__HIVE_DEFAULT_PARTITION__` sentinel.
+/// Key names and values are percent-encoded by [`escape_partition_path`], which
+/// reproduces official DuckLake's on-disk layout byte for byte. Official escapes
+/// both halves through `HivePartitioning::Escape` in
+/// `src/storage/ducklake_partition_data.cpp`, and its insert path delegates
+/// directory naming to DuckDB core's partitioned COPY, which applies that same
+/// escape.
+///
+/// The catalog (`ducklake_file_partition_value`) remains the authoritative source
+/// for pruning — nothing reads values back out of the path — but the encoding is
+/// reversible, so the directory name alone identifies the partition value the way
+/// official's `HivePartitioning::Unescape` expects.
 pub(crate) fn hive_subpath(key_names: &[String], values: &[Option<String>]) -> String {
     let mut rel = String::new();
     for (i, value) in values.iter().enumerate() {
-        let name = key_names.get(i).map(String::as_str).unwrap_or("key");
+        let name = escape_partition_path(key_names.get(i).map(String::as_str).unwrap_or("key"));
         let encoded = match value {
-            Some(v) => sanitize_partition_path(v),
-            None => "__HIVE_DEFAULT_PARTITION__".to_string(),
+            Some(v) => escape_partition_path(v),
+            None => escape_partition_path("__HIVE_DEFAULT_PARTITION__"),
         };
         if rel.is_empty() {
             rel = format!("{name}={encoded}");
@@ -377,19 +382,31 @@ pub(crate) fn hive_subpath(key_names: &[String], values: &[Option<String>]) -> S
     rel
 }
 
-/// Sanitize a partition value for use in a Hive-style directory name — see
-/// [`hive_subpath`] for why a lossy mapping is safe here.
-fn sanitize_partition_path(value: &str) -> String {
-    value
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | ':') {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect()
+/// Percent-encode one Hive directory-name component, byte for byte identical to
+/// DuckDB's `StringUtil::URLEncode` with `encode_slash = true` — the escape
+/// official DuckLake applies to every partition key name and value.
+///
+/// `A-Z`, `a-z`, `0-9`, `_`, `-`, `~` and `.` pass through; every other byte
+/// becomes `%` plus two **uppercase** hex digits. Encoding per byte rather than
+/// per `char` is what keeps multi-byte UTF-8 identical to DuckDB, which walks the
+/// string a byte at a time. `/` is escaped rather than preserved, so a value can
+/// never introduce a directory level or escape the partition directory.
+fn escape_partition_path(value: &str) -> String {
+    const HEX_DIGIT: &[u8; 16] = b"0123456789ABCDEF";
+    let mut out = String::with_capacity(value.len());
+    for byte in value.as_bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'_' | b'-' | b'~' | b'.' => {
+                out.push(char::from(*byte))
+            },
+            _ => {
+                out.push('%');
+                out.push(char::from(HEX_DIGIT[usize::from(byte >> 4)]));
+                out.push(char::from(HEX_DIGIT[usize::from(byte & 15)]));
+            },
+        }
+    }
+    out
 }
 
 /// One partition group of a partitioned write: the per-key partition values every
@@ -694,18 +711,58 @@ mod tests {
             hive_subpath(&keys, &[Some("us".into()), Some("3".into())]),
             "region=us/day=3"
         );
-        // A NULL partition value uses DuckDB's sentinel directory name.
+        // A NULL partition value uses DuckDB's sentinel directory name. Every
+        // byte of it is unreserved, so escaping leaves it verbatim.
         assert_eq!(
             hive_subpath(&keys, &[None, Some("3".into())]),
             "region=__HIVE_DEFAULT_PARTITION__/day=3"
         );
-        // Path separators in a value can never escape the partition directory.
+        // Path separators in a value can never introduce a directory level or
+        // escape the partition directory: `/` encodes to %2F.
         assert_eq!(
             hive_subpath(&keys[..1], &[Some("a/../b".into())]),
-            "region=a_.._b"
+            "region=a%2F..%2Fb"
+        );
+        // A key name is escaped on the same terms as a value.
+        assert_eq!(
+            hive_subpath(&["odd name".to_string()], &[Some("x".into())]),
+            "odd%20name=x"
         );
         // No keys: the file lives directly under the table directory.
         assert_eq!(hive_subpath(&[], &[]), "");
+    }
+
+    /// Golden directory names captured from the official DuckLake extension
+    /// (DuckDB v1.5.5): a `timestamptz`-partitioned table written by
+    /// `ALTER TABLE … SET PARTITIONED BY (ts)` produced exactly these paths in
+    /// `ducklake_data_file.path`. The stored `partition_value` was the
+    /// unescaped `2024-01-15 12:30:00+00`, so this pins only the path encoding.
+    #[test]
+    fn hive_subpath_matches_official_ducklake_paths() {
+        let keys = vec!["ts".to_string()];
+        assert_eq!(
+            hive_subpath(&keys, &[Some("2024-01-15 12:30:00+00".into())]),
+            "ts=2024-01-15%2012%3A30%3A00%2B00"
+        );
+        assert_eq!(
+            hive_subpath(&keys, &[Some("2024-06-02 04:00:00.5+00".into())]),
+            "ts=2024-06-02%2004%3A00%3A00.5%2B00"
+        );
+    }
+
+    #[test]
+    fn escape_partition_path_matches_duckdb_url_encode() {
+        // Unreserved set is exactly A-Za-z0-9 and `_ - ~ .`.
+        assert_eq!(
+            escape_partition_path("aZ09_-~."),
+            "aZ09_-~.",
+            "unreserved bytes must pass through"
+        );
+        // Uppercase hex, and `+` is escaped rather than treated as a space.
+        assert_eq!(escape_partition_path(" :+/=%"), "%20%3A%2B%2F%3D%25");
+        // Encoded per byte, not per char: 'é' is U+00E9 => C3 A9 in UTF-8.
+        assert_eq!(escape_partition_path("é"), "%C3%A9");
+        assert_eq!(escape_partition_path(""), "");
     }
 
     #[test]

--- a/tests/it/partition_write_tests.rs
+++ b/tests/it/partition_write_tests.rs
@@ -1378,3 +1378,155 @@ async fn empty_overwrite_truncates_partitioned_table() {
         "empty INSERT OVERWRITE must truncate the partitioned table, not conflict"
     );
 }
+
+/// An identity partition key on a `timestamptz` column: writable at all (the
+/// partition value could not be encoded before timezone-aware statistics landed),
+/// with the catalog value and the Hive directory name both matching what the
+/// official DuckLake extension produces for the same instants.
+///
+/// The goldens come from DuckDB v1.5.5 + the official `ducklake` extension:
+/// `ALTER TABLE p SET PARTITIONED BY (ts)` then inserting these two values wrote
+/// `ducklake_file_partition_value` rows `2024-01-15 12:30:00+00` /
+/// `2024-06-02 04:00:00.5+00` and file paths under
+/// `ts=2024-01-15%2012%3A30%3A00%2B00` / `ts=2024-06-02%2004%3A00%3A00.5%2B00`.
+#[tokio::test(flavor = "multi_thread")]
+async fn identity_partition_on_timestamptz_matches_official_layout() {
+    use arrow::array::{ArrayRef, Int32Array, RecordBatch, TimestampMicrosecondArray};
+    use arrow::datatypes::{Field, Schema};
+    use datafusion_ducklake::table_writer::DuckLakeTableWriter;
+
+    let temp = TempDir::new().unwrap();
+    let db_path = temp.path().join("tz.db");
+    let data_path = temp.path().join("data");
+    std::fs::create_dir_all(&data_path).unwrap();
+    let conn_str = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    let ts_type = DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()));
+    let cols = vec![
+        ColumnDef::from_arrow("id", &DataType::Int32, false).unwrap(),
+        ColumnDef::from_arrow("ts", &ts_type, true).unwrap(),
+    ];
+
+    let writer = SqliteMetadataWriter::new_with_init(&conn_str)
+        .await
+        .unwrap();
+    writer.set_data_path(data_path.to_str().unwrap()).unwrap();
+    let s = writer
+        .begin_write_transaction("main", "tz_events", &cols, WriteMode::Replace)
+        .unwrap();
+    writer
+        .publish_snapshot(
+            s.table_id,
+            "main",
+            "tz_events",
+            s.snapshot_id,
+            WriteMode::Replace,
+            s.base_snapshot_id,
+            &cols,
+            &s.column_ids,
+        )
+        .unwrap();
+    writer
+        .set_partition_spec(
+            s.table_id,
+            &[("ts".to_string(), PartitionTransform::Identity)],
+        )
+        .unwrap();
+    let table_id = s.table_id;
+
+    // The two instants the official extension was measured with.
+    let a: i64 = 1_705_321_800_000_000; // 2024-01-15 12:30:00+00
+    let b: i64 = 1_717_300_800_500_000; // 2024-06-02 04:00:00.5+00
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("ts", ts_type, true),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2])) as ArrayRef,
+            Arc::new(TimestampMicrosecondArray::from(vec![a, b]).with_timezone("UTC")) as ArrayRef,
+        ],
+    )
+    .unwrap();
+
+    let writer = SqliteMetadataWriter::new_with_init(&conn_str)
+        .await
+        .unwrap();
+    let object_store: Arc<dyn object_store::ObjectStore> =
+        Arc::new(object_store::local::LocalFileSystem::new());
+    let table_writer = DuckLakeTableWriter::new(Arc::new(writer), object_store).unwrap();
+    let mut session = table_writer
+        .begin_write("main", "tz_events", schema.as_ref(), WriteMode::Append)
+        .unwrap();
+    session.write_batch(&batch).unwrap();
+    let result = session.finish().await.unwrap();
+    assert_eq!(result.records_written, 2);
+    assert_eq!(
+        result.files_written, 2,
+        "each distinct timestamptz identity value is its own partition"
+    );
+
+    // The authoritative catalog values, and the Hive directory names, must both
+    // match official byte for byte.
+    let provider = SqliteMetadataProvider::new(&conn_str).await.unwrap();
+    let snap = provider.get_current_snapshot().unwrap();
+    let page = provider
+        .get_table_file_metadata_page(table_id, snap, None, 4096)
+        .unwrap();
+    assert_eq!(page.len(), 2);
+    let mut pairs: Vec<(String, String)> = page
+        .iter()
+        .map(|meta| {
+            let value = meta
+                .file
+                .partition_values
+                .first()
+                .and_then(|(_, v)| v.clone())
+                .expect("a timestamptz identity key must record a partition value");
+            (value, meta.file.file.path.clone())
+        })
+        .collect();
+    pairs.sort();
+    assert_eq!(pairs[0].0, "2024-01-15 12:30:00+00");
+    assert_eq!(pairs[1].0, "2024-06-02 04:00:00.5+00");
+    assert!(
+        pairs[0].1.starts_with("ts=2024-01-15%2012%3A30%3A00%2B00/"),
+        "expected official's percent-encoded Hive path, got {}",
+        pairs[0].1
+    );
+    assert!(
+        pairs[1]
+            .1
+            .starts_with("ts=2024-06-02%2004%3A00%3A00.5%2B00/"),
+        "expected official's percent-encoded Hive path, got {}",
+        pairs[1].1
+    );
+
+    // Both rows read back, and a filter prunes to the single matching partition.
+    let ctx = read_ctx(&conn_str).await;
+    let rows = ctx
+        .sql("SELECT id FROM ducklake.main.tz_events ORDER BY id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(rows.iter().map(|b| b.num_rows()).sum::<usize>(), 2);
+
+    let pruned = ctx
+        .sql(
+            "SELECT id FROM ducklake.main.tz_events \
+             WHERE ts = '2024-01-15T12:30:00Z' ORDER BY id",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(
+        pruned.iter().map(|b| b.num_rows()).sum::<usize>(),
+        1,
+        "filtering on the partition key must return exactly the matching row"
+    );
+}


### PR DESCRIPTION
### Summary

Hive partition directory names are now percent-encoded, matching official DuckLake byte for byte.

The previous mapping replaced every character outside `[A-Za-z0-9-_.:]` with `_`. For a
`timestamptz` identity key that produced a directory official never writes, and one that cannot be
decoded back to the value:

```
ours (before):  ts=2024-01-15_12:30:00_00
official:       ts=2024-01-15%2012%3A30%3A00%2B00
```

### Why official's form is the right target

Official escapes **both** the partition key name and its value through `HivePartitioning::Escape`
in `src/storage/ducklake_partition_data.cpp`, which is `StringUtil::URLEncode` with
`encode_slash = true`. Its insert path does not build the directory name itself — it hands
`partition_columns` to DuckDB core's partitioned COPY (`src/storage/ducklake_insert.cpp`), and core
applies that same escape. So this is not recent upstream drift: the encoding has always been
percent-based, and core ships a matching `Unescape` → `URLDecode`, which is how a Hive path is read
back into a value.

The rule replicated here: `A-Z`, `a-z`, `0-9`, `_`, `-`, `~`, `.` pass through; every other byte
becomes `%` plus two **uppercase** hex digits. Encoding is per byte rather than per `char`, so
multi-byte UTF-8 matches DuckDB, which walks the string a byte at a time. `/` is escaped, so a
value can never introduce a directory level.

### Consequences of the old form

- **Not reversible.** Both a space and a `+` became `_`, so the value could not be recovered from
  the directory name — the one thing official's `Unescape` relies on. This is also what
  `ducklake_add_data_files` uses when it decodes Hive partition values from a path.
- **Collisions.** Two distinct values could map to one directory. The previous doc comment
  acknowledged this and argued it was harmless; percent-encoding removes the caveat instead of
  documenting around it.
- **The doc comment claimed parity we did not have.** It stated the layout matched official's. It
  did not.

### Compatibility

Only newly written files are affected, and no catalog is damaged:

- Existing files are located by the path recorded in `ducklake_data_file`, which is unchanged.
- Pruning has always used the authoritative `ducklake_file_partition_value`, never the directory
  name. That column already stored the unescaped value and still does.

Verified directly rather than argued: a catalog was laid out the old way (underscore directories,
matching `ducklake_data_file.path`) and read with the official extension. It returned correct rows
for a full scan, an equality filter and a range filter, and still pruned — `Total Files Read: 1` of
2. So a pre-existing catalog keeps working under either encoding, and no migration is required.

### Also in this change

`timestamptz` as an identity partition key now works and is covered. It previously failed every
`INSERT` with an unsupported-value error, because the partition value could not be encoded; #260
made it encodable as a side effect of recording timezone-aware statistics, without a test or a
CHANGELOG note. This adds both.

### Goldens

Every expected string comes from DuckDB v1.5.5 with the official `ducklake` extension, not from
reading source. `ALTER TABLE p SET PARTITIONED BY (ts)` on a `TIMESTAMPTZ` column, inserting
`2024-01-15 12:30:00+00` and `2024-06-02 04:00:00.5+00`, produced:

```
ducklake_file_partition_value.partition_value:
  2024-01-15 12:30:00+00
  2024-06-02 04:00:00.5+00

ducklake_data_file.path:
  ts=2024-01-15%2012%3A30%3A00%2B00/ducklake-….parquet
  ts=2024-06-02%2004%3A00%3A00.5%2B00/ducklake-….parquet
```

`identity_partition_on_timestamptz_matches_official_layout` asserts both columns against exactly
those values.

### Verification

- `cargo fmt --all -- --check`: passed.
- `cargo clippy --all-targets --all-features --no-deps -- -D warnings`: passed.
- `RUSTDOCFLAGS='-D warnings' cargo doc --all-features --no-deps`: passed.
- `cargo test --features "skip-tests-with-docker write-sqlite" --lib`: passed, 355 tests.
- `cargo test --features "skip-tests-with-docker write-sqlite" --test it`: passed, 358 tests,
  3 ignored — including the sqllogictests and the compaction Hive-structure test, which re-derive
  partition paths through the same helper.

### Base

Branched from `origin/main` at `fa9595a`, one commit above it.
