### PR TITLE
chore(release): 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,33 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-08-15
+
 ### Added
-- Recursive `list`, `struct`, and `map` columns use standard `ducklake_column` parent links and
-  matching Parquet field IDs across reads, writes, schema evolution, rewrites, and compaction.
-- `PostgresSingleCatalogMetadataWriter` — writes the **standard, spec-compliant** single-catalog DuckLake layout on PostgreSQL (no `catalog_id` columns, no `ducklake_catalog*` map tables, unscoped relative paths), so Postgres catalogs are interchangeable with the SQLite/MySQL backends and DuckDB's `ducklake` extension. SQL `CREATE TABLE AS SELECT` works on this path, unlike the multicatalog writer (#165).
-- Atomic append+delete commits accept SEVERAL appended data files: `MetadataWriter::register_data_files_with_deletes` (and its conditional `_and_commit_metadata` sibling) register N data files plus M positional delete files in ONE snapshot — matching the reference implementation, where one transaction carries both the new data files and the new delete files. A keyed mutation (update/upsert) therefore works on a partitioned table and on a write that rolled past `target_file_size` (#214).
-- SQL `UPDATE` on a PARTITIONED table: each rewritten row is routed by its own post-assignment key values, so an assignment that changes a partition key moves the row to its new partition (calendar transforms included). A rewrite spanning several partitions writes one file per partition and commits them all — with the positional deletes — in one snapshot, preserving every row's `rowid` lineage. Rewritten rows adopt the table's live spec, so a table that adopted partitioning after data was written partitions its updated rows (#214).
-- `DuckLakeTable::files_matching` — the data files a predicate could match, pruned by exactly the catalog statistics and partition bounds a `SELECT` with the same filter uses. A caller driving its own per-file work (a keyed update, an upsert, a positional delete resolved with `resolve_positions`) no longer has to open every data file in the table to find the ones holding a key. Pruning is fail-open: a file is dropped only when its own statistics prove it cannot match, and files are read in bounded pages so peak memory tracks the result rather than the table.
-- `DuckLakeTable::file_has_embedded_rowid` is now public, and available without the write features. It reports where a row's `rowid` comes from — the file's embedded row-id column when it has one, `row_id_start + physical position` otherwise. It is not a precondition for `resolve_positions` or for a keyed mutation; see the `### Fixed` note below.
+- Sort order: `ALTER TABLE … SET`/`RESET SORTED BY (col [ASC|DESC] [NULLS FIRST|LAST])`, recorded in `ducklake_sort_info`/`ducklake_sort_expression` and applied to insert, `UPDATE` rewrites, and compaction output so per-file statistics tighten (#206, #211).
+- `PostgresSingleCatalogMetadataWriter` — writes the **standard, spec-compliant** single-catalog DuckLake layout on PostgreSQL (no `catalog_id` columns, no `ducklake_catalog*` map tables, unscoped relative paths), so Postgres catalogs are interchangeable with the SQLite/MySQL backends and DuckDB's `ducklake` extension. SQL `CREATE TABLE AS SELECT` works on this path, unlike the multicatalog writer (#231).
+- Snapshot time travel: `DuckLakeCatalog::with_snapshot_at` and `ducklake_table_at()` select a snapshot by id or timestamp (#236).
+- Recursive `list`, `struct`, and `map` columns use standard `ducklake_column` parent links and matching Parquet field IDs across reads, writes, schema evolution, rewrites, and compaction (#230).
+- Partitioned writes on **every** writable backend: compaction, the low-level `write_rows`/`write_table`/`append_table` entry points, and `register_existing_data_file` (promote) all honour the table's live spec, and every commit path is fenced against it (#213).
+- Atomic append+delete commits accept SEVERAL appended data files: `MetadataWriter::register_data_files_with_deletes` (and its conditional `_and_commit_metadata` sibling) register N data files plus M positional delete files in ONE snapshot, matching the reference implementation. A keyed mutation therefore works on a partitioned table and on a write that rolled past `target_file_size` (#214, #223).
+- SQL `UPDATE` on a PARTITIONED table: each rewritten row is routed by its own post-assignment key values, so an assignment that changes a partition key moves the row to its new partition (calendar transforms included). A rewrite spanning several partitions writes one file per partition and commits them all — with the positional deletes — in one snapshot, preserving every row's `rowid` lineage (#239).
+- Snapshot metadata and write preconditions: one DuckLake change row per committed snapshot, optional author/message/opaque extra info, and conditional writes fenced against table generation changes, on SQLite and PostgreSQL (#209).
+- A streaming write rolls a new data file once the current one passes `target_file_size` (512 MiB default, floored at 4096 bytes) and commits them all in one snapshot, matching official DuckLake; `begin_write_single_file` opts out for sessions finished with `finish_with_deletes` (#224).
+- Targeted rewrites: `rewrite_data_files` accepts caller-selected live files without a delete threshold, and streams sort output through DataFusion's spill-capable operator (#211).
+- `DuckLakeTable::files_matching` — the data files a predicate could match, pruned by exactly the catalog statistics and partition bounds a `SELECT` with the same filter uses, so a caller driving its own per-file work no longer has to open every data file to find the ones holding a key. Pruning is fail-open and files are read in bounded pages (#240).
+- `DuckLakeTable::file_has_embedded_rowid` is now public, and available without the write features. It reports where a row's `rowid` comes from — the file's embedded row-id column when it has one, `row_id_start + physical position` otherwise (#258).
+- `column_size_bytes` is populated per column on write (summed from the parquet footer, no extra I/O), and `compute_column_stats` is exposed for callers that already hold a parsed footer (#201).
+- Tracing spans over the write path — `ducklake.begin_write_transaction`, `ducklake.register_data_files`, `ducklake.finalize_snapshot`, `ducklake.write_session_finish`, `ducklake.upload_staged_file` (#252).
 
 ### Changed
-- **BREAKING**: `ducklake_table_changes`, `ducklake_table_insertions` and
-  `ducklake_table_deletions` resolve each data file's columns **by field id**, as of the window's
-  end snapshot, instead of by current name — matching official DuckLake. Output changes, silently,
-  on any table whose columns were renamed or dropped and re-added:
-  - a renamed column returned NULL for rows in files written before the rename, and now returns
-    those rows' values;
-  - a column dropped and re-added under the same name returned the DROPPED column's values for
-    rows in files written before the re-add, and now returns NULL there (the re-added column has
-    its own field id, and those files predate it);
-  - two columns whose names were swapped returned each other's values, and now return their own;
-  - a field renamed inside a `STRUCT` behaves the same way as a top-level one.
+- **BREAKING**: `ducklake_table_changes`, `ducklake_table_insertions` and `ducklake_table_deletions` resolve each data file's columns **by field id**, as of the window's end snapshot, instead of by current name — matching official DuckLake. Output changes, silently, on any table whose columns were renamed or dropped and re-added: a renamed column returned NULL for rows in files written before the rename and now returns those rows' values; a column dropped and re-added under the same name returned the DROPPED column's values and now returns NULL there; two columns whose names were swapped returned each other's values and now return their own; a field renamed inside a `STRUCT` behaves the same way as a top-level one.
 
-  The fix is **not retroactive**: it changes what the feeds return from now on, and nothing in the
-  catalog was damaged, so no repair tooling is needed — but anything derived from earlier feed
-  output on an affected table is still wrong. **Re-derive anything built from change-feed output on
-  a table whose columns were renamed, or dropped and re-added.** To find those tables, look for a
-  `column_id` with more than one row, or a name shared by two `column_id`s:
+  The fix is **not retroactive**: nothing in the catalog was damaged, so no repair tooling is needed — but anything derived from earlier feed output on an affected table is still wrong. **Re-derive anything built from change-feed output on a table whose columns were renamed, or dropped and re-added.** To find those tables:
 
   ```sql
   SELECT table_id, column_id, count(*) AS generations
@@ -43,70 +38,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   FROM ducklake_column GROUP BY table_id, column_name HAVING count(DISTINCT column_id) > 1;
   ```
 
-  Field ids come from each file's parquet footer, so the feeds now read one footer per data file —
-  the insert-only feed previously read none — and each per-file scan carries one more plan node.
-  On a table with **encrypted** files the footers cannot be read, so a feed whose window spans a
-  rename or a drop-and-re-add is refused with an error rather than served by name. That refusal is
-  conservative and catches some column changes that would have been safe to match by name, and only
-  `ducklake_table_changes` / `ducklake_table_insertions` give the explanatory error; see
-  COMPATIBILITY.md.
-- `TableChangesTable`, `TableInsertionsTable` and `TableDeletionsTable` accept the table's columns
-  through a new `with_columns` builder. No signature changed; without it the columns are read from
-  the metadata provider on each scan.
-- **BREAKING**: PostgreSQL metadata features no longer select a TLS provider. Consumers that need
-  TLS must also enable one of `tls-native-tls`, `tls-rustls-aws-lc-rs`, or `tls-rustls-ring`.
-  Without one, SQLx rejects connections that require TLS and may try plaintext when `sslmode`
-  prefers TLS. No catalog or data migration is needed.
-- **BREAKING**: S3 support is no longer selected by the library. Consumers using
-  `object_store::aws` must enable `object_store/aws` in their application or register another
-  `ObjectStore` implementation with DataFusion. Local filesystem support remains available through
-  DataFusion without extra configuration. No catalog or data migration is needed.
+  Field ids come from each file's parquet footer, so the feeds now read one footer per data file — the insert-only feed previously read none. On a table with **encrypted** files the footers cannot be read, so a feed whose window spans a rename or a drop-and-re-add is refused with an error rather than served by name; see COMPATIBILITY.md (#253).
+- **BREAKING**: PostgreSQL metadata features no longer select a TLS provider. Consumers that need TLS must also enable one of `tls-native-tls`, `tls-rustls-aws-lc-rs`, or `tls-rustls-ring`. Without one, SQLx rejects connections that require TLS and may try plaintext when `sslmode` prefers TLS. No catalog or data migration is needed (#247).
+- **BREAKING**: S3 support is no longer selected by the library. Consumers using `object_store::aws` must enable `object_store/aws` in their application or register another `ObjectStore` implementation with DataFusion. Local filesystem support remains available through DataFusion without extra configuration. No catalog or data migration is needed (#247).
+- **BREAKING**: DataFusion is depended on with `default-features = false` (only `parquet`, `recursive_protection`, and `sql`). Consumers relying on a DataFusion feature that used to arrive transitively must enable it themselves (#265).
+- **BREAKING**: the minimum supported Rust version is now 1.94, the floor set by sqlx 0.9 (#205).
 - `TableWriteSession::finish_with_deletes` no longer refuses a session that produced more than one appended file; it commits them all in the snapshot that carries the deletes (#214).
+- `TableChangesTable`, `TableInsertionsTable` and `TableDeletionsTable` accept the table's columns through a new `with_columns` builder. No signature changed; without it the columns are read from the metadata provider on each scan (#253).
+- The multicatalog Postgres writer sends per-column statistics as one `UNNEST` insert per table instead of a statement per column, removing a round trip per column from every commit (#252).
 
 ### Fixed
-- Timezone-aware timestamp writes now record UTC min/max statistics for file pruning; catalogs
-  written before this change remain readable with absent bounds.
-- A keyed `DELETE` or `UPDATE` works on a data file that compaction has rewritten. The filtered
-  delete path previously refused such a file outright — a v1 scope limit, documented as though
-  position resolution depended on `rowid = row_id_start + physical position`. It does not:
-  `resolve_positions` reads a file's true physical row positions, and a delete file's `pos` is a
-  physical index, which a rewrite leaves meaningful (the rewritten rows sit at `0..n-1`). What a
-  rewrite disturbs is the rowid *sequence* — `rewrite_data_files` drops deleted rows, so the
-  survivors' rowids carry holes and the catalog records no `row_id_start` at all, making that
-  arithmetic not merely unreliable but uncomputable. DuckLake itself performs keyed mutations
-  against merged, reordered and partition-merged files, so this brings the crate in line with the
-  reference implementation. The consequence for callers: a table can be compacted and still take
-  `DELETE`/`UPDATE`/upsert, which previously required choosing one or the other.
-- `types::build_read_schema_with_field_id_mapping` declares the `PARQUET:field_id` of every nested
-  node the data file tags — list elements, struct children, map key/value, at any depth. A nested
-  node's field id is part of its parent's Arrow type, so a read schema that omitted it disagreed with
-  the batches the parquet reader produces from the very file it describes ("column types must match
-  schema types"). Callers that pair that schema with arrow-rs themselves hit the error directly;
-  scans through this crate's `TableProvider` were unaffected, because DataFusion's parquet opener
-  casts a metadata-only difference away. Files without nested field ids (external, or written before
-  nested nodes were tagged) are still described without them, and the table's catalog schema stays
-  free of storage metadata. Dropping the ids on the way out is a relabel rather than a conversion, so
-  a scan over a nested column keeps its filter and limit pushdown.
-- A write upgrades legacy single‑row `list<T>` metadata to recursive list and element rows without
-  changing the existing list column ID or invalidating historical snapshots.
-- Reads null‑fill fields added inside structs, including non‑nullable fields and structs nested in
-  lists, while preserving field‑ID‑based nested renames and drops.
-- The CDC table functions resolve the TABLE and its schema at the window's end snapshot, not at the
-  catalog's current snapshot. A window over a table that was dropped afterwards failed with
-  "Table 'main.t' not found in catalog" even though every snapshot in the window still had the
-  table; it now returns that window's changes, and a window whose end snapshot is past the drop
-  reports that the table does not exist at that snapshot — matching official DuckLake. One window
-  changes the other way: a window ending BEFORE the table was created used to resolve the table at
-  the current snapshot and return an empty feed, and now reports that the table does not exist at
-  that snapshot. Official DuckLake errors on that window too, so this is convergence rather than a
-  new restriction (#196).
-- A `SELECT` over a table whose struct child was added or renamed by DDL no longer fails with
-  "Cannot cast nullable struct field … to non-nullable field". DuckLake records such a child as
-  non-nullable while the physical parquet node stays optional, and a file written before the change
-  does not carry the child at all; `build_read_schema_with_field_id_mapping` now relaxes nested
-  nullability exactly as the sibling `build_arrow_schema` does. Map keys stay non-nullable. The read
-  schema is then type-identical to the catalog schema, so the rename layer above the scan is a
-  relabel and filters and limits reach the parquet reader's pruning on tables with nested columns.
+- `ducklake_table_deletions` silently missed deletions, or emitted the wrong row's content and rowid, whenever DataFusion parallelized its scans: `DeletedRowsExec` inherited the data scan's partitioning, so the optimizer inserted round-robin repartitions and the per-stream offset counted arrival order rather than physical position. It now reports single partitioning, keeps its internal scans away from the optimizer, and matches deleted rows by true physical position (#178, #200).
+- Float pruning is NaN-aware. Catalog float min/max exclude NaN while NaN sorts above every value, so a file whose NaN state was unknown or positive could be wrongly pruned on `x > C` while holding matching rows. Stored float maxima are now gated on `contains_nan = false` at every consumption point, and NaN-unsafe predicates no longer reach the parquet reader's row-group and page pruning (#203).
+- `decimal(P)` with `P > 38` maps to `Decimal256` instead of an invalid `Decimal128`, which could panic or truncate on decode; and a parquet file carrying two columns with the same `field_id` drops both from the field-id map — the reader null-fills instead of binding the wrong column on the renamed-column read path (#193, #198, #202).
+- Timezone-aware timestamp writes now record UTC min/max statistics for file pruning; catalogs written before this change remain readable with absent bounds (#260).
+- A keyed `DELETE` or `UPDATE` works on a data file that compaction has rewritten. The filtered delete path previously refused such a file outright — a v1 scope limit documented as though position resolution depended on `rowid = row_id_start + physical position`. It does not: `resolve_positions` reads a file's true physical row positions, and a delete file's `pos` is a physical index, which a rewrite leaves meaningful. A table can now be compacted and still take `DELETE`/`UPDATE`/upsert, which previously required choosing one or the other (#258).
+- PostgreSQL `commit_compaction` persists partition metadata, so a merged or rewritten file of a partitioned table keeps its `partition_id` and `ducklake_file_partition_value` rows. Reads stayed correct because zone maps still prune, which is what made this quiet — partition-value pruning was permanently gone while queries still returned the right rows (#246).
+- PostgreSQL `register_data_file_with_deletes` persists partition metadata, so the append+delete (update/upsert) path no longer leaves an appended file that can never be partition-pruned again (#225).
+- Multicatalog data paths are scoped per catalog: each catalog's root is stored on the registry and resolved for writer, reader, and maintenance paths, with the global metadata path kept as a migration fallback (#266).
+- Pruning survives missing statistics. An absent per-file bound is now a typed null, so one file without statistics no longer makes a column unusable for the whole candidate set; files with unknown bounds are kept and exactly-non-matching files are still dropped (#250).
+- Conjunctive pruning predicates are applied repeatedly over bounded pages of file metadata, so partition pruning can expose usable range statistics without loading the full file list (#207).
+- A data file the catalog records as holding exactly zero rows is dropped before statistics are consulted, saving a pruning pass and closing the residual case where such a file carries no per-column statistics row at all and defeats pruning on that column for the whole page. Only a recorded count of exactly 0 counts as proof; an unset `record_count` keeps the file (#244).
+- `types::build_read_schema_with_field_id_mapping` declares the `PARQUET:field_id` of every nested node the data file tags — list elements, struct children, map key/value, at any depth. A nested node's field id is part of its parent's Arrow type, so a read schema that omitted it disagreed with the batches the parquet reader produces from the very file it describes ("column types must match schema types"). Scans through this crate's `TableProvider` were unaffected; callers pairing that schema with arrow-rs themselves hit the error directly (#249).
+- A `SELECT` over a table whose struct child was added or renamed by DDL no longer fails with "Cannot cast nullable struct field … to non-nullable field". DuckLake records such a child as non-nullable while the physical parquet node stays optional; nested nullability is now relaxed exactly as the sibling `build_arrow_schema` does, and map keys stay non-nullable (#253).
+- Reads null-fill fields added inside structs, including non-nullable fields and structs nested in lists, while preserving field-ID-based nested renames and drops; and a write upgrades legacy single-row `list<T>` metadata to recursive list and element rows without changing the existing list column ID or invalidating historical snapshots (#230).
+- The CDC table functions resolve the TABLE and its schema at the window's end snapshot, not at the catalog's current snapshot. A window over a table that was dropped afterwards failed with "Table 'main.t' not found in catalog" even though every snapshot in the window still had the table; it now returns that window's changes. A window whose end snapshot is past the drop — or before the create — reports that the table does not exist at that snapshot, matching official DuckLake (#196, #253).
 
 ## [0.6.0] - 2026-07-20
 
@@ -299,7 +255,9 @@ Initial release.
 - Filter pushdown to Parquet
 - Query-scoped snapshot isolation
 
-[Unreleased]: https://github.com/hotdata-dev/datafusion-ducklake/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/hotdata-dev/datafusion-ducklake/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/hotdata-dev/datafusion-ducklake/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/hotdata-dev/datafusion-ducklake/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/hotdata-dev/datafusion-ducklake/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/hotdata-dev/datafusion-ducklake/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/hotdata-dev/datafusion-ducklake/compare/v0.3.0...v0.3.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1909,7 +1909,7 @@ checksum = "cb9e7e5d11130c48c8bd4e80c79a9772dd28ce6dc330baca9246205d245b9e2e"
 
 [[package]]
 name = "datafusion-ducklake"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "arrow 58.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "benchmark"]
 
 [package]
 name = "datafusion-ducklake"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 # Floor set by sqlx 0.9, which requires 1.94.
 rust-version = "1.94.0"

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ via feature flags. See [COMPATIBILITY.md](COMPATIBILITY.md) for the full matrix.
 
 ```toml
 # Cargo.toml — read PostgreSQL catalogs
-# (for the experimental multi-catalog write path, use features = ["write-postgres"])
+# (to write them too, use features = ["write-postgres"])
 [dependencies.datafusion-ducklake]
-version = "0.6"
+version = "0.7"
 default-features = false
 features = ["metadata-postgres", "tls-rustls-aws-lc-rs"]
 ```
@@ -197,9 +197,11 @@ byte size). See [`DuckLakeTableWriter`](https://docs.rs/datafusion-ducklake) for
 writer options.
 
 > Writing to a **standard, single-catalog** DuckLake store (the spec-compliant layout) is
-> supported today for **SQLite** via `SqliteMetadataWriter` (feature `write-sqlite`),
-> where SQL `CREATE TABLE AS SELECT` and `INSERT INTO` both work. See
-> [`tests/it/sql_write_tests.rs`](tests/it/sql_write_tests.rs).
+> supported today for **SQLite** via `SqliteMetadataWriter` (feature `write-sqlite`) and for
+> **PostgreSQL** via `PostgresSingleCatalogMetadataWriter` (feature `write-postgres`), where
+> SQL `CREATE TABLE AS SELECT` and `INSERT INTO` both work. See
+> [`tests/it/sql_write_tests.rs`](tests/it/sql_write_tests.rs) and
+> [`tests/it/postgres_single_catalog_write_tests.rs`](tests/it/postgres_single_catalog_write_tests.rs).
 
 ---
 
@@ -222,9 +224,33 @@ Writes split rows into one Parquet file per partition value; reads then prune no
 files automatically. Supported transforms are `identity` (the raw value) and
 `year`/`month`/`day`/`hour`; pruning currently applies to `identity` and `year`
 (`month`/`day`/`hour` are recorded but not yet used to skip files). Partitioned **writes**
-are supported on **SQLite** today; **read + pruning** work on all backends. `RESET
-PARTITIONED BY` turns it off. See [COMPATIBILITY.md](COMPATIBILITY.md) and
+work on every writable backend — SQL `INSERT`/`UPDATE`, the low-level write entry points,
+the streaming session, compaction, and promote all honour the live spec — and **read +
+pruning** work on all backends. `RESET PARTITIONED BY` turns it off. See
+[COMPATIBILITY.md](COMPATIBILITY.md) and
 [`tests/it/partition_write_tests.rs`](tests/it/partition_write_tests.rs).
+
+---
+
+## Sort order
+
+Order the rows inside each written file so that per-file statistics stay tight and
+range-filtered scans skip more:
+
+```rust
+execute_ducklake_sql(
+    &ctx,
+    &catalog,
+    "ALTER TABLE ducklake.main.sales SET SORTED BY (sale_date DESC NULLS LAST)",
+)
+.await?;
+```
+
+The spec is recorded in the catalog (`ducklake_sort_info` / `ducklake_sort_expression`) and
+applied on insert, to `UPDATE` rewrites, and to compaction output; rows are sorted before the
+partition split, so each per-partition file stays a sorted subsequence. Bare-column keys are
+produced; other expressions are tolerated on read but never produced. `RESET SORTED BY`
+turns it off.
 
 ---
 
@@ -237,8 +263,9 @@ useful for multi-tenant deployments or keeping many logical lakehouses in one da
 > DuckLake specification** and is not (yet) supported or accepted upstream. Catalogs
 > written this way are read back only through this crate's `MulticatalogProvider` — they
 > are **not** interchangeable with a standard single-catalog DuckLake store. The API and
-> on-disk/in-catalog layout may change. PostgreSQL write support currently depends on this
-> path, so treat it as a preview.
+> on-disk/in-catalog layout may change, so treat it as a preview. PostgreSQL writes no
+> longer require this path — use `PostgresSingleCatalogMetadataWriter` for the
+> spec-compliant layout.
 
 - **Create and manage** catalogs with `MulticatalogManager` (feature `write-postgres`):
   `initialize_multicatalog_schema` bootstraps the shared tables, then `create_catalog`,
@@ -289,9 +316,10 @@ A few highlights worth knowing up front:
 
 - Reads work on DuckDB, SQLite, PostgreSQL, and MySQL; **writes are SQLite/PostgreSQL only**.
 - Object stores: local filesystem and S3-compatible (S3, MinIO).
-- Snapshots can be selected through `DuckLakeCatalog` or per query with
+- Snapshots can be selected through `DuckLakeCatalog` (by id or timestamp) or per query with
   `ducklake_table_at`; DataFusion does not support `AS OF` syntax.
-- Table partitioning: read + file pruning on all backends; partitioned writes on SQLite.
+- Table partitioning: read + file pruning on all backends; partitioned writes on every
+  writable backend.
 - Data inlined by DuckDB's ducklake extension is **not read** — see COMPATIBILITY.md for
   the `COUNT(*)` undercount caveat and how to avoid it.
 


### PR DESCRIPTION
Bump the version 0.6.0 -> 0.7.0 (Cargo.toml + Cargo.lock), promote the CHANGELOG `[Unreleased]` entries to `[0.7.0]`, and refresh the README for what shipped this cycle.

The `[Unreleased]` section covered only 9 of the 39 commits since v0.6.0, so this audits the rest and adds the missing entries: sort order, time travel, partition parity, snapshot metadata, rolling streaming writes, targeted rewrites, and the NaN/decimal/CDC correctness fixes. It also restores the CHANGELOG compare links, which lost `[0.6.0]` and still pointed `[Unreleased]` at v0.5.0.

## Headline for 0.7.0

- **Standard, spec-compliant single-catalog PostgreSQL writer** (#231) — Postgres catalogs are interchangeable with SQLite/MySQL and DuckDB's `ducklake` extension, and no longer need the experimental multicatalog path.
- **DuckLake sort order** — `ALTER TABLE … SET/RESET SORTED BY` (#206, #211).
- **Snapshot time travel** by id or timestamp (#236).
- **Recursive `list`/`struct`/`map` columns** (#230).
- **Partitioned writes on every writable backend**, including keyed `UPDATE`/upsert (#213, #214, #223, #239).

## Breaking

- CDC feeds resolve columns by **field id** (#253) — re-derive anything built from earlier feed output on a table whose columns were renamed, or dropped and re-added. The CHANGELOG carries the detection SQL.
- The library no longer selects a PostgreSQL TLS provider or S3 support (#247), nor DataFusion default features (#265).
- MSRV is now 1.94 (#205).

## Verification

`cargo publish --dry-run` passes (packages and builds clean at 0.7.0). No source changes in this PR — version, CHANGELOG, and README only.

Merging this does **not** publish; pushing the `v0.7.0` tag afterwards is what triggers the crates.io release workflow.